### PR TITLE
refactor coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,61 @@
+# Unitex/GramLab clang-format code formatting styles
+# clang-format is a tool for re-formatting C++ code
+# This file contains clang-format (>= v3.8) customizations
+# for the Unitex/GramLab C++ Core. To test type in a
+# terminal, e.g.: `clang-format -style=file foo.cpp`
+# @see clang.llvm.org/docs/ClangFormat.html  for
+# further information about how to use `clang-format`
+
+# Starting Unitex/GramLab v3.2, we will start to follow
+# the Google C++ Style Guide. This only applies for new
+# code files (i.e not for legacy sources previous to the
+# v3.2-alpha). For more information about the C++ guide
+# @see https://google.github.io/styleguide/cppguide.html
+BasedOnStyle: Google
+IndentWidth: 2
+
+# Extra customizations
+# @see http://goo.gl/om1VOJ
+
+# The column limit
+#ColumnLimit: 82
+
+# The penalty for each character outside of the column limit
+#PenaltyExcessCharacter: 1
+
+# The penalty for each line break introduced inside a string literal
+#PenaltyBreakString: 50
+
+# The maximum number of consecutive empty lines to keep
+MaxEmptyLinesToKeep: 3
+
+# Allows contracting simple braced statements to a single line
+AllowShortBlocksOnASingleLine: true
+
+# `if (a) return;` can not be put on a single line
+AllowShortIfStatementsOnASingleLine: false
+
+# `while (true) continue;` can not be put on a single line
+AllowShortLoopsOnASingleLine: false
+
+# Analyze first the formatted file for the most common alignment
+# of & and \*, then use PointerAlignment below as fallback
+DerivePointerAlignment: true
+
+# The & and * alignment style: align pointer to the right
+PointerAlignment: Left
+
+# `int f() { return 0; }` can not be put on a single line
+AllowShortFunctionsOnASingleLine: false
+
+# Starting clang-format v3.8, not attempt to re-flow comments
+ReflowComments: false
+
+# Aligns consecutive assignments
+AlignConsecutiveAssignments: true
+
+# Indent only in inner namespaces (nested in other namespaces)
+NamespaceIndentation: Inner
+
+# Align parameters on the open bracket
+AlignAfterOpenBracket: Align

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,58 @@
+# Unitex/GramLab code formatting styles
+# This file is for unifying the coding style for different editors and IDEs
+# see http://editorconfig.org for information about how to use it
+# add by martinec
+
+# top-most EditorConfig file
+root = true
+
+# default settings
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+# C++ Files
+[*.{c,cpp,h,c.in,h.in,cpp.in}]
+curly_bracket_next_line = true
+indent_brace_style = 1TBS
+trim_trailing_whitespace = true
+end_of_line = lf
+
+#[{*.java,*.xml,*.js,*.css]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Makefiles
+[{Makefile, Makefile.am}]
+indent_style = tab
+indent_size = 4
+
+# VS studio files
+[*.{sln,user,csproj,props,vcproj,vcxproj,vcxproj.filters}]
+end_of_line = crlf
+indent_size = 2
+
+# Markdown
+[*.{md,md.in}]
+trim_trailing_whitespace = false
+
+# Unix shell scripts
+[*.sh]
+end_of_line = lf
+
+# Windows shell scripts
+[*.{cmd, bat}]
+end_of_line = crlf
+
+# CI configuration
+[{.appveyor.yml,.travis.yml}]
+indent_style = space
+indent_size = 2
+
+# Some things to ignore
+[{misc,vendor,build}/**]
+insert_final_newline = ignore
+trim_trailing_whitespace = ignore
+end_of_line = ignore

--- a/AbstractAllocator.cpp
+++ b/AbstractAllocator.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -208,7 +208,7 @@ int get_allocator_flag(Abstract_allocator aa)
     if (aa != NULL)
     {
         if (aa->pub.fnc_get_flag_allocator != NULL)
-            ret = (aa->pub.fnc_get_flag_allocator)(aa->pub.abstract_allocator_ptr);      
+            ret = (aa->pub.fnc_get_flag_allocator)(aa->pub.abstract_allocator_ptr);
     }
     return ret;
 }
@@ -219,7 +219,7 @@ int get_allocator_creation_flag(Abstract_allocator aa)
     int ret=0;
     if (aa != NULL)
     {
-        ret = (aa->creation_flag);      
+        ret = (aa->creation_flag);
     }
     return ret;
 }
@@ -229,7 +229,7 @@ size_t get_allocator_expected_creation_size(Abstract_allocator aa)
     size_t ret=0;
     if (aa != NULL)
     {
-        ret = (aa->expected_creation_size);      
+        ret = (aa->expected_creation_size);
     }
     return ret;
 }
@@ -240,7 +240,7 @@ int get_allocator_statistic_info(Abstract_allocator aa,int iStatNum,size_t*p_val
     if (aa != NULL)
     {
         if (aa->pub.fnc_get_statistic_allocator_info != NULL)
-            ret = (aa->pub.fnc_get_statistic_allocator_info)(iStatNum,p_value,aa->pub.abstract_allocator_ptr);   
+            ret = (aa->pub.fnc_get_statistic_allocator_info)(iStatNum,p_value,aa->pub.abstract_allocator_ptr);
     }
     return ret;
 }

--- a/AbstractAllocator.cpp
+++ b/AbstractAllocator.cpp
@@ -43,14 +43,14 @@
 //namespace unitex {
 
 struct AllocatorSpace {
-	t_allocator_func_array func_array;
-	void* privateAllocatorSpacePtr;
+    t_allocator_func_array func_array;
+    void* privateAllocatorSpacePtr;
 } ;
 
 
 struct List_AllocatorSpace {
-	AllocatorSpace aas;
-	List_AllocatorSpace* next;
+    AllocatorSpace aas;
+    List_AllocatorSpace* next;
 } ;
 
 
@@ -60,55 +60,55 @@ struct List_AllocatorSpace* p_allocator_info_list=NULL;
 
 UNITEX_FUNC int UNITEX_CALL AddAllocatorSpace(const t_allocator_func_array* func_array,void* privateAllocatorSpacePtr)
 {
-	struct List_AllocatorSpace* new_item;
-	new_item = (struct List_AllocatorSpace*)malloc(sizeof(struct List_AllocatorSpace));
-	if (new_item == NULL)
-		return 0;
+    struct List_AllocatorSpace* new_item;
+    new_item = (struct List_AllocatorSpace*)malloc(sizeof(struct List_AllocatorSpace));
+    if (new_item == NULL)
+        return 0;
 
-	new_item->aas.func_array = *func_array;
-	new_item->aas.privateAllocatorSpacePtr = privateAllocatorSpacePtr;
-	new_item->next = NULL;
+    new_item->aas.func_array = *func_array;
+    new_item->aas.privateAllocatorSpacePtr = privateAllocatorSpacePtr;
+    new_item->next = NULL;
 
-	if (p_allocator_info_list == NULL)
-		p_allocator_info_list = new_item;
-	else {
-		struct List_AllocatorSpace* tmp = p_allocator_info_list;
-		while ((tmp->next) != NULL)
-			tmp = tmp->next;
-		tmp->next = new_item;
-	}
+    if (p_allocator_info_list == NULL)
+        p_allocator_info_list = new_item;
+    else {
+        struct List_AllocatorSpace* tmp = p_allocator_info_list;
+        while ((tmp->next) != NULL)
+            tmp = tmp->next;
+        tmp->next = new_item;
+    }
 
-	if ((new_item->aas.func_array.fnc_Init_AllocatorSpace) != NULL)
-		(*(new_item->aas.func_array.fnc_Init_AllocatorSpace))(new_item->aas.privateAllocatorSpacePtr);
+    if ((new_item->aas.func_array.fnc_Init_AllocatorSpace) != NULL)
+        (*(new_item->aas.func_array.fnc_Init_AllocatorSpace))(new_item->aas.privateAllocatorSpacePtr);
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL RemoveAllocatorSpace(const t_allocator_func_array* func_array,void* privateAllocatorSpacePtr)
 {
-	struct List_AllocatorSpace* tmp = p_allocator_info_list;
-	struct List_AllocatorSpace* tmp_previous = NULL;
+    struct List_AllocatorSpace* tmp = p_allocator_info_list;
+    struct List_AllocatorSpace* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->aas.func_array,func_array,sizeof(t_allocator_func_array))==0) &&
-			(tmp->aas.privateAllocatorSpacePtr == privateAllocatorSpacePtr))
-		{
-			if (tmp_previous == NULL)
-				p_allocator_info_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->aas.func_array,func_array,sizeof(t_allocator_func_array))==0) &&
+            (tmp->aas.privateAllocatorSpacePtr == privateAllocatorSpacePtr))
+        {
+            if (tmp_previous == NULL)
+                p_allocator_info_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->aas.func_array.fnc_Uninit_AllocatorSpace) != NULL)
-				(*(tmp->aas.func_array.fnc_Uninit_AllocatorSpace))(tmp->aas.privateAllocatorSpacePtr);
+            if ((tmp->aas.func_array.fnc_Uninit_AllocatorSpace) != NULL)
+                (*(tmp->aas.func_array.fnc_Uninit_AllocatorSpace))(tmp->aas.privateAllocatorSpacePtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 
@@ -116,23 +116,23 @@ UNITEX_FUNC int UNITEX_CALL GetNbAllocatorSpaceInstalled()
 {
     int count=0;
     struct List_AllocatorSpace* tmp = p_allocator_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 const AllocatorSpace * GetAllocatorSpaceForParam(const char*creator,int flagAllocator,size_t expected_size_item,const void* private_create_ptr)
 {
-	const struct List_AllocatorSpace* tmp = p_allocator_info_list;
-	const AllocatorSpace * best_aas = NULL;
-	int best_priority = 0;
+    const struct List_AllocatorSpace* tmp = p_allocator_info_list;
+    const AllocatorSpace * best_aas = NULL;
+    int best_priority = 0;
 
-	while (tmp != NULL)
-	{
-		const AllocatorSpace * test_aas = &(tmp->aas);
+    while (tmp != NULL)
+    {
+        const AllocatorSpace * test_aas = &(tmp->aas);
 
         int cur_priority = tmp->aas.func_array.fnc_is_param_allocator_compatible(creator,flagAllocator,expected_size_item,private_create_ptr,tmp->aas.privateAllocatorSpacePtr) ;
 
@@ -142,9 +142,9 @@ const AllocatorSpace * GetAllocatorSpaceForParam(const char*creator,int flagAllo
             best_priority = cur_priority;
         }
 
-		tmp = tmp->next;
-	}
-	return best_aas;
+        tmp = tmp->next;
+    }
+    return best_aas;
 }
 
 
@@ -162,7 +162,7 @@ Abstract_allocator build_Abstract_allocator_from_AllocatorSpace(const t_allocato
         return NULL;
     }
 
-	aas->size_abstract_allocator = sizeof(abstract_allocator);
+    aas->size_abstract_allocator = sizeof(abstract_allocator);
     aas->fnc_delete_abstract_allocator = p_func_array->fnc_delete_abstract_allocator;
     aas->privateAllocatorSpacePtr = privateAllocatorSpacePtr;
     aas->creation_flag = creation_flagAllocator;
@@ -247,16 +247,16 @@ int get_allocator_statistic_info(Abstract_allocator aa,int iStatNum,size_t*p_val
 
 int clean_allocator(Abstract_allocator aa)
 {
-	int flag=0;
+    int flag=0;
     if (aa != NULL)
     {
         if (aa->pub.fnc_get_flag_allocator != NULL)
             flag = (aa->pub.fnc_get_flag_allocator)(aa->pub.abstract_allocator_ptr);
-		if ((flag & AllocatorCleanPresent) != 0)
-			if (aa->pub.fnc_clean_allocator != NULL) {
-				(aa->pub.fnc_clean_allocator)(aa->pub.abstract_allocator_ptr);
-				return 1;
-			}
+        if ((flag & AllocatorCleanPresent) != 0)
+            if (aa->pub.fnc_clean_allocator != NULL) {
+                (aa->pub.fnc_clean_allocator)(aa->pub.abstract_allocator_ptr);
+                return 1;
+            }
     }
     return 0;
 }

--- a/AbstractAllocator.h
+++ b/AbstractAllocator.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -68,7 +68,7 @@ typedef void (ABSTRACT_CALLBACK_UNITEX* t_fnc_delete_abstract_allocator)(struct 
 
 typedef struct tag_abstract_allocator_info_public_with_allocator
 {
-	size_t size_abstract_allocator_info_size;
+    size_t size_abstract_allocator_info_size;
     fnc_alloc_t fnc_alloc;
     fnc_realloc_t fnc_realloc;
     fnc_free_t fnc_free;
@@ -80,7 +80,7 @@ typedef struct tag_abstract_allocator_info_public_with_allocator
 
 typedef struct tag_abstract_allocator
 {
-	size_t size_abstract_allocator;
+    size_t size_abstract_allocator;
     abstract_allocator_info_public_with_allocator pub;
 
     /* only for delete */
@@ -120,8 +120,8 @@ typedef abstract_allocator* Abstract_allocator;
 /*
  create_abstract_allocator is used when an function need an allocator
  creator is a string with the name of caller
- creationFlagAllocator : can contain a AllocatorCreationFlag* value 
- expected_size_item : if non zero, the size of item which be allocated. 
+ creationFlagAllocator : can contain a AllocatorCreationFlag* value
+ expected_size_item : if non zero, the size of item which be allocated.
  This mean we will always request object of same size
  */
 

--- a/AbstractAllocatorPlugCallback.h
+++ b/AbstractAllocatorPlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/AbstractCallbackFuncModifier.h
+++ b/AbstractCallbackFuncModifier.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/AbstractDelaLoad.cpp
+++ b/AbstractDelaLoad.cpp
@@ -46,14 +46,14 @@
 using namespace unitex;
 
 struct AbstractDelaSpace {
-	t_persistent_dic_func_array func_array;
-	void* privateSpacePtr;
+    t_persistent_dic_func_array func_array;
+    void* privateSpacePtr;
 } ;
 
 
 struct List_AbstractDelaSpace {
-	AbstractDelaSpace afs;
-	List_AbstractDelaSpace* next;
+    AbstractDelaSpace afs;
+    List_AbstractDelaSpace* next;
 } ;
 
 
@@ -63,55 +63,55 @@ struct List_AbstractDelaSpace* p_abstract_dela_space_list=NULL;
 
 UNITEX_FUNC int UNITEX_CALL AddAbstractDelaSpace(const t_persistent_dic_func_array* func_array,void* privateSpacePtr)
 {
-	struct List_AbstractDelaSpace* new_item;
-	new_item = (struct List_AbstractDelaSpace*)malloc(sizeof(struct List_AbstractDelaSpace));
-	if (new_item == NULL)
-		return 0;
+    struct List_AbstractDelaSpace* new_item;
+    new_item = (struct List_AbstractDelaSpace*)malloc(sizeof(struct List_AbstractDelaSpace));
+    if (new_item == NULL)
+        return 0;
 
-	new_item->afs.func_array = *func_array;
-	new_item->afs.privateSpacePtr = privateSpacePtr;
-	new_item->next = NULL;
+    new_item->afs.func_array = *func_array;
+    new_item->afs.privateSpacePtr = privateSpacePtr;
+    new_item->next = NULL;
 
-	if (p_abstract_dela_space_list == NULL)
-		p_abstract_dela_space_list = new_item;
-	else {
-		struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
-		while ((tmp->next) != NULL)
-			tmp = tmp->next;
-		tmp->next = new_item;
-	}
+    if (p_abstract_dela_space_list == NULL)
+        p_abstract_dela_space_list = new_item;
+    else {
+        struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
+        while ((tmp->next) != NULL)
+            tmp = tmp->next;
+        tmp->next = new_item;
+    }
 
-	if ((new_item->afs.func_array.fnc_Init_DelaSpace) != NULL)
-		(*(new_item->afs.func_array.fnc_Init_DelaSpace))(new_item->afs.privateSpacePtr);
+    if ((new_item->afs.func_array.fnc_Init_DelaSpace) != NULL)
+        (*(new_item->afs.func_array.fnc_Init_DelaSpace))(new_item->afs.privateSpacePtr);
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL RemoveAbstractDelaSpace(const t_persistent_dic_func_array* func_array,void* privateSpacePtr)
 {
-	struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
-	struct List_AbstractDelaSpace* tmp_previous = NULL;
+    struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
+    struct List_AbstractDelaSpace* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->afs.func_array,func_array,sizeof(t_persistent_dic_func_array))==0) &&
-			(tmp->afs.privateSpacePtr == privateSpacePtr))
-		{
-			if (tmp_previous == NULL)
-				p_abstract_dela_space_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->afs.func_array,func_array,sizeof(t_persistent_dic_func_array))==0) &&
+            (tmp->afs.privateSpacePtr == privateSpacePtr))
+        {
+            if (tmp_previous == NULL)
+                p_abstract_dela_space_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->afs.func_array.fnc_Uninit_DelaSpace) != NULL)
-				(*(tmp->afs.func_array.fnc_Uninit_DelaSpace))(tmp->afs.privateSpacePtr);
+            if ((tmp->afs.func_array.fnc_Uninit_DelaSpace) != NULL)
+                (*(tmp->afs.func_array.fnc_Uninit_DelaSpace))(tmp->afs.privateSpacePtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 
@@ -119,82 +119,82 @@ UNITEX_FUNC int UNITEX_CALL GetNbAbstractDelaSpaceInstalled()
 {
     int count=0;
     struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 
 const AbstractDelaSpace * GetDelaSpaceForFileName(const char*name)
 {
-	const struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
+    const struct List_AbstractDelaSpace* tmp = p_abstract_dela_space_list;
 
-	while (tmp != NULL)
-	{
-		const AbstractDelaSpace * test_afs = &(tmp->afs);
-		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;
+    while (tmp != NULL)
+    {
+        const AbstractDelaSpace * test_afs = &(tmp->afs);
+        if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
+            return test_afs;
 
-		tmp = tmp->next;
-	}
-	return NULL;
+        tmp = tmp->next;
+    }
+    return NULL;
 }
 
 /*******************************/
 
 int is_abstract_or_persistent_dictionary_filename(const char* filename)
 {
-	if (GetDelaSpaceForFileName(filename))
-		return 1;
-	if (get_persistent_structure(filename))
-		return 1;
-	return 0;
+    if (GetDelaSpaceForFileName(filename))
+        return 1;
+    if (get_persistent_structure(filename))
+        return 1;
+    return 0;
 }
 
 
 const struct INF_codes* load_abstract_INF_file(const VersatileEncodingConfig* vec,const char* name,struct INF_free_info* p_inf_free_info)
 {
-	struct INF_codes* res = NULL;
-	const AbstractDelaSpace * pads = GetDelaSpaceForFileName(name) ;
-	if (pads == NULL)
-	{
-		res = load_INF_file(vec,name);
-		if (res != NULL)
-		{
-			p_inf_free_info->must_be_free = 1;
-			p_inf_free_info->func_free_inf = NULL;
-			p_inf_free_info->private_ptr = NULL;
-		}
-		return res;
-	}
-	else
-	{
-		p_inf_free_info->must_be_free = 0;
-		p_inf_free_info->private_ptr = NULL;
-		p_inf_free_info->privateSpacePtr = pads->privateSpacePtr;
-		p_inf_free_info->func_free_inf = (void*)(pads->func_array.fnc_free_abstract_INF);
-		res = (*(pads->func_array.fnc_load_abstract_INF_file))(vec, name,p_inf_free_info,pads->privateSpacePtr);
-		return res;
-	}
+    struct INF_codes* res = NULL;
+    const AbstractDelaSpace * pads = GetDelaSpaceForFileName(name) ;
+    if (pads == NULL)
+    {
+        res = load_INF_file(vec,name);
+        if (res != NULL)
+        {
+            p_inf_free_info->must_be_free = 1;
+            p_inf_free_info->func_free_inf = NULL;
+            p_inf_free_info->private_ptr = NULL;
+        }
+        return res;
+    }
+    else
+    {
+        p_inf_free_info->must_be_free = 0;
+        p_inf_free_info->private_ptr = NULL;
+        p_inf_free_info->privateSpacePtr = pads->privateSpacePtr;
+        p_inf_free_info->func_free_inf = (void*)(pads->func_array.fnc_free_abstract_INF);
+        res = (*(pads->func_array.fnc_load_abstract_INF_file))(vec, name,p_inf_free_info,pads->privateSpacePtr);
+        return res;
+    }
 }
 
 void free_abstract_INF(const struct INF_codes* INF,struct INF_free_info* p_inf_free_info)
 {
-	if (INF != NULL)
-		if (p_inf_free_info->must_be_free != 0)
-	{
-		if (p_inf_free_info->func_free_inf == NULL)
-			free_INF_codes((struct INF_codes*)INF);
-		else
-		{
-			t_fnc_free_abstract_INF fnc_free_abstract_INF = (t_fnc_free_abstract_INF)(p_inf_free_info->func_free_inf);
-			if (fnc_free_abstract_INF != NULL)
-				(*fnc_free_abstract_INF)((struct INF_codes*)INF,p_inf_free_info,p_inf_free_info->privateSpacePtr);
-		}
-	}
+    if (INF != NULL)
+        if (p_inf_free_info->must_be_free != 0)
+    {
+        if (p_inf_free_info->func_free_inf == NULL)
+            free_INF_codes((struct INF_codes*)INF);
+        else
+        {
+            t_fnc_free_abstract_INF fnc_free_abstract_INF = (t_fnc_free_abstract_INF)(p_inf_free_info->func_free_inf);
+            if (fnc_free_abstract_INF != NULL)
+                (*fnc_free_abstract_INF)((struct INF_codes*)INF,p_inf_free_info,p_inf_free_info->privateSpacePtr);
+        }
+    }
 }
 
 
@@ -210,10 +210,10 @@ void ABSTRACT_CALLBACK_UNITEX func_free_mapbin(unsigned char* BIN,
 
 const unsigned char* load_abstract_BIN_file(const char* name,long*file_size,struct BIN_free_info* p_bin_free_info)
 {
-	unsigned char* res = NULL;
-	const AbstractDelaSpace * pads = GetDelaSpaceForFileName(name) ;
-	if (pads == NULL)
-	{
+    unsigned char* res = NULL;
+    const AbstractDelaSpace * pads = GetDelaSpaceForFileName(name) ;
+    if (pads == NULL)
+    {
         ABSTRACTMAPFILE *amf;
         amf=af_open_mapfile(name,MAPFILE_OPTION_READ,0);
         if (amf != NULL) {
@@ -223,42 +223,42 @@ const unsigned char* load_abstract_BIN_file(const char* name,long*file_size,stru
             }
         }
         if (res != NULL)
-		{
-			p_bin_free_info->must_be_free = 1;
-			p_bin_free_info->func_free_bin = (void*)func_free_mapbin;
-			p_bin_free_info->private_ptr = amf;
-			if (file_size!=NULL)
-				*file_size=(long)af_get_mapfile_size(amf);
-		}
-		return res;
-	}
-	else
-	{
-		p_bin_free_info->must_be_free = 0;
-		p_bin_free_info->private_ptr = NULL;
-		p_bin_free_info->privateSpacePtr = pads->privateSpacePtr;
-		p_bin_free_info->func_free_bin = (void*)(pads->func_array.fnc_free_abstract_BIN);
-		res = (*(pads->func_array.fnc_load_abstract_BIN_file_ex))(name,file_size,p_bin_free_info,pads->privateSpacePtr);
-		return res;
-	}
+        {
+            p_bin_free_info->must_be_free = 1;
+            p_bin_free_info->func_free_bin = (void*)func_free_mapbin;
+            p_bin_free_info->private_ptr = amf;
+            if (file_size!=NULL)
+                *file_size=(long)af_get_mapfile_size(amf);
+        }
+        return res;
+    }
+    else
+    {
+        p_bin_free_info->must_be_free = 0;
+        p_bin_free_info->private_ptr = NULL;
+        p_bin_free_info->privateSpacePtr = pads->privateSpacePtr;
+        p_bin_free_info->func_free_bin = (void*)(pads->func_array.fnc_free_abstract_BIN);
+        res = (*(pads->func_array.fnc_load_abstract_BIN_file_ex))(name,file_size,p_bin_free_info,pads->privateSpacePtr);
+        return res;
+    }
 }
 
 void free_abstract_BIN(const unsigned char* BIN,struct BIN_free_info* p_bin_free_info)
 {
-	if (BIN != NULL)
-		if (p_bin_free_info->must_be_free != 0)
-	{
-		if (p_bin_free_info->func_free_bin == NULL)
-		{
-			fatal_error("no func_free_bin defined in free_abstract_BIN");
-		}
-		else
-		{
-			t_fnc_free_abstract_BIN fnc_free_abstract_BIN = (t_fnc_free_abstract_BIN)(p_bin_free_info->func_free_bin);
-			if (fnc_free_abstract_BIN != NULL)
-			(*fnc_free_abstract_BIN)((unsigned char*)BIN,p_bin_free_info,p_bin_free_info->privateSpacePtr);
-		}
-	}
+    if (BIN != NULL)
+        if (p_bin_free_info->must_be_free != 0)
+    {
+        if (p_bin_free_info->func_free_bin == NULL)
+        {
+            fatal_error("no func_free_bin defined in free_abstract_BIN");
+        }
+        else
+        {
+            t_fnc_free_abstract_BIN fnc_free_abstract_BIN = (t_fnc_free_abstract_BIN)(p_bin_free_info->func_free_bin);
+            if (fnc_free_abstract_BIN != NULL)
+            (*fnc_free_abstract_BIN)((unsigned char*)BIN,p_bin_free_info,p_bin_free_info->privateSpacePtr);
+        }
+    }
 }
 
 //} // namespace unitex

--- a/AbstractDelaLoad.cpp
+++ b/AbstractDelaLoad.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -136,7 +136,7 @@ const AbstractDelaSpace * GetDelaSpaceForFileName(const char*name)
 	{
 		const AbstractDelaSpace * test_afs = &(tmp->afs);
 		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;		
+			return test_afs;
 
 		tmp = tmp->next;
 	}

--- a/AbstractDelaLoad.h
+++ b/AbstractDelaLoad.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -45,20 +45,20 @@ using namespace unitex;
 
 struct INF_free_info
 {
-	void *func_free_inf;
-	void *private_ptr;
-	void *privateSpacePtr;
-	int must_be_free;
+    void *func_free_inf;
+    void *private_ptr;
+    void *privateSpacePtr;
+    int must_be_free;
 } ;
 
 const struct INF_free_info INF_free_info_init={NULL,NULL,NULL,1};
 
 struct BIN_free_info
 {
-	void *func_free_bin;
-	void *private_ptr;
-	void *privateSpacePtr;
-	int must_be_free;
+    void *func_free_bin;
+    void *private_ptr;
+    void *privateSpacePtr;
+    int must_be_free;
 } ;
 
 const struct BIN_free_info BIN_free_info_init={NULL,NULL,NULL,1};

--- a/AbstractDelaPlugCallback.h
+++ b/AbstractDelaPlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -121,7 +121,7 @@ typedef void (ABSTRACT_CALLBACK_UNITEX* t_fnc_free_abstract_BIN)(unsigned char* 
 
 typedef struct
 {
-	size_t size_func_array;
+    size_t size_func_array;
 
     t_fnc_is_filename_DelaSpace_object fnc_is_filename_object;
 

--- a/AbstractFilePlugCallback.h
+++ b/AbstractFilePlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -113,7 +113,7 @@ typedef int (ABSTRACT_CALLBACK_UNITEX *t_fnc_memLowLevelSetSizeReservation)(ABST
 typedef int (ABSTRACT_CALLBACK_UNITEX *t_fnc_memFileRemove)(const char* lpFileName,void* privateSpacePtr);
 typedef int (ABSTRACT_CALLBACK_UNITEX *t_fnc_memFileRename)(const char * _OldFilename, const char * _NewFilename,void* privateSpacePtr);
 
-/* get a read only pointer on a portion of a file, from pos to pos+len (file mapped io logic). Can 
+/* get a read only pointer on a portion of a file, from pos to pos+len (file mapped io logic). Can
         be NULL if the file space don't support this function (but Unitex will use more CPU time and memory */
 typedef const void* (ABSTRACT_CALLBACK_UNITEX *t_fnc_memFile_getMapPointer)(ABSTRACTFILE_PTR llFile, afs_size_type pos, afs_size_type len,int options,afs_size_type value_for_options,void* privateSpacePtr);
 

--- a/AbstractFst2Load.cpp
+++ b/AbstractFst2Load.cpp
@@ -46,14 +46,14 @@
 using namespace unitex;
 
 struct AbstractFst2Space {
-	t_persistent_fst2_func_array func_array;
-	void* privateSpacePtr;
+    t_persistent_fst2_func_array func_array;
+    void* privateSpacePtr;
 } ;
 
 
 struct List_AbstractFst2Space {
-	AbstractFst2Space afs;
-	List_AbstractFst2Space* next;
+    AbstractFst2Space afs;
+    List_AbstractFst2Space* next;
 } ;
 
 
@@ -63,55 +63,55 @@ struct List_AbstractFst2Space* p_abstract_fst2_space_list=NULL;
 
 UNITEX_FUNC int UNITEX_CALL AddAbstractFst2Space(const t_persistent_fst2_func_array* func_array,void* privateSpacePtr)
 {
-	struct List_AbstractFst2Space* new_item;
-	new_item = (struct List_AbstractFst2Space*)malloc(sizeof(struct List_AbstractFst2Space));
-	if (new_item == NULL)
-		return 0;
+    struct List_AbstractFst2Space* new_item;
+    new_item = (struct List_AbstractFst2Space*)malloc(sizeof(struct List_AbstractFst2Space));
+    if (new_item == NULL)
+        return 0;
 
-	new_item->afs.func_array = *func_array;
-	new_item->afs.privateSpacePtr = privateSpacePtr;
-	new_item->next = NULL;
+    new_item->afs.func_array = *func_array;
+    new_item->afs.privateSpacePtr = privateSpacePtr;
+    new_item->next = NULL;
 
-	if (p_abstract_fst2_space_list == NULL)
-		p_abstract_fst2_space_list = new_item;
-	else {
-		struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
-		while ((tmp->next) != NULL)
-			tmp = tmp->next;
-		tmp->next = new_item;
-	}
+    if (p_abstract_fst2_space_list == NULL)
+        p_abstract_fst2_space_list = new_item;
+    else {
+        struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
+        while ((tmp->next) != NULL)
+            tmp = tmp->next;
+        tmp->next = new_item;
+    }
 
-	if ((new_item->afs.func_array.fnc_Init_Fst2Space) != NULL)
-		(*(new_item->afs.func_array.fnc_Init_Fst2Space))(new_item->afs.privateSpacePtr);
+    if ((new_item->afs.func_array.fnc_Init_Fst2Space) != NULL)
+        (*(new_item->afs.func_array.fnc_Init_Fst2Space))(new_item->afs.privateSpacePtr);
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL RemoveAbstractFst2Space(const t_persistent_fst2_func_array* func_array,void* privateSpacePtr)
 {
-	struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
-	struct List_AbstractFst2Space* tmp_previous = NULL;
+    struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
+    struct List_AbstractFst2Space* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->afs.func_array,func_array,sizeof(t_persistent_fst2_func_array))==0) &&
-			(tmp->afs.privateSpacePtr == privateSpacePtr))
-		{
-			if (tmp_previous == NULL)
-				p_abstract_fst2_space_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->afs.func_array,func_array,sizeof(t_persistent_fst2_func_array))==0) &&
+            (tmp->afs.privateSpacePtr == privateSpacePtr))
+        {
+            if (tmp_previous == NULL)
+                p_abstract_fst2_space_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->afs.func_array.fnc_Uninit_Fst2Space) != NULL)
-				(*(tmp->afs.func_array.fnc_Uninit_Fst2Space))(tmp->afs.privateSpacePtr);
+            if ((tmp->afs.func_array.fnc_Uninit_Fst2Space) != NULL)
+                (*(tmp->afs.func_array.fnc_Uninit_Fst2Space))(tmp->afs.privateSpacePtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 
@@ -119,28 +119,28 @@ UNITEX_FUNC int UNITEX_CALL GetNbAbstractFst2SpaceInstalled()
 {
     int count=0;
     struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 
 const AbstractFst2Space * GetFst2SpaceForFileName(const char*name)
 {
-	const struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
+    const struct List_AbstractFst2Space* tmp = p_abstract_fst2_space_list;
 
-	while (tmp != NULL)
-	{
-		const AbstractFst2Space * test_afs = &(tmp->afs);
-		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;
+    while (tmp != NULL)
+    {
+        const AbstractFst2Space * test_afs = &(tmp->afs);
+        if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
+            return test_afs;
 
-		tmp = tmp->next;
-	}
-	return NULL;
+        tmp = tmp->next;
+    }
+    return NULL;
 }
 
 /*******************************/
@@ -148,47 +148,47 @@ const AbstractFst2Space * GetFst2SpaceForFileName(const char*name)
 
 Fst2* load_abstract_fst2(const VersatileEncodingConfig* vec,const char* filename,int read_names,struct FST2_free_info* p_fst2_free_info)
 {
-	Fst2* res = NULL;
-	const AbstractFst2Space * pads = GetFst2SpaceForFileName(filename) ;
-	if (pads == NULL)
-	{
-		res = load_fst2(vec, filename, read_names);
+    Fst2* res = NULL;
+    const AbstractFst2Space * pads = GetFst2SpaceForFileName(filename) ;
+    if (pads == NULL)
+    {
+        res = load_fst2(vec, filename, read_names);
 
-		if ((res != NULL) && (p_fst2_free_info != NULL))
-		{
-			p_fst2_free_info->must_be_free = 1;
-			p_fst2_free_info->func_free_fst2 = NULL;
-			p_fst2_free_info->private_ptr = NULL;
-		}
-		return res;
-	}
-	else
-	{
-		if (p_fst2_free_info != NULL)
-		{
-			p_fst2_free_info->must_be_free = 0;
-			p_fst2_free_info->private_ptr = NULL;
-			p_fst2_free_info->privateSpacePtr = pads->privateSpacePtr;
-			p_fst2_free_info->func_free_fst2 = (void*)(pads->func_array.fnc_free_abstract_fst2);
-		}
-		res = (*(pads->func_array.fnc_load_abstract_fst2))(vec, filename,read_names,p_fst2_free_info,pads->privateSpacePtr);
-		return res;
-	}
+        if ((res != NULL) && (p_fst2_free_info != NULL))
+        {
+            p_fst2_free_info->must_be_free = 1;
+            p_fst2_free_info->func_free_fst2 = NULL;
+            p_fst2_free_info->private_ptr = NULL;
+        }
+        return res;
+    }
+    else
+    {
+        if (p_fst2_free_info != NULL)
+        {
+            p_fst2_free_info->must_be_free = 0;
+            p_fst2_free_info->private_ptr = NULL;
+            p_fst2_free_info->privateSpacePtr = pads->privateSpacePtr;
+            p_fst2_free_info->func_free_fst2 = (void*)(pads->func_array.fnc_free_abstract_fst2);
+        }
+        res = (*(pads->func_array.fnc_load_abstract_fst2))(vec, filename,read_names,p_fst2_free_info,pads->privateSpacePtr);
+        return res;
+    }
 }
 
 int is_abstract_fst2_filename(const char* filename)
 {
-	return ((GetFst2SpaceForFileName(filename) == NULL) ? 0 : 1);
+    return ((GetFst2SpaceForFileName(filename) == NULL) ? 0 : 1);
 }
 
 
 int is_abstract_or_persistent_fst2_filename(const char* filename)
 {
-	if (GetFst2SpaceForFileName(filename))
-		return 1;
-	if (get_persistent_structure(filename))
-		return 1;
-	return 0;
+    if (GetFst2SpaceForFileName(filename))
+        return 1;
+    if (get_persistent_structure(filename))
+        return 1;
+    return 0;
 }
 
 
@@ -200,17 +200,17 @@ void free_abstract_Fst2(Fst2* fst2,struct FST2_free_info* p_fst2_free_info)
             free_Fst2(fst2);
         else
         {
-		    if (p_fst2_free_info->must_be_free != 0)
-		    {
-			    if (p_fst2_free_info->func_free_fst2 == NULL)
-				    free_Fst2(fst2);
-			    else
-			    {
-				    t_fnc_free_abstract_fst2 fnc_free_abstract_fst2 = (t_fnc_free_abstract_fst2)(p_fst2_free_info->func_free_fst2);
-				    if (fnc_free_abstract_fst2 != NULL)
-					    (*fnc_free_abstract_fst2)(fst2,p_fst2_free_info,p_fst2_free_info->privateSpacePtr);
-			    }
-		    }
+            if (p_fst2_free_info->must_be_free != 0)
+            {
+                if (p_fst2_free_info->func_free_fst2 == NULL)
+                    free_Fst2(fst2);
+                else
+                {
+                    t_fnc_free_abstract_fst2 fnc_free_abstract_fst2 = (t_fnc_free_abstract_fst2)(p_fst2_free_info->func_free_fst2);
+                    if (fnc_free_abstract_fst2 != NULL)
+                        (*fnc_free_abstract_fst2)(fst2,p_fst2_free_info,p_fst2_free_info->privateSpacePtr);
+                }
+            }
         }
     }
 }

--- a/AbstractFst2Load.cpp
+++ b/AbstractFst2Load.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -136,7 +136,7 @@ const AbstractFst2Space * GetFst2SpaceForFileName(const char*name)
 	{
 		const AbstractFst2Space * test_afs = &(tmp->afs);
 		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;		
+			return test_afs;
 
 		tmp = tmp->next;
 	}

--- a/AbstractFst2Load.h
+++ b/AbstractFst2Load.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -43,10 +43,10 @@
 using namespace unitex;
 struct FST2_free_info
 {
-	void *func_free_fst2;
-	void *private_ptr;
-	void *privateSpacePtr;
-	int must_be_free;
+    void *func_free_fst2;
+    void *private_ptr;
+    void *privateSpacePtr;
+    int must_be_free;
 } ;
 
 const struct FST2_free_info FST2_free_info_init={NULL,NULL,NULL,1};

--- a/AbstractFst2PlugCallback.h
+++ b/AbstractFst2PlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -66,7 +66,7 @@ typedef void (ABSTRACT_CALLBACK_UNITEX* t_fnc_free_abstract_fst2)(Fst2* fst2,str
 
 typedef struct
 {
-	size_t size_func_array;
+    size_t size_func_array;
     t_fnc_is_filename_Fst2Space_object fnc_is_filename_object;
 
     t_fnc_Init_Fst2Space fnc_Init_Fst2Space;

--- a/ActivityLogger.cpp
+++ b/ActivityLogger.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/ActivityLogger.cpp
+++ b/ActivityLogger.cpp
@@ -45,14 +45,14 @@
 namespace unitex {
 
 struct LoggerInfo {
-	t_logger_func_array_ex_1 func_array;
-	void* privateLoggerPtr;
+    t_logger_func_array_ex_1 func_array;
+    void* privateLoggerPtr;
 } ;
 
 
 struct List_LoggerInfo {
-	LoggerInfo lgi;
-	List_LoggerInfo* next;
+    LoggerInfo lgi;
+    List_LoggerInfo* next;
 } ;
 
 
@@ -63,86 +63,86 @@ struct List_LoggerInfo* p_logger_info_list=NULL;
 
 UNITEX_FUNC int UNITEX_CALL AddLoggerInfoEx1(const t_logger_func_array_ex_1* func_array,void* privateLoggerPtr)
 {
-	struct List_LoggerInfo* new_item;
-	new_item = (struct List_LoggerInfo*)malloc(sizeof(struct List_LoggerInfo));
-	if (new_item == NULL)
-		return 0;
+    struct List_LoggerInfo* new_item;
+    new_item = (struct List_LoggerInfo*)malloc(sizeof(struct List_LoggerInfo));
+    if (new_item == NULL)
+        return 0;
 
-	new_item->lgi.func_array = *func_array;
-	new_item->lgi.privateLoggerPtr = privateLoggerPtr;
-	new_item->next = NULL;
+    new_item->lgi.func_array = *func_array;
+    new_item->lgi.privateLoggerPtr = privateLoggerPtr;
+    new_item->next = NULL;
 
-	if (p_logger_info_list == NULL)
-		p_logger_info_list = new_item;
-	else {
-		struct List_LoggerInfo* tmp = p_logger_info_list;
-		while ((tmp->next) != NULL)
-			tmp = tmp->next;
-		tmp->next = new_item;
-	}
+    if (p_logger_info_list == NULL)
+        p_logger_info_list = new_item;
+    else {
+        struct List_LoggerInfo* tmp = p_logger_info_list;
+        while ((tmp->next) != NULL)
+            tmp = tmp->next;
+        tmp->next = new_item;
+    }
 
-	if ((new_item->lgi.func_array.fnc_Init_Logger) != NULL)
-		(*(new_item->lgi.func_array.fnc_Init_Logger))(new_item->lgi.privateLoggerPtr);
+    if ((new_item->lgi.func_array.fnc_Init_Logger) != NULL)
+        (*(new_item->lgi.func_array.fnc_Init_Logger))(new_item->lgi.privateLoggerPtr);
 
-	return 1;
+    return 1;
 }
 
 
 UNITEX_FUNC int UNITEX_CALL RemoveLoggerInfoEx1(const t_logger_func_array_ex_1* func_array,void* privateLoggerPtr)
 {
-	struct List_LoggerInfo* tmp = p_logger_info_list;
-	struct List_LoggerInfo* tmp_previous = NULL;
+    struct List_LoggerInfo* tmp = p_logger_info_list;
+    struct List_LoggerInfo* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->lgi.func_array,func_array,sizeof(t_logger_func_array))==0) &&
-			(tmp->lgi.privateLoggerPtr == privateLoggerPtr))
-		{
-			if (tmp_previous == NULL)
-				p_logger_info_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->lgi.func_array,func_array,sizeof(t_logger_func_array))==0) &&
+            (tmp->lgi.privateLoggerPtr == privateLoggerPtr))
+        {
+            if (tmp_previous == NULL)
+                p_logger_info_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->lgi.func_array.fnc_Uninit_Logger) != NULL)
-				(*(tmp->lgi.func_array.fnc_Uninit_Logger))(tmp->lgi.privateLoggerPtr);
+            if ((tmp->lgi.func_array.fnc_Uninit_Logger) != NULL)
+                (*(tmp->lgi.func_array.fnc_Uninit_Logger))(tmp->lgi.privateLoggerPtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 UNITEX_FUNC int UNITEX_CALL AddLoggerInfo(const t_logger_func_array* func_array, void* privateLoggerPtr)
 {
-	t_logger_func_array_ex_1 func_array_ex_1;
-	memset(&func_array_ex_1, 0, sizeof(t_logger_func_array_ex_1));
-	memcpy(&func_array_ex_1, func_array, my_min(func_array->size_struct, sizeof(t_logger_func_array_ex_1)));
-	func_array_ex_1.size_struct = sizeof(t_logger_func_array_ex_1);
-	return AddLoggerInfoEx1(&func_array_ex_1, privateLoggerPtr);
+    t_logger_func_array_ex_1 func_array_ex_1;
+    memset(&func_array_ex_1, 0, sizeof(t_logger_func_array_ex_1));
+    memcpy(&func_array_ex_1, func_array, my_min(func_array->size_struct, sizeof(t_logger_func_array_ex_1)));
+    func_array_ex_1.size_struct = sizeof(t_logger_func_array_ex_1);
+    return AddLoggerInfoEx1(&func_array_ex_1, privateLoggerPtr);
 }
 
 UNITEX_FUNC int UNITEX_CALL RemoveLoggerInfo(const t_logger_func_array* func_array, void* privateLoggerPtr)
 {
-	t_logger_func_array_ex_1 func_array_ex_1;
-	memset(&func_array_ex_1, 0, sizeof(t_logger_func_array_ex_1));
-	memcpy(&func_array_ex_1, func_array, my_min(func_array->size_struct, sizeof(t_logger_func_array_ex_1)));
-	func_array_ex_1.size_struct = sizeof(t_logger_func_array_ex_1);
-	return RemoveLoggerInfoEx1(&func_array_ex_1, privateLoggerPtr);
+    t_logger_func_array_ex_1 func_array_ex_1;
+    memset(&func_array_ex_1, 0, sizeof(t_logger_func_array_ex_1));
+    memcpy(&func_array_ex_1, func_array, my_min(func_array->size_struct, sizeof(t_logger_func_array_ex_1)));
+    func_array_ex_1.size_struct = sizeof(t_logger_func_array_ex_1);
+    return RemoveLoggerInfoEx1(&func_array_ex_1, privateLoggerPtr);
 }
 
 UNITEX_FUNC int UNITEX_CALL GetNbLoggerInfoInstalled()
 {
     int count=0;
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 
@@ -150,207 +150,207 @@ UNITEX_FUNC int UNITEX_CALL GetNbLoggerInfoInstalled()
 void Call_logger_fnc_before_af_fopen(const char* name,const char* MODE)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_af_fopen) != NULL)
             (*(tmp->lgi.func_array.fnc_before_af_fopen))(name,MODE,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_after_af_fopen(const char* name,const char* MODE,ABSTRACTFILE* af)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_fopen) != NULL)
             (*(tmp->lgi.func_array.fnc_after_af_fopen))(name,MODE,af,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_before_af_fclose(ABSTRACTFILE* af)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_af_fclose) != NULL)
             (*(tmp->lgi.func_array.fnc_before_af_fclose))(af,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_after_af_fclose(ABSTRACTFILE* af,int ret)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_fclose) != NULL)
             (*(tmp->lgi.func_array.fnc_after_af_fclose))(af,ret,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_before_af_rename(const char* name1,const char* name2)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_af_rename) != NULL)
             (*(tmp->lgi.func_array.fnc_before_af_rename))(name1,name2,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_after_af_rename(const char* name1,const char* name2,int ret)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_rename) != NULL)
             (*(tmp->lgi.func_array.fnc_after_af_rename))(name1,name2,ret,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_before_af_copy(const char* name1,const char* name2)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_af_copy) != NULL)
             (*(tmp->lgi.func_array.fnc_before_af_copy))(name1,name2,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_after_af_copy(const char* name1,const char* name2,int ret)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_copy) != NULL)
             (*(tmp->lgi.func_array.fnc_after_af_copy))(name1,name2,ret,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 
 void Call_logger_fnc_before_af_remove(const char* name)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_af_remove) != NULL)
             (*(tmp->lgi.func_array.fnc_before_af_remove))(name,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 
 void Call_logger_fnc_after_af_remove(const char* name,int ret)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_remove) != NULL)
             (*(tmp->lgi.func_array.fnc_after_af_remove))(name,ret,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 
 void Call_logger_fnc_before_af_remove_folder(const char* name)
 {
-	struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
-		if (tmp->lgi.func_array.size_struct >= sizeof(t_logger_func_array_ex_1))
-			if ((tmp->lgi.func_array.fnc_before_af_remove_folder) != NULL) {
-				(*(tmp->lgi.func_array.fnc_before_af_remove_folder))(name, tmp->lgi.privateLoggerPtr);
-			}
-		tmp = tmp->next;
-	}
+    struct List_LoggerInfo* tmp = p_logger_info_list;
+    while (tmp != NULL)
+    {
+        if (tmp->lgi.func_array.size_struct >= sizeof(t_logger_func_array_ex_1))
+            if ((tmp->lgi.func_array.fnc_before_af_remove_folder) != NULL) {
+                (*(tmp->lgi.func_array.fnc_before_af_remove_folder))(name, tmp->lgi.privateLoggerPtr);
+            }
+        tmp = tmp->next;
+    }
 }
 
 
 void Call_logger_fnc_after_af_remove_folder(const char* name, int ret)
 {
-	struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
-		if (tmp->lgi.func_array.size_struct >= sizeof(t_logger_func_array_ex_1))
-			if ((tmp->lgi.func_array.fnc_after_af_remove_folder) != NULL) {
-				(*(tmp->lgi.func_array.fnc_after_af_remove_folder))(name, ret, tmp->lgi.privateLoggerPtr);
-			}
-		tmp = tmp->next;
-	}
+    struct List_LoggerInfo* tmp = p_logger_info_list;
+    while (tmp != NULL)
+    {
+        if (tmp->lgi.func_array.size_struct >= sizeof(t_logger_func_array_ex_1))
+            if ((tmp->lgi.func_array.fnc_after_af_remove_folder) != NULL) {
+                (*(tmp->lgi.func_array.fnc_after_af_remove_folder))(name, ret, tmp->lgi.privateLoggerPtr);
+            }
+        tmp = tmp->next;
+    }
 }
 
 
 int Call_logger_need_log_af_remove()
 {
-	struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
-		t_logger_func_array_ex_1* func_array = &(tmp->lgi.func_array);
-		if ((func_array->fnc_before_af_remove) != NULL)
-			return 1;
-		if ((func_array->fnc_after_af_remove) != NULL)
-			return 1;
-		if (func_array->size_struct >= sizeof(t_logger_func_array_ex_1)) {
-			if ((func_array->fnc_before_af_remove_folder) != NULL)
-				return 1;
-			if ((func_array->fnc_after_af_remove_folder) != NULL)
-				return 1;
-		}
-		tmp = tmp->next;
-	}
-	return 0;
+    struct List_LoggerInfo* tmp = p_logger_info_list;
+    while (tmp != NULL)
+    {
+        t_logger_func_array_ex_1* func_array = &(tmp->lgi.func_array);
+        if ((func_array->fnc_before_af_remove) != NULL)
+            return 1;
+        if ((func_array->fnc_after_af_remove) != NULL)
+            return 1;
+        if (func_array->size_struct >= sizeof(t_logger_func_array_ex_1)) {
+            if ((func_array->fnc_before_af_remove_folder) != NULL)
+                return 1;
+            if ((func_array->fnc_after_af_remove_folder) != NULL)
+                return 1;
+        }
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 void Call_logger_fnc_before_calling_tool(mainFunc* fnc,int argc,char* const argv[])
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_before_calling_tool) != NULL)
             (*(tmp->lgi.func_array.fnc_before_calling_tool))(fnc,argc,argv,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_after_calling_tool(mainFunc* fnc,int argc,char* const argv[],int ret)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_after_af_remove) != NULL)
             (*(tmp->lgi.func_array.fnc_after_calling_tool))(fnc,argc,argv,ret,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_LogOutWrite(const void*Buf, size_t size)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_LogOutWrite) != NULL)
             (*(tmp->lgi.func_array.fnc_LogOutWrite))(Buf,size,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 void Call_logger_fnc_LogErrWrite(const void*Buf, size_t size)
 {
     struct List_LoggerInfo* tmp = p_logger_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if ((tmp->lgi.func_array.fnc_LogErrWrite) != NULL)
             (*(tmp->lgi.func_array.fnc_LogErrWrite))(Buf,size,tmp->lgi.privateLoggerPtr);
-		tmp = tmp->next;
-	}
+        tmp = tmp->next;
+    }
 }
 
 } // namespace unitex

--- a/ActivityLogger.h
+++ b/ActivityLogger.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/ActivityLoggerPlugCallback.h
+++ b/ActivityLoggerPlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -59,7 +59,7 @@ extern "C" {
  */
 
 
-/* there fopen callback are called when an Unitex tool open a file 
+/* there fopen callback are called when an Unitex tool open a file
  *  In the Unitex context, MODE is one of these value :
  *   - "rb" : open the file in read only mode
  *   - "wb" : open the file in write only mode (the previous file is erased, if exist)
@@ -126,35 +126,35 @@ typedef struct
 
 typedef struct
 {
-	unsigned int size_struct;
+    unsigned int size_struct;
 
-	t_fnc_Init_Logger fnc_Init_Logger;
-	t_fnc_Uninit_Logger fnc_Uninit_Logger;
+    t_fnc_Init_Logger fnc_Init_Logger;
+    t_fnc_Uninit_Logger fnc_Uninit_Logger;
 
-	t_fnc_before_af_fopen fnc_before_af_fopen;
-	t_fnc_after_af_fopen  fnc_after_af_fopen;
+    t_fnc_before_af_fopen fnc_before_af_fopen;
+    t_fnc_after_af_fopen  fnc_after_af_fopen;
 
-	t_fnc_before_af_fclose fnc_before_af_fclose;
-	t_fnc_after_af_fclose fnc_after_af_fclose;
+    t_fnc_before_af_fclose fnc_before_af_fclose;
+    t_fnc_after_af_fclose fnc_after_af_fclose;
 
-	t_fnc_before_af_rename fnc_before_af_rename;
-	t_fnc_after_af_rename fnc_after_af_rename;
+    t_fnc_before_af_rename fnc_before_af_rename;
+    t_fnc_after_af_rename fnc_after_af_rename;
 
-	t_fnc_before_af_copy fnc_before_af_copy;
-	t_fnc_after_af_copy fnc_after_af_copy;
+    t_fnc_before_af_copy fnc_before_af_copy;
+    t_fnc_after_af_copy fnc_after_af_copy;
 
-	t_fnc_before_af_remove fnc_before_af_remove;
-	t_fnc_after_af_remove fnc_after_af_remove;
+    t_fnc_before_af_remove fnc_before_af_remove;
+    t_fnc_after_af_remove fnc_after_af_remove;
 
-	t_fnc_before_calling_tool fnc_before_calling_tool;
-	t_fnc_after_calling_tool fnc_after_calling_tool;
+    t_fnc_before_calling_tool fnc_before_calling_tool;
+    t_fnc_after_calling_tool fnc_after_calling_tool;
 
-	t_fnc_LogOutWrite fnc_LogOutWrite;
-	t_fnc_LogErrWrite fnc_LogErrWrite;
+    t_fnc_LogOutWrite fnc_LogOutWrite;
+    t_fnc_LogErrWrite fnc_LogErrWrite;
 
 
-	t_fnc_before_af_remove_folder fnc_before_af_remove_folder;
-	t_fnc_after_af_remove_folder fnc_after_af_remove_folder;
+    t_fnc_before_af_remove_folder fnc_before_af_remove_folder;
+    t_fnc_after_af_remove_folder fnc_after_af_remove_folder;
 } t_logger_func_array_ex_1;
 
 /* these functions respectively add and remove logger.

--- a/Af_stdio.cpp
+++ b/Af_stdio.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -63,7 +63,7 @@ struct List_AbstractFileSpace* p_abstract_file_space_list=NULL;
 
 
 static void FillFuncArrayExtensibleFromFuncArrayExtensible(t_fileio_func_array_extensible *func_array_extensible_res,
-	                                                       const t_fileio_func_array_extensible* func_array_extensible_src) 
+	                                                       const t_fileio_func_array_extensible* func_array_extensible_src)
 {
     memset(func_array_extensible_res,0,sizeof(t_fileio_func_array_extensible));
 	size_t copy_size = (func_array_extensible_src->size_func_array < sizeof(t_fileio_func_array_extensible)) ?
@@ -162,7 +162,7 @@ const AbstractFileSpace * GetFileSpaceForFileName(const char*name)
 	{
 		const AbstractFileSpace * test_afs = &(tmp->afs);
 		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;		
+			return test_afs;
 
 		tmp = tmp->next;
 	}
@@ -258,7 +258,7 @@ struct stdwrite_param* get_std_write_param(ABSTRACTFILE*stream)
 	return NULL;
 }
 
-UNITEX_FUNC int UNITEX_CALL SetStdWriteCB(enum stdwrite_kind swk, int trashOutput, 
+UNITEX_FUNC int UNITEX_CALL SetStdWriteCB(enum stdwrite_kind swk, int trashOutput,
 										t_fnc_stdOutWrite fnc_stdOutWrite,void* privatePtr)
 {
 	if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
@@ -268,7 +268,7 @@ UNITEX_FUNC int UNITEX_CALL SetStdWriteCB(enum stdwrite_kind swk, int trashOutpu
 	{
 		(*(stdwrite_setparam[swk].fnc_stdOutWrite))(NULL,0,stdwrite_setparam[swk].privatePtr);
 	}
-	
+
 	stdwrite_setparam[swk].trashOutput = trashOutput;
 	stdwrite_setparam[swk].fnc_stdOutWrite = fnc_stdOutWrite;
 	stdwrite_setparam[swk].privatePtr = privatePtr;
@@ -276,7 +276,7 @@ UNITEX_FUNC int UNITEX_CALL SetStdWriteCB(enum stdwrite_kind swk, int trashOutpu
 	return 1;
 }
 
-UNITEX_FUNC int UNITEX_CALL GetStdWriteCB(enum stdwrite_kind swk, int* p_trashOutput, 
+UNITEX_FUNC int UNITEX_CALL GetStdWriteCB(enum stdwrite_kind swk, int* p_trashOutput,
 										t_fnc_stdOutWrite* p_fnc_stdOutWrite,void** p_privatePtr)
 {
 	if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
@@ -326,7 +326,7 @@ UNITEX_FUNC int UNITEX_CALL SetStdInCB(t_fnc_stdIn fnc_stdInRead,void* privatePt
 	{
 		(*(stdin_param.fnc_stdIn))(NULL,0,stdin_param.privatePtr);
 	}
-	
+
 	stdin_param.fnc_stdIn = fnc_stdInRead;
 	stdin_param.privatePtr = privatePtr;
 
@@ -346,7 +346,7 @@ UNITEX_FUNC int UNITEX_CALL GetStdInCB(t_fnc_stdIn* p_fnc_stdInRead,void** p_pri
 
 
 /*
- * is_filename_in_abstract_file_space return 
+ * is_filename_in_abstract_file_space return
        0 if a filename is a file opened with fopen
        1 if a filename use an installed abstract filespace
  */
@@ -406,7 +406,7 @@ ABSTRACTFILE* af_fopen_unlogged(const char* name,const char* MODE)
         else
         {
           if ((*(MODE))=='a')
-              (*(pafs->func_array.fnc_memLowLevelSeek))(vf->fabstr,0,SEEK_END,pafs->privateSpacePtr);        
+              (*(pafs->func_array.fnc_memLowLevelSeek))(vf->fabstr,0,SEEK_END,pafs->privateSpacePtr);
         }
 	}
 	return (ABSTRACTFILE*)vf;
@@ -501,7 +501,7 @@ char *af_fgets(char * _Buf, int count, ABSTRACTFILE * stream)
 	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
 	if (p_abfr->afs == NULL)
 		return fgets(_Buf,count,p_abfr->f);
-	else { 
+	else {
 		char* retval = _Buf;
 		char* pointer = _Buf;
 
@@ -525,7 +525,7 @@ char *af_fgets(char * _Buf, int count, ABSTRACTFILE * stream)
             }
 			*pointer = '\0';
         }
-		return retval;	
+		return retval;
 	}
 }
 
@@ -720,14 +720,14 @@ void af_release_mapfile_pointer(ABSTRACTMAPFILE*streammap, const void* buf, size
 
 /* when we create a new file, before write into, we can set the filesize,
    (if we known the size of result file)
-   like the chsize or _chsize . This can help to avoid fragmentation or 
+   like the chsize or _chsize . This can help to avoid fragmentation or
    rewrite the File allocation table often, by example */
 void af_setsizereservation(ABSTRACTFILE* stream, long size_planned)
 {
 	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
 	if (p_abfr->afs != NULL)
 		if (p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation != NULL)
-			(*(p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation))(p_abfr->fabstr, size_planned,p_abfr->afs->privateSpacePtr);	
+			(*(p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation))(p_abfr->fabstr, size_planned,p_abfr->afs->privateSpacePtr);
 }
 
 
@@ -736,7 +736,7 @@ char** af_get_list_file(const char*name)
 {
 	const AbstractFileSpace * pafs ;
 	pafs = GetFileSpaceForFileName(name);
-	 
+
 	if (pafs == NULL)
 	{
 		return buildListFileInDiskDir(name);
@@ -759,7 +759,7 @@ char** af_get_list_file(const char*name)
 					if (!strncmp(name, all_files[i], name_length)) {
 						keep[i] = 1;
 						nb_files_to_keep++;
-					} 
+					}
 				}
 			}
 			char** files = (char**)malloc((nb_files_to_keep + 1) * sizeof(char*));
@@ -771,7 +771,7 @@ char** af_get_list_file(const char*name)
 				}
 			}
 			files[nb_files_to_keep] = NULL;
-			free(keep);			
+			free(keep);
 
 			if ((pafs->func_array.fnc_memFile_releaseList != NULL) && (all_files!=NULL)) {
 				(*(pafs->func_array.fnc_memFile_releaseList))(all_files,pafs->privateSpacePtr);
@@ -853,13 +853,13 @@ int af_copy_unlogged(const char* srcFile, const char* dstFile)
         af_fclose(vfRead);
         free(szBuffer);
         return 1;
-    }    
+    }
 
     af_setsizereservation(vfWrite, size_to_do);
 
     if (af_fseek(vfRead, 0, SEEK_SET) != 0)
 	{
-        af_fclose(vfWrite);        
+        af_fclose(vfWrite);
         af_fclose(vfRead);
         free(szBuffer);
         return -1;
@@ -875,7 +875,7 @@ int af_copy_unlogged(const char* srcFile, const char* dstFile)
         if (iReadDone == 0)
             break;
         iWriteDone = (int)af_fwrite(szBuffer,1,iReadDone,vfWrite);
-        if (iWriteDone != iReadDone) { 
+        if (iWriteDone != iReadDone) {
             ret_in_error = 1;
             break;
         }
@@ -989,7 +989,7 @@ int af_remove_folder(const char*folderName)
 	int retValue ;
 	if (Call_logger_need_log_af_remove() == 0)
 		return af_remove_folder_unlogged(folderName);
-	 
+
 	Call_logger_fnc_before_af_remove_folder(folderName);
 	char*folderNameStar = (char*)malloc(strlen(folderName) + 4);
 	if (folderNameStar == NULL)
@@ -1002,7 +1002,7 @@ int af_remove_folder(const char*folderName)
 
 	int retValue1 = af_remove(folderNameStar);
 	free(folderNameStar);
-	 
+
 	if (is_filename_in_abstract_file_space(folderName) == 0)
 		retValue3 = RemoveFileSystemFolder(folderName);
 

--- a/Af_stdio.cpp
+++ b/Af_stdio.cpp
@@ -47,14 +47,14 @@
 using namespace unitex;
 
 struct AbstractFileSpace {
-	t_fileio_func_array_extensible func_array;
-	void* privateSpacePtr;
+    t_fileio_func_array_extensible func_array;
+    void* privateSpacePtr;
 } ;
 
 
 struct List_AbstractFileSpace {
-	AbstractFileSpace afs;
-	List_AbstractFileSpace* next;
+    AbstractFileSpace afs;
+    List_AbstractFileSpace* next;
 } ;
 
 
@@ -63,81 +63,81 @@ struct List_AbstractFileSpace* p_abstract_file_space_list=NULL;
 
 
 static void FillFuncArrayExtensibleFromFuncArrayExtensible(t_fileio_func_array_extensible *func_array_extensible_res,
-	                                                       const t_fileio_func_array_extensible* func_array_extensible_src)
+                                                           const t_fileio_func_array_extensible* func_array_extensible_src)
 {
     memset(func_array_extensible_res,0,sizeof(t_fileio_func_array_extensible));
-	size_t copy_size = (func_array_extensible_src->size_func_array < sizeof(t_fileio_func_array_extensible)) ?
-							(func_array_extensible_res->size_func_array) : sizeof(t_fileio_func_array_extensible);
-	memcpy(func_array_extensible_res,func_array_extensible_src,copy_size);
-	func_array_extensible_res->size_func_array = sizeof(t_fileio_func_array_extensible);
+    size_t copy_size = (func_array_extensible_src->size_func_array < sizeof(t_fileio_func_array_extensible)) ?
+                            (func_array_extensible_res->size_func_array) : sizeof(t_fileio_func_array_extensible);
+    memcpy(func_array_extensible_res,func_array_extensible_src,copy_size);
+    func_array_extensible_res->size_func_array = sizeof(t_fileio_func_array_extensible);
 }
 
 
 
 UNITEX_FUNC int UNITEX_CALL AddAbstractFileSpaceExtensible(const t_fileio_func_array_extensible* func_array_extensible_param,void* privateSpacePtr)
 {
-	struct List_AbstractFileSpace* new_item;
-	new_item = (struct List_AbstractFileSpace*)malloc(sizeof(struct List_AbstractFileSpace));
-	if (new_item == NULL)
-		return 0;
+    struct List_AbstractFileSpace* new_item;
+    new_item = (struct List_AbstractFileSpace*)malloc(sizeof(struct List_AbstractFileSpace));
+    if (new_item == NULL)
+        return 0;
 
-	FillFuncArrayExtensibleFromFuncArrayExtensible(&(new_item->afs.func_array),func_array_extensible_param);
+    FillFuncArrayExtensibleFromFuncArrayExtensible(&(new_item->afs.func_array),func_array_extensible_param);
 
-	new_item->afs.privateSpacePtr = privateSpacePtr;
-	new_item->next = NULL;
+    new_item->afs.privateSpacePtr = privateSpacePtr;
+    new_item->next = NULL;
 
-	if (p_abstract_file_space_list == NULL)
-		p_abstract_file_space_list = new_item;
-	else {
-		// give priority to optimized filesystem with fnc_memLowLevelSetSizeReservation function
-		int put_at_first = (func_array_extensible_param->fnc_memLowLevelSetSizeReservation) ? 1 : 0;
-		if (put_at_first) {
-			new_item->next = p_abstract_file_space_list;
-			p_abstract_file_space_list = new_item;
-		}
-		else {
-			struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
-			while ((tmp->next) != NULL)
-				tmp = tmp->next;
-			tmp->next = new_item;
-		}
-	}
+    if (p_abstract_file_space_list == NULL)
+        p_abstract_file_space_list = new_item;
+    else {
+        // give priority to optimized filesystem with fnc_memLowLevelSetSizeReservation function
+        int put_at_first = (func_array_extensible_param->fnc_memLowLevelSetSizeReservation) ? 1 : 0;
+        if (put_at_first) {
+            new_item->next = p_abstract_file_space_list;
+            p_abstract_file_space_list = new_item;
+        }
+        else {
+            struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
+            while ((tmp->next) != NULL)
+                tmp = tmp->next;
+            tmp->next = new_item;
+        }
+    }
 
-	if ((new_item->afs.func_array.fnc_Init_FileSpace) != NULL)
-		(*(new_item->afs.func_array.fnc_Init_FileSpace))(new_item->afs.privateSpacePtr);
+    if ((new_item->afs.func_array.fnc_Init_FileSpace) != NULL)
+        (*(new_item->afs.func_array.fnc_Init_FileSpace))(new_item->afs.privateSpacePtr);
 
-	return 1;
+    return 1;
 }
 
 
 UNITEX_FUNC int UNITEX_CALL RemoveAbstractFileSpaceExtensible(const t_fileio_func_array_extensible* func_array_extensible_param,void* privateSpacePtr)
 {
-	t_fileio_func_array_extensible func_array_extensible_work;
-	FillFuncArrayExtensibleFromFuncArrayExtensible(&func_array_extensible_work,func_array_extensible_param);
+    t_fileio_func_array_extensible func_array_extensible_work;
+    FillFuncArrayExtensibleFromFuncArrayExtensible(&func_array_extensible_work,func_array_extensible_param);
 
-	struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
-	struct List_AbstractFileSpace* tmp_previous = NULL;
+    struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
+    struct List_AbstractFileSpace* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->afs.func_array,&func_array_extensible_work,sizeof(t_fileio_func_array_extensible))==0) &&
-			(tmp->afs.privateSpacePtr == privateSpacePtr))
-		{
-			if (tmp_previous == NULL)
-				p_abstract_file_space_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->afs.func_array,&func_array_extensible_work,sizeof(t_fileio_func_array_extensible))==0) &&
+            (tmp->afs.privateSpacePtr == privateSpacePtr))
+        {
+            if (tmp_previous == NULL)
+                p_abstract_file_space_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->afs.func_array.fnc_Uninit_FileSpace) != NULL)
-				(*(tmp->afs.func_array.fnc_Uninit_FileSpace))(tmp->afs.privateSpacePtr);
+            if ((tmp->afs.func_array.fnc_Uninit_FileSpace) != NULL)
+                (*(tmp->afs.func_array.fnc_Uninit_FileSpace))(tmp->afs.privateSpacePtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 
@@ -145,28 +145,28 @@ UNITEX_FUNC int UNITEX_CALL GetNbAbstractFileSpaceInstalled()
 {
     int count=0;
     struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 
 const AbstractFileSpace * GetFileSpaceForFileName(const char*name)
 {
-	const struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
+    const struct List_AbstractFileSpace* tmp = p_abstract_file_space_list;
 
-	while (tmp != NULL)
-	{
-		const AbstractFileSpace * test_afs = &(tmp->afs);
-		if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
-			return test_afs;
+    while (tmp != NULL)
+    {
+        const AbstractFileSpace * test_afs = &(tmp->afs);
+        if (tmp->afs.func_array.fnc_is_filename_object(name,tmp->afs.privateSpacePtr) != 0)
+            return test_afs;
 
-		tmp = tmp->next;
-	}
-	return NULL;
+        tmp = tmp->next;
+    }
+    return NULL;
 }
 
 
@@ -174,29 +174,29 @@ const AbstractFileSpace * GetFileSpaceForFileName(const char*name)
 
 typedef struct _ABSTRACTFILE_REAL
 {
-	union
-	{
-		FILE* f;
-		ABSTRACTFILE_PTR fabstr;
-	} ;
-	const AbstractFileSpace * afs;
+    union
+    {
+        FILE* f;
+        ABSTRACTFILE_PTR fabstr;
+    } ;
+    const AbstractFileSpace * afs;
 } ABSTRACTFILE_REAL;
 
 
 typedef struct _ABSTRACTMAPFILE_REAL
 {
-	union
-	{
+    union
+    {
         struct {
-		  MAPFILE* f;
+          MAPFILE* f;
         } mf;
         struct {
           ABSTRACTFILE_PTR fabstr;
           int options_for_mapfile;
           size_t size_for_options_for_mapfile;
         } af;
-	} ;
-	const AbstractFileSpace * afs;
+    } ;
+    const AbstractFileSpace * afs;
 } ABSTRACTMAPFILE_REAL;
 
 /*********************************************************************/
@@ -213,30 +213,30 @@ const ABSTRACTFILE* pVF_StdErr = (const ABSTRACTFILE*)&VF_StdErr;
 
 int IsStdIn(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	return (((p_abfr->f)==stdin) && (p_abfr->afs==NULL));
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    return (((p_abfr->f)==stdin) && (p_abfr->afs==NULL));
 }
 
 
 int IsStdOut(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	return (((p_abfr->f)==stdout) && (p_abfr->afs==NULL));
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    return (((p_abfr->f)==stdout) && (p_abfr->afs==NULL));
 }
 
 
 int IsStdErr(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	return (((p_abfr->f)==stderr) && (p_abfr->afs==NULL));
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    return (((p_abfr->f)==stderr) && (p_abfr->afs==NULL));
 }
 
 
 struct stdwrite_param
 {
-	int trashOutput;
-	t_fnc_stdOutWrite fnc_stdOutWrite;
-	void* privatePtr;
+    int trashOutput;
+    t_fnc_stdOutWrite fnc_stdOutWrite;
+    void* privatePtr;
 };
 
 
@@ -245,53 +245,53 @@ struct stdwrite_param stdwrite_setparam[2] = { { 0 , NULL, NULL } , { 0 , NULL ,
 
 struct stdwrite_param* get_std_write_param(ABSTRACTFILE*stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-	{
-		if ((p_abfr->f)==stdout)
-			return &stdwrite_setparam[stdwrite_kind_out];
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+    {
+        if ((p_abfr->f)==stdout)
+            return &stdwrite_setparam[stdwrite_kind_out];
 
-		if ((p_abfr->f)==stderr)
-			return &stdwrite_setparam[stdwrite_kind_err];
-	}
+        if ((p_abfr->f)==stderr)
+            return &stdwrite_setparam[stdwrite_kind_err];
+    }
 
-	return NULL;
+    return NULL;
 }
 
 UNITEX_FUNC int UNITEX_CALL SetStdWriteCB(enum stdwrite_kind swk, int trashOutput,
-										t_fnc_stdOutWrite fnc_stdOutWrite,void* privatePtr)
+                                        t_fnc_stdOutWrite fnc_stdOutWrite,void* privatePtr)
 {
-	if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
-		return 0;
+    if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
+        return 0;
 
-	if ((stdwrite_setparam[swk].trashOutput == 0) && (stdwrite_setparam[swk].fnc_stdOutWrite != NULL))
-	{
-		(*(stdwrite_setparam[swk].fnc_stdOutWrite))(NULL,0,stdwrite_setparam[swk].privatePtr);
-	}
+    if ((stdwrite_setparam[swk].trashOutput == 0) && (stdwrite_setparam[swk].fnc_stdOutWrite != NULL))
+    {
+        (*(stdwrite_setparam[swk].fnc_stdOutWrite))(NULL,0,stdwrite_setparam[swk].privatePtr);
+    }
 
-	stdwrite_setparam[swk].trashOutput = trashOutput;
-	stdwrite_setparam[swk].fnc_stdOutWrite = fnc_stdOutWrite;
-	stdwrite_setparam[swk].privatePtr = privatePtr;
+    stdwrite_setparam[swk].trashOutput = trashOutput;
+    stdwrite_setparam[swk].fnc_stdOutWrite = fnc_stdOutWrite;
+    stdwrite_setparam[swk].privatePtr = privatePtr;
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL GetStdWriteCB(enum stdwrite_kind swk, int* p_trashOutput,
-										t_fnc_stdOutWrite* p_fnc_stdOutWrite,void** p_privatePtr)
+                                        t_fnc_stdOutWrite* p_fnc_stdOutWrite,void** p_privatePtr)
 {
-	if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
-		return 0;
+    if ((swk != stdwrite_kind_out) && (swk != stdwrite_kind_err))
+        return 0;
 
-	if (p_trashOutput != NULL)
-		*p_trashOutput = stdwrite_setparam[swk].trashOutput ;
+    if (p_trashOutput != NULL)
+        *p_trashOutput = stdwrite_setparam[swk].trashOutput ;
 
-	if (p_fnc_stdOutWrite != NULL)
-		*p_fnc_stdOutWrite = stdwrite_setparam[swk].fnc_stdOutWrite ;
+    if (p_fnc_stdOutWrite != NULL)
+        *p_fnc_stdOutWrite = stdwrite_setparam[swk].fnc_stdOutWrite ;
 
-	if (p_privatePtr != NULL)
-		*p_privatePtr = stdwrite_setparam[swk].privatePtr ;
+    if (p_privatePtr != NULL)
+        *p_privatePtr = stdwrite_setparam[swk].privatePtr ;
 
-	return 1;
+    return 1;
 }
 
 
@@ -300,8 +300,8 @@ UNITEX_FUNC int UNITEX_CALL GetStdWriteCB(enum stdwrite_kind swk, int* p_trashOu
 
 struct t_stdin_param
 {
-	t_fnc_stdIn fnc_stdIn;
-	void* privatePtr;
+    t_fnc_stdIn fnc_stdIn;
+    void* privatePtr;
 };
 
 
@@ -310,38 +310,38 @@ struct t_stdin_param stdin_param = { 0 , NULL } ;
 
 struct t_stdin_param* get_std_in(ABSTRACTFILE*stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-	{
-		if ((p_abfr->f)==stdin)
-			return &stdin_param;
-	}
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+    {
+        if ((p_abfr->f)==stdin)
+            return &stdin_param;
+    }
 
-	return NULL;
+    return NULL;
 }
 
 UNITEX_FUNC int UNITEX_CALL SetStdInCB(t_fnc_stdIn fnc_stdInRead,void* privatePtr)
 {
-	if (stdin_param.fnc_stdIn != NULL)
-	{
-		(*(stdin_param.fnc_stdIn))(NULL,0,stdin_param.privatePtr);
-	}
+    if (stdin_param.fnc_stdIn != NULL)
+    {
+        (*(stdin_param.fnc_stdIn))(NULL,0,stdin_param.privatePtr);
+    }
 
-	stdin_param.fnc_stdIn = fnc_stdInRead;
-	stdin_param.privatePtr = privatePtr;
+    stdin_param.fnc_stdIn = fnc_stdInRead;
+    stdin_param.privatePtr = privatePtr;
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL GetStdInCB(t_fnc_stdIn* p_fnc_stdInRead,void** p_privatePtr)
 {
-	if (p_fnc_stdInRead != NULL)
-		*p_fnc_stdInRead = stdin_param.fnc_stdIn;
+    if (p_fnc_stdInRead != NULL)
+        *p_fnc_stdInRead = stdin_param.fnc_stdIn;
 
-	if (p_privatePtr != NULL)
-		*p_privatePtr = stdin_param.privatePtr ;
+    if (p_privatePtr != NULL)
+        *p_privatePtr = stdin_param.privatePtr ;
 
-	return 1;
+    return 1;
 }
 
 
@@ -365,38 +365,38 @@ int is_filename_in_abstract_file_space(const char*name)
  */
 ABSTRACTFILE* af_fopen_unlogged(const char* name,const char* MODE)
 {
-	ABSTRACTFILE_REAL* vf= (ABSTRACTFILE_REAL*)malloc(sizeof(ABSTRACTFILE_REAL));
-	const AbstractFileSpace * pafs ;
-	if (vf==NULL) {
-		fatal_alloc_error("af_fopen");
-		return NULL;
-	}
+    ABSTRACTFILE_REAL* vf= (ABSTRACTFILE_REAL*)malloc(sizeof(ABSTRACTFILE_REAL));
+    const AbstractFileSpace * pafs ;
+    if (vf==NULL) {
+        fatal_alloc_error("af_fopen");
+        return NULL;
+    }
 
-	pafs = GetFileSpaceForFileName(name);
-	vf->afs = pafs;
-	if (pafs == NULL) {
-		vf->f = fopen(name,MODE);
-		if (vf->f == NULL) {
-			free(vf);
-			vf = NULL;
-		}
-	}
-	else
-	{
+    pafs = GetFileSpaceForFileName(name);
+    vf->afs = pafs;
+    if (pafs == NULL) {
+        vf->f = fopen(name,MODE);
+        if (vf->f == NULL) {
+            free(vf);
+            vf = NULL;
+        }
+    }
+    else
+    {
         TYPEOPEN_MF TypeOpen;
         if ((*(MODE))=='w')
             TypeOpen = OPEN_CREATE_MF;
         else {
             TypeOpen = OPEN_READWRITE_MF;
-			if ((*(MODE))=='r')
-				if ((*(MODE+1))=='b')
-					if ((*(MODE+2))=='\0')
-						TypeOpen = OPEN_READ_MF;
-		}
+            if ((*(MODE))=='r')
+                if ((*(MODE+1))=='b')
+                    if ((*(MODE+2))=='\0')
+                        TypeOpen = OPEN_READ_MF;
+        }
         //vfRet -> Std_Stream_Type = STD_STREAM_MEMFILE;
-		vf->afs = pafs;
-		vf->fabstr = (*(pafs->func_array.fnc_memOpenLowLevel))(name, TypeOpen,
-			                      pafs->privateSpacePtr);
+        vf->afs = pafs;
+        vf->fabstr = (*(pafs->func_array.fnc_memOpenLowLevel))(name, TypeOpen,
+                                  pafs->privateSpacePtr);
 
         if (vf->fabstr == NULL)
         {
@@ -408,114 +408,114 @@ ABSTRACTFILE* af_fopen_unlogged(const char* name,const char* MODE)
           if ((*(MODE))=='a')
               (*(pafs->func_array.fnc_memLowLevelSeek))(vf->fabstr,0,SEEK_END,pafs->privateSpacePtr);
         }
-	}
-	return (ABSTRACTFILE*)vf;
+    }
+    return (ABSTRACTFILE*)vf;
 }
 
 
 int af_fclose_unlogged(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	ABSTRACTFILE_REAL abfr=*p_abfr;
-	free(p_abfr);
-	if (abfr.afs == NULL)
-		return fclose(abfr.f);
-	else
-		return (*(abfr.afs->func_array.fnc_memLowLevelClose))(abfr.fabstr,abfr.afs->privateSpacePtr);
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    ABSTRACTFILE_REAL abfr=*p_abfr;
+    free(p_abfr);
+    if (abfr.afs == NULL)
+        return fclose(abfr.f);
+    else
+        return (*(abfr.afs->func_array.fnc_memLowLevelClose))(abfr.fabstr,abfr.afs->privateSpacePtr);
 }
 
 
 size_t af_fread(void *ptr,size_t sizeItem,size_t nmemb,ABSTRACTFILE *stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-	{
-		struct t_stdin_param* p_stdin_param = get_std_in(stream);
-		if (p_stdin_param != NULL)
-			if (p_stdin_param -> fnc_stdIn != NULL) {
-				size_t nbByteToRead = sizeItem * nmemb;
-				size_t res = (*(p_stdin_param -> fnc_stdIn))(ptr,nbByteToRead,p_stdin_param->privatePtr);
-				if ((res > 0) && (sizeItem>0))
-					res /= sizeItem;
-				return res;
-			}
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+    {
+        struct t_stdin_param* p_stdin_param = get_std_in(stream);
+        if (p_stdin_param != NULL)
+            if (p_stdin_param -> fnc_stdIn != NULL) {
+                size_t nbByteToRead = sizeItem * nmemb;
+                size_t res = (*(p_stdin_param -> fnc_stdIn))(ptr,nbByteToRead,p_stdin_param->privatePtr);
+                if ((res > 0) && (sizeItem>0))
+                    res /= sizeItem;
+                return res;
+            }
 
-		return fread(ptr,sizeItem,nmemb,p_abfr->f);
-	}
-	else {
-		size_t nbByteToRead = sizeItem * nmemb;
-		size_t res = (*(p_abfr->afs->func_array.fnc_memLowLevelRead))(p_abfr->fabstr,ptr,nbByteToRead,p_abfr->afs->privateSpacePtr);
-		if ((res > 0) && (sizeItem>0))
-			res /= sizeItem;
-		return res;
-	}
+        return fread(ptr,sizeItem,nmemb,p_abfr->f);
+    }
+    else {
+        size_t nbByteToRead = sizeItem * nmemb;
+        size_t res = (*(p_abfr->afs->func_array.fnc_memLowLevelRead))(p_abfr->fabstr,ptr,nbByteToRead,p_abfr->afs->privateSpacePtr);
+        if ((res > 0) && (sizeItem>0))
+            res /= sizeItem;
+        return res;
+    }
 }
 
 size_t af_fwrite(const void *ptr,size_t sizeItem,size_t nmemb,ABSTRACTFILE *stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-	{
-		struct stdwrite_param* p_std_write_param = get_std_write_param(stream);
-		if (p_std_write_param != NULL)
-		{
-			/* trashOutput == 2 mean hard trash : no log of output, include logger */
-			/* trashOutput == 1 mean softer trash : log of output go to logger */
-			if (p_std_write_param->trashOutput != 2)
-			{
-				if (IsStdOut(stream))
-					Call_logger_fnc_LogOutWrite(ptr,sizeItem*nmemb);
-				if (IsStdErr(stream))
-					Call_logger_fnc_LogErrWrite(ptr,sizeItem*nmemb);
-			}
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+    {
+        struct stdwrite_param* p_std_write_param = get_std_write_param(stream);
+        if (p_std_write_param != NULL)
+        {
+            /* trashOutput == 2 mean hard trash : no log of output, include logger */
+            /* trashOutput == 1 mean softer trash : log of output go to logger */
+            if (p_std_write_param->trashOutput != 2)
+            {
+                if (IsStdOut(stream))
+                    Call_logger_fnc_LogOutWrite(ptr,sizeItem*nmemb);
+                if (IsStdErr(stream))
+                    Call_logger_fnc_LogErrWrite(ptr,sizeItem*nmemb);
+            }
 
-			if (p_std_write_param->trashOutput != 0)
-				return nmemb;
+            if (p_std_write_param->trashOutput != 0)
+                return nmemb;
 
-			if (p_std_write_param->fnc_stdOutWrite != NULL)
-			{
-				size_t nbByteToWrite = sizeItem * nmemb;
-				if (nbByteToWrite == 0)
-					return 0;
-				size_t res = (*(p_std_write_param->fnc_stdOutWrite))(ptr,nbByteToWrite,p_std_write_param->privatePtr);
-				if ((res > 0) && (sizeItem>0))
-					res /= sizeItem;
-				return res;
-			}
+            if (p_std_write_param->fnc_stdOutWrite != NULL)
+            {
+                size_t nbByteToWrite = sizeItem * nmemb;
+                if (nbByteToWrite == 0)
+                    return 0;
+                size_t res = (*(p_std_write_param->fnc_stdOutWrite))(ptr,nbByteToWrite,p_std_write_param->privatePtr);
+                if ((res > 0) && (sizeItem>0))
+                    res /= sizeItem;
+                return res;
+            }
 
-		}
-		return fwrite(ptr,sizeItem,nmemb,p_abfr->f);
-	}
-	else {
-		size_t nbByteToWrite = sizeItem * nmemb;
-		size_t res = (*(p_abfr->afs->func_array.fnc_memLowLevelWrite))(p_abfr->fabstr,ptr,nbByteToWrite,p_abfr->afs->privateSpacePtr);
-		if ((res > 0) && (sizeItem>0))
-			res /= sizeItem;
-		return res;
-	}
+        }
+        return fwrite(ptr,sizeItem,nmemb,p_abfr->f);
+    }
+    else {
+        size_t nbByteToWrite = sizeItem * nmemb;
+        size_t res = (*(p_abfr->afs->func_array.fnc_memLowLevelWrite))(p_abfr->fabstr,ptr,nbByteToWrite,p_abfr->afs->privateSpacePtr);
+        if ((res > 0) && (sizeItem>0))
+            res /= sizeItem;
+        return res;
+    }
 }
 
 
 char *af_fgets(char * _Buf, int count, ABSTRACTFILE * stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-		return fgets(_Buf,count,p_abfr->f);
-	else {
-		char* retval = _Buf;
-		char* pointer = _Buf;
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+        return fgets(_Buf,count,p_abfr->f);
+    else {
+        char* retval = _Buf;
+        char* pointer = _Buf;
 
-		if(retval!=NULL)
+        if(retval!=NULL)
         {
             while (--count)
             {
               char ch;
               if (((*(p_abfr->afs->func_array.fnc_memLowLevelRead))(p_abfr->fabstr,&ch,1,p_abfr->afs->privateSpacePtr))!=1)
                     {
-						if (pointer == _Buf)
-							return NULL;
-						else
-							return retval;
+                        if (pointer == _Buf)
+                            return NULL;
+                        else
+                            return retval;
                     }
 
               (*(pointer)) = ch ;
@@ -523,71 +523,71 @@ char *af_fgets(char * _Buf, int count, ABSTRACTFILE * stream)
               if (ch == '\n')
                 break;
             }
-			*pointer = '\0';
+            *pointer = '\0';
         }
-		return retval;
-	}
+        return retval;
+    }
 }
 
 
 int af_fseek(ABSTRACTFILE* stream, long offset, int whence)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-		return fseek(p_abfr->f,offset,whence);
-	else
-		return (*(p_abfr->afs->func_array.fnc_memLowLevelSeek))(p_abfr->fabstr, offset,whence,p_abfr->afs->privateSpacePtr);
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+        return fseek(p_abfr->f,offset,whence);
+    else
+        return (*(p_abfr->afs->func_array.fnc_memLowLevelSeek))(p_abfr->fabstr, offset,whence,p_abfr->afs->privateSpacePtr);
 }
 
 long af_ftell(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-		return ftell(p_abfr->f);
-	else {
-		afs_size_type pos=0;
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+        return ftell(p_abfr->f);
+    else {
+        afs_size_type pos=0;
         (*(p_abfr->afs->func_array.fnc_memLowLevelTell))(p_abfr->fabstr, &pos,p_abfr->afs->privateSpacePtr);
         return (long)pos;
-	}
+    }
 }
 
 
 int af_feof(ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-		return feof(p_abfr->f);
-	else {
-		afs_size_type pos=0;
-		afs_size_type sizeFile = 0;
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+        return feof(p_abfr->f);
+    else {
+        afs_size_type pos=0;
+        afs_size_type sizeFile = 0;
         (*(p_abfr->afs->func_array.fnc_memLowLevelTell))(p_abfr->fabstr, &pos,p_abfr->afs->privateSpacePtr);
-		(*(p_abfr->afs->func_array.fnc_memLowLevelGetSize))(p_abfr->fabstr, &sizeFile,p_abfr->afs->privateSpacePtr);
-		if (sizeFile == pos)
-			return 1;
-		else
-			return 0;
-	}
+        (*(p_abfr->afs->func_array.fnc_memLowLevelGetSize))(p_abfr->fabstr, &sizeFile,p_abfr->afs->privateSpacePtr);
+        if (sizeFile == pos)
+            return 1;
+        else
+            return 0;
+    }
 }
 
 int af_ungetc(int ch, ABSTRACTFILE* stream)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs == NULL)
-		return ungetc(ch,p_abfr->f);
-	else
-		return (af_fseek(stream,-1,SEEK_CUR) != 0 ) ? EOF:ch;
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs == NULL)
+        return ungetc(ch,p_abfr->f);
+    else
+        return (af_fseek(stream,-1,SEEK_CUR) != 0 ) ? EOF:ch;
 }
 
 
 
 ABSTRACTMAPFILE* af_open_mapfile_unlogged(const char* name,int options, size_t value_for_option)
 {
-	ABSTRACTMAPFILE_REAL* vf= (ABSTRACTMAPFILE_REAL*)malloc(sizeof(ABSTRACTMAPFILE_REAL));
-	const AbstractFileSpace * pafs ;
-	if (vf==NULL) {
-		fatal_alloc_error("af_open_mapfile_unlogged");
-		return NULL;
-	}
+    ABSTRACTMAPFILE_REAL* vf= (ABSTRACTMAPFILE_REAL*)malloc(sizeof(ABSTRACTMAPFILE_REAL));
+    const AbstractFileSpace * pafs ;
+    if (vf==NULL) {
+        fatal_alloc_error("af_open_mapfile_unlogged");
+        return NULL;
+    }
 
     /*
      * in the future, if options can have write/create value,
@@ -595,23 +595,23 @@ ABSTRACTMAPFILE* af_open_mapfile_unlogged(const char* name,int options, size_t v
      * for set size
      */
 
-	pafs = GetFileSpaceForFileName(name);
-	vf->afs = pafs;
-	if (pafs == NULL) {
-		vf->mf.f = iomap_open_mapfile(name,options, value_for_option);
-		if (vf->mf.f == NULL) {
-			free(vf);
-			vf = NULL;
-		}
-	}
-	else
-	{
+    pafs = GetFileSpaceForFileName(name);
+    vf->afs = pafs;
+    if (pafs == NULL) {
+        vf->mf.f = iomap_open_mapfile(name,options, value_for_option);
+        if (vf->mf.f == NULL) {
+            free(vf);
+            vf = NULL;
+        }
+    }
+    else
+    {
         TYPEOPEN_MF TypeOpen;
         TypeOpen = OPEN_READ_MF;
 
-		vf->afs = pafs;
-		vf->af.fabstr = (*(pafs->func_array.fnc_memOpenLowLevel))(name, TypeOpen,
-			                      pafs->privateSpacePtr);
+        vf->afs = pafs;
+        vf->af.fabstr = (*(pafs->func_array.fnc_memOpenLowLevel))(name, TypeOpen,
+                                  pafs->privateSpacePtr);
         vf->af.options_for_mapfile = options;
         vf->af.size_for_options_for_mapfile = value_for_option;
 
@@ -620,37 +620,37 @@ ABSTRACTMAPFILE* af_open_mapfile_unlogged(const char* name,int options, size_t v
             free(vf);
             vf= NULL;
         }
-	}
-	return (ABSTRACTMAPFILE*)vf;
+    }
+    return (ABSTRACTMAPFILE*)vf;
 }
 
 
 void af_close_mapfile_unlogged(ABSTRACTMAPFILE* stream)
 {
-	ABSTRACTMAPFILE_REAL* p_abfr=(ABSTRACTMAPFILE_REAL*)stream;
+    ABSTRACTMAPFILE_REAL* p_abfr=(ABSTRACTMAPFILE_REAL*)stream;
     if (p_abfr == NULL)
         return ;
-	ABSTRACTMAPFILE_REAL abfr=*p_abfr;
-	free(p_abfr);
-	if (abfr.afs == NULL)
-		return iomap_close_mapfile(abfr.mf.f);
-	else
-		/*return*/ (*(abfr.afs->func_array.fnc_memLowLevelClose))(abfr.af.fabstr,abfr.afs->privateSpacePtr);
+    ABSTRACTMAPFILE_REAL abfr=*p_abfr;
+    free(p_abfr);
+    if (abfr.afs == NULL)
+        return iomap_close_mapfile(abfr.mf.f);
+    else
+        /*return*/ (*(abfr.afs->func_array.fnc_memLowLevelClose))(abfr.af.fabstr,abfr.afs->privateSpacePtr);
 }
 
 
 size_t af_get_mapfile_size(ABSTRACTMAPFILE* streammap)
 {
-	ABSTRACTMAPFILE_REAL* p_abfr=(ABSTRACTMAPFILE_REAL*)streammap;
+    ABSTRACTMAPFILE_REAL* p_abfr=(ABSTRACTMAPFILE_REAL*)streammap;
     if (p_abfr == NULL)
         return 0;
-	if (p_abfr->afs == NULL)
-		return iomap_get_mapfile_size(p_abfr->mf.f);
-	else {
-		afs_size_type pos=0;
+    if (p_abfr->afs == NULL)
+        return iomap_get_mapfile_size(p_abfr->mf.f);
+    else {
+        afs_size_type pos=0;
         (*(p_abfr->afs->func_array.fnc_memLowLevelGetSize))(p_abfr->af.fabstr, &pos,p_abfr->afs->privateSpacePtr);
         return (size_t)pos;
-	}
+    }
 }
 
 const void* af_get_mapfile_pointer(ABSTRACTMAPFILE* streammap, size_t pos, size_t sizemap)
@@ -666,9 +666,9 @@ const void* af_get_mapfile_pointer(ABSTRACTMAPFILE* streammap, size_t pos, size_
     if (pos>filesize)
         return NULL;
 
-	if (p_abfr->afs == NULL)
-		return iomap_get_mapfile_pointer(p_abfr->mf.f,pos,sizemap);
-	else {
+    if (p_abfr->afs == NULL)
+        return iomap_get_mapfile_pointer(p_abfr->mf.f,pos,sizemap);
+    else {
         if (p_abfr->afs->func_array.fnc_memFile_getMapPointer != NULL)
             return (*(p_abfr->afs->func_array.fnc_memFile_getMapPointer))(p_abfr->af.fabstr,
                         pos, sizemap,
@@ -694,7 +694,7 @@ const void* af_get_mapfile_pointer(ABSTRACTMAPFILE* streammap, size_t pos, size_
             }
             return buf;
         }
-	}
+    }
 }
 
 void af_release_mapfile_pointer(ABSTRACTMAPFILE*streammap, const void* buf, size_t sizemap)
@@ -702,9 +702,9 @@ void af_release_mapfile_pointer(ABSTRACTMAPFILE*streammap, const void* buf, size
     ABSTRACTMAPFILE_REAL* p_abfr=(ABSTRACTMAPFILE_REAL*)streammap;
     if (p_abfr == NULL)
         return ;
-	if (p_abfr->afs == NULL)
-		return iomap_release_mapfile_pointer(p_abfr->mf.f,buf);
-	else {
+    if (p_abfr->afs == NULL)
+        return iomap_release_mapfile_pointer(p_abfr->mf.f,buf);
+    else {
         if (p_abfr->afs->func_array.fnc_memFile_getMapPointer != NULL) {
             if (p_abfr->afs->func_array.fnc_memFile_releaseMapPointer != NULL) {
                 (*(p_abfr->afs->func_array.fnc_memFile_releaseMapPointer))(p_abfr->af.fabstr, buf, sizemap,p_abfr->afs->privateSpacePtr);
@@ -715,7 +715,7 @@ void af_release_mapfile_pointer(ABSTRACTMAPFILE*streammap, const void* buf, size
             if (buf != NULL)
                 free((void*)buf);
         }
-	}
+    }
 }
 
 /* when we create a new file, before write into, we can set the filesize,
@@ -724,95 +724,95 @@ void af_release_mapfile_pointer(ABSTRACTMAPFILE*streammap, const void* buf, size
    rewrite the File allocation table often, by example */
 void af_setsizereservation(ABSTRACTFILE* stream, long size_planned)
 {
-	ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
-	if (p_abfr->afs != NULL)
-		if (p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation != NULL)
-			(*(p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation))(p_abfr->fabstr, size_planned,p_abfr->afs->privateSpacePtr);
+    ABSTRACTFILE_REAL* p_abfr=(ABSTRACTFILE_REAL*)stream;
+    if (p_abfr->afs != NULL)
+        if (p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation != NULL)
+            (*(p_abfr->afs->func_array.fnc_memLowLevelSetSizeReservation))(p_abfr->fabstr, size_planned,p_abfr->afs->privateSpacePtr);
 }
 
 
 
 char** af_get_list_file(const char*name)
 {
-	const AbstractFileSpace * pafs ;
-	pafs = GetFileSpaceForFileName(name);
+    const AbstractFileSpace * pafs ;
+    pafs = GetFileSpaceForFileName(name);
 
-	if (pafs == NULL)
-	{
-		return buildListFileInDiskDir(name);
-	}
-	else {
+    if (pafs == NULL)
+    {
+        return buildListFileInDiskDir(name);
+    }
+    else {
         if (pafs->func_array.fnc_memFile_getList != NULL) {
-			char** all_files = (*(pafs->func_array.fnc_memFile_getList))(pafs->privateSpacePtr);
-			size_t nb_files = 0;
-			if (all_files != NULL) {
-				while (all_files[nb_files] != NULL) {
-					nb_files++;
-				}
-			}
-			char* keep = (char*)malloc((nb_files + 1) * sizeof(char));
-			size_t nb_files_to_keep = 0;
-			size_t name_length = strlen(name);
-			for (size_t i = 0; i < nb_files; i++) {
-				keep[i] = 0;
-				if (strlen(all_files[i]) >= name_length) {
-					if (!strncmp(name, all_files[i], name_length)) {
-						keep[i] = 1;
-						nb_files_to_keep++;
-					}
-				}
-			}
-			char** files = (char**)malloc((nb_files_to_keep + 1) * sizeof(char*));
-			size_t j = 0;
-			for (size_t i = 0; i < nb_files; i++) {
-				if (keep[i]) {
-					files[j] = strdup(all_files[i]);
-					j++;
-				}
-			}
-			files[nb_files_to_keep] = NULL;
-			free(keep);
+            char** all_files = (*(pafs->func_array.fnc_memFile_getList))(pafs->privateSpacePtr);
+            size_t nb_files = 0;
+            if (all_files != NULL) {
+                while (all_files[nb_files] != NULL) {
+                    nb_files++;
+                }
+            }
+            char* keep = (char*)malloc((nb_files + 1) * sizeof(char));
+            size_t nb_files_to_keep = 0;
+            size_t name_length = strlen(name);
+            for (size_t i = 0; i < nb_files; i++) {
+                keep[i] = 0;
+                if (strlen(all_files[i]) >= name_length) {
+                    if (!strncmp(name, all_files[i], name_length)) {
+                        keep[i] = 1;
+                        nb_files_to_keep++;
+                    }
+                }
+            }
+            char** files = (char**)malloc((nb_files_to_keep + 1) * sizeof(char*));
+            size_t j = 0;
+            for (size_t i = 0; i < nb_files; i++) {
+                if (keep[i]) {
+                    files[j] = strdup(all_files[i]);
+                    j++;
+                }
+            }
+            files[nb_files_to_keep] = NULL;
+            free(keep);
 
-			if ((pafs->func_array.fnc_memFile_releaseList != NULL) && (all_files!=NULL)) {
-				(*(pafs->func_array.fnc_memFile_releaseList))(all_files,pafs->privateSpacePtr);
-			}
+            if ((pafs->func_array.fnc_memFile_releaseList != NULL) && (all_files!=NULL)) {
+                (*(pafs->func_array.fnc_memFile_releaseList))(all_files,pafs->privateSpacePtr);
+            }
 
-			return files;
+            return files;
         }
-	}
-	return NULL;
+    }
+    return NULL;
 }
 
 void af_release_list_file(const char*name,char**list)
 {
-	DISCARD_UNUSED_PARAMETER(name);
-	if (list == NULL) return;
-	 /*
-	const AbstractFileSpace * pafs ;
-	pafs = GetFileSpaceForFileName(name);
-	if (pafs == NULL) {
-		return ;
-	}
-	else
-	*/
-	{
-		char** list_walk=list;
-		while ((*list_walk)!=NULL) {
-			free(*list_walk);
-			list_walk++;
-		}
-		free(list);
-	}
+    DISCARD_UNUSED_PARAMETER(name);
+    if (list == NULL) return;
+     /*
+    const AbstractFileSpace * pafs ;
+    pafs = GetFileSpaceForFileName(name);
+    if (pafs == NULL) {
+        return ;
+    }
+    else
+    */
+    {
+        char** list_walk=list;
+        while ((*list_walk)!=NULL) {
+            free(*list_walk);
+            list_walk++;
+        }
+        free(list);
+    }
 }
 
 
 int af_remove_unlogged(const char * Filename)
 {
-	const AbstractFileSpace * pafs = GetFileSpaceForFileName(Filename);
-	if (pafs==NULL)
-		return remove(Filename);
-	else
-		return (*(pafs->func_array.fnc_memFileRemove))(Filename,pafs->privateSpacePtr);
+    const AbstractFileSpace * pafs = GetFileSpaceForFileName(Filename);
+    if (pafs==NULL)
+        return remove(Filename);
+    else
+        return (*(pafs->func_array.fnc_memFileRemove))(Filename,pafs->privateSpacePtr);
 }
 
 
@@ -831,21 +831,21 @@ int af_copy_unlogged(const char* srcFile, const char* dstFile)
         return -1;
 
     if (af_fseek(vfRead, 0, SEEK_END) == 0)
-	{
-		size_to_do = af_ftell(vfRead);
-		buffer_size = ((size_to_do+1) < BUFFER_IO_SIZE) ? ((int)size_to_do+1) : BUFFER_IO_SIZE;
-		szBuffer = (char *)malloc(buffer_size);
-		if (szBuffer == NULL)
-		{
-			af_fclose(vfRead);
-			return -1;
-		}
-	}
-	else
-	{
+    {
+        size_to_do = af_ftell(vfRead);
+        buffer_size = ((size_to_do+1) < BUFFER_IO_SIZE) ? ((int)size_to_do+1) : BUFFER_IO_SIZE;
+        szBuffer = (char *)malloc(buffer_size);
+        if (szBuffer == NULL)
+        {
+            af_fclose(vfRead);
+            return -1;
+        }
+    }
+    else
+    {
         af_fclose(vfRead);
         return -1;
-	}
+    }
 
     vfWrite = af_fopen(dstFile,"wb");
     if (vfWrite == NULL)
@@ -858,12 +858,12 @@ int af_copy_unlogged(const char* srcFile, const char* dstFile)
     af_setsizereservation(vfWrite, size_to_do);
 
     if (af_fseek(vfRead, 0, SEEK_SET) != 0)
-	{
+    {
         af_fclose(vfWrite);
         af_fclose(vfRead);
         free(szBuffer);
         return -1;
-	}
+    }
 
     int ret_in_error = -1;
 
@@ -887,129 +887,129 @@ int af_copy_unlogged(const char* srcFile, const char* dstFile)
 
     if (size_to_do==0)
         return 0; /* success */
-	else
+    else
         return ret_in_error;
 }
 
 
 int af_rename_unlogged(const char * OldFilename, const char * NewFilename)
 {
-	const AbstractFileSpace * pafsOld = GetFileSpaceForFileName(OldFilename);
-	const AbstractFileSpace * pafsNew = GetFileSpaceForFileName(NewFilename);
+    const AbstractFileSpace * pafsOld = GetFileSpaceForFileName(OldFilename);
+    const AbstractFileSpace * pafsNew = GetFileSpaceForFileName(NewFilename);
 
-	if (pafsOld == pafsNew)
-	{
-		if (pafsOld==NULL)
-			return rename(OldFilename,NewFilename);
-		else
-			return (*(pafsOld->func_array.fnc_memFileRename))(OldFilename,NewFilename,pafsOld->privateSpacePtr);
-	}
-	else
-	{
-		int ret = af_copy(OldFilename,NewFilename);
-		if (ret != 0)
-			return ret;
-		return af_remove(OldFilename);
-	}
+    if (pafsOld == pafsNew)
+    {
+        if (pafsOld==NULL)
+            return rename(OldFilename,NewFilename);
+        else
+            return (*(pafsOld->func_array.fnc_memFileRename))(OldFilename,NewFilename,pafsOld->privateSpacePtr);
+    }
+    else
+    {
+        int ret = af_copy(OldFilename,NewFilename);
+        if (ret != 0)
+            return ret;
+        return af_remove(OldFilename);
+    }
 }
 
 
 static int af_remove_folder_recursive_unlogged(const char* foldername)
 {
-	size_t len_folder = strlen(foldername);
-	char**list = af_get_list_file(foldername);
-	int ret=-1;
-	if (list != NULL) {
+    size_t len_folder = strlen(foldername);
+    char**list = af_get_list_file(foldername);
+    int ret=-1;
+    if (list != NULL) {
 
-		unsigned int iter_file = 0;
-		while ((*(list + iter_file)) != NULL)
-		{
-			const char* subfile = (*(list + iter_file));
-			if (strlen(subfile) > len_folder) {
-				if (af_remove_folder_recursive_unlogged(subfile) == 0)
-					ret=0;
-			}
-			if (af_remove_unlogged(subfile)==0)
-				ret=0;
-			iter_file++;
-		}
-		af_release_list_file(foldername, list);
-	}
-	return ret;
+        unsigned int iter_file = 0;
+        while ((*(list + iter_file)) != NULL)
+        {
+            const char* subfile = (*(list + iter_file));
+            if (strlen(subfile) > len_folder) {
+                if (af_remove_folder_recursive_unlogged(subfile) == 0)
+                    ret=0;
+            }
+            if (af_remove_unlogged(subfile)==0)
+                ret=0;
+            iter_file++;
+        }
+        af_release_list_file(foldername, list);
+    }
+    return ret;
 }
 
 
 int af_remove_folder_unlogged(const char*folderName)
 {
-	if (is_filename_in_abstract_file_space(folderName) == 0)
-		return RemoveFileSystemFolder(folderName);
-	else
-	{
-		char*folderNameStar = (char*)malloc(strlen(folderName) + 4);
-		if (folderNameStar == NULL)
-			return -1;
-		strcpy(folderNameStar, folderName);
-		strcat(folderNameStar, "*");
-		int retValue1 = af_remove_unlogged(folderNameStar);
-		free(folderNameStar);
-		int retValue2 = af_remove_folder_recursive_unlogged(folderName);
-		return ((retValue1==0) || (retValue2==0)) ? 0 : -1;
-	}
+    if (is_filename_in_abstract_file_space(folderName) == 0)
+        return RemoveFileSystemFolder(folderName);
+    else
+    {
+        char*folderNameStar = (char*)malloc(strlen(folderName) + 4);
+        if (folderNameStar == NULL)
+            return -1;
+        strcpy(folderNameStar, folderName);
+        strcat(folderNameStar, "*");
+        int retValue1 = af_remove_unlogged(folderNameStar);
+        free(folderNameStar);
+        int retValue2 = af_remove_folder_recursive_unlogged(folderName);
+        return ((retValue1==0) || (retValue2==0)) ? 0 : -1;
+    }
 }
 
 
 static int af_remove_folder_recursive(const char* foldername)
 {
-	size_t len_folder = strlen(foldername);
-	char**list = af_get_list_file(foldername);
-	int ret = -1;
-	if (list != NULL) {
+    size_t len_folder = strlen(foldername);
+    char**list = af_get_list_file(foldername);
+    int ret = -1;
+    if (list != NULL) {
 
-		unsigned int iter_file = 0;
-		while ((*(list + iter_file)) != NULL)
-		{
-			const char* subfile = (*(list + iter_file));
-			if (strlen(subfile) > len_folder) {
-				if (af_remove_folder_recursive(subfile) == 0)
-					ret = 0;
-			}
-			if (af_remove(subfile) == 0)
-				ret = 0;
-			iter_file++;
-		}
-		af_release_list_file(foldername, list);
-	}
-	return ret;
+        unsigned int iter_file = 0;
+        while ((*(list + iter_file)) != NULL)
+        {
+            const char* subfile = (*(list + iter_file));
+            if (strlen(subfile) > len_folder) {
+                if (af_remove_folder_recursive(subfile) == 0)
+                    ret = 0;
+            }
+            if (af_remove(subfile) == 0)
+                ret = 0;
+            iter_file++;
+        }
+        af_release_list_file(foldername, list);
+    }
+    return ret;
 }
 
 
 int af_remove_folder(const char*folderName)
 {
-	int retValue3 = -1;
-	int retValue ;
-	if (Call_logger_need_log_af_remove() == 0)
-		return af_remove_folder_unlogged(folderName);
+    int retValue3 = -1;
+    int retValue ;
+    if (Call_logger_need_log_af_remove() == 0)
+        return af_remove_folder_unlogged(folderName);
 
-	Call_logger_fnc_before_af_remove_folder(folderName);
-	char*folderNameStar = (char*)malloc(strlen(folderName) + 4);
-	if (folderNameStar == NULL)
-		return -1;
-	strcpy(folderNameStar, folderName);
-	strcat(folderNameStar, "*");
+    Call_logger_fnc_before_af_remove_folder(folderName);
+    char*folderNameStar = (char*)malloc(strlen(folderName) + 4);
+    if (folderNameStar == NULL)
+        return -1;
+    strcpy(folderNameStar, folderName);
+    strcat(folderNameStar, "*");
 
-	// we first call "manual" recursive delete, because we can log record all remove
-	int retValue2 = af_remove_folder_recursive(folderName);
+    // we first call "manual" recursive delete, because we can log record all remove
+    int retValue2 = af_remove_folder_recursive(folderName);
 
-	int retValue1 = af_remove(folderNameStar);
-	free(folderNameStar);
+    int retValue1 = af_remove(folderNameStar);
+    free(folderNameStar);
 
-	if (is_filename_in_abstract_file_space(folderName) == 0)
-		retValue3 = RemoveFileSystemFolder(folderName);
+    if (is_filename_in_abstract_file_space(folderName) == 0)
+        retValue3 = RemoveFileSystemFolder(folderName);
 
-	retValue = ((retValue1 == 0) || (retValue2 == 0) || (retValue3 == 0)) ? 0 : -1;
+    retValue = ((retValue1 == 0) || (retValue2 == 0) || (retValue3 == 0)) ? 0 : -1;
 
-	Call_logger_fnc_after_af_remove_folder(folderName, retValue);
-	return retValue;
+    Call_logger_fnc_after_af_remove_folder(folderName, retValue);
+    return retValue;
 }
 
 

--- a/Af_stdio.h
+++ b/Af_stdio.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Alphabet.cpp
+++ b/Alphabet.cpp
@@ -34,15 +34,15 @@ namespace unitex {
 #define ENLARGE_ARRAYCOLLECTION_FACTOR 0x10
 
 void enlarge_buffer_alphabet(Alphabet* alphabet) {
-	alphabet->i_nb_array_pos_allocated = alphabet->i_nb_array_pos_allocated * ENLARGE_ARRAYCOLLECTION_FACTOR;
-	if (alphabet->i_nb_array_pos_allocated > 0x10000)
-		alphabet->i_nb_array_pos_allocated = 0x10000;
+    alphabet->i_nb_array_pos_allocated = alphabet->i_nb_array_pos_allocated * ENLARGE_ARRAYCOLLECTION_FACTOR;
+    if (alphabet->i_nb_array_pos_allocated > 0x10000)
+        alphabet->i_nb_array_pos_allocated = 0x10000;
 
-	alphabet->t_array_collection=(unichar**)realloc(alphabet->t_array_collection,
-		                      alphabet->i_nb_array_pos_allocated*sizeof(unichar*));
-	if (alphabet->t_array_collection == NULL) {
-		fatal_alloc_error("enlarge_buffer_alphabet");
-	}
+    alphabet->t_array_collection=(unichar**)realloc(alphabet->t_array_collection,
+                              alphabet->i_nb_array_pos_allocated*sizeof(unichar*));
+    if (alphabet->t_array_collection == NULL) {
+        fatal_alloc_error("enlarge_buffer_alphabet");
+    }
 }
 
 
@@ -142,9 +142,9 @@ if (alphabet->korean_equivalent_syllable!=NULL) {
 
 int is_abstract_or_persistent_alphabet_filename(const char* filename)
 {
-	if (get_persistent_structure(filename))
-		return 1;
-	return 0;
+    if (get_persistent_structure(filename))
+        return 1;
+    return 0;
 }
 
 
@@ -156,7 +156,7 @@ int is_abstract_or_persistent_alphabet_filename(const char* filename)
 Alphabet* load_alphabet(const VersatileEncodingConfig* vec,const char* filename,int korean) {
 void* a=get_persistent_structure(filename);
 if (a!=NULL) {
-	return (Alphabet*)a;
+    return (Alphabet*)a;
 }
 U_FILE* f;
 f=u_fopen(vec,filename,U_READ);
@@ -169,8 +169,8 @@ unichar lower,upper;
 while ((c=u_fgetc(f))!=EOF) {
       upper=(unichar)c;
       if (upper=='\n') {
-    	  /* We skip empty lines */
-    	  continue;
+          /* We skip empty lines */
+          continue;
       }
       if (upper=='#') {
          // we are in the case of an interval #AZ -> [A..Z]
@@ -183,13 +183,13 @@ while ((c=u_fgetc(f))!=EOF) {
             return NULL;
          }
          for (c=lower;c<=upper;c++) {
-		   SET_CASE_FLAG_MACRO(c,alphabet,1|2);
+           SET_CASE_FLAG_MACRO(c,alphabet,1|2);
            add_letter_equivalence(alphabet,(unichar)c,(unichar)c);
          }
          u_fgetc(f); // reading the \n
       }
       else {
-		SET_CASE_FLAG_MACRO(upper,alphabet,1);
+        SET_CASE_FLAG_MACRO(upper,alphabet,1);
         lower=(unichar)u_fgetc(f);
         if (lower!='\n') {
           SET_CASE_FLAG_MACRO(lower,alphabet,2);
@@ -300,14 +300,14 @@ return is_equal_or_uppercase(a,b,alph);
 int is_equal_or_uppercase_qp(const unichar* a,const unichar* b,const Alphabet* alphabet) {
 int i=0,quotes=0;
 while (a[i] && b[i]) {
-	if (!test_qp(a[i],b[i],quotes,alphabet)) return 0;
-	if (a[i]=='"') {
-		quotes=!quotes;
-	} else if (a[i]=='\\') {
-		i++;
-		if (!test_qp(a[i],b[i],quotes,alphabet)) return 0;
-	}
-	i++;
+    if (!test_qp(a[i],b[i],quotes,alphabet)) return 0;
+    if (a[i]=='"') {
+        quotes=!quotes;
+    } else if (a[i]=='\\') {
+        i++;
+        if (!test_qp(a[i],b[i],quotes,alphabet)) return 0;
+    }
+    i++;
 }
 return (a[i]=='\0' && b[i]=='\0');
 }
@@ -510,14 +510,14 @@ while (src[i]!='\0') {
                  * uppercase variant of the letter */
                 dest[j++]=u_toupper(src[i]);
              } else {
-			 unichar* tbrowse = NULL;
-			 int i_pos_in_array_of_string = a->pos_in_represent_list[src[i]];
-			 if (i_pos_in_array_of_string != 0)
-				 tbrowse = a->t_array_collection[i_pos_in_array_of_string];
-			 if (tbrowse != NULL)
-				 while ((*tbrowse) != '\0') {
-					 dest[j++]=*(tbrowse++);
-				 }
+             unichar* tbrowse = NULL;
+             int i_pos_in_array_of_string = a->pos_in_represent_list[src[i]];
+             if (i_pos_in_array_of_string != 0)
+                 tbrowse = a->t_array_collection[i_pos_in_array_of_string];
+             if (tbrowse != NULL)
+                 while ((*tbrowse) != '\0') {
+                     dest[j++]=*(tbrowse++);
+                 }
              }
              if (!inside_a_set) dest[j++]=']';
              i++;
@@ -546,18 +546,18 @@ while (src[i]!='\0') {
              if (!inside_a_set) dest[j++]='[';
              dest[j++]=src[i];
              if (inside_a_set && src[i+1]=='-') {
-            	 /* Special case:
-            	  * if we had [a-d], we don't want to turn it into
-            	  * [aA-dD], but rather into [a-dA-D]. In such a case,
-            	  * we just use u_toupper
-            	  */
-            	 i=i+2;
-            	 dest[j++]='-';
-            	 dest[j++]=src[i++];
-            	 dest[j++]=u_toupper(dest[i-3]);
-            	 dest[j++]='-';
-            	 dest[j++]=u_toupper(src[i-1]);
-            	 continue;
+                 /* Special case:
+                  * if we had [a-d], we don't want to turn it into
+                  * [aA-dD], but rather into [a-dA-D]. In such a case,
+                  * we just use u_toupper
+                  */
+                 i=i+2;
+                 dest[j++]='-';
+                 dest[j++]=src[i++];
+                 dest[j++]=u_toupper(dest[i-3]);
+                 dest[j++]='-';
+                 dest[j++]=u_toupper(src[i-1]);
+                 continue;
              }
 
              if (a==NULL) {

--- a/Alphabet.cpp
+++ b/Alphabet.cpp
@@ -29,7 +29,7 @@
 
 namespace unitex {
 
-// 0x400 in final release, good for all langage 
+// 0x400 in final release, good for all langage
 #define FIRST_SIZE_ARRAYCOLLECTION 0x400
 #define ENLARGE_ARRAYCOLLECTION_FACTOR 0x10
 
@@ -222,7 +222,7 @@ return load_alphabet(vec,filename,0);
  */
 int is_upper_of(unichar lower,unichar upper,const Alphabet* alphabet) {
 if (alphabet==NULL) {
-   return upper==u_toupper(lower);   
+   return upper==u_toupper(lower);
 }
 int i_pos_in_array_of_string = alphabet->pos_in_represent_list[lower];
 if (i_pos_in_array_of_string == 0) return 0;

--- a/Alphabet.h
+++ b/Alphabet.h
@@ -31,12 +31,12 @@
 namespace unitex {
 
 struct alphabet_ {
-	
+
   //unichar* t[0x10000]; // obsolete
   // t['e']= "E{E+'}" where {E+'} stands for the unicode
                        // character representing the E with accent
   //char t2[0x10000]; // obsolete
-  
+
   int i_last_array_pos_used;
   int i_nb_array_pos_allocated;
   unichar** t_array_collection;
@@ -65,7 +65,7 @@ struct alphabet_ {
   // remember : (c >> 2) == (c / 4)
   //            (c & 3)  == (c % 4)
   //            (x << 1) == (x * 2)
-  
+
   /* This array is only used for Korean alphabets, because it is useful to
    * know for a given Chinese character its Hangul syllable equivalent */
   unichar* korean_equivalent_syllable;
@@ -77,16 +77,16 @@ typedef struct alphabet_ Alphabet;
 #define SHIFT_BIT(c) (((c) & 3) << 1)
 
 #define SET_CASE_FLAG_MACRO(c,alphabet,value) \
-	            ((alphabet)->array_case_flags[ARRAY_ITEM(c)] |= ((value) << SHIFT_BIT(c)))
+                ((alphabet)->array_case_flags[ARRAY_ITEM(c)] |= ((value) << SHIFT_BIT(c)))
 
 #define CASE_FLAG_MACRO(c,alphabet) \
-	            ((((alphabet)->array_case_flags[ARRAY_ITEM(c)]) >> SHIFT_BIT(c)) & 3)
+                ((((alphabet)->array_case_flags[ARRAY_ITEM(c)]) >> SHIFT_BIT(c)) & 3)
 
 #define IS_LOWER_MACRO(c,alphabet) \
-	            ((CASE_FLAG_MACRO(c,alphabet)) & 2)
+                ((CASE_FLAG_MACRO(c,alphabet)) & 2)
 
 #define IS_UPPER_MACRO(c,alphabet) \
-	            ((CASE_FLAG_MACRO(c,alphabet)) & 1)
+                ((CASE_FLAG_MACRO(c,alphabet)) & 1)
 
 Alphabet* load_alphabet(const VersatileEncodingConfig*,const char*);
 Alphabet* load_alphabet(const VersatileEncodingConfig*,const char*,int);

--- a/ApplyDic.cpp
+++ b/ApplyDic.cpp
@@ -227,7 +227,7 @@ if (word_array->element[token_number]==NULL) {
 }
 unichar* s=NULL;
 if (output!=NULL && output->len!=0) {
-	s=output->str;
+    s=output->str;
 }
 word_array->element[token_number]->list=get_offset(offset,word_array->element[token_number]->list,content,base,s);
 }
@@ -283,14 +283,14 @@ if (token[pos]=='\0') {
    inflected[pos]='\0';
    if (final) {
       /* If the node is final */
-	   if (info->word_array!=NULL) add_offset_for_token(info->word_array,token_number,offset,inflected,0,NULL);
+       if (info->word_array!=NULL) add_offset_for_token(info->word_array,token_number,offset,inflected,0,NULL);
       int p=0;
       if (info->simple_word!=NULL) p=get_value(info->simple_word,token_number);
       if (p==0 || p==priority) {
          /* We save the token only if it has not already been matched by
           * dictionary with a greater priority. Moreover, we indicate that
           * this token is part of a word and that it has been processed. */
-    	  if (info->part_of_a_word!=NULL) set_value(info->part_of_a_word,token_number,1);
+          if (info->part_of_a_word!=NULL) set_value(info->part_of_a_word,token_number,1);
          if (info->simple_word!=NULL) set_value(info->simple_word,token_number,priority);
          /* We get the INF codes */
          struct list_ustring* head;
@@ -298,10 +298,10 @@ if (token[pos]=='\0') {
          struct list_ustring* tmp=head;
          /* Then, we produce the DELAF line corresponding to each compressed line */
          while (tmp!=NULL) {
-        	 if (info->dic_name[0]!='\0') {
-        		u_fprintf(info->dlf,"%s\n",info->dic_name);
-        		info->dic_name[0]='\0';
-        	 }
+             if (info->dic_name[0]!='\0') {
+                u_fprintf(info->dlf,"%s\n",info->dic_name);
+                info->dic_name[0]='\0';
+             }
              display_uncompressed_entry(info->dlf,inflected,tmp->string);
              tmp=tmp->next;
          }
@@ -309,8 +309,8 @@ if (token[pos]=='\0') {
          base=ustr->len;
       }
    } else {
-	   /* The node is not final */
-	   if (info->word_array!=NULL) add_offset_for_token(info->word_array,token_number,offset,inflected,base,ustr);
+       /* The node is not final */
+       if (info->word_array!=NULL) add_offset_for_token(info->word_array,token_number,offset,inflected,base,ustr);
    }
    /* If we are at the end of the token, there is no need to look at the
     * outgoing transitions */
@@ -319,7 +319,7 @@ if (token[pos]=='\0') {
 }
 /* If we are in a final node */
 if (final) {
-	base=ustr->len;
+    base=ustr->len;
 }
 offset=new_offset;
 unichar c;
@@ -327,7 +327,7 @@ int offset_dest;
 for (int i=0;i<n_transitions;i++) {
    /* For each outgoing transition, we look if the transition character is
     * compatible with the token's one */
-	offset=read_dictionary_transition(info->d,offset,&c,&offset_dest,ustr);
+    offset=read_dictionary_transition(info->d,offset,&c,&offset_dest,ustr);
     if (is_equal_or_uppercase(c,token[pos],info->alphabet)) {
       /* We copy the transition character so that 'inflected' will contain
        * the exact inflected form */
@@ -409,7 +409,7 @@ if (current_token[pos_in_current_token]=='\0') {
    /* And we add the current offset to the node list */
    if (final) {
       /* If this node is final */
-	   trans->node->list=get_offset(offset,trans->node->list,inflected,0,NULL);
+       trans->node->list=get_offset(offset,trans->node->list,inflected,0,NULL);
       token_sequence[pos_token_sequence]=-1;
       /* We look if the compound word has already been matched */
       int w=was_already_in_tct_hash(token_sequence,info->tct_h,priority);
@@ -432,7 +432,7 @@ if (current_token[pos_in_current_token]=='\0') {
          while (tmp!=NULL) {
             /* For each compressed code of the INF line, we save the corresponding
              * DELAF line in 'info->dlc' */
-        	uncompress_entry(inflected,tmp->string,line_buf);
+            uncompress_entry(inflected,tmp->string,line_buf);
             u_fprintf(info->dlc,"%S\n",line_buf->str);
             tmp=tmp->next;
          }
@@ -440,14 +440,14 @@ if (current_token[pos_in_current_token]=='\0') {
       }
       base=ustr->len;
    } else {
-	   /* The node is not final */
-	   trans->node->list=get_offset(offset,trans->node->list,inflected,base,ustr->str);
+       /* The node is not final */
+       trans->node->list=get_offset(offset,trans->node->list,inflected,base,ustr->str);
    }
    pos_offset++;
    /* Then, we go on with the next token in the text, so we update 'current_token',
     * but only if we haven't reached the end of the text buffer */
    if (current_start_pos+pos_offset >= info->text_cod_size_nb_int) {
-	   restore_output(z,ustr);
+       restore_output(z,ustr);
       return;
    }
    current_token=info->tokens->token[info->text_cod_buf[current_start_pos+pos_offset]];
@@ -462,11 +462,11 @@ if (current_token[pos_in_current_token]=='\0') {
  * reached the end of the current token. */
 if (current_token[pos_in_current_token]=='\0') {
    restore_output(z,ustr);
-	return;
+    return;
 }
 /* If we are in a final node */
 if (final) {
-	base=ustr->len;
+    base=ustr->len;
 }
 unichar c;
 int adr;
@@ -555,7 +555,7 @@ while (current_start_pos<info->text_cod_size_nb_int) {/*
       }
       struct offset_list* l=w->list;
 
-	  if (current_start_pos+pos_offset < info->text_cod_size_nb_int) {
+      if (current_start_pos+pos_offset < info->text_cod_size_nb_int) {
         while (l!=NULL) {
            /* If there are dictionary nodes to explore, we do so. For each node
             * we copy into 'entry' the sequence of character that leads to it in
@@ -566,7 +566,7 @@ while (current_start_pos<info->text_cod_size_nb_int) {/*
              pos_offset,token_sequence,current_token_in_compound,priority,current_start_pos,line_buf,ustr,l->base);
            l=l->next;
         }
-	  }
+      }
    }
    current_start_pos++;
 }
@@ -593,9 +593,9 @@ for (int i=0;i<info->tokens->N;i++) {
           info->UNKNOWN_WORDS=info->UNKNOWN_WORDS+info->n_occurrences[i];
           u_fprintf(info->err,"%S\n",info->tokens->token[i]);
           if (!get_value(info->part_of_a_word2,i)) {
-        	  if (info->tags_err!=NULL) {
-        		  u_fprintf(info->tags_err,"%S\n",info->tokens->token[i]);
-        	  }
+              if (info->tags_err!=NULL) {
+                  u_fprintf(info->tags_err,"%S\n",info->tokens->token[i]);
+              }
           }
       }
       else {
@@ -641,7 +641,7 @@ info->part_of_a_word2=new_bit_array(tokens->N,ONE_BIT);
 info->simple_word=new_bit_array(tokens->N,TWO_BITS);
 info->n_occurrences=(int*)malloc(tokens->N*sizeof(int));
 if (info->part_of_a_word==NULL || info->part_of_a_word2==NULL
-		|| info->simple_word==NULL || info->n_occurrences==NULL) {
+        || info->simple_word==NULL || info->n_occurrences==NULL) {
    fatal_alloc_error("init_dico_application");
 }
 for (int j=0;j<tokens->N;j++) {
@@ -678,7 +678,7 @@ free(info->n_occurrences);
 free_tct_hash(info->tct_h);
 free_tct_hash(info->tct_h_tags_ind);
 for (int i=0;i<info->n_tag_sequences;i++) {
-	free_match_list_element(info->tag_sequences[i]);
+    free_match_list_element(info->tag_sequences[i]);
 }
 free_Dictionary(info->d);
 free(info->tag_sequences);
@@ -698,8 +698,8 @@ remove_extension(name_bin,name_inf);
 strcat(name_inf,".inf");
 info->d=new_Dictionary(vec,name_bin,name_inf);
 if (info->d==NULL) {
-	error("Cannot open dictionary %s\n",name_bin);
-	return 1;
+    error("Cannot open dictionary %s\n",name_bin);
+    return 1;
 }
 info->word_array=new_word_struct_array(info->tokens->N);
 /* And then we look simple and then compound words.
@@ -761,25 +761,25 @@ int add_tag_sequence(struct dico_application_info* info,struct match_list* match
 int foo[3]={match->m.start_pos_in_token,match->m.end_pos_in_token,-1};
 int w=was_already_in_tct_hash(foo,info->tct_h_tags_ind,priority);
 if (w!=0 && w!=priority) {
-	/* If the match has already been processed
-	 * with a greater priority, we skip it */
-	return 0;
+    /* If the match has already been processed
+     * with a greater priority, we skip it */
+    return 0;
 }
 /* And we note that the match has been taken into account
  * with that priority */
 add_tct_token_sequence(foo,info->tct_h_tags_ind,priority);
 if (info->n_tag_sequences==info->tag_sequences_capacity) {
    /* If we have to enlarge the array, doubling its capacity */
-	if (info->tag_sequences_capacity==0) {
-		info->tag_sequences_capacity=32;
-	}
-	else {
-		info->tag_sequences_capacity=2*info->tag_sequences_capacity;
-	}
-	info->tag_sequences=(struct match_list**)realloc(info->tag_sequences,info->tag_sequences_capacity*sizeof(struct match_list*));
-	if (info->tag_sequences==NULL) {
-	   fatal_alloc_error("add_tag_sequence");
-	}
+    if (info->tag_sequences_capacity==0) {
+        info->tag_sequences_capacity=32;
+    }
+    else {
+        info->tag_sequences_capacity=2*info->tag_sequences_capacity;
+    }
+    info->tag_sequences=(struct match_list**)realloc(info->tag_sequences,info->tag_sequences_capacity*sizeof(struct match_list*));
+    if (info->tag_sequences==NULL) {
+       fatal_alloc_error("add_tag_sequence");
+    }
 }
 info->tag_sequences[(info->n_tag_sequences)++]=match;
 return 1;
@@ -788,11 +788,11 @@ return 1;
 
 void check_tag_sequence_validity(unichar* s,Alphabet* alph) {
 if (s==NULL || s[0]=='\0') {
-	fatal_error("Invalid tag sequence: %S\n",s);
+    fatal_error("Invalid tag sequence: %S\n",s);
 }
 vector_ptr* v=tokenize_normalization_output(s,alph);
 if (v==NULL) {
-	fatal_error("Invalid tag sequence: %S\n",s);
+    fatal_error("Invalid tag sequence: %S\n",s);
 }
 free_vector_ptr(v,(void(*)(void*))free_output_info);
 }
@@ -824,25 +824,25 @@ merge_dic_locate_results_abstract_allocator=create_abstract_allocator("merge_dic
                                                         0);
 while (l!=NULL) {
    if (l->output!=NULL && l->output[0]=='/') {
-	   /* If we have a tag sequence to be used at the time of
-	    * building the text automaton */
-	   check_tag_sequence_validity(l->output+1,info->alphabet);
-	   /* If the tag sequence is not valid, a fatal error will be raised */
-	   if (add_tag_sequence(info,l,priority)) {
-		   /* If we have found and handled a valid tag sequence, we process
-			* the next match in the list, AND WE DON'T FREE THE CURRENT
-			* MATCH, since it's now in a pointer array. */
-		   for (int i=l->m.start_pos_in_token;i<=l->m.end_pos_in_token;i++) {
-			   set_value(info->part_of_a_word2,info->text_cod_buf[i],1);
-		   }
-		   l=l->next;
-	   } else {
-		   /* The match was already there, we have to free it */
-		   struct match_list* tmp=l->next;
-		   free_match_list_element(l);
-		   l=tmp;
-	   }
-	   continue;
+       /* If we have a tag sequence to be used at the time of
+        * building the text automaton */
+       check_tag_sequence_validity(l->output+1,info->alphabet);
+       /* If the tag sequence is not valid, a fatal error will be raised */
+       if (add_tag_sequence(info,l,priority)) {
+           /* If we have found and handled a valid tag sequence, we process
+            * the next match in the list, AND WE DON'T FREE THE CURRENT
+            * MATCH, since it's now in a pointer array. */
+           for (int i=l->m.start_pos_in_token;i<=l->m.end_pos_in_token;i++) {
+               set_value(info->part_of_a_word2,info->text_cod_buf[i],1);
+           }
+           l=l->next;
+       } else {
+           /* The match was already there, we have to free it */
+           struct match_list* tmp=l->next;
+           free_match_list_element(l);
+           l=tmp;
+       }
+       continue;
    }
    /* We test if the match is a valid dictionary entry */
    struct dela_entry* entry=tokenize_DELAF_line(l->output, 1, merge_dic_locate_results_abstract_allocator);
@@ -854,9 +854,9 @@ while (l!=NULL) {
          if (token_number==-1) {
             /* If we find in the dictionary a token that is not in the text,
              * we fail */
-        	 error("Ignoring line because the inflected form does not appear in the text:\n%S\n",l->output);
+             error("Ignoring line because the inflected form does not appear in the text:\n%S\n",l->output);
          } else {
-        	int p=get_value(info->simple_word,token_number);
+            int p=get_value(info->simple_word,token_number);
             if (p==0 || p==priority) {
                /* We save the simple word only if it hasn't already been processed with
                 * a greater priority */
@@ -875,22 +875,22 @@ while (l!=NULL) {
          /* If it is a compound word, we turn it into a token sequence
           * ended by -1 */
          if (build_token_sequence(entry->inflected,info->tokens,token_tab_coumpounds)) {
-        	 int w=was_already_in_tct_hash(token_tab_coumpounds,info->tct_h,priority);
-        	 if (w==0 || w==priority) {
-        		 /* We save the compound word only if it hasn't already been processed
-        		  * with a greater priority */
-        		 for (int k=0;token_tab_coumpounds[k]!=-1;k++) {
-        			 /* If we have matched a compound word, then all its part all not
-        			  * unknown words */
-        			 set_value(info->part_of_a_word,token_tab_coumpounds[k],1);
-        		 }
-        		 /* We save it to the DLC */
-        		 u_fprintf(info->dlc,"%S\n",l->output);
-        		 /* If needed, we save it to the morpho.dic file */
-        		 if (export_to_morpho_dic) {
-        			 u_fprintf(info->morpho,"%S\n",l->output);
-        		 }
-        	 }
+             int w=was_already_in_tct_hash(token_tab_coumpounds,info->tct_h,priority);
+             if (w==0 || w==priority) {
+                 /* We save the compound word only if it hasn't already been processed
+                  * with a greater priority */
+                 for (int k=0;token_tab_coumpounds[k]!=-1;k++) {
+                     /* If we have matched a compound word, then all its part all not
+                      * unknown words */
+                     set_value(info->part_of_a_word,token_tab_coumpounds[k],1);
+                 }
+                 /* We save it to the DLC */
+                 u_fprintf(info->dlc,"%S\n",l->output);
+                 /* If needed, we save it to the morpho.dic file */
+                 if (export_to_morpho_dic) {
+                     u_fprintf(info->morpho,"%S\n",l->output);
+                 }
+             }
          }
       }
       /* Finally, we free the entry */

--- a/ApplyDic.cpp
+++ b/ApplyDic.cpp
@@ -250,7 +250,7 @@ while (l!=NULL) {
 
 /* display uncompress entry
  * function extracted from explore_bin_simple_words, because each recursive call
- * allocated 4096 unichar (and produce stack overflow) 
+ * allocated 4096 unichar (and produce stack overflow)
  */
 void display_uncompressed_entry(U_FILE* f,unichar* inflected,unichar* INF_code) {
 Ustring* s=new_Ustring(DIC_LINE_SIZE);
@@ -485,7 +485,7 @@ for (int i=0;i<n_transitions;i++) {
 }
 }
 
- 
+
 /**
  * This function looks for compound words in the text file set in 'info'.
  * When a compound word is found, the corresponding DELAF lines are saved in
@@ -515,7 +515,7 @@ u_printf("First block...              \r");
 while (current_start_pos<info->text_cod_size_nb_int) {/*
    if (!info->buffer->end_of_file
        && current_start_pos>(info->buffer->size-MARGIN_BEFORE_BUFFER_END)) {
-      // If we must change of block and if we can 
+      // If we must change of block and if we can
       u_printf("Block %d...              \r",++current_block);
       fill_buffer(info->buffer,current_start_pos,info->text_cod);
       current_start_pos=0;
@@ -868,7 +868,7 @@ while (l!=NULL) {
                if (export_to_morpho_dic) {
                   u_fprintf(info->morpho,"%S\n",l->output);
                }
-            }	
+            }
          }
       }
       else {
@@ -930,9 +930,9 @@ switch (compare_matches(&((*A)->m),&((*B)->m))) {
    case A_BEFORE_B:
    case A_BEFORE_B_OVERLAP:
    case A_INCLUDES_B: return -1;
-   
+
    case A_EQUALS_B: return u_strcmp((*A)->output,(*B)->output);
-   
+
    case A_AFTER_B:
    case A_AFTER_B_OVERLAP:
    case B_INCLUDES_A: return 1;

--- a/Arabic.cpp
+++ b/Arabic.cpp
@@ -32,55 +32,55 @@ namespace unitex {
 unichar to_buckwalter(unichar c) {
 switch (c) {
 /* Plain letters */
-case ABS_AR_HAMZA: 						return '\'';
-case ABS_AR_ALEF_WITH_MADDA_ABOVE: 		return '|';
-case ABS_AR_ALEF_WITH_HAMZA_ABOVE: 		return '>';
-case ABS_AR_WAW_WITH_HAMZA_ABOVE: 		return '&';
-case ABS_AR_ALEF_WITH_HAMZA_BELOW: 		return '<';
-case ABS_AR_YEH_WITH_HAMZA_ABOVE: 		return '}';
-case ABS_AR_ALEF: 						return 'A';
-case ABS_AR_BEH: 						return 'b';
-case ABS_AR_TEH_MARBUTA: 				return 'p';
-case ABS_AR_TEH: 						return 't';
-case ABS_AR_THEH: 						return 'v';
-case ABS_AR_JEEM: 						return 'j';
-case ABS_AR_HAH: 						return 'H';
-case ABS_AR_KHAH: 						return 'x';
-case ABS_AR_DAL: 						return 'd';
-case ABS_AR_THAL:						return '*';
-case ABS_AR_REH: 						return 'r';
-case ABS_AR_ZAIN:						return 'z';
-case ABS_AR_SEEN: 						return 's';
-case ABS_AR_SHEEN: 						return '$';
-case ABS_AR_SAD:	 					return 'S';
-case ABS_AR_DAD:	 					return 'D';
-case ABS_AR_TAH:	 					return 'T';
-case ABS_AR_ZAH:	 					return 'Z';
-case ABS_AR_AIN:	 					return 'E';
-case ABS_AR_GHAIN:						return 'g';
-case ABS_AR_TATWEEL: 					return '_';
-case ABS_AR_FEH:	 					return 'f';
-case ABS_AR_QAF:	 					return 'q';
-case ABS_AR_KAF:	 					return 'k';
-case ABS_AR_LAM:	 					return 'l';
-case ABS_AR_MEEM:	 					return 'm';
-case ABS_AR_NOON:	 					return 'n';
-case ABS_AR_HEH:	 					return 'h';
-case ABS_AR_WAW:	 					return 'w';
-case ABS_AR_ALEF_MAQSURA:				return 'Y';
-case ABS_AR_YEH:	 					return 'y';
+case ABS_AR_HAMZA:                      return '\'';
+case ABS_AR_ALEF_WITH_MADDA_ABOVE:      return '|';
+case ABS_AR_ALEF_WITH_HAMZA_ABOVE:      return '>';
+case ABS_AR_WAW_WITH_HAMZA_ABOVE:       return '&';
+case ABS_AR_ALEF_WITH_HAMZA_BELOW:      return '<';
+case ABS_AR_YEH_WITH_HAMZA_ABOVE:       return '}';
+case ABS_AR_ALEF:                       return 'A';
+case ABS_AR_BEH:                        return 'b';
+case ABS_AR_TEH_MARBUTA:                return 'p';
+case ABS_AR_TEH:                        return 't';
+case ABS_AR_THEH:                       return 'v';
+case ABS_AR_JEEM:                       return 'j';
+case ABS_AR_HAH:                        return 'H';
+case ABS_AR_KHAH:                       return 'x';
+case ABS_AR_DAL:                        return 'd';
+case ABS_AR_THAL:                       return '*';
+case ABS_AR_REH:                        return 'r';
+case ABS_AR_ZAIN:                       return 'z';
+case ABS_AR_SEEN:                       return 's';
+case ABS_AR_SHEEN:                      return '$';
+case ABS_AR_SAD:                        return 'S';
+case ABS_AR_DAD:                        return 'D';
+case ABS_AR_TAH:                        return 'T';
+case ABS_AR_ZAH:                        return 'Z';
+case ABS_AR_AIN:                        return 'E';
+case ABS_AR_GHAIN:                      return 'g';
+case ABS_AR_TATWEEL:                    return '_';
+case ABS_AR_FEH:                        return 'f';
+case ABS_AR_QAF:                        return 'q';
+case ABS_AR_KAF:                        return 'k';
+case ABS_AR_LAM:                        return 'l';
+case ABS_AR_MEEM:                       return 'm';
+case ABS_AR_NOON:                       return 'n';
+case ABS_AR_HEH:                        return 'h';
+case ABS_AR_WAW:                        return 'w';
+case ABS_AR_ALEF_MAQSURA:               return 'Y';
+case ABS_AR_YEH:                        return 'y';
 /* Diacritics */
-case ABS_AR_FATHATAN:					return 'F';
-case ABS_AR_DAMMATAN:					return 'N';
-case ABS_AR_KASRATAN:					return 'K';
-case ABS_AR_FATHA:						return 'a';
-case ABS_AR_DAMMA:						return 'u';
-case ABS_AR_KASRA:						return 'i';
-case ABS_AR_SHADDA:						return '~';
-case ABS_AR_SUKUN:						return 'o';
-case ABS_AR_SUPERSCRIPT_ALEF:			return '`';
+case ABS_AR_FATHATAN:                   return 'F';
+case ABS_AR_DAMMATAN:                   return 'N';
+case ABS_AR_KASRATAN:                   return 'K';
+case ABS_AR_FATHA:                      return 'a';
+case ABS_AR_DAMMA:                      return 'u';
+case ABS_AR_KASRA:                      return 'i';
+case ABS_AR_SHADDA:                     return '~';
+case ABS_AR_SUKUN:                      return 'o';
+case ABS_AR_SUPERSCRIPT_ALEF:           return '`';
 /* Hamza variant */
-case ABS_AR_ALEF_WASLA:					return '{';
+case ABS_AR_ALEF_WASLA:                 return '{';
 default: return c;
 }
 }
@@ -92,43 +92,43 @@ default: return c;
 unichar to_buckwalter_plusplus(unichar c) {
 unichar c2=to_buckwalter(c);
 if (c==c2) {
-	/* If the character wasn't converted by to_buckwalter, it was not
-	 * an Arabic char, so we return it. Doing so avoid problems when using
-	 * to_buckwalter_plus_plus to convert an Arabic text containing {, } or any
-	 * character using in this transliteration */
-	return c;
+    /* If the character wasn't converted by to_buckwalter, it was not
+     * an Arabic char, so we return it. Doing so avoid problems when using
+     * to_buckwalter_plus_plus to convert an Arabic text containing {, } or any
+     * character using in this transliteration */
+    return c;
 }
 switch(c2) {
-case '\'': 	return 'c';
-case '|': 	return 'C';
-case '>': 	return 'O';
-case '&': 	return 'W';
-case '<': 	return 'I';
-case '}': 	return 'e';
-case '*': 	return 'J';
-case '$': 	return 'M';
-case '~': 	return 'G';
-case '`': 	return 'R';
-case '{': 	return 'L';
-default: 	return c2;
+case '\'':  return 'c';
+case '|':   return 'C';
+case '>':   return 'O';
+case '&':   return 'W';
+case '<':   return 'I';
+case '}':   return 'e';
+case '*':   return 'J';
+case '$':   return 'M';
+case '~':   return 'G';
+case '`':   return 'R';
+case '{':   return 'L';
+default:    return c2;
 }
 }
 
 
 unichar buckwalter_plusplus_to_buckwalter(unichar c) {
 switch(c) {
-case 'c': 	return '\'';
-case 'C': 	return '|';
-case 'O': 	return '>';
-case 'W': 	return '&';
-case 'I': 	return '<';
-case 'e': 	return '}';
-case 'J': 	return '*';
-case 'M': 	return '$';
-case 'G': 	return '~';
-case 'R': 	return '`';
-case 'L': 	return '{';
-default: 	return c;
+case 'c':   return '\'';
+case 'C':   return '|';
+case 'O':   return '>';
+case 'W':   return '&';
+case 'I':   return '<';
+case 'e':   return '}';
+case 'J':   return '*';
+case 'M':   return '$';
+case 'G':   return '~';
+case 'R':   return '`';
+case 'L':   return '{';
+default:    return c;
 }
 }
 
@@ -136,55 +136,55 @@ default: 	return c;
 unichar from_buckwalter(unichar c) {
 switch (c) {
 /* Plain letters */
-case '\'':	return ABS_AR_HAMZA;
-case '|':	return ABS_AR_ALEF_WITH_MADDA_ABOVE;
-case '>':	return ABS_AR_ALEF_WITH_HAMZA_ABOVE;
-case '&':	return ABS_AR_WAW_WITH_HAMZA_ABOVE;
-case '<':	return ABS_AR_ALEF_WITH_HAMZA_BELOW;
-case '}':	return ABS_AR_YEH_WITH_HAMZA_ABOVE;
-case 'A':	return ABS_AR_ALEF;
-case 'b':	return ABS_AR_BEH;
-case 'p':	return ABS_AR_TEH_MARBUTA;
-case 't':	return ABS_AR_TEH;
-case 'v':	return ABS_AR_THEH;
-case 'j':	return ABS_AR_JEEM;
-case 'H':	return ABS_AR_HAH;
-case 'x':	return ABS_AR_KHAH;
-case 'd':	return ABS_AR_DAL;
-case '*':	return ABS_AR_THAL;
-case 'r':	return ABS_AR_REH;
-case 'z':	return ABS_AR_ZAIN;
-case 's':	return ABS_AR_SEEN;
-case '$':	return ABS_AR_SHEEN;
-case 'S':	return ABS_AR_SAD;
-case 'D':	return ABS_AR_DAD;
-case 'T':	return ABS_AR_TAH;
-case 'Z':	return ABS_AR_ZAH;
-case 'E':	return ABS_AR_AIN;
-case 'g':	return ABS_AR_GHAIN;
-case '_':	return ABS_AR_TATWEEL;
-case 'f':	return ABS_AR_FEH;
-case 'q':	return ABS_AR_QAF;
-case 'k':	return ABS_AR_KAF;
-case 'l':	return ABS_AR_LAM;
-case 'm':	return ABS_AR_MEEM;
-case 'n':	return ABS_AR_NOON;
-case 'h':	return ABS_AR_HEH;
-case 'w':	return ABS_AR_WAW;
-case 'Y':	return ABS_AR_ALEF_MAQSURA;
-case 'y':	return ABS_AR_YEH;
+case '\'':  return ABS_AR_HAMZA;
+case '|':   return ABS_AR_ALEF_WITH_MADDA_ABOVE;
+case '>':   return ABS_AR_ALEF_WITH_HAMZA_ABOVE;
+case '&':   return ABS_AR_WAW_WITH_HAMZA_ABOVE;
+case '<':   return ABS_AR_ALEF_WITH_HAMZA_BELOW;
+case '}':   return ABS_AR_YEH_WITH_HAMZA_ABOVE;
+case 'A':   return ABS_AR_ALEF;
+case 'b':   return ABS_AR_BEH;
+case 'p':   return ABS_AR_TEH_MARBUTA;
+case 't':   return ABS_AR_TEH;
+case 'v':   return ABS_AR_THEH;
+case 'j':   return ABS_AR_JEEM;
+case 'H':   return ABS_AR_HAH;
+case 'x':   return ABS_AR_KHAH;
+case 'd':   return ABS_AR_DAL;
+case '*':   return ABS_AR_THAL;
+case 'r':   return ABS_AR_REH;
+case 'z':   return ABS_AR_ZAIN;
+case 's':   return ABS_AR_SEEN;
+case '$':   return ABS_AR_SHEEN;
+case 'S':   return ABS_AR_SAD;
+case 'D':   return ABS_AR_DAD;
+case 'T':   return ABS_AR_TAH;
+case 'Z':   return ABS_AR_ZAH;
+case 'E':   return ABS_AR_AIN;
+case 'g':   return ABS_AR_GHAIN;
+case '_':   return ABS_AR_TATWEEL;
+case 'f':   return ABS_AR_FEH;
+case 'q':   return ABS_AR_QAF;
+case 'k':   return ABS_AR_KAF;
+case 'l':   return ABS_AR_LAM;
+case 'm':   return ABS_AR_MEEM;
+case 'n':   return ABS_AR_NOON;
+case 'h':   return ABS_AR_HEH;
+case 'w':   return ABS_AR_WAW;
+case 'Y':   return ABS_AR_ALEF_MAQSURA;
+case 'y':   return ABS_AR_YEH;
 /* Diacritics */
-case 'F':	return ABS_AR_FATHATAN;
-case 'N':	return ABS_AR_DAMMATAN;
-case 'K':	return ABS_AR_KASRATAN;
-case 'a':	return ABS_AR_FATHA;
-case 'u':	return ABS_AR_DAMMA;
-case 'i':	return ABS_AR_KASRA;
-case '~':	return ABS_AR_SHADDA;
-case 'o':	return ABS_AR_SUKUN;
-case '`':	return ABS_AR_SUPERSCRIPT_ALEF;
+case 'F':   return ABS_AR_FATHATAN;
+case 'N':   return ABS_AR_DAMMATAN;
+case 'K':   return ABS_AR_KASRATAN;
+case 'a':   return ABS_AR_FATHA;
+case 'u':   return ABS_AR_DAMMA;
+case 'i':   return ABS_AR_KASRA;
+case '~':   return ABS_AR_SHADDA;
+case 'o':   return ABS_AR_SUKUN;
+case '`':   return ABS_AR_SUPERSCRIPT_ALEF;
 /* Hamza variant */
-case '{':	return ABS_AR_ALEF_WASLA;
+case '{':   return ABS_AR_ALEF_WASLA;
 default: return c;
 }
 }
@@ -237,7 +237,7 @@ case AR_MEEM:
 case AR_HEH:
 case AR_WAW:
 case AR_YEH:
-case AR_ALEF_WASLA:	return 1;
+case AR_ALEF_WASLA: return 1;
 default: return 0;
 }
 }
@@ -263,15 +263,15 @@ return 1;
 int load_arabic_typo_rules(const VersatileEncodingConfig* vec,const char* name,ArabicTypoRules *rules) {
 memset(rules,0,sizeof(ArabicTypoRules));
 if (name==NULL) {
-	fatal_error("NULL arabic rule configuration file name!\n");
+    fatal_error("NULL arabic rule configuration file name!\n");
 }
 if (rules==NULL) {
-	fatal_error("Unexpected NULL pointer in load_arabic_typo_rules\n");
+    fatal_error("Unexpected NULL pointer in load_arabic_typo_rules\n");
 }
 struct string_hash* h=load_key_value_list(name,vec,'=');
 if (h==NULL) {
-	error("Cannot load %s\n",name);
-	return 0;
+    error("Cannot load %s\n",name);
+    return 0;
 }
 (*rules).rules_enabled=1;
 (*rules).fatha_omission=test(h,FATHA_OMISSION);
@@ -313,9 +313,9 @@ return 1;
  * conjunctions w(a) and f(a).
  *
  * Examples:
- * 		Alraeiysu + pos=2 => OK
- * 		lilraeiysu + pos=3 => OK
- * 		llraeiysu + pos=2 => OK, but only if the i omission rule is active
+ *      Alraeiysu + pos=2 => OK
+ *      lilraeiysu + pos=3 => OK
+ *      llraeiysu + pos=2 => OK, but only if the i omission rule is active
  */
 int was_Al_before(const unichar* token,int pos,ArabicTypoRules rules) {
 if (pos<=1) return 0;
@@ -323,54 +323,54 @@ pos--;
 if (token[pos--]!=AR_LAM) return 0;
 int ok=0;
 int lil=0;
-if (token[pos]==AR_ALEF) { ok=1; pos--; }								/* Al */
-else if (token[pos]==AR_ALEF_WASLA) { ok=rules.al_with_wasla; pos--; }	/* Ll */
-else if (token[pos]==AR_LAM) { ok=rules.kasra_omission; pos--; lil=1; }	/* ll */
-else if (pos>0 && token[pos]==AR_KASRA && token[pos-1]==AR_LAM) {		/* lil */
-	ok=1;
-	pos=pos-2;
-	lil=1;
+if (token[pos]==AR_ALEF) { ok=1; pos--; }                               /* Al */
+else if (token[pos]==AR_ALEF_WASLA) { ok=rules.al_with_wasla; pos--; }  /* Ll */
+else if (token[pos]==AR_LAM) { ok=rules.kasra_omission; pos--; lil=1; } /* ll */
+else if (pos>0 && token[pos]==AR_KASRA && token[pos-1]==AR_LAM) {       /* lil */
+    ok=1;
+    pos=pos-2;
+    lil=1;
 }
 if (!ok) return 0;
 if (pos==-1) return 1;
 if (!lil) {
-	/* Before Al or Ll, we can find bi or ka */
-	if (token[pos]==AR_KASRA && pos>0 && token[pos-1]==AR_BEH) {	/* bi */
-		pos=pos-2;
-	} else if (token[pos]==AR_BEH) {								/* b */
-		if (!rules.kasra_omission) return 0;
-		pos--;
-	} else if (token[pos]==AR_FATHA) {
-		/* If we have a 'a', it can be 'ka', or 'wa'/'fa' */
-		if (pos==-1) return 0;
-		if (token[pos]==AR_WAW || token[pos]==AR_FEH) { 			/* wa or fa */
-			/* We must be at the beginning of the word */
-			return pos==0;
-		} else if (token[pos]==AR_KAF) {							/* ka */
-			pos--;
-		} else {
-			return 0;
-		}
-	} else if (token[pos]==AR_KAF) {								/* k */
-		if (!rules.fatha_omission) return 0;
-		pos--;
-	} else if (token[pos]==AR_WAW) {								/* w */
-		return pos==0 && rules.fatha_omission;
-	} else if (token[pos]==AR_BEH) {								/* b */
-		return pos==0 && rules.fatha_omission;
-	} else {
-		return 0;
-	}
+    /* Before Al or Ll, we can find bi or ka */
+    if (token[pos]==AR_KASRA && pos>0 && token[pos-1]==AR_BEH) {    /* bi */
+        pos=pos-2;
+    } else if (token[pos]==AR_BEH) {                                /* b */
+        if (!rules.kasra_omission) return 0;
+        pos--;
+    } else if (token[pos]==AR_FATHA) {
+        /* If we have a 'a', it can be 'ka', or 'wa'/'fa' */
+        if (pos==-1) return 0;
+        if (token[pos]==AR_WAW || token[pos]==AR_FEH) {             /* wa or fa */
+            /* We must be at the beginning of the word */
+            return pos==0;
+        } else if (token[pos]==AR_KAF) {                            /* ka */
+            pos--;
+        } else {
+            return 0;
+        }
+    } else if (token[pos]==AR_KAF) {                                /* k */
+        if (!rules.fatha_omission) return 0;
+        pos--;
+    } else if (token[pos]==AR_WAW) {                                /* w */
+        return pos==0 && rules.fatha_omission;
+    } else if (token[pos]==AR_BEH) {                                /* b */
+        return pos==0 && rules.fatha_omission;
+    } else {
+        return 0;
+    }
 }
 if (pos==-1) return 1;
-if (token[pos]==AR_WAW || token[pos]==AR_FEH) { 					/* w or f */
-	/* We must be at the beginning of the word */
-	return pos==0 && rules.fatha_omission;
-} else if (token[pos]==AR_FATHA) {									/* wa or fa */
-	pos--;
-	return pos==0 && (token[pos]==AR_WAW || token[pos]==AR_FEH);
+if (token[pos]==AR_WAW || token[pos]==AR_FEH) {                     /* w or f */
+    /* We must be at the beginning of the word */
+    return pos==0 && rules.fatha_omission;
+} else if (token[pos]==AR_FATHA) {                                  /* wa or fa */
+    pos--;
+    return pos==0 && (token[pos]==AR_WAW || token[pos]==AR_FEH);
 } else {
-	return 0;
+    return 0;
 }
 }
 

--- a/Arabic.h
+++ b/Arabic.h
@@ -33,106 +33,106 @@ namespace unitex {
 /* Here are the absolute definition of the arabic letters */
 
 /* Plain letters */
-#define ABS_AR_HAMZA 						0x0621
-#define ABS_AR_ALEF_WITH_MADDA_ABOVE 		0x0622
-#define ABS_AR_ALEF_WITH_HAMZA_ABOVE 		0x0623
-#define ABS_AR_WAW_WITH_HAMZA_ABOVE 		0x0624
-#define ABS_AR_ALEF_WITH_HAMZA_BELOW 		0x0625
-#define ABS_AR_YEH_WITH_HAMZA_ABOVE 		0x0626
-#define ABS_AR_ALEF 						0x0627
-#define ABS_AR_BEH 							0x0628
-#define ABS_AR_TEH_MARBUTA 					0x0629
-#define ABS_AR_TEH 							0x062A
-#define ABS_AR_THEH 						0x062B
-#define ABS_AR_JEEM 						0x062C
-#define ABS_AR_HAH 							0x062D
-#define ABS_AR_KHAH 						0x062E
-#define ABS_AR_DAL 							0x062F
-#define ABS_AR_THAL							0x0630
-#define ABS_AR_REH 							0x0631
-#define ABS_AR_ZAIN 						0x0632
-#define ABS_AR_SEEN 						0x0633
-#define ABS_AR_SHEEN 						0x0634
-#define ABS_AR_SAD	 						0x0635
-#define ABS_AR_DAD	 						0x0636
-#define ABS_AR_TAH	 						0x0637
-#define ABS_AR_ZAH	 						0x0638
-#define ABS_AR_AIN	 						0x0639
-#define ABS_AR_GHAIN						0x063A
-#define ABS_AR_TATWEEL 						0x0640
-#define ABS_AR_FEH	 						0x0641
-#define ABS_AR_QAF	 						0x0642
-#define ABS_AR_KAF	 						0x0643
-#define ABS_AR_LAM	 						0x0644
-#define ABS_AR_MEEM	 						0x0645
-#define ABS_AR_NOON	 						0x0646
-#define ABS_AR_HEH	 						0x0647
-#define ABS_AR_WAW	 						0x0648
-#define ABS_AR_ALEF_MAQSURA					0x0649
-#define ABS_AR_YEH	 						0x064A
+#define ABS_AR_HAMZA                        0x0621
+#define ABS_AR_ALEF_WITH_MADDA_ABOVE        0x0622
+#define ABS_AR_ALEF_WITH_HAMZA_ABOVE        0x0623
+#define ABS_AR_WAW_WITH_HAMZA_ABOVE         0x0624
+#define ABS_AR_ALEF_WITH_HAMZA_BELOW        0x0625
+#define ABS_AR_YEH_WITH_HAMZA_ABOVE         0x0626
+#define ABS_AR_ALEF                         0x0627
+#define ABS_AR_BEH                          0x0628
+#define ABS_AR_TEH_MARBUTA                  0x0629
+#define ABS_AR_TEH                          0x062A
+#define ABS_AR_THEH                         0x062B
+#define ABS_AR_JEEM                         0x062C
+#define ABS_AR_HAH                          0x062D
+#define ABS_AR_KHAH                         0x062E
+#define ABS_AR_DAL                          0x062F
+#define ABS_AR_THAL                         0x0630
+#define ABS_AR_REH                          0x0631
+#define ABS_AR_ZAIN                         0x0632
+#define ABS_AR_SEEN                         0x0633
+#define ABS_AR_SHEEN                        0x0634
+#define ABS_AR_SAD                          0x0635
+#define ABS_AR_DAD                          0x0636
+#define ABS_AR_TAH                          0x0637
+#define ABS_AR_ZAH                          0x0638
+#define ABS_AR_AIN                          0x0639
+#define ABS_AR_GHAIN                        0x063A
+#define ABS_AR_TATWEEL                      0x0640
+#define ABS_AR_FEH                          0x0641
+#define ABS_AR_QAF                          0x0642
+#define ABS_AR_KAF                          0x0643
+#define ABS_AR_LAM                          0x0644
+#define ABS_AR_MEEM                         0x0645
+#define ABS_AR_NOON                         0x0646
+#define ABS_AR_HEH                          0x0647
+#define ABS_AR_WAW                          0x0648
+#define ABS_AR_ALEF_MAQSURA                 0x0649
+#define ABS_AR_YEH                          0x064A
 /* Diacritics */
-#define ABS_AR_FATHATAN						0x064B
-#define ABS_AR_DAMMATAN						0x064C
-#define ABS_AR_KASRATAN						0x064D
-#define ABS_AR_FATHA						0x064E
-#define ABS_AR_DAMMA						0x064F
-#define ABS_AR_KASRA						0x0650
-#define ABS_AR_SHADDA						0x0651
-#define ABS_AR_SUKUN						0x0652
-#define ABS_AR_SUPERSCRIPT_ALEF				0x0670
+#define ABS_AR_FATHATAN                     0x064B
+#define ABS_AR_DAMMATAN                     0x064C
+#define ABS_AR_KASRATAN                     0x064D
+#define ABS_AR_FATHA                        0x064E
+#define ABS_AR_DAMMA                        0x064F
+#define ABS_AR_KASRA                        0x0650
+#define ABS_AR_SHADDA                       0x0651
+#define ABS_AR_SUKUN                        0x0652
+#define ABS_AR_SUPERSCRIPT_ALEF             0x0670
 /* Hamza variant */
-#define ABS_AR_ALEF_WASLA					0x0671
+#define ABS_AR_ALEF_WASLA                   0x0671
 
 /* Here are the absolute definition of the Buckwalter transliterations */
-#define BW_AR_HAMZA 					'c'
-#define BW_AR_ALEF_WITH_MADDA_ABOVE 	'C'
-#define BW_AR_ALEF_WITH_HAMZA_ABOVE 	'O'
-#define BW_AR_WAW_WITH_HAMZA_ABOVE 		'W'
-#define BW_AR_ALEF_WITH_HAMZA_BELOW 	'I'
-#define BW_AR_YEH_WITH_HAMZA_ABOVE 		'e'
-#define BW_AR_ALEF 						'A'
-#define BW_AR_BEH 					 	'b'
-#define BW_AR_TEH_MARBUTA 				'p'
-#define BW_AR_TEH 						't'
-#define BW_AR_THEH 						'v'
-#define BW_AR_JEEM 						'j'
-#define BW_AR_HAH 						'H'
-#define BW_AR_KHAH 						'x'
-#define BW_AR_DAL 						'd'
-#define BW_AR_THAL						'J'
-#define BW_AR_REH 						'r'
-#define BW_AR_ZAIN						'z'
-#define BW_AR_SEEN 						's'
-#define BW_AR_SHEEN 					'M'
-#define BW_AR_SAD	 					'S'
-#define BW_AR_DAD	 					'D'
-#define BW_AR_TAH	 					'T'
-#define BW_AR_ZAH	 					'Z'
-#define BW_AR_AIN	 					'E'
-#define BW_AR_GHAIN						'g'
-#define BW_AR_TATWEEL 					'_'
-#define BW_AR_FEH	 					'f'
-#define BW_AR_QAF	 					'q'
-#define BW_AR_KAF	 					'k'
-#define BW_AR_LAM	 					'l'
-#define BW_AR_MEEM	 					'm'
-#define BW_AR_NOON	 					'n'
-#define BW_AR_HEH	 					'h'
-#define BW_AR_WAW	 					'w'
-#define BW_AR_ALEF_MAQSURA				'Y'
-#define BW_AR_YEH	 					'y'
+#define BW_AR_HAMZA                     'c'
+#define BW_AR_ALEF_WITH_MADDA_ABOVE     'C'
+#define BW_AR_ALEF_WITH_HAMZA_ABOVE     'O'
+#define BW_AR_WAW_WITH_HAMZA_ABOVE      'W'
+#define BW_AR_ALEF_WITH_HAMZA_BELOW     'I'
+#define BW_AR_YEH_WITH_HAMZA_ABOVE      'e'
+#define BW_AR_ALEF                      'A'
+#define BW_AR_BEH                       'b'
+#define BW_AR_TEH_MARBUTA               'p'
+#define BW_AR_TEH                       't'
+#define BW_AR_THEH                      'v'
+#define BW_AR_JEEM                      'j'
+#define BW_AR_HAH                       'H'
+#define BW_AR_KHAH                      'x'
+#define BW_AR_DAL                       'd'
+#define BW_AR_THAL                      'J'
+#define BW_AR_REH                       'r'
+#define BW_AR_ZAIN                      'z'
+#define BW_AR_SEEN                      's'
+#define BW_AR_SHEEN                     'M'
+#define BW_AR_SAD                       'S'
+#define BW_AR_DAD                       'D'
+#define BW_AR_TAH                       'T'
+#define BW_AR_ZAH                       'Z'
+#define BW_AR_AIN                       'E'
+#define BW_AR_GHAIN                     'g'
+#define BW_AR_TATWEEL                   '_'
+#define BW_AR_FEH                       'f'
+#define BW_AR_QAF                       'q'
+#define BW_AR_KAF                       'k'
+#define BW_AR_LAM                       'l'
+#define BW_AR_MEEM                      'm'
+#define BW_AR_NOON                      'n'
+#define BW_AR_HEH                       'h'
+#define BW_AR_WAW                       'w'
+#define BW_AR_ALEF_MAQSURA              'Y'
+#define BW_AR_YEH                       'y'
 /* Diacritics */
-#define BW_AR_FATHATAN					'F'
-#define BW_AR_DAMMATAN					'N'
-#define BW_AR_KASRATAN					'K'
-#define BW_AR_FATHA						'a'
-#define BW_AR_DAMMA						'u'
-#define BW_AR_KASRA						'i'
-#define BW_AR_SHADDA					'G'
-#define BW_AR_SUKUN						'o'
-#define BW_AR_SUPERSCRIPT_ALEF			'R'
+#define BW_AR_FATHATAN                  'F'
+#define BW_AR_DAMMATAN                  'N'
+#define BW_AR_KASRATAN                  'K'
+#define BW_AR_FATHA                     'a'
+#define BW_AR_DAMMA                     'u'
+#define BW_AR_KASRA                     'i'
+#define BW_AR_SHADDA                    'G'
+#define BW_AR_SUKUN                     'o'
+#define BW_AR_SUPERSCRIPT_ALEF          'R'
 /* Hamza variant */
-#define BW_AR_ALEF_WASLA					'|'
+#define BW_AR_ALEF_WASLA                    '|'
 
 
 /* This macro is for debug only. You should not use it unless you are me. SP */
@@ -144,107 +144,107 @@ namespace unitex {
 #ifndef AR_WORK_ON_TRANSLITERATED_FORMS
 
 /* Plain letters */
-#define AR_HAMZA 						0x0621
-#define AR_ALEF_WITH_MADDA_ABOVE 		0x0622
-#define AR_ALEF_WITH_HAMZA_ABOVE 		0x0623
-#define AR_WAW_WITH_HAMZA_ABOVE 		0x0624
-#define AR_ALEF_WITH_HAMZA_BELOW 		0x0625
-#define AR_YEH_WITH_HAMZA_ABOVE 		0x0626
-#define AR_ALEF 						0x0627
-#define AR_BEH 							0x0628
-#define AR_TEH_MARBUTA 					0x0629
-#define AR_TEH 							0x062A
-#define AR_THEH 						0x062B
-#define AR_JEEM 						0x062C
-#define AR_HAH 							0x062D
-#define AR_KHAH 						0x062E
-#define AR_DAL 							0x062F
-#define AR_THAL							0x0630
-#define AR_REH 							0x0631
-#define AR_ZAIN 						0x0632
-#define AR_SEEN 						0x0633
-#define AR_SHEEN 						0x0634
-#define AR_SAD	 						0x0635
-#define AR_DAD	 						0x0636
-#define AR_TAH	 						0x0637
-#define AR_ZAH	 						0x0638
-#define AR_AIN	 						0x0639
-#define AR_GHAIN						0x063A
-#define AR_TATWEEL 						0x0640
-#define AR_FEH	 						0x0641
-#define AR_QAF	 						0x0642
-#define AR_KAF	 						0x0643
-#define AR_LAM	 						0x0644
-#define AR_MEEM	 						0x0645
-#define AR_NOON	 						0x0646
-#define AR_HEH	 						0x0647
-#define AR_WAW	 						0x0648
-#define AR_ALEF_MAQSURA					0x0649
-#define AR_YEH	 						0x064A
+#define AR_HAMZA                        0x0621
+#define AR_ALEF_WITH_MADDA_ABOVE        0x0622
+#define AR_ALEF_WITH_HAMZA_ABOVE        0x0623
+#define AR_WAW_WITH_HAMZA_ABOVE         0x0624
+#define AR_ALEF_WITH_HAMZA_BELOW        0x0625
+#define AR_YEH_WITH_HAMZA_ABOVE         0x0626
+#define AR_ALEF                         0x0627
+#define AR_BEH                          0x0628
+#define AR_TEH_MARBUTA                  0x0629
+#define AR_TEH                          0x062A
+#define AR_THEH                         0x062B
+#define AR_JEEM                         0x062C
+#define AR_HAH                          0x062D
+#define AR_KHAH                         0x062E
+#define AR_DAL                          0x062F
+#define AR_THAL                         0x0630
+#define AR_REH                          0x0631
+#define AR_ZAIN                         0x0632
+#define AR_SEEN                         0x0633
+#define AR_SHEEN                        0x0634
+#define AR_SAD                          0x0635
+#define AR_DAD                          0x0636
+#define AR_TAH                          0x0637
+#define AR_ZAH                          0x0638
+#define AR_AIN                          0x0639
+#define AR_GHAIN                        0x063A
+#define AR_TATWEEL                      0x0640
+#define AR_FEH                          0x0641
+#define AR_QAF                          0x0642
+#define AR_KAF                          0x0643
+#define AR_LAM                          0x0644
+#define AR_MEEM                         0x0645
+#define AR_NOON                         0x0646
+#define AR_HEH                          0x0647
+#define AR_WAW                          0x0648
+#define AR_ALEF_MAQSURA                 0x0649
+#define AR_YEH                          0x064A
 /* Diacritics */
-#define AR_FATHATAN						0x064B
-#define AR_DAMMATAN						0x064C
-#define AR_KASRATAN						0x064D
-#define AR_FATHA						0x064E
-#define AR_DAMMA						0x064F
-#define AR_KASRA						0x0650
-#define AR_SHADDA						0x0651
-#define AR_SUKUN						0x0652
-#define AR_SUPERSCRIPT_ALEF				0x0670
+#define AR_FATHATAN                     0x064B
+#define AR_DAMMATAN                     0x064C
+#define AR_KASRATAN                     0x064D
+#define AR_FATHA                        0x064E
+#define AR_DAMMA                        0x064F
+#define AR_KASRA                        0x0650
+#define AR_SHADDA                       0x0651
+#define AR_SUKUN                        0x0652
+#define AR_SUPERSCRIPT_ALEF             0x0670
 /* Hamza variant */
-#define AR_ALEF_WASLA					0x0671
+#define AR_ALEF_WASLA                   0x0671
 
 #else
 /* Here are the Buckwalter++ transliterated forms */
-#define AR_HAMZA 						'c'
-#define AR_ALEF_WITH_MADDA_ABOVE 		'C'
-#define AR_ALEF_WITH_HAMZA_ABOVE 		'O'
-#define AR_WAW_WITH_HAMZA_ABOVE 		'W'
-#define AR_ALEF_WITH_HAMZA_BELOW 		'I'
-#define AR_YEH_WITH_HAMZA_ABOVE 		'e'
-#define AR_ALEF 						'A'
-#define AR_BEH 						 	'b'
-#define AR_TEH_MARBUTA 					'p'
-#define AR_TEH 							't'
-#define AR_THEH 						'v'
-#define AR_JEEM 						'j'
-#define AR_HAH 							'H'
-#define AR_KHAH 						'x'
-#define AR_DAL 							'd'
-#define AR_THAL							'J'
-#define AR_REH 							'r'
-#define AR_ZAIN							'z'
-#define AR_SEEN 						's'
-#define AR_SHEEN 						'M'
-#define AR_SAD	 						'S'
-#define AR_DAD	 						'D'
-#define AR_TAH	 						'T'
-#define AR_ZAH	 						'Z'
-#define AR_AIN	 						'E'
-#define AR_GHAIN						'g'
-#define AR_TATWEEL 						'_'
-#define AR_FEH	 						'f'
-#define AR_QAF	 						'q'
-#define AR_KAF	 						'k'
-#define AR_LAM	 						'l'
-#define AR_MEEM	 						'm'
-#define AR_NOON	 						'n'
-#define AR_HEH	 						'h'
-#define AR_WAW	 						'w'
-#define AR_ALEF_MAQSURA					'Y'
-#define AR_YEH	 						'y'
+#define AR_HAMZA                        'c'
+#define AR_ALEF_WITH_MADDA_ABOVE        'C'
+#define AR_ALEF_WITH_HAMZA_ABOVE        'O'
+#define AR_WAW_WITH_HAMZA_ABOVE         'W'
+#define AR_ALEF_WITH_HAMZA_BELOW        'I'
+#define AR_YEH_WITH_HAMZA_ABOVE         'e'
+#define AR_ALEF                         'A'
+#define AR_BEH                          'b'
+#define AR_TEH_MARBUTA                  'p'
+#define AR_TEH                          't'
+#define AR_THEH                         'v'
+#define AR_JEEM                         'j'
+#define AR_HAH                          'H'
+#define AR_KHAH                         'x'
+#define AR_DAL                          'd'
+#define AR_THAL                         'J'
+#define AR_REH                          'r'
+#define AR_ZAIN                         'z'
+#define AR_SEEN                         's'
+#define AR_SHEEN                        'M'
+#define AR_SAD                          'S'
+#define AR_DAD                          'D'
+#define AR_TAH                          'T'
+#define AR_ZAH                          'Z'
+#define AR_AIN                          'E'
+#define AR_GHAIN                        'g'
+#define AR_TATWEEL                      '_'
+#define AR_FEH                          'f'
+#define AR_QAF                          'q'
+#define AR_KAF                          'k'
+#define AR_LAM                          'l'
+#define AR_MEEM                         'm'
+#define AR_NOON                         'n'
+#define AR_HEH                          'h'
+#define AR_WAW                          'w'
+#define AR_ALEF_MAQSURA                 'Y'
+#define AR_YEH                          'y'
 /* Diacritics */
-#define AR_FATHATAN						'F'
-#define AR_DAMMATAN						'N'
-#define AR_KASRATAN						'K'
-#define AR_FATHA						'a'
-#define AR_DAMMA						'u'
-#define AR_KASRA						'i'
-#define AR_SHADDA						'G'
-#define AR_SUKUN						'o'
-#define AR_SUPERSCRIPT_ALEF				'R'
+#define AR_FATHATAN                     'F'
+#define AR_DAMMATAN                     'N'
+#define AR_KASRATAN                     'K'
+#define AR_FATHA                        'a'
+#define AR_DAMMA                        'u'
+#define AR_KASRA                        'i'
+#define AR_SHADDA                       'G'
+#define AR_SUKUN                        'o'
+#define AR_SUPERSCRIPT_ALEF             'R'
 /* Hamza variant */
-#define AR_ALEF_WASLA					'|'
+#define AR_ALEF_WASLA                   '|'
 
 #endif
 
@@ -301,39 +301,39 @@ namespace unitex {
 /* This bit-field structure is used to know which rules must be applied
  * during the dictionary lookup in morphological mode */
 typedef struct {
-	/* This field is used to know if we really have a rule set or not.
-	 * It is used to avoid something like a test to NULL on a structure
-	 * pointer before testing the structure itself
-	 */
-	unsigned int rules_enabled: 1;
+    /* This field is used to know if we really have a rule set or not.
+     * It is used to avoid something like a test to NULL on a structure
+     * pointer before testing the structure itself
+     */
+    unsigned int rules_enabled: 1;
 
-	unsigned int fatha_omission: 1;
-	unsigned int damma_omission: 1;
-	unsigned int kasra_omission: 1;
-	unsigned int sukun_omission: 1;
-	unsigned int superscript_alef_omission: 1;
-	unsigned int fathatan_omission_at_end: 1;
-	unsigned int dammatan_omission_at_end: 1;
-	unsigned int kasratan_omission_at_end: 1;
-	unsigned int shadda_fatha_omission_at_end: 1;
-	unsigned int shadda_damma_omission_at_end: 1;
-	unsigned int shadda_kasra_omission_at_end: 1;
-	unsigned int shadda_fathatan_omission_at_end: 1;
-	unsigned int shadda_dammatan_omission_at_end: 1;
-	unsigned int shadda_kasratan_omission_at_end: 1;
-	unsigned int shadda_fatha_omission: 1;
-	unsigned int shadda_damma_omission: 1;
-	unsigned int shadda_kasra_omission: 1;
-	unsigned int shadda_superscript_alef_omission: 1;
-	unsigned int solar_assimilation: 1;
-	unsigned int lunar_assimilation: 1;
-	unsigned int al_with_wasla: 1;
-	unsigned int alef_hamza_above_O_to_A: 1;
-	unsigned int alef_hamza_below_I_to_A: 1;
-	unsigned int alef_hamza_below_I_to_L: 1;
-	unsigned int fathatan_alef_equiv_alef_fathatan: 1;
-	unsigned int fathatan_alef_maqsura_equiv_alef_maqsura_fathatan: 1;
-	unsigned int alef_maqsura_hamza_equiv_hamza_above_yeh: 1;
+    unsigned int fatha_omission: 1;
+    unsigned int damma_omission: 1;
+    unsigned int kasra_omission: 1;
+    unsigned int sukun_omission: 1;
+    unsigned int superscript_alef_omission: 1;
+    unsigned int fathatan_omission_at_end: 1;
+    unsigned int dammatan_omission_at_end: 1;
+    unsigned int kasratan_omission_at_end: 1;
+    unsigned int shadda_fatha_omission_at_end: 1;
+    unsigned int shadda_damma_omission_at_end: 1;
+    unsigned int shadda_kasra_omission_at_end: 1;
+    unsigned int shadda_fathatan_omission_at_end: 1;
+    unsigned int shadda_dammatan_omission_at_end: 1;
+    unsigned int shadda_kasratan_omission_at_end: 1;
+    unsigned int shadda_fatha_omission: 1;
+    unsigned int shadda_damma_omission: 1;
+    unsigned int shadda_kasra_omission: 1;
+    unsigned int shadda_superscript_alef_omission: 1;
+    unsigned int solar_assimilation: 1;
+    unsigned int lunar_assimilation: 1;
+    unsigned int al_with_wasla: 1;
+    unsigned int alef_hamza_above_O_to_A: 1;
+    unsigned int alef_hamza_below_I_to_A: 1;
+    unsigned int alef_hamza_below_I_to_L: 1;
+    unsigned int fathatan_alef_equiv_alef_fathatan: 1;
+    unsigned int fathatan_alef_maqsura_equiv_alef_maqsura_fathatan: 1;
+    unsigned int alef_maqsura_hamza_equiv_hamza_above_yeh: 1;
 } ArabicTypoRules;
 
 

--- a/AsciiSearchTree.cpp
+++ b/AsciiSearchTree.cpp
@@ -52,7 +52,7 @@ return tree;
  * This function inserts a string in the tree whose root is 'node'. 'position' is the current
  * position in the string. If the string is already associated to a value, 0 is returned;
  * 1 otherwise.
- * 
+ *
  * IMPORTANT: this function assumes that the given string is neither NULL
  *            nor empty
  */
@@ -66,7 +66,7 @@ if ((*node)==NULL) {
 if (string[position+1]=='\0' && string[position]==(*node)->c) {
 	/* If we are at the end of the string on the correct node */
 	if ((*node)->is_final) {
-		/* If the string is already associated to a value, 
+		/* If the string is already associated to a value,
 		 * then we raise a fatal error. */
 		 return 0;
 	}
@@ -118,7 +118,7 @@ int get_string_number(const struct search_tree_node* node,const char* string,int
 if (node==NULL) {
 	/* If we find a NULL node, it means that the tree does not
 	 * contain the string, so we return 0. */
-	return 0;	
+	return 0;
 }
 if (string[position]==node->c && string[position+1]=='\0') {
 	/* If we are on the node with the correct letter, and if we are

--- a/AsciiSearchTree.cpp
+++ b/AsciiSearchTree.cpp
@@ -59,33 +59,33 @@ return tree;
 int insert_string(struct search_tree_node* *node,const char* string,int position,
                                   int value) {
 if ((*node)==NULL) {
-	/* If we need to allocate the tree node */
-	(*node)=new_search_tree();
-	(*node)->c=string[position];
+    /* If we need to allocate the tree node */
+    (*node)=new_search_tree();
+    (*node)->c=string[position];
 }
 if (string[position+1]=='\0' && string[position]==(*node)->c) {
-	/* If we are at the end of the string on the correct node */
-	if ((*node)->is_final) {
-		/* If the string is already associated to a value,
-		 * then we raise a fatal error. */
-		 return 0;
-	}
-	(*node)->is_final=1;
-	(*node)->value=value;
-	return 1;
+    /* If we are at the end of the string on the correct node */
+    if ((*node)->is_final) {
+        /* If the string is already associated to a value,
+         * then we raise a fatal error. */
+         return 0;
+    }
+    (*node)->is_final=1;
+    (*node)->value=value;
+    return 1;
 }
 /* If we are not at the end of the string */
 if (string[position]==(*node)->c) {
-	/* If the current node is tagged by the current letter, then
-	 * we increase the position in the string and we explore the
-	 * 'middle' tree. */
-	 return insert_string(&((*node)->middle),string,position+1,value);
+    /* If the current node is tagged by the current letter, then
+     * we increase the position in the string and we explore the
+     * 'middle' tree. */
+     return insert_string(&((*node)->middle),string,position+1,value);
 }
 if (string[position]<(*node)->c) {
-	/* If the current node is tagged by a letter that is greater than
-	 * the current letter, we look for the good node in the 'left' tree, but
-	 * we do not modify the position in the string. */
-	 return insert_string(&((*node)->left),string,position,value);
+    /* If the current node is tagged by a letter that is greater than
+     * the current letter, we look for the good node in the 'left' tree, but
+     * we do not modify the position in the string. */
+     return insert_string(&((*node)->left),string,position,value);
 }
 /* Finally, if the current node is tagged by a that is lower than
  * the current letter, we look for the good node in the 'right' tree, but
@@ -101,7 +101,7 @@ return insert_string(&((*node)->right),string,position,value);
  */
 int insert_string(struct search_tree_node* *root,const char* string,int value) {
 if (string==NULL || string[0]=='\0') {
-	fatal_error("NULL or empty string in insert_string\n");
+    fatal_error("NULL or empty string in insert_string\n");
 }
 return insert_string(root,string,0,value);
 }
@@ -116,28 +116,28 @@ return insert_string(root,string,0,value);
  */
 int get_string_number(const struct search_tree_node* node,const char* string,int position,int *result) {
 if (node==NULL) {
-	/* If we find a NULL node, it means that the tree does not
-	 * contain the string, so we return 0. */
-	return 0;
+    /* If we find a NULL node, it means that the tree does not
+     * contain the string, so we return 0. */
+    return 0;
 }
 if (string[position]==node->c && string[position+1]=='\0') {
-	/* If we are on the node with the correct letter, and if we are
-	 * at the end of the string, and if the node is final, then we
-	 * store the associated value and we return 1; otherwise we return 0. */
-	if (!node->is_final) return 0;
-	(*result)=node->value;
-	return 1;
+    /* If we are on the node with the correct letter, and if we are
+     * at the end of the string, and if the node is final, then we
+     * store the associated value and we return 1; otherwise we return 0. */
+    if (!node->is_final) return 0;
+    (*result)=node->value;
+    return 1;
 }
 if (string[position]==node->c) {
-	/* If have the correct letter but we are not at the end of the string,
-	 * then we explore the next letter in the 'middle' tree. */
-	return get_string_number(node->middle,string,position+1,result);
+    /* If have the correct letter but we are not at the end of the string,
+     * then we explore the next letter in the 'middle' tree. */
+    return get_string_number(node->middle,string,position+1,result);
 }
 if (string[position]<node->c) {
-	/* If the current node is tagged by a letter that is greater than
-	 * the current letter, we look for the good node in the 'left' tree, but
-	 * we do not modify the position in the string. */
-	return get_string_number(node->left,string,position,result);
+    /* If the current node is tagged by a letter that is greater than
+     * the current letter, we look for the good node in the 'left' tree, but
+     * we do not modify the position in the string. */
+    return get_string_number(node->left,string,position,result);
 }
 /* Finally, if the current node is tagged by a that is greater than
  * the current letter, we look for the good node in the 'right' tree, but
@@ -154,7 +154,7 @@ return get_string_number(node->right,string,position,result);
  */
 int get_string_number(const struct search_tree_node* root,const char* string,int *result) {
 if (string==NULL || string[0]=='\0') {
-	fatal_error("NULL or empty string in get_string_number\n");
+    fatal_error("NULL or empty string in get_string_number\n");
 }
 return get_string_number(root,string,0,result);
 }
@@ -165,13 +165,13 @@ return get_string_number(root,string,0,result);
  */
 void free_search_tree_node(struct search_tree_node* root)
 {
-	if (root != NULL)
-	{
-		free_search_tree_node(root->left);
-		free_search_tree_node(root->middle);
-		free_search_tree_node(root->right);
-		free(root);
-	}
+    if (root != NULL)
+    {
+        free_search_tree_node(root->left);
+        free_search_tree_node(root->middle);
+        free_search_tree_node(root->right);
+        free(root);
+    }
 }
 
 } // namespace unitex

--- a/AsciiSearchTree.h
+++ b/AsciiSearchTree.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef AsciiSearchTreeH
 #define AsciiSearchTreeH
 
@@ -30,7 +30,7 @@ namespace unitex {
 
 /**
  * This structure is used to integer values associated to strings.
- * 
+ *
  * - 'c' is the character of the node
  * - 'is_final' is null if the node is not a final one and non null otherwise
  * - 'value' is the value associated to the string represented by this nod
@@ -39,12 +39,12 @@ namespace unitex {
  * - 'right' is the tree of all strings that start with a letter > 'c'
  */
 struct search_tree_node {
-	char c;
-	char is_final;
-	int value;
-	struct search_tree_node* left;
-	struct search_tree_node* middle;
-	struct search_tree_node* right;
+    char c;
+    char is_final;
+    int value;
+    struct search_tree_node* left;
+    struct search_tree_node* middle;
+    struct search_tree_node* right;
 };
 
 

--- a/AutComplementation.cpp
+++ b/AutComplementation.cpp
@@ -65,7 +65,7 @@ while (trans!=NULL) {
          free_symbols(POS[i]);
       }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-	  free(POS);
+      free(POS);
 #endif
       return NULL;
    }

--- a/AutComplementation.cpp
+++ b/AutComplementation.cpp
@@ -30,7 +30,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1

--- a/AutDeterminization.cpp
+++ b/AutDeterminization.cpp
@@ -69,7 +69,7 @@ for (int current_state_set=0;current_state_set<ARRAY->size;current_state_set++) 
          index=state_set_array_add(ARRAY,T->destination);
       }
       if (T->label->next!=NULL) {
-    	  fatal_error("elag_determinize: symbol list error should not happen\n");
+          fatal_error("elag_determinize: symbol list error should not happen\n");
       }
       add_outgoing_transition(q,T->label,index);
    }

--- a/AutIntersection.cpp
+++ b/AutIntersection.cpp
@@ -166,7 +166,7 @@ for (Transition* transA=A->states[q1]->outgoing_transitions;transA!=NULL;transA=
    int found=0;
    for (Transition* transB=B->states[q2]->outgoing_transitions;transB!=NULL;transB=transB->next) {
       if (symbol_in_symbol(transA->label,transB->label)) {
-     	 if (found) {
+         if (found) {
             fatal_error("intersect_states_text_grammar: non deterministic automaton\n");
          }
          found=1;

--- a/AutMinimization.h
+++ b/AutMinimization.h
@@ -38,7 +38,7 @@ namespace unitex {
  * and Ullman. This idea of this algorithm is to take a deterministic
  * automaton and to find out which states can be merged.
  * The color flavor of this implementation is dued to Eric Laporte.
- * 
+ *
  * Author: Eric Laporte
  * Cleaned and commented by Sébastien Paumier
  */

--- a/AutomatonDictionary2Bin.cpp
+++ b/AutomatonDictionary2Bin.cpp
@@ -40,8 +40,8 @@ namespace unitex {
  */
 void number_node_old_style(struct dictionary_node* node,int *bin_size) {
 if (node->offset!=-1) {
-	/* Nothing to do if there is already an offset */
-	return;
+    /* Nothing to do if there is already an offset */
+    return;
 }
 /* We give an offset to the node */
 node->offset=(*bin_size);
@@ -51,20 +51,20 @@ node->offset=(*bin_size);
 (*bin_size)=(*bin_size)+2;
 
 if (node->single_INF_code_list!=NULL) {
-	/* If the node is a final one, we add 3 bytes for coding the INF line number */
-	(*bin_size)+=3;
+    /* If the node is a final one, we add 3 bytes for coding the INF line number */
+    (*bin_size)+=3;
 }
 /* Then we count the transitions */
 node->n_trans=0;
 struct dictionary_node_transition* tmp;
 tmp=node->trans;
 while (tmp!=NULL) {
-	/* For each transition, we count 2 bytes for the letter and 3 bytes for the
-	 * destination offset */
-	(*bin_size)+=5;
-	tmp=tmp->next;
-  	/* We update the number of transitions */
-	(node->n_trans)++;
+    /* For each transition, we count 2 bytes for the letter and 3 bytes for the
+     * destination offset */
+    (*bin_size)+=5;
+    tmp=tmp->next;
+    /* We update the number of transitions */
+    (node->n_trans)++;
 }
 /* Finally, we number all the children of the node */
 tmp=node->trans;
@@ -80,89 +80,89 @@ while (tmp!=NULL) {
  * the fact that information may be encoded in variable ways.
  */
 void number_node_new_style(struct dictionary_node* node,int *bin_size,
-		BinStateEncoding state_encoding,
-		t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
-		int* inf_indirection) {
+        BinStateEncoding state_encoding,
+        t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
+        int* inf_indirection) {
 if (node->offset!=-1) {
-	/* Nothing to do if there is already an offset */
-	return;
+    /* Nothing to do if there is already an offset */
+    return;
 }
 if (node->trans==NULL) {
-	/* No transition? We can give an offset to this state */
-	node->offset=(*bin_size);
-	if (state_encoding==BIN_CLASSIC_STATE) {
-    	/* A classic final state with no transition takes 5 bytes */
-    	(*bin_size)+=5;
+    /* No transition? We can give an offset to this state */
+    node->offset=(*bin_size);
+    if (state_encoding==BIN_CLASSIC_STATE) {
+        /* A classic final state with no transition takes 5 bytes */
+        (*bin_size)+=5;
     } else if (state_encoding==BIN_NEW_STATE) {
-    	/* A new style final state starts with a variable length value
-    	 * representing the finality and the number of transitions.
-    	 * Since there is no transition, this means 1 byte.
-    	 * We then add the space needed by the inf number, if any */
-    	(*bin_size)+=1+bin_get_value_length(inf_indirection[node->INF_code],inf_number_write_function);
+        /* A new style final state starts with a variable length value
+         * representing the finality and the number of transitions.
+         * Since there is no transition, this means 1 byte.
+         * We then add the space needed by the inf number, if any */
+        (*bin_size)+=1+bin_get_value_length(inf_indirection[node->INF_code],inf_number_write_function);
     } else {
-    	/* A .bin2 state has no inf number */
-    	(*bin_size)+=1;
+        /* A .bin2 state has no inf number */
+        (*bin_size)+=1;
     }
-	return;
+    return;
 }
 /* If there are transitions, we have to attribute offsets to all pointed states first */
 struct dictionary_node_transition* tmp;
 tmp=node->trans;
 while (tmp!=NULL) {
-	number_node_new_style(tmp->node,bin_size,state_encoding,char_write_function,inf_number_write_function,offset_write_function,inf_indirection);
-	(node->n_trans)++;
-	tmp=tmp->next;
+    number_node_new_style(tmp->node,bin_size,state_encoding,char_write_function,inf_number_write_function,offset_write_function,inf_indirection);
+    (node->n_trans)++;
+    tmp=tmp->next;
 }
 /* Now, we can securely assign an offset to the current node */
 node->offset=(*bin_size);
 if (state_encoding==BIN_CLASSIC_STATE) {
-	/* A classic state takes 2 bytes */
-	(*bin_size)+=2;
-	/* Plus 3 bytes if it's final */
-	if (node->single_INF_code_list!=NULL) (*bin_size)+=3;
+    /* A classic state takes 2 bytes */
+    (*bin_size)+=2;
+    /* Plus 3 bytes if it's final */
+    if (node->single_INF_code_list!=NULL) (*bin_size)+=3;
 } else if (state_encoding==BIN_NEW_STATE) {
-	/* A new style state starts with a variable length value
-	 * representing the finality and the number of transitions.
-	 * Since there is no transition, this means 1 byte.
-	 * We then add the space needed by the inf number, if any */
-	int value=node->n_trans<<1;
-	(*bin_size)+=bin_get_value_length(value,BIN_VARIABLE);
-	if (node->single_INF_code_list!=NULL) (*bin_size)+=bin_get_value_length(inf_indirection[node->INF_code],inf_number_write_function);
+    /* A new style state starts with a variable length value
+     * representing the finality and the number of transitions.
+     * Since there is no transition, this means 1 byte.
+     * We then add the space needed by the inf number, if any */
+    int value=node->n_trans<<1;
+    (*bin_size)+=bin_get_value_length(value,BIN_VARIABLE);
+    if (node->single_INF_code_list!=NULL) (*bin_size)+=bin_get_value_length(inf_indirection[node->INF_code],inf_number_write_function);
 } else {
-	/* A .bin2 state has no inf number */
-	int value=node->n_trans<<1;
-	(*bin_size)+=bin_get_value_length(value,BIN_VARIABLE);
+    /* A .bin2 state has no inf number */
+    int value=node->n_trans<<1;
+    (*bin_size)+=bin_get_value_length(value,BIN_VARIABLE);
 }
 /* Finally, we update the bin size by taking into account the space
  * needed by the outgoing transitions */
 tmp=node->trans;
 while (tmp!=NULL) {
-	(*bin_size)+=bin_get_value_length(tmp->letter,char_write_function);
-	if (state_encoding!=BIN_BIN2_STATE) {
-		(*bin_size)+=bin_get_value_length(tmp->node->offset,offset_write_function);
-	} else {
-		/* For a .bin2 transition, we use an extra bit to note if there is an output */
-		(*bin_size)+=bin_get_value_length(tmp->node->offset<<1,offset_write_function);
-		if (tmp->output && tmp->output[0]!='\0') {
-			(*bin_size)+=bin_get_string_length(tmp->output,char_write_function);
-		}
-	}
-	tmp=tmp->next;
+    (*bin_size)+=bin_get_value_length(tmp->letter,char_write_function);
+    if (state_encoding!=BIN_BIN2_STATE) {
+        (*bin_size)+=bin_get_value_length(tmp->node->offset,offset_write_function);
+    } else {
+        /* For a .bin2 transition, we use an extra bit to note if there is an output */
+        (*bin_size)+=bin_get_value_length(tmp->node->offset<<1,offset_write_function);
+        if (tmp->output && tmp->output[0]!='\0') {
+            (*bin_size)+=bin_get_string_length(tmp->output,char_write_function);
+        }
+    }
+    tmp=tmp->next;
 }
 }
 
 
 void number_node(struct dictionary_node* root,int *bin_size,int new_style_bin,
-		BinStateEncoding state_encoding,
-		t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
-		int* inf_indirection) {
+        BinStateEncoding state_encoding,
+        t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
+        int* inf_indirection) {
 if (root==NULL) return;
 if (!new_style_bin) {
-	number_node_old_style(root,bin_size);
-	return;
+    number_node_old_style(root,bin_size);
+    return;
 }
 number_node_new_style(root,bin_size,state_encoding,char_write_function,inf_number_write_function,offset_write_function,
-		inf_indirection);
+        inf_indirection);
 }
 
 
@@ -178,13 +178,13 @@ number_node_new_style(root,bin_size,state_encoding,char_write_function,inf_numbe
  * and transitions of the dictionary automaton.
  */
 void fill_bin_array(struct dictionary_node* node,int *n_states,int *n_transitions,
-						unsigned char* bin,int* inf_indirection,
-						BinStateEncoding state_encoding,
-						t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
-						BinType bin_type) {
+                        unsigned char* bin,int* inf_indirection,
+                        BinStateEncoding state_encoding,
+                        t_fnc_bin_write_bytes char_write_function,t_fnc_bin_write_bytes inf_number_write_function,t_fnc_bin_write_bytes offset_write_function,
+                        BinType bin_type) {
 if (node==NULL) return;
 if (node->INF_code==-1) {
-	/* We use this test to know if the node has already been dumped */
+    /* We use this test to know if the node has already been dumped */
    return;
 }
 /* We increase the number of states */
@@ -195,10 +195,10 @@ int pos=node->offset;
 int final=(node->single_INF_code_list!=NULL);
 int inf_code=-1;
 if (final && bin_type==BIN_CLASSIC) {
-	inf_code=inf_indirection[node->INF_code];
-	if (inf_code==-1) {
-		fatal_error("fill_bin_array: Invalid INF line number redirection for code #%d\n",node->INF_code);
-	}
+    inf_code=inf_indirection[node->INF_code];
+    if (inf_code==-1) {
+        fatal_error("fill_bin_array: Invalid INF line number redirection for code #%d\n",node->INF_code);
+    }
 }
 write_dictionary_state(bin,state_encoding,inf_number_write_function,&pos,final,node->n_trans,inf_code);
 /* Then, we assign -1 to 'node->INF_code' in order to mark that the node
@@ -208,14 +208,14 @@ node->INF_code=-1;
 struct dictionary_node_transition* tmp;
 tmp=node->trans;
 while (tmp!=NULL) {
-	/* We increase the number of transitions */
-	(*n_transitions)++;
-	write_dictionary_transition(bin,&pos,char_write_function,offset_write_function,tmp->letter,tmp->node->offset,
-			bin_type,tmp->output);
-	/* And we dump the destination node recursively */
-	fill_bin_array(tmp->node,n_states,n_transitions,bin,inf_indirection,
-			state_encoding,char_write_function,inf_number_write_function,offset_write_function,bin_type);
-	tmp=tmp->next;
+    /* We increase the number of transitions */
+    (*n_transitions)++;
+    write_dictionary_transition(bin,&pos,char_write_function,offset_write_function,tmp->letter,tmp->node->offset,
+            bin_type,tmp->output);
+    /* And we dump the destination node recursively */
+    fill_bin_array(tmp->node,n_states,n_transitions,bin,inf_indirection,
+            state_encoding,char_write_function,inf_number_write_function,offset_write_function,bin_type);
+    tmp=tmp->next;
 }
 }
 
@@ -228,8 +228,8 @@ while (tmp!=NULL) {
  * of the resulting .bin file.
  */
 void create_and_save_bin(struct dictionary_node* root,const char* output,int *n_states,
-						int *n_transitions,int *bin_size,int* inf_indirection,int new_style_bin,
-						BinType bin_type) {
+                        int *n_transitions,int *bin_size,int* inf_indirection,int new_style_bin,
+                        BinType bin_type) {
 U_FILE* f;
 /* The output file must be opened as a binary one */
 f=u_fopen(BINARY,output,U_WRITE);
@@ -246,14 +246,14 @@ BinEncoding inf_number_encoding=BIN_3BYTES;
 BinEncoding offset_encoding=BIN_3BYTES;
 (*bin_size)=BIN_V1_HEADER_SIZE;
 if (new_style_bin) {
-	state_encoding=BIN_NEW_STATE;
-	char_encoding=BIN_VARIABLE;
-	inf_number_encoding=BIN_VARIABLE;
-	offset_encoding=BIN_VARIABLE;
-	(*bin_size)=BIN_V2_HEADER_SIZE;
+    state_encoding=BIN_NEW_STATE;
+    char_encoding=BIN_VARIABLE;
+    inf_number_encoding=BIN_VARIABLE;
+    offset_encoding=BIN_VARIABLE;
+    (*bin_size)=BIN_V2_HEADER_SIZE;
 }
 if (bin_type==BIN_BIN2) {
-	state_encoding=BIN_BIN2_STATE;
+    state_encoding=BIN_BIN2_STATE;
 }
 
 
@@ -264,9 +264,9 @@ t_fnc_bin_write_bytes offset_write_function=get_bin_write_function_for_encoding(
 
 /* We give offsets to the dictionary node and we get the .bin size */
 number_node(root,bin_size,new_style_bin,state_encoding,char_write_function,inf_number_write_function,offset_write_function,
-		inf_indirection);
+        inf_indirection);
 if (!new_style_bin && (*bin_size >= (1<<24))) {
-	fatal_error("The output .bin would be larger than 16Mb. Recompress this dictionary with --v2.\n");
+    fatal_error("The output .bin would be larger than 16Mb. Recompress this dictionary with --v2.\n");
 }
 /* An then we allocate a byte array of the correct size */
 unsigned char* bin=(unsigned char*)malloc((*bin_size)*sizeof(unsigned char));
@@ -276,23 +276,23 @@ if (bin==NULL) {
 for (int i=0;i<*bin_size;i++) bin[i]=0xF1;
 int pos=0;
 if (!new_style_bin) {
-	bin_write_4bytes(bin,*bin_size,&pos);
+    bin_write_4bytes(bin,*bin_size,&pos);
 } else {
-	write_new_bin_header(bin_type,bin,&pos,state_encoding,char_encoding,inf_number_encoding,offset_encoding,root->offset);
+    write_new_bin_header(bin_type,bin,&pos,state_encoding,char_encoding,inf_number_encoding,offset_encoding,root->offset);
 }
 /* Then we fill the 'bin' array */
 fill_bin_array(root,n_states,n_transitions,bin,inf_indirection,
-		state_encoding,char_write_function,inf_number_write_function,offset_write_function,bin_type);
+        state_encoding,char_write_function,inf_number_write_function,offset_write_function,bin_type);
 /* And we dump it to the output file */
 if (fwrite(bin,1,(*bin_size),f)!=(unsigned)(*bin_size)) {
   fatal_error("Error while writing file %s\n",output);
 }
 if (new_style_bin) {
-	/* Adding 4 null bytes to allow an optimization in bin_read_variable_length */
-	uint32_t i=0;
-	if (fwrite(&i,4,1,f)!=1) {
-	    fatal_error("Error while writing file %s\n",output);
-	}
+    /* Adding 4 null bytes to allow an optimization in bin_read_variable_length */
+    uint32_t i=0;
+    if (fwrite(&i,4,1,f)!=1) {
+        fatal_error("Error while writing file %s\n",output);
+    }
 }
 u_fclose(f);
 free(bin);

--- a/BitArray.cpp
+++ b/BitArray.cpp
@@ -74,7 +74,7 @@ free_cb(bit_array,prv_alloc);
 /**
  * Associates 'value' to the 'n'th element of the given bit array.
  * A fatal error will be raised if 'n' is not in the bounds
- * of the array or if 'value' is not compatible with the 
+ * of the array or if 'value' is not compatible with the
  * information length of the array.
  */
 void set_value(struct bit_array* array,int n,int value) {

--- a/BitArray.cpp
+++ b/BitArray.cpp
@@ -39,7 +39,7 @@ namespace unitex {
 struct bit_array* new_bit_array(int number_of_elements,InfoLength info_length,Abstract_allocator prv_alloc) {
 struct bit_array* bit_array=(struct bit_array*)malloc_cb(sizeof(struct bit_array),prv_alloc);
 if (bit_array==NULL) {
-	fatal_alloc_error("new_bit_array");
+    fatal_alloc_error("new_bit_array");
 }
 if (number_of_elements<0) {
    fatal_error("Invalid number of elements (%d) in new_bit_array\n",number_of_elements);
@@ -53,7 +53,7 @@ switch(info_length) {
 bit_array->size_in_bytes=(number_of_elements/bit_array->divider)+1;
 bit_array->array=(unsigned char*)malloc_cb(sizeof(unsigned char)*(bit_array->size_in_bytes),prv_alloc);
 if (bit_array->array==NULL) {
-	fatal_alloc_error("new_bit_array");
+    fatal_alloc_error("new_bit_array");
 }
 memset(bit_array->array,0,sizeof(unsigned char)*(bit_array->size_in_bytes));
 bit_array->info_length=info_length;

--- a/BitArray.h
+++ b/BitArray.h
@@ -43,16 +43,16 @@ typedef enum length_ InfoLength;
 
 
 /**
- * This structure represents a bit array. This can be used for encoding 1-bit, 2-bits 
- * or 4-bits information without wasting space. Its is defined by the number of 
- * elements to be encoded, the actual size in bytes of the array and the length (1, 2 or 4 bits) 
+ * This structure represents a bit array. This can be used for encoding 1-bit, 2-bits
+ * or 4-bits information without wasting space. Its is defined by the number of
+ * elements to be encoded, the actual size in bytes of the array and the length (1, 2 or 4 bits)
  * of one information. 'divider' is the divider that corresponds to the length. Its possible
  * values are respectively 8, 4 and 2.
  */
 struct bit_array {
-	int size_in_elements;
+    int size_in_elements;
    int size_in_bytes;
-	unsigned char* array;
+    unsigned char* array;
    InfoLength info_length;
    int divider;
 };

--- a/Buffer.cpp
+++ b/Buffer.cpp
@@ -38,7 +38,7 @@ namespace unitex {
 struct buffer* new_buffer(int capacity,BufferType type) {
 struct buffer* buffer=(struct buffer*)malloc(sizeof(struct buffer));
 if (buffer==NULL) {
-	fatal_alloc_error("new_buffer");
+    fatal_alloc_error("new_buffer");
 }
 buffer->type=type;
 switch (type) {
@@ -73,13 +73,13 @@ struct buffer* new_buffer_for_file(BufferType type,U_FILE* fileread,int capacity
 int item_size=1;
 switch (type) {
    case INTEGER_BUFFER:
-	   item_size = sizeof(int);
-	   break;
+       item_size = sizeof(int);
+       break;
    case UNICHAR_BUFFER:
        int is_UTF16 = u_is_UTF16(fileread);
        if ((is_UTF16 == UTF16_LITTLE_ENDIAN_FILE) || (is_UTF16 == UTF16_BIG_ENDIAN_FILE))
            item_size = sizeof(unichar);
-	   break;
+       break;
 }
 long save_pos=ftell(fileread);
 fseek(fileread,0,SEEK_END);
@@ -87,7 +87,7 @@ long file_size=ftell(fileread);
 fseek(fileread,save_pos,SEEK_SET);
 int capacity=(int)((file_size/item_size)+0x10);
 if ((capacity_limit != 0) && (capacity>capacity_limit)) {
-	capacity=capacity_limit;
+    capacity=capacity_limit;
 }
 return new_buffer(capacity,type);
 }
@@ -201,25 +201,25 @@ return fill_buffer(buffer,buffer->MAXIMUM_BUFFER_SIZE,0,f);
 
 
 int fill_buffer(struct buffer* buffer, int pos, U_FILE* f) {
-	return fill_buffer(buffer, pos, 0, f);
+    return fill_buffer(buffer, pos, 0, f);
 }
 
 
 int fill_buffer_raw(struct buffer* buffer, U_FILE* f) {
-	return fill_buffer(buffer, buffer->MAXIMUM_BUFFER_SIZE, 1, f);
+    return fill_buffer(buffer, buffer->MAXIMUM_BUFFER_SIZE, 1, f);
 }
 
 
 int fill_buffer_raw(struct buffer* buffer, int pos, U_FILE* f) {
-	return fill_buffer(buffer, pos, 1, f);
+    return fill_buffer(buffer, pos, 1, f);
 }
 
 int fill_buffer_keepCR_option(struct buffer* buffer, int pos, int keep_cr, U_FILE* f) {
-	return fill_buffer(buffer, pos, keep_cr, f);
+    return fill_buffer(buffer, pos, keep_cr, f);
 }
 
 int fill_buffer_keepCR_option(struct buffer* buffer, int keep_cr, U_FILE* f) {
-	return fill_buffer(buffer, buffer->MAXIMUM_BUFFER_SIZE, keep_cr, f);
+    return fill_buffer(buffer, buffer->MAXIMUM_BUFFER_SIZE, keep_cr, f);
 }
 
 

--- a/Buffer.h
+++ b/Buffer.h
@@ -46,12 +46,12 @@ typedef enum buffer_type_ BufferType;
  */
 struct buffer {
    BufferType type;
-	int MAXIMUM_BUFFER_SIZE;
+    int MAXIMUM_BUFFER_SIZE;
    union {
-	   int* int_buffer;
+       int* int_buffer;
       unichar* unichar_buffer;
    };
-	int size;
+    int size;
    int end_of_file;
 };
 

--- a/BuildKrMwuDic.cpp
+++ b/BuildKrMwuDic.cpp
@@ -73,7 +73,7 @@ const struct option_TS lopts_BuildKrMwuDic[]= {
   {"output",required_argument_TS,NULL,'o'},
   {"directory",required_argument_TS,NULL,'d'},
   {"alphabet",required_argument_TS,NULL,'a'},
-  {"binary",required_argument_TS,NULL,'b'},      
+  {"binary",required_argument_TS,NULL,'b'},
   {"only_verify_arguments",no_argument_TS,NULL,'V'},
   {"help",no_argument_TS,NULL,'h'},
   {"always-recompile-graphs",no_argument_TS,NULL,'f'},
@@ -140,7 +140,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_BuildKrMwuDic,lopts_Buil
              break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 'f': graph_recompilation_policy = ALWAYS_RECOMPILE; break;
    case 'n': graph_recompilation_policy = NEVER_RECOMPILE;  break;
@@ -188,7 +188,7 @@ if (dic_bin[0]=='\0') {
 }
 
 if (only_verify_arguments) {
-  // freeing all allocated memory 
+  // freeing all allocated memory
   return SUCCESS_RETURN_CODE;
 }
 
@@ -201,7 +201,7 @@ if (delas==NULL) {
 U_FILE* grf=u_fopen(&vec,output,U_WRITE);
 if (grf==NULL) {
    error("Cannot open %s\n",output);
-   u_fclose(delas);  
+   u_fclose(delas);
    return DEFAULT_ERROR_CODE;
 }
 

--- a/BuildTextAutomaton.cpp
+++ b/BuildTextAutomaton.cpp
@@ -49,13 +49,13 @@ namespace unitex {
  * given buffer.
  */
 int count_non_space_tokens(const int* buffer, int length, int SPACE) {
-	int n = 0;
-	for (int i = 0; i < length; i++) {
-		if (buffer[i] != SPACE) {
-			n++;
-		}
-	}
-	return n;
+    int n = 0;
+    for (int i = 0; i < length; i++) {
+        if (buffer[i] != SPACE) {
+            n++;
+        }
+    }
+    return n;
 }
 
 /**
@@ -76,92 +76,92 @@ int count_non_space_tokens(const int* buffer, int length, int SPACE) {
  * in the token buffer. 'tmp_tags' represents the tags of the current graph.
  */
 void explore_dictionary_tree(int pos, const unichar* token, unichar* inflected,
-		int pos_inflected, const struct string_hash_tree_node* n,
-		const struct DELA_tree* tree, struct info* INFO,
-		SingleGraphState state, int shift, int start_state_index,
-		int *is_not_unknown_token, int first_token_index,
-		int current_token_index, struct string_hash* tmp_tags, Ustring* foo,
-		language_t* language, unichar* tag_buffer) {
-	if (token[pos] == '\0') {
-		if (shift == 1 && n->value_index != -1) {
-			/* If we are on the first token and if there are some DELA entries for it,
-			 * then it is not an unknown one */
-			(*is_not_unknown_token) = 1;
-		}
-		struct dela_entry_list* list = NULL;
-		if (n->value_index != -1)
-			list = tree->dela_entries[n->value_index];
-		inflected[pos_inflected] = '\0';
-		while (list != NULL) {
-			/* If there are DELA entries for the current inflected form,
-			 * we add the corresponding transitions to the automaton */
-			struct dela_entry* entry = list->entry;
-			if (language != NULL) {
-				entry = filter_dela_entry(list->entry, NULL, language, 0);
-			}
-			if (entry != NULL) {
-				//unichar tag[4096];
-				unichar* tag = tag_buffer;
-				build_tag(entry, inflected, tag);
-				u_sprintf(foo, "@STD\n@%S\n@%d.0.0-%d.%d.0\n.\n", tag,
-						first_token_index, current_token_index, pos - 1);
-				add_outgoing_transition(state, get_value_index(foo->str,
-						tmp_tags), start_state_index + shift);
-				if (entry != list->entry) {
-					free_dela_entry(entry);
-				}
-			}
-			list = list->next;
-		}
-		/* We try to go on with the next token in the sentence */
-		if (current_token_index < INFO->length_max - 1) {
-			/* but only if we are not at the end of the sentence */
-			if (INFO->buffer[current_token_index] != INFO->SPACE) {
-				/* The states do not take spaces into acccount, so, if we have read
-				 * a space, we do nothing; otherwise, we can move one state right */
-				shift++;
-			}
-			current_token_index++;
-			explore_dictionary_tree(0,
-					INFO->tok->token[INFO->buffer[current_token_index]],
-					inflected, pos_inflected, n, tree, INFO, state, shift,
-					start_state_index, is_not_unknown_token, first_token_index,
-					current_token_index, tmp_tags, foo, language, tag_buffer);
-		}
-		return;
-	}
-	struct string_hash_tree_transition* trans = n->trans;
-	inflected[pos_inflected] = token[pos];
-	while (trans != NULL) {
-		if (is_equal_or_uppercase(trans->letter, token[pos], INFO->alph)) {
-			/* For each transition, we follow it if its letter matches the
-			 * token one */
-			explore_dictionary_tree(pos + 1, token, inflected, pos_inflected
-					+ 1, trans->node, tree, INFO, state, shift,
-					start_state_index, is_not_unknown_token, first_token_index,
-					current_token_index, tmp_tags, foo, language, tag_buffer);
-		}
-		trans = trans->next;
-	}
+        int pos_inflected, const struct string_hash_tree_node* n,
+        const struct DELA_tree* tree, struct info* INFO,
+        SingleGraphState state, int shift, int start_state_index,
+        int *is_not_unknown_token, int first_token_index,
+        int current_token_index, struct string_hash* tmp_tags, Ustring* foo,
+        language_t* language, unichar* tag_buffer) {
+    if (token[pos] == '\0') {
+        if (shift == 1 && n->value_index != -1) {
+            /* If we are on the first token and if there are some DELA entries for it,
+             * then it is not an unknown one */
+            (*is_not_unknown_token) = 1;
+        }
+        struct dela_entry_list* list = NULL;
+        if (n->value_index != -1)
+            list = tree->dela_entries[n->value_index];
+        inflected[pos_inflected] = '\0';
+        while (list != NULL) {
+            /* If there are DELA entries for the current inflected form,
+             * we add the corresponding transitions to the automaton */
+            struct dela_entry* entry = list->entry;
+            if (language != NULL) {
+                entry = filter_dela_entry(list->entry, NULL, language, 0);
+            }
+            if (entry != NULL) {
+                //unichar tag[4096];
+                unichar* tag = tag_buffer;
+                build_tag(entry, inflected, tag);
+                u_sprintf(foo, "@STD\n@%S\n@%d.0.0-%d.%d.0\n.\n", tag,
+                        first_token_index, current_token_index, pos - 1);
+                add_outgoing_transition(state, get_value_index(foo->str,
+                        tmp_tags), start_state_index + shift);
+                if (entry != list->entry) {
+                    free_dela_entry(entry);
+                }
+            }
+            list = list->next;
+        }
+        /* We try to go on with the next token in the sentence */
+        if (current_token_index < INFO->length_max - 1) {
+            /* but only if we are not at the end of the sentence */
+            if (INFO->buffer[current_token_index] != INFO->SPACE) {
+                /* The states do not take spaces into acccount, so, if we have read
+                 * a space, we do nothing; otherwise, we can move one state right */
+                shift++;
+            }
+            current_token_index++;
+            explore_dictionary_tree(0,
+                    INFO->tok->token[INFO->buffer[current_token_index]],
+                    inflected, pos_inflected, n, tree, INFO, state, shift,
+                    start_state_index, is_not_unknown_token, first_token_index,
+                    current_token_index, tmp_tags, foo, language, tag_buffer);
+        }
+        return;
+    }
+    struct string_hash_tree_transition* trans = n->trans;
+    inflected[pos_inflected] = token[pos];
+    while (trans != NULL) {
+        if (is_equal_or_uppercase(trans->letter, token[pos], INFO->alph)) {
+            /* For each transition, we follow it if its letter matches the
+             * token one */
+            explore_dictionary_tree(pos + 1, token, inflected, pos_inflected
+                    + 1, trans->node, tree, INFO, state, shift,
+                    start_state_index, is_not_unknown_token, first_token_index,
+                    current_token_index, tmp_tags, foo, language, tag_buffer);
+        }
+        trans = trans->next;
+    }
 }
 
 /**
  * Returns 1 if the given tag description seems to describe a {xx,xx.xx} tag; 0 otherwise.
  */
 int is_high_weight_tag(unichar* s) {
-	if (u_starts_with(s, "@<E>\n")) {
-		/* If we have an EPSILON tag, we consider it as a normal tag, in order
-		 * not to penalize the best path heuristic */
-		return 1;
-	}
-	if (u_starts_with(s, "@STD\n")) {
-		if (s[6] == '{' && s[7] != '\n') {
-			return 1;
-		}
-		return 0;
-	}
-	fatal_error("Unsupported tag type in is_high_weight_tag\n");
-	return 0;
+    if (u_starts_with(s, "@<E>\n")) {
+        /* If we have an EPSILON tag, we consider it as a normal tag, in order
+         * not to penalize the best path heuristic */
+        return 1;
+    }
+    if (u_starts_with(s, "@STD\n")) {
+        if (s[6] == '{' && s[7] != '\n') {
+            return 1;
+        }
+        return 0;
+    }
+    fatal_error("Unsupported tag type in is_high_weight_tag\n");
+    return 0;
 }
 
 /**
@@ -170,38 +170,38 @@ int is_high_weight_tag(unichar* s) {
  * numbers of tokens are stored in 'weight'.
  */
 void compute_best_paths(int state, SingleGraph graph, int* weight,
-		struct string_hash* tmp_tags) {
-	int w;
-	w = weight[state];
-	Transition* trans = graph->states[state]->outgoing_transitions;
-	while (trans != NULL) {
-		unichar* tmp = tmp_tags->value[trans->tag_number];
-		int w_tmp = w;
-		if (!is_high_weight_tag(tmp)) {
-			/* If the transition is tagged by an unknown token made of letters */
-			w_tmp = w_tmp + 1;
-		}
-		if (w_tmp < weight[trans->state_number]) {
-			/* If we have a better path than the existing one, we keep it */
-			weight[trans->state_number] = w_tmp;
-			/* and we mark the destination state as modified */
-			set_bit_mask(&(graph->states[trans->state_number]->control),
-					MARK1_BIT_MASK);
-		}
-		trans = trans->next;
-	}
-	trans = graph->states[state]->outgoing_transitions;
-	while (trans != NULL) {
-		if (is_bit_mask_set(graph->states[trans->state_number]->control,
-				MARK1_BIT_MASK)) {
-			/* If the state was modified, we reset its control value */
-			unset_bit_mask(&(graph->states[trans->state_number]->control),
-					MARK1_BIT_MASK);
-			/* and we explore it recursively */
-			compute_best_paths(trans->state_number, graph, weight, tmp_tags);
-		}
-		trans = trans->next;
-	}
+        struct string_hash* tmp_tags) {
+    int w;
+    w = weight[state];
+    Transition* trans = graph->states[state]->outgoing_transitions;
+    while (trans != NULL) {
+        unichar* tmp = tmp_tags->value[trans->tag_number];
+        int w_tmp = w;
+        if (!is_high_weight_tag(tmp)) {
+            /* If the transition is tagged by an unknown token made of letters */
+            w_tmp = w_tmp + 1;
+        }
+        if (w_tmp < weight[trans->state_number]) {
+            /* If we have a better path than the existing one, we keep it */
+            weight[trans->state_number] = w_tmp;
+            /* and we mark the destination state as modified */
+            set_bit_mask(&(graph->states[trans->state_number]->control),
+                    MARK1_BIT_MASK);
+        }
+        trans = trans->next;
+    }
+    trans = graph->states[state]->outgoing_transitions;
+    while (trans != NULL) {
+        if (is_bit_mask_set(graph->states[trans->state_number]->control,
+                MARK1_BIT_MASK)) {
+            /* If the state was modified, we reset its control value */
+            unset_bit_mask(&(graph->states[trans->state_number]->control),
+                    MARK1_BIT_MASK);
+            /* and we explore it recursively */
+            compute_best_paths(trans->state_number, graph, weight, tmp_tags);
+        }
+        trans = trans->next;
+    }
 }
 
 /**
@@ -212,21 +212,21 @@ void compute_best_paths(int state, SingleGraph graph, int* weight,
  * those that reach a state #x with a weight > weight[x].
  */
 Transition* remove_bad_path_transitions(int min_weight, Transition* trans,
-		SingleGraph graph, int* weight, struct string_hash* tmp_tags) {
-	if (trans == NULL)
-		return NULL;
-	unichar* s = tmp_tags->value[trans->tag_number];
-	if ((!is_high_weight_tag(s) && weight[trans->state_number] < (min_weight
-			+ 1)) || (weight[trans->state_number] < min_weight)) {
-		/* If we have to remove the transition */
-		Transition* tmp = trans->next;
-		free(trans);
-		return remove_bad_path_transitions(min_weight, tmp, graph, weight,
-				tmp_tags);
-	}
-	trans->next = remove_bad_path_transitions(min_weight, trans->next, graph,
-			weight, tmp_tags);
-	return trans;
+        SingleGraph graph, int* weight, struct string_hash* tmp_tags) {
+    if (trans == NULL)
+        return NULL;
+    unichar* s = tmp_tags->value[trans->tag_number];
+    if ((!is_high_weight_tag(s) && weight[trans->state_number] < (min_weight
+            + 1)) || (weight[trans->state_number] < min_weight)) {
+        /* If we have to remove the transition */
+        Transition* tmp = trans->next;
+        free(trans);
+        return remove_bad_path_transitions(min_weight, tmp, graph, weight,
+                tmp_tags);
+    }
+    trans->next = remove_bad_path_transitions(min_weight, trans->next, graph,
+            weight, tmp_tags);
+    return trans;
 }
 
 /**
@@ -242,26 +242,26 @@ Transition* remove_bad_path_transitions(int min_weight, Transition* trans,
  * ("Aujourd") while the second contains none.
  */
 void keep_best_paths(SingleGraph graph, struct string_hash* tmp_tags) {
-	int i;
-	int* weight = (int*) malloc(sizeof(int) * graph->number_of_states);
-	if (weight == NULL) {
-		fatal_alloc_error("keep_best_paths");
-	}
-	/* We initialize the initial state with 0 untagged transition */
-	weight[0] = 0;
-	/* and all other states with a value that is larger that the
-	 * longest possible path. As the automaton is acyclic, the longest
-	 * path cannot be greater than the number of states */
-	for (i = 1; i < graph->number_of_states; i++) {
-		weight[i] = graph->number_of_states;
-	}
-	compute_best_paths(0, graph, weight, tmp_tags);
-	for (i = 0; i < graph->number_of_states; i++) {
-		graph->states[i]->outgoing_transitions = remove_bad_path_transitions(
-				weight[i], graph->states[i]->outgoing_transitions, graph,
-				weight, tmp_tags);
-	}
-	free(weight);
+    int i;
+    int* weight = (int*) malloc(sizeof(int) * graph->number_of_states);
+    if (weight == NULL) {
+        fatal_alloc_error("keep_best_paths");
+    }
+    /* We initialize the initial state with 0 untagged transition */
+    weight[0] = 0;
+    /* and all other states with a value that is larger that the
+     * longest possible path. As the automaton is acyclic, the longest
+     * path cannot be greater than the number of states */
+    for (i = 1; i < graph->number_of_states; i++) {
+        weight[i] = graph->number_of_states;
+    }
+    compute_best_paths(0, graph, weight, tmp_tags);
+    for (i = 0; i < graph->number_of_states; i++) {
+        graph->states[i]->outgoing_transitions = remove_bad_path_transitions(
+                weight[i], graph->states[i]->outgoing_transitions, graph,
+                weight, tmp_tags);
+    }
+    free(weight);
 }
 
 
@@ -270,49 +270,49 @@ void keep_best_paths(SingleGraph graph, struct string_hash* tmp_tags) {
  * Allocates, initializes and returns a struct output_info*
  */
 struct output_info* new_output_info(unichar* tag) {
-	if (tag == NULL) {
-		fatal_error("Invalid NULL tag in new_output_info\n");
-	}
-	struct output_info* x = (struct output_info*) malloc(
-			sizeof(struct output_info));
-	if (x == NULL) {
-		fatal_alloc_error("new_output_info");
-	}
-	x->output = u_strdup(tag);
-	if (tag[0] == '{' && tag[1] != '\0') {
-		struct dela_entry* entry = tokenize_tag_token(tag,1);
-		if (entry == NULL) {
-			free_dela_entry(entry);
-			free(x->output);
-			free(x);
-			error("new_output_info: Invalid tag token %S\n", tag);
-			return NULL;
-		}
-		x->content = u_strdup(entry->inflected);
-		free_dela_entry(entry);
-	} else {
-		x->content = u_strdup(tag);
-	}
-	x->start_pos = -1;
-	x->end_pos = -1;
-	x->start_pos_char = -1;
-	x->end_pos_char = -1;
-	/* We can initialize xxx_letter fields to 0, because in non Korean mode, there
-	 * is exactly one letter per character. Korean case will be especially handled */
-	x->start_pos_letter = 0;
-	x->end_pos_letter = 0;
-	return x;
+    if (tag == NULL) {
+        fatal_error("Invalid NULL tag in new_output_info\n");
+    }
+    struct output_info* x = (struct output_info*) malloc(
+            sizeof(struct output_info));
+    if (x == NULL) {
+        fatal_alloc_error("new_output_info");
+    }
+    x->output = u_strdup(tag);
+    if (tag[0] == '{' && tag[1] != '\0') {
+        struct dela_entry* entry = tokenize_tag_token(tag,1);
+        if (entry == NULL) {
+            free_dela_entry(entry);
+            free(x->output);
+            free(x);
+            error("new_output_info: Invalid tag token %S\n", tag);
+            return NULL;
+        }
+        x->content = u_strdup(entry->inflected);
+        free_dela_entry(entry);
+    } else {
+        x->content = u_strdup(tag);
+    }
+    x->start_pos = -1;
+    x->end_pos = -1;
+    x->start_pos_char = -1;
+    x->end_pos_char = -1;
+    /* We can initialize xxx_letter fields to 0, because in non Korean mode, there
+     * is exactly one letter per character. Korean case will be especially handled */
+    x->start_pos_letter = 0;
+    x->end_pos_letter = 0;
+    return x;
 }
 
 /**
  * Frees all the memory associated to the given struct output_info*
  */
 void free_output_info(struct output_info* x) {
-	if (x == NULL)
-		return;
-	free(x->output);
-	free(x->content);
-	free(x);
+    if (x == NULL)
+        return;
+    free(x->output);
+    free(x->content);
+    free(x);
 }
 
 /**
@@ -324,62 +324,62 @@ void free_output_info(struct output_info* x) {
  * The vector contains struct output_info*
  */
 vector_ptr* tokenize_normalization_output(unichar* s, const Alphabet* alph) {
-	if (s == NULL)
-		return NULL;
-	vector_ptr* result = new_vector_ptr(4);
-	unichar tmp[2048];
-	int i;
-	int j;
-	i = 0;
-	while (s[i] != '\0') {
-		while (s[i] == ' ') {
-			/* We ignore spaces */
-			i++;
-		}
-		if (s[i] != '\0') {
-			/* If we are not at the end of the string */
-			if (s[i] == '{') {
-				/* Case of a tag like "{de,.PREP}" */
-				j = 0;
-				while (s[i] != '\0' && s[i] != '}') {
-					tmp[j++] = s[i++];
-				}
-				if (s[i] != '\0') {
-					/* The end of string is an error (no closing '}'), so we save the
-					 * tag only if it is a valid one */
-					tmp[j] = '}';
-					tmp[j + 1] = '\0';
-					/* We go on the next char */
-					i++;
-					struct output_info* foo=new_output_info(tmp);
-					if (foo!=NULL) vector_ptr_add(result, foo);
-				}
-			} else if (is_letter(s[i], alph)) {
-				/* Case of a letter sequence like "Rivoli" */
-				j = 0;
-				while (is_letter(s[i], alph)) {
-					tmp[j++] = s[i++];
-				}
-				tmp[j] = '\0';
-				/* We don't have to go on the next char, we are already on it */
-				struct output_info* foo=new_output_info(tmp);
-				if (foo!=NULL) vector_ptr_add(result, foo);
-			} else {
-				/* Case of a single non-space char like "-" */
-				tmp[0] = s[i];
-				tmp[1] = '\0';
-				/* We go on the next char of the string */
-				i++;
-				struct output_info* foo=new_output_info(tmp);
-				if (foo!=NULL) vector_ptr_add(result, foo);
-			}
-		}
-	}
-	if (result->nbelems == 0) {
-		free_vector_ptr(result, (void(*)(void*)) free_output_info);
-		return NULL;
-	}
-	return result;
+    if (s == NULL)
+        return NULL;
+    vector_ptr* result = new_vector_ptr(4);
+    unichar tmp[2048];
+    int i;
+    int j;
+    i = 0;
+    while (s[i] != '\0') {
+        while (s[i] == ' ') {
+            /* We ignore spaces */
+            i++;
+        }
+        if (s[i] != '\0') {
+            /* If we are not at the end of the string */
+            if (s[i] == '{') {
+                /* Case of a tag like "{de,.PREP}" */
+                j = 0;
+                while (s[i] != '\0' && s[i] != '}') {
+                    tmp[j++] = s[i++];
+                }
+                if (s[i] != '\0') {
+                    /* The end of string is an error (no closing '}'), so we save the
+                     * tag only if it is a valid one */
+                    tmp[j] = '}';
+                    tmp[j + 1] = '\0';
+                    /* We go on the next char */
+                    i++;
+                    struct output_info* foo=new_output_info(tmp);
+                    if (foo!=NULL) vector_ptr_add(result, foo);
+                }
+            } else if (is_letter(s[i], alph)) {
+                /* Case of a letter sequence like "Rivoli" */
+                j = 0;
+                while (is_letter(s[i], alph)) {
+                    tmp[j++] = s[i++];
+                }
+                tmp[j] = '\0';
+                /* We don't have to go on the next char, we are already on it */
+                struct output_info* foo=new_output_info(tmp);
+                if (foo!=NULL) vector_ptr_add(result, foo);
+            } else {
+                /* Case of a single non-space char like "-" */
+                tmp[0] = s[i];
+                tmp[1] = '\0';
+                /* We go on the next char of the string */
+                i++;
+                struct output_info* foo=new_output_info(tmp);
+                if (foo!=NULL) vector_ptr_add(result, foo);
+            }
+        }
+    }
+    if (result->nbelems == 0) {
+        free_vector_ptr(result, (void(*)(void*)) free_output_info);
+        return NULL;
+    }
+    return result;
 }
 
 /* This value must be negative */
@@ -393,223 +393,223 @@ vector_ptr* tokenize_normalization_output(unichar* s, const Alphabet* alph) {
  * fight with inner mysteries of Korean Hangul/Jamo tricks. Trust me.
  */
 void solve_alignment_puzzle_for_Korean(vector_ptr* vector, int start, int end,
-		struct info* INFO, Korean* korean, unichar* output) {
-	if (vector == NULL) {
-		fatal_error("NULL vector in solve_alignment_puzzle\n");
-	}
-	if (vector->nbelems == 0) {
-		fatal_error("Empty vector in solve_alignment_puzzle\n");
-	}
-	struct output_info** tab = (struct output_info**) vector->tab;
+        struct info* INFO, Korean* korean, unichar* output) {
+    if (vector == NULL) {
+        fatal_error("NULL vector in solve_alignment_puzzle\n");
+    }
+    if (vector->nbelems == 0) {
+        fatal_error("Empty vector in solve_alignment_puzzle\n");
+    }
+    struct output_info** tab = (struct output_info**) vector->tab;
 
-	if (vector->nbelems == 1) {
-		/* If there is only one tag, there is no puzzle to solve */
-		tab[0]->start_pos = start;
-		tab[0]->start_pos_char = 0;
-		tab[0]->end_pos = end;
-		tab[0]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
-				- 1;
-		tab[0]->end_pos_letter = get_length_in_jamo(
-				INFO->tok->token[INFO->buffer[end]][tab[0]->end_pos_char],
-				korean) - 1;
-		return;
-	}
+    if (vector->nbelems == 1) {
+        /* If there is only one tag, there is no puzzle to solve */
+        tab[0]->start_pos = start;
+        tab[0]->start_pos_char = 0;
+        tab[0]->end_pos = end;
+        tab[0]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
+                - 1;
+        tab[0]->end_pos_letter = get_length_in_jamo(
+                INFO->tok->token[INFO->buffer[end]][tab[0]->end_pos_char],
+                korean) - 1;
+        return;
+    }
 
-	/* We try to find an exact match (modulo case variations) between the text and the tags' content */
-	int current_token = start;
-	int current_tag = 0;
-	int current_pos_in_char_in_token = 0;
-	/* Warning: the next 2 variable are not to be confused.
-	 * - current_index_in_jamo_token is the index used to browse the jamo string
-	 * - current_pos_in_letter_in_token is not the same, since it does not take syllable bounds
-	 *   into account. Moreover, this one is reinitialized to 0 everytime we cross a syllable
-	 *   bound
-	 */
-	int current_index_in_jamo_token = 0;
-	int current_pos_in_letter_in_token = 0;
-	/* The same for the next 2 variables */
-	int current_index_in_jamo_tag = 0;
+    /* We try to find an exact match (modulo case variations) between the text and the tags' content */
+    int current_token = start;
+    int current_tag = 0;
+    int current_pos_in_char_in_token = 0;
+    /* Warning: the next 2 variable are not to be confused.
+     * - current_index_in_jamo_token is the index used to browse the jamo string
+     * - current_pos_in_letter_in_token is not the same, since it does not take syllable bounds
+     *   into account. Moreover, this one is reinitialized to 0 everytime we cross a syllable
+     *   bound
+     */
+    int current_index_in_jamo_token = 0;
+    int current_pos_in_letter_in_token = 0;
+    /* The same for the next 2 variables */
+    int current_index_in_jamo_tag = 0;
 
-	tab[current_tag]->start_pos = current_token;
-	tab[current_tag]->start_pos_char = 0;
-	unichar* token = INFO->tok->token[INFO->buffer[current_token]];
-	unichar jamo_token[256];
-	unichar jamo_tag[256];
-	Hanguls_to_Jamos(token, jamo_token, korean, 0);
-	if (!u_strcmp(tab[current_tag]->content, "<E>")) {
-		fatal_error(
-				"solve_alignment_puzzle_for_Korean: {<E>,xxx.yyy} tag is not supposed to start a tag sequence at line:\n%S\n",
-				output);
-	}
-	Hanguls_to_Jamos(tab[current_tag]->content, jamo_tag, korean, 0);
+    tab[current_tag]->start_pos = current_token;
+    tab[current_tag]->start_pos_char = 0;
+    unichar* token = INFO->tok->token[INFO->buffer[current_token]];
+    unichar jamo_token[256];
+    unichar jamo_tag[256];
+    Hanguls_to_Jamos(token, jamo_token, korean, 0);
+    if (!u_strcmp(tab[current_tag]->content, "<E>")) {
+        fatal_error(
+                "solve_alignment_puzzle_for_Korean: {<E>,xxx.yyy} tag is not supposed to start a tag sequence at line:\n%S\n",
+                output);
+    }
+    Hanguls_to_Jamos(tab[current_tag]->content, jamo_tag, korean, 0);
 
-	int everything_still_OK = 1;
-	while (everything_still_OK) {
-		if (jamo_tag[current_index_in_jamo_tag] == '\0') {
-			/* If we are at the end of a tag */
-			tab[current_tag]->end_pos = current_token;
-			tab[current_tag]->end_pos_char = current_pos_in_char_in_token;
-			/* letter-1 because we moved on */
-			tab[current_tag]->end_pos_letter = current_pos_in_letter_in_token
-					- 1;
-			if (current_tag == vector->nbelems - 1) {
-				/* If we are at the end of the last tag, we must also be
-				 * at the end of the last token if we want to have a perfect alignment */
-				if (current_token == end
-						&& jamo_token[current_index_in_jamo_token] == '\0') {
-					return;
-				}
-				break;
-			}
-			/* We are not at the last tag, so we have to move to the next tag.
-			 * However, we have to deal with the special case of tags like
-			 * {<E>,xx.yy}. For those tags, we don't move in the text token,
-			 * and we have to set end_pos_letter=-1. As we don't know if several
-			 * <E> tags can be combined, we use a loop for safety */
-			for (;;) {
-				if (current_tag == vector->nbelems - 1) {
-					/* We have taken the loop more than once, and we have reached the last tag.
-					 * Then, we must also be at the end of the last token if we want to have a
-					 * perfect alignment */
-					if (current_token == end
-							&& jamo_token[current_index_in_jamo_token] == '\0') {
-						return;
-					}
-					/* If not, we fail */
-					everything_still_OK = 0;
-					break;
-				}
-				current_tag++;
-				tab[current_tag]->start_pos = current_token;
-				tab[current_tag]->start_pos_char = UNDEF_KR_TAG_START;//current_pos_in_char_in_token;
-				tab[current_tag]->start_pos_letter = UNDEF_KR_TAG_START;//current_pos_in_letter_in_token;
-				current_index_in_jamo_tag = 0;
-				if (!u_strcmp(tab[current_tag]->content, "<E>")) {
-					/* If we have a {<E>,xx.yy} tag */
-					tab[current_tag]->start_pos_char
-							= current_pos_in_char_in_token;
-					tab[current_tag]->start_pos_letter
-							= current_pos_in_letter_in_token - 1;
-					tab[current_tag]->end_pos = tab[current_tag]->start_pos;
-					tab[current_tag]->end_pos_char
-							= tab[current_tag]->start_pos_char;
-					tab[current_tag]->end_pos_letter = -1;
-				} else {
-					/* We have a non <E> tag, so we can set 'jamo_tag' and get out of the for(;;) loop */
-					Hanguls_to_Jamos(tab[current_tag]->content, jamo_tag,
-							korean, 0);
-					break;
-				}
+    int everything_still_OK = 1;
+    while (everything_still_OK) {
+        if (jamo_tag[current_index_in_jamo_tag] == '\0') {
+            /* If we are at the end of a tag */
+            tab[current_tag]->end_pos = current_token;
+            tab[current_tag]->end_pos_char = current_pos_in_char_in_token;
+            /* letter-1 because we moved on */
+            tab[current_tag]->end_pos_letter = current_pos_in_letter_in_token
+                    - 1;
+            if (current_tag == vector->nbelems - 1) {
+                /* If we are at the end of the last tag, we must also be
+                 * at the end of the last token if we want to have a perfect alignment */
+                if (current_token == end
+                        && jamo_token[current_index_in_jamo_token] == '\0') {
+                    return;
+                }
+                break;
+            }
+            /* We are not at the last tag, so we have to move to the next tag.
+             * However, we have to deal with the special case of tags like
+             * {<E>,xx.yy}. For those tags, we don't move in the text token,
+             * and we have to set end_pos_letter=-1. As we don't know if several
+             * <E> tags can be combined, we use a loop for safety */
+            for (;;) {
+                if (current_tag == vector->nbelems - 1) {
+                    /* We have taken the loop more than once, and we have reached the last tag.
+                     * Then, we must also be at the end of the last token if we want to have a
+                     * perfect alignment */
+                    if (current_token == end
+                            && jamo_token[current_index_in_jamo_token] == '\0') {
+                        return;
+                    }
+                    /* If not, we fail */
+                    everything_still_OK = 0;
+                    break;
+                }
+                current_tag++;
+                tab[current_tag]->start_pos = current_token;
+                tab[current_tag]->start_pos_char = UNDEF_KR_TAG_START;//current_pos_in_char_in_token;
+                tab[current_tag]->start_pos_letter = UNDEF_KR_TAG_START;//current_pos_in_letter_in_token;
+                current_index_in_jamo_tag = 0;
+                if (!u_strcmp(tab[current_tag]->content, "<E>")) {
+                    /* If we have a {<E>,xx.yy} tag */
+                    tab[current_tag]->start_pos_char
+                            = current_pos_in_char_in_token;
+                    tab[current_tag]->start_pos_letter
+                            = current_pos_in_letter_in_token - 1;
+                    tab[current_tag]->end_pos = tab[current_tag]->start_pos;
+                    tab[current_tag]->end_pos_char
+                            = tab[current_tag]->start_pos_char;
+                    tab[current_tag]->end_pos_letter = -1;
+                } else {
+                    /* We have a non <E> tag, so we can set 'jamo_tag' and get out of the for(;;) loop */
+                    Hanguls_to_Jamos(tab[current_tag]->content, jamo_tag,
+                            korean, 0);
+                    break;
+                }
 
-			} /* End of for(;;) loop to move on next tag */
-			continue;
-		}
-		/* We are not at the end of a tag, but we can be at the end of the current token */
-		if (jamo_token[current_index_in_jamo_token] == '\0') {
-			if (current_token == end) {
-				/* If this is the last token, then we cannot have a perfect alignment */
-				break;
-			}
-			current_token++;
-			if (tab[current_tag]->start_pos_char == UNDEF_KR_TAG_START) {
-				/* If we change of token whereas we have not started to read the current tag,
-				 * we can say that the current tag starts on the current token */
-				(tab[current_tag]->start_pos)++;
-				tab[current_tag]->start_pos_char = 0;
-				tab[current_tag]->start_pos_letter = 0;
-			}
-			if (INFO->buffer[current_token] == INFO->SPACE
-					&& current_index_in_jamo_tag == 0) {
-				/* If 1) the new token is a space and 2) we are at the beginning of a tag
-				 * (that, by construction, cannot start with a space), then we must skip this
-				 * space token */
-				if (current_token == end) {
-					/* If this space token was the last token, then we cannot have a perfect alignement */
-					break;
-				}
-				/* By construction, we cannot have 2 contiguous spaces, but we raise an error in
-				 * order not to forget that the day this rule will change */
-				current_token++;
-				/* See comment above */
-				(tab[current_tag]->start_pos)++;
-				tab[current_tag]->start_pos_char = 0;
-				tab[current_tag]->start_pos_letter = 0;
-				if (INFO->buffer[current_token] == INFO->SPACE) {
-					fatal_error(
-							"Contiguous spaces not handled in solve_alignment_puzzle_for_Korean at line:\n%S\n",
-							output);
-				}
-			}
-			token = INFO->tok->token[INFO->buffer[current_token]];
-			current_pos_in_char_in_token = 0;
-			current_index_in_jamo_token = 0;
-			current_pos_in_letter_in_token = 0;
-			Hanguls_to_Jamos(token, jamo_token, korean, 0);
-			continue;
-		}
-		if (jamo_token[current_index_in_jamo_token] == KR_SYLLABLE_BOUND) {
-			/* If we find a syllable bound in the jamo token, we have to change the current
-			 * character and to update start_pos_letter to 0 */
-			current_index_in_jamo_token++;
-			if (jamo_token[current_index_in_jamo_token] == KR_SYLLABLE_BOUND) {
-				fatal_error(
-						"Contiguous syllable bounds in jamo token in solve_alignment_puzzle_for_Korean at line:\n%S\n",
-						output);
-			}
-			if (jamo_token[current_index_in_jamo_token] == '\0') {
-				fatal_error(
-						"Unexpected end of jamo token in solve_alignment_puzzle_for_Korean at line:\n%S\n",
-						output);
-			}
-			if (current_index_in_jamo_token != 1) {
-				/* We update the char position only if we find a syllable bound that is not the
-				 * first one */
-				current_pos_in_char_in_token++;
-			}
-			current_pos_in_letter_in_token = 0;
-			/* No need to 'continue' here; we can deal with the jamo tag first */
-			/* continue; */
-		}
-		if (tab[current_tag]->start_pos_char == UNDEF_KR_TAG_START) {
-			/* If the start_pos_... of the new jamo tag have not been set yet, we do it now */
-			tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
-			tab[current_tag]->start_pos_letter = current_pos_in_letter_in_token;
-		}
-		if (jamo_tag[current_index_in_jamo_tag] == KR_SYLLABLE_BOUND) {
-			current_index_in_jamo_tag++;
-			if (jamo_tag[current_index_in_jamo_tag] == KR_SYLLABLE_BOUND) {
-				fatal_error(
-						"Contiguous syllable bounds in jamo tag in solve_alignment_puzzle_for_Korean at line:\n%S\n",
-						output);
-			}
-			if (jamo_tag[current_index_in_jamo_tag] == '\0') {
-				fatal_error(
-						"Unexpected end of jamo tag in solve_alignment_puzzle_for_Korean at line:\n%S\n",
-						output);
-			}
-		}
-		/* If we arrive here, we have 2 characters to be compared in the token and the tag */
-		if (jamo_tag[current_index_in_jamo_tag]
-				!= jamo_token[current_index_in_jamo_token]) {
-			break;
-		}
+            } /* End of for(;;) loop to move on next tag */
+            continue;
+        }
+        /* We are not at the end of a tag, but we can be at the end of the current token */
+        if (jamo_token[current_index_in_jamo_token] == '\0') {
+            if (current_token == end) {
+                /* If this is the last token, then we cannot have a perfect alignment */
+                break;
+            }
+            current_token++;
+            if (tab[current_tag]->start_pos_char == UNDEF_KR_TAG_START) {
+                /* If we change of token whereas we have not started to read the current tag,
+                 * we can say that the current tag starts on the current token */
+                (tab[current_tag]->start_pos)++;
+                tab[current_tag]->start_pos_char = 0;
+                tab[current_tag]->start_pos_letter = 0;
+            }
+            if (INFO->buffer[current_token] == INFO->SPACE
+                    && current_index_in_jamo_tag == 0) {
+                /* If 1) the new token is a space and 2) we are at the beginning of a tag
+                 * (that, by construction, cannot start with a space), then we must skip this
+                 * space token */
+                if (current_token == end) {
+                    /* If this space token was the last token, then we cannot have a perfect alignement */
+                    break;
+                }
+                /* By construction, we cannot have 2 contiguous spaces, but we raise an error in
+                 * order not to forget that the day this rule will change */
+                current_token++;
+                /* See comment above */
+                (tab[current_tag]->start_pos)++;
+                tab[current_tag]->start_pos_char = 0;
+                tab[current_tag]->start_pos_letter = 0;
+                if (INFO->buffer[current_token] == INFO->SPACE) {
+                    fatal_error(
+                            "Contiguous spaces not handled in solve_alignment_puzzle_for_Korean at line:\n%S\n",
+                            output);
+                }
+            }
+            token = INFO->tok->token[INFO->buffer[current_token]];
+            current_pos_in_char_in_token = 0;
+            current_index_in_jamo_token = 0;
+            current_pos_in_letter_in_token = 0;
+            Hanguls_to_Jamos(token, jamo_token, korean, 0);
+            continue;
+        }
+        if (jamo_token[current_index_in_jamo_token] == KR_SYLLABLE_BOUND) {
+            /* If we find a syllable bound in the jamo token, we have to change the current
+             * character and to update start_pos_letter to 0 */
+            current_index_in_jamo_token++;
+            if (jamo_token[current_index_in_jamo_token] == KR_SYLLABLE_BOUND) {
+                fatal_error(
+                        "Contiguous syllable bounds in jamo token in solve_alignment_puzzle_for_Korean at line:\n%S\n",
+                        output);
+            }
+            if (jamo_token[current_index_in_jamo_token] == '\0') {
+                fatal_error(
+                        "Unexpected end of jamo token in solve_alignment_puzzle_for_Korean at line:\n%S\n",
+                        output);
+            }
+            if (current_index_in_jamo_token != 1) {
+                /* We update the char position only if we find a syllable bound that is not the
+                 * first one */
+                current_pos_in_char_in_token++;
+            }
+            current_pos_in_letter_in_token = 0;
+            /* No need to 'continue' here; we can deal with the jamo tag first */
+            /* continue; */
+        }
+        if (tab[current_tag]->start_pos_char == UNDEF_KR_TAG_START) {
+            /* If the start_pos_... of the new jamo tag have not been set yet, we do it now */
+            tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
+            tab[current_tag]->start_pos_letter = current_pos_in_letter_in_token;
+        }
+        if (jamo_tag[current_index_in_jamo_tag] == KR_SYLLABLE_BOUND) {
+            current_index_in_jamo_tag++;
+            if (jamo_tag[current_index_in_jamo_tag] == KR_SYLLABLE_BOUND) {
+                fatal_error(
+                        "Contiguous syllable bounds in jamo tag in solve_alignment_puzzle_for_Korean at line:\n%S\n",
+                        output);
+            }
+            if (jamo_tag[current_index_in_jamo_tag] == '\0') {
+                fatal_error(
+                        "Unexpected end of jamo tag in solve_alignment_puzzle_for_Korean at line:\n%S\n",
+                        output);
+            }
+        }
+        /* If we arrive here, we have 2 characters to be compared in the token and the tag */
+        if (jamo_tag[current_index_in_jamo_tag]
+                != jamo_token[current_index_in_jamo_token]) {
+            break;
+        }
 
-		current_index_in_jamo_tag++;
-		current_index_in_jamo_token++;
-		current_pos_in_letter_in_token++;
-	}
+        current_index_in_jamo_tag++;
+        current_index_in_jamo_token++;
+        current_pos_in_letter_in_token++;
+    }
 
-	/* Default case: all tags will have the same start/end bounds */
-	for (int i = 0; i < vector->nbelems; i++) {
-		tab[i]->start_pos = start;
-		tab[i]->start_pos_char = 0;
-		tab[i]->end_pos = end;
-		tab[i]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
-				- 1;
-		tab[i]->end_pos_letter = get_length_in_jamo(
-				INFO->tok->token[INFO->buffer[end]][tab[i]->end_pos_char],
-				korean) - 1;
-	}
+    /* Default case: all tags will have the same start/end bounds */
+    for (int i = 0; i < vector->nbelems; i++) {
+        tab[i]->start_pos = start;
+        tab[i]->start_pos_char = 0;
+        tab[i]->end_pos = end;
+        tab[i]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
+                - 1;
+        tab[i]->end_pos_letter = get_length_in_jamo(
+                INFO->tok->token[INFO->buffer[end]][tab[i]->end_pos_char],
+                korean) - 1;
+    }
 }
 
 /**
@@ -617,142 +617,142 @@ void solve_alignment_puzzle_for_Korean(vector_ptr* vector, int start, int end,
  * to be produced.
  */
 void solve_alignment_puzzle(vector_ptr* vector, int start, int end,
-		struct info* INFO, const Alphabet* alph, Korean* korean,
-		unichar* output) {
-	if (korean != NULL) {
-		/* The Korean case is so special that it seems risky to merge it with the
-		 * normal case that works fine */
-		solve_alignment_puzzle_for_Korean(vector, start, end, INFO, korean,
-				output);
-		return;
-	}
-	if (vector == NULL) {
-		fatal_error("NULL vector in solve_alignment_puzzle\n");
-	}
-	if (vector->nbelems == 0) {
-		fatal_error("Empty vector in solve_alignment_puzzle\n");
-	}
-	struct output_info** tab = (struct output_info**) vector->tab;
+        struct info* INFO, const Alphabet* alph, Korean* korean,
+        unichar* output) {
+    if (korean != NULL) {
+        /* The Korean case is so special that it seems risky to merge it with the
+         * normal case that works fine */
+        solve_alignment_puzzle_for_Korean(vector, start, end, INFO, korean,
+                output);
+        return;
+    }
+    if (vector == NULL) {
+        fatal_error("NULL vector in solve_alignment_puzzle\n");
+    }
+    if (vector->nbelems == 0) {
+        fatal_error("Empty vector in solve_alignment_puzzle\n");
+    }
+    struct output_info** tab = (struct output_info**) vector->tab;
 
-	if (vector->nbelems == 1) {
-		/* If there is only one tag, there is no puzzle to solve */
-		tab[0]->start_pos = start;
-		tab[0]->start_pos_char = 0;
-		tab[0]->end_pos = end;
-		tab[0]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
-				- 1;
-		/* No need to deal with xxx_letter fields in non Korean mode, since
-		 * default initialization to 0 is OK */
-		return;
-	}
+    if (vector->nbelems == 1) {
+        /* If there is only one tag, there is no puzzle to solve */
+        tab[0]->start_pos = start;
+        tab[0]->start_pos_char = 0;
+        tab[0]->end_pos = end;
+        tab[0]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
+                - 1;
+        /* No need to deal with xxx_letter fields in non Korean mode, since
+         * default initialization to 0 is OK */
+        return;
+    }
 
-	/* We try to find an exact match (modulo case variations) between the text and the tags' content */
-	int current_token = start;
-	int current_tag = 0;
-	int current_pos_in_char_in_token = 0;
-	int current_pos_in_char_in_tag = 0;
-	tab[current_tag]->start_pos = current_token;
-	tab[current_tag]->start_pos_char = 0;
-	unichar* token = INFO->tok->token[INFO->buffer[current_token]];
-	for (;;) {
-		if (!u_strcmp(tab[current_tag]->content, "<E>")) {
-			/* If we have a {<E>,xx.yy} tag */
-			tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
-			tab[current_tag]->start_pos_letter = 0;
-			tab[current_tag]->end_pos = tab[current_tag]->start_pos;
-			tab[current_tag]->end_pos_char = tab[current_tag]->start_pos_char;
-			tab[current_tag]->end_pos_letter = -1;
-			if (current_tag == vector->nbelems - 1) {
-				/* If we are at the end of the last tag, we must also be
-				 * at the end of the last token if we want to have a perfect alignment */
-				if (current_token==end && token[current_pos_in_char_in_token]=='\0') {
-					return;
-				}
-				break;
-			}
-			current_tag++;
-			tab[current_tag]->start_pos = current_token;
-			tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
-			current_pos_in_char_in_tag = 0;
-			continue;
-		}
-		if (tab[current_tag]->content[current_pos_in_char_in_tag] == '\0') {
-			/* If we are at the end of a tag */
-			tab[current_tag]->end_pos = current_token;
-			tab[current_tag]->end_pos_char = current_pos_in_char_in_token - 1;
-			if (current_tag == vector->nbelems - 1) {
-				/* If we are at the end of the last tag, we must also be
-				 * at the end of the last token if we want to have a perfect alignment */
-				if (current_token == end && token[current_pos_in_char_in_token]
-						== '\0') {
-					return;
-				}
-				break;
-			}
-			/* We are not at the last tag */
-			current_tag++;
-			tab[current_tag]->start_pos = current_token;
-			tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
-			current_pos_in_char_in_tag = 0;
-			continue;
-		}
-		/* We are not at the end of a tag, but we can be at the end of the current token */
-		if (token[current_pos_in_char_in_token] == '\0') {
-			if (current_token == end) {
-				/* If this is the last token, then we cannot have a perfect alignement */
-				break;
-			}
-			current_token++;
-			if (current_pos_in_char_in_tag == 0) {
-				/* If we change of token whereas we have not started to read the current tag,
-				 * we can say that the current tag starts on the current token */
-				(tab[current_tag]->start_pos)++;
-				tab[current_tag]->start_pos_char = 0;
-			}
-			if (INFO->buffer[current_token] == INFO->SPACE
-					&& current_pos_in_char_in_tag == 0) {
-				/* If 1) the new token is a space and 2) we are at the beginning of a tag
-				 * (that, by construction, cannot start with a space), then we must skip this
-				 * space token */
-				if (current_token == end) {
-					/* If this space token was the last token, then we cannot have a perfect alignement */
-					/*debug("current tag=%S/%d  current token=%S/%d\n",tab[current_tag]->content,
-					 current_pos_in_char_in_tag,token,current_pos_in_char_in_token);*/
-					break;
-				}
-				/* By construction, we cannot have 2 contiguous spaces, but we raise an error in
-				 * order not to forget that the day this rule will change */
-				current_token++;
-				/* See comment above */
-				(tab[current_tag]->start_pos)++;
-				tab[current_tag]->start_pos_char = 0;
-				if (INFO->buffer[current_token] == INFO->SPACE) {
-					fatal_error(
-							"Contiguous spaces not handled in solve_alignment_puzzle\n");
-				}
-			}
-			token = INFO->tok->token[INFO->buffer[current_token]];
-			current_pos_in_char_in_token = 0;
-			continue;
-		}
-		/* We are neither at the end of the tag nor at the end of the token */
-		if (!is_equal_ignore_case(
-				tab[current_tag]->content[current_pos_in_char_in_tag],
-				token[current_pos_in_char_in_token], alph)) {
-			break;
-		}
-		current_pos_in_char_in_tag++;
-		current_pos_in_char_in_token++;
-	}
+    /* We try to find an exact match (modulo case variations) between the text and the tags' content */
+    int current_token = start;
+    int current_tag = 0;
+    int current_pos_in_char_in_token = 0;
+    int current_pos_in_char_in_tag = 0;
+    tab[current_tag]->start_pos = current_token;
+    tab[current_tag]->start_pos_char = 0;
+    unichar* token = INFO->tok->token[INFO->buffer[current_token]];
+    for (;;) {
+        if (!u_strcmp(tab[current_tag]->content, "<E>")) {
+            /* If we have a {<E>,xx.yy} tag */
+            tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
+            tab[current_tag]->start_pos_letter = 0;
+            tab[current_tag]->end_pos = tab[current_tag]->start_pos;
+            tab[current_tag]->end_pos_char = tab[current_tag]->start_pos_char;
+            tab[current_tag]->end_pos_letter = -1;
+            if (current_tag == vector->nbelems - 1) {
+                /* If we are at the end of the last tag, we must also be
+                 * at the end of the last token if we want to have a perfect alignment */
+                if (current_token==end && token[current_pos_in_char_in_token]=='\0') {
+                    return;
+                }
+                break;
+            }
+            current_tag++;
+            tab[current_tag]->start_pos = current_token;
+            tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
+            current_pos_in_char_in_tag = 0;
+            continue;
+        }
+        if (tab[current_tag]->content[current_pos_in_char_in_tag] == '\0') {
+            /* If we are at the end of a tag */
+            tab[current_tag]->end_pos = current_token;
+            tab[current_tag]->end_pos_char = current_pos_in_char_in_token - 1;
+            if (current_tag == vector->nbelems - 1) {
+                /* If we are at the end of the last tag, we must also be
+                 * at the end of the last token if we want to have a perfect alignment */
+                if (current_token == end && token[current_pos_in_char_in_token]
+                        == '\0') {
+                    return;
+                }
+                break;
+            }
+            /* We are not at the last tag */
+            current_tag++;
+            tab[current_tag]->start_pos = current_token;
+            tab[current_tag]->start_pos_char = current_pos_in_char_in_token;
+            current_pos_in_char_in_tag = 0;
+            continue;
+        }
+        /* We are not at the end of a tag, but we can be at the end of the current token */
+        if (token[current_pos_in_char_in_token] == '\0') {
+            if (current_token == end) {
+                /* If this is the last token, then we cannot have a perfect alignement */
+                break;
+            }
+            current_token++;
+            if (current_pos_in_char_in_tag == 0) {
+                /* If we change of token whereas we have not started to read the current tag,
+                 * we can say that the current tag starts on the current token */
+                (tab[current_tag]->start_pos)++;
+                tab[current_tag]->start_pos_char = 0;
+            }
+            if (INFO->buffer[current_token] == INFO->SPACE
+                    && current_pos_in_char_in_tag == 0) {
+                /* If 1) the new token is a space and 2) we are at the beginning of a tag
+                 * (that, by construction, cannot start with a space), then we must skip this
+                 * space token */
+                if (current_token == end) {
+                    /* If this space token was the last token, then we cannot have a perfect alignement */
+                    /*debug("current tag=%S/%d  current token=%S/%d\n",tab[current_tag]->content,
+                     current_pos_in_char_in_tag,token,current_pos_in_char_in_token);*/
+                    break;
+                }
+                /* By construction, we cannot have 2 contiguous spaces, but we raise an error in
+                 * order not to forget that the day this rule will change */
+                current_token++;
+                /* See comment above */
+                (tab[current_tag]->start_pos)++;
+                tab[current_tag]->start_pos_char = 0;
+                if (INFO->buffer[current_token] == INFO->SPACE) {
+                    fatal_error(
+                            "Contiguous spaces not handled in solve_alignment_puzzle\n");
+                }
+            }
+            token = INFO->tok->token[INFO->buffer[current_token]];
+            current_pos_in_char_in_token = 0;
+            continue;
+        }
+        /* We are neither at the end of the tag nor at the end of the token */
+        if (!is_equal_ignore_case(
+                tab[current_tag]->content[current_pos_in_char_in_tag],
+                token[current_pos_in_char_in_token], alph)) {
+            break;
+        }
+        current_pos_in_char_in_tag++;
+        current_pos_in_char_in_token++;
+    }
 
-	/* Default case: all tags will have the same start/end bounds */
-	for (int i = 0; i < vector->nbelems; i++) {
-		tab[i]->start_pos = start;
-		tab[i]->start_pos_char = 0;
-		tab[i]->end_pos = end;
-		tab[i]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
-				- 1;
-	}
+    /* Default case: all tags will have the same start/end bounds */
+    for (int i = 0; i < vector->nbelems; i++) {
+        tab[i]->start_pos = start;
+        tab[i]->start_pos_char = 0;
+        tab[i]->end_pos = end;
+        tab[i]->end_pos_char = u_strlen(INFO->tok->token[INFO->buffer[end]])
+                - 1;
+    }
 }
 
 /**
@@ -765,46 +765,46 @@ void solve_alignment_puzzle(vector_ptr* vector, int start, int end,
  *  19 -- {le,.PRO:ms} --> 7
  */
 void add_path_to_sentence_automaton(int start_pos, int end_pos,
-		int start_state_index, const Alphabet* alph, SingleGraph graph,
-		struct string_hash* tmp_tags, unichar* s, int destination_state_index,
-		Ustring* foo, struct info* INFO, Korean* korean) {
-	//error("start=%d end=%d  output=%S\n",start_state_index,destination_state_index,s);
-	if (!u_strcmp(s, "<E>")) {
-		/* Special case of the <E> insertion */
-		add_outgoing_transition(graph->states[start_state_index], 0,
-				destination_state_index);
-	}
-	vector_ptr* vector = tokenize_normalization_output(s, alph);
-	if (vector == NULL) {
-		/* If the output to be generated has no interest, we do nothing */
-		error("Skipping incorrect output <%S>\n", s);
-		return;
-	}
-	solve_alignment_puzzle(vector, start_pos, end_pos, INFO, alph, korean, s);
-	int current_state = start_state_index;
-	for (int i = 0; i < vector->nbelems; i++) {
-		struct output_info* info = (struct output_info*) (vector->tab[i]);
-		u_sprintf(foo, "@STD\n@%S\n@%d.%d.%d-%d.%d.%d\n.\n", info->output,
-				info->start_pos, info->start_pos_char, info->start_pos_letter,
-				info->end_pos, info->end_pos_char, info->end_pos_letter);
-		if (i == vector->nbelems - 1) {
-			/* If this is the last transition to create, we make it point to the
-			 * destination state */
-			add_outgoing_transition(graph->states[current_state],
-					get_value_index(foo->str, tmp_tags),
-					destination_state_index);
-			//error("last transition by %S from %d to %d\n",info->output,current_state,destination_state_index);
-		} else {
-			/* If this transition is not the last one, we must create a new state */
-			add_outgoing_transition(graph->states[current_state],
-					get_value_index(foo->str, tmp_tags),
-					graph->number_of_states);
-			//error("transition by %S from %d to %d\n",info->output,current_state,graph->number_of_states);
-			current_state = graph->number_of_states;
-			add_state(graph);
-		}
-	}
-	free_vector_ptr(vector, (void(*)(void*)) free_output_info);
+        int start_state_index, const Alphabet* alph, SingleGraph graph,
+        struct string_hash* tmp_tags, unichar* s, int destination_state_index,
+        Ustring* foo, struct info* INFO, Korean* korean) {
+    //error("start=%d end=%d  output=%S\n",start_state_index,destination_state_index,s);
+    if (!u_strcmp(s, "<E>")) {
+        /* Special case of the <E> insertion */
+        add_outgoing_transition(graph->states[start_state_index], 0,
+                destination_state_index);
+    }
+    vector_ptr* vector = tokenize_normalization_output(s, alph);
+    if (vector == NULL) {
+        /* If the output to be generated has no interest, we do nothing */
+        error("Skipping incorrect output <%S>\n", s);
+        return;
+    }
+    solve_alignment_puzzle(vector, start_pos, end_pos, INFO, alph, korean, s);
+    int current_state = start_state_index;
+    for (int i = 0; i < vector->nbelems; i++) {
+        struct output_info* info = (struct output_info*) (vector->tab[i]);
+        u_sprintf(foo, "@STD\n@%S\n@%d.%d.%d-%d.%d.%d\n.\n", info->output,
+                info->start_pos, info->start_pos_char, info->start_pos_letter,
+                info->end_pos, info->end_pos_char, info->end_pos_letter);
+        if (i == vector->nbelems - 1) {
+            /* If this is the last transition to create, we make it point to the
+             * destination state */
+            add_outgoing_transition(graph->states[current_state],
+                    get_value_index(foo->str, tmp_tags),
+                    destination_state_index);
+            //error("last transition by %S from %d to %d\n",info->output,current_state,destination_state_index);
+        } else {
+            /* If this transition is not the last one, we must create a new state */
+            add_outgoing_transition(graph->states[current_state],
+                    get_value_index(foo->str, tmp_tags),
+                    graph->number_of_states);
+            //error("transition by %S from %d to %d\n",info->output,current_state,graph->number_of_states);
+            current_state = graph->number_of_states;
+            add_state(graph);
+        }
+    }
+    free_vector_ptr(vector, (void(*)(void*)) free_output_info);
 }
 
 /**
@@ -821,42 +821,42 @@ void add_path_to_sentence_automaton(int start_pos, int end_pos,
  * WARNING: this function MUST NOT BE CALLED when the current token is a space.
  */
 void explore_normalization_tree(int first_pos_in_buffer,
-		int current_pos_in_buffer, int token, struct info* INFO,
-		SingleGraph graph, struct string_hash* tmp_tags,
-		struct normalization_tree* norm_tree_node, int first_state_index,
-		int shift, Ustring* foo, int increment, language_t* language,
-		Korean* korean) {
-	struct list_ustring* outputs = norm_tree_node->outputs;
-	while (outputs != NULL) {
-		/* If there are outputs, we add paths in the text automaton */
-		add_path_to_sentence_automaton(first_pos_in_buffer,
-				current_pos_in_buffer - increment, first_state_index,
-				INFO->alph, graph, tmp_tags, outputs->string, first_state_index
-						+ shift - 1, foo, INFO, korean);
-		outputs = outputs->next;
-	}
-	/* Then, we explore the transitions from this node. Note that transitions
-	 * are tagged with token numbers that are unique. So, at most one transition
-	 * can match. */
-	struct normalization_tree_transition* trans = norm_tree_node->trans;
-	while (trans != NULL) {
-		if (trans->token == token) {
-			/* If we have a transition for the current token */
-			int increment_loc = 1;
-			if (INFO->buffer[current_pos_in_buffer + 1] == INFO->SPACE) {
-				increment_loc++;
-			}
-			explore_normalization_tree(first_pos_in_buffer,
-					current_pos_in_buffer + increment_loc,
-					INFO->buffer[current_pos_in_buffer + increment_loc], INFO,
-					graph, tmp_tags, trans->node, first_state_index, shift + 1,
-					foo, increment_loc, language, korean);
-			/* As there can be only one matching transition, we exit the while */
-			trans = NULL;
-		} else {
-			trans = trans->next;
-		}
-	}
+        int current_pos_in_buffer, int token, struct info* INFO,
+        SingleGraph graph, struct string_hash* tmp_tags,
+        struct normalization_tree* norm_tree_node, int first_state_index,
+        int shift, Ustring* foo, int increment, language_t* language,
+        Korean* korean) {
+    struct list_ustring* outputs = norm_tree_node->outputs;
+    while (outputs != NULL) {
+        /* If there are outputs, we add paths in the text automaton */
+        add_path_to_sentence_automaton(first_pos_in_buffer,
+                current_pos_in_buffer - increment, first_state_index,
+                INFO->alph, graph, tmp_tags, outputs->string, first_state_index
+                        + shift - 1, foo, INFO, korean);
+        outputs = outputs->next;
+    }
+    /* Then, we explore the transitions from this node. Note that transitions
+     * are tagged with token numbers that are unique. So, at most one transition
+     * can match. */
+    struct normalization_tree_transition* trans = norm_tree_node->trans;
+    while (trans != NULL) {
+        if (trans->token == token) {
+            /* If we have a transition for the current token */
+            int increment_loc = 1;
+            if (INFO->buffer[current_pos_in_buffer + 1] == INFO->SPACE) {
+                increment_loc++;
+            }
+            explore_normalization_tree(first_pos_in_buffer,
+                    current_pos_in_buffer + increment_loc,
+                    INFO->buffer[current_pos_in_buffer + increment_loc], INFO,
+                    graph, tmp_tags, trans->node, first_state_index, shift + 1,
+                    foo, increment_loc, language, korean);
+            /* As there can be only one matching transition, we exit the while */
+            trans = NULL;
+        } else {
+            trans = trans->next;
+        }
+    }
 }
 
 /**
@@ -864,184 +864,184 @@ void explore_normalization_tree(int first_pos_in_buffer,
  * given token buffer. It saves it into the given file.
  */
 void build_sentence_automaton(const int* buffer, int length,
-		const struct text_tokens* tokens, const struct DELA_tree* DELA_tree,
-		const Alphabet* alph, U_FILE* out_tfst, U_FILE* out_tind,
-		int sentence_number, int we_must_clean,
-		struct normalization_tree* norm_tree, struct match_list* *tag_list,
-		int current_global_position_in_tokens,
-		int current_global_position_in_chars, language_t* language,
-		Korean* korean, struct hash_table* form_frequencies) {
-	/* We declare the graph that will represent the sentence as well as
-	 * a temporary string_hash 'tmp_tags' that will be used to store the tags of this
-	 * graph. We don't put tags directly in the main 'tags', because a tag can
-	 * be introduced and then removed by cleaning */
-	Tfst* tfst = new_Tfst(NULL, NULL, 0);
-	tfst->current_sentence = sentence_number;
-	tfst->automaton = new_SingleGraph();
-	tfst->offset_in_tokens = current_global_position_in_tokens;
-	tfst->offset_in_chars = current_global_position_in_chars;
+        const struct text_tokens* tokens, const struct DELA_tree* DELA_tree,
+        const Alphabet* alph, U_FILE* out_tfst, U_FILE* out_tind,
+        int sentence_number, int we_must_clean,
+        struct normalization_tree* norm_tree, struct match_list* *tag_list,
+        int current_global_position_in_tokens,
+        int current_global_position_in_chars, language_t* language,
+        Korean* korean, struct hash_table* form_frequencies) {
+    /* We declare the graph that will represent the sentence as well as
+     * a temporary string_hash 'tmp_tags' that will be used to store the tags of this
+     * graph. We don't put tags directly in the main 'tags', because a tag can
+     * be introduced and then removed by cleaning */
+    Tfst* tfst = new_Tfst(NULL, NULL, 0);
+    tfst->current_sentence = sentence_number;
+    tfst->automaton = new_SingleGraph();
+    tfst->offset_in_tokens = current_global_position_in_tokens;
+    tfst->offset_in_chars = current_global_position_in_chars;
 
-	struct string_hash* tags = new_string_hash(32);
-	struct string_hash* tmp_tags = new_string_hash(32);
-	unichar EPSILON_TAG[] = { '@', '<', 'E', '>', '\n', '.', '\n', '\0' };
-	/* The epsilon tag is always the first one */
-	get_value_index(EPSILON_TAG, tmp_tags);
-	get_value_index(EPSILON_TAG, tags);
+    struct string_hash* tags = new_string_hash(32);
+    struct string_hash* tmp_tags = new_string_hash(32);
+    unichar EPSILON_TAG[] = { '@', '<', 'E', '>', '\n', '.', '\n', '\0' };
+    /* The epsilon tag is always the first one */
+    get_value_index(EPSILON_TAG, tmp_tags);
+    get_value_index(EPSILON_TAG, tags);
 
-	int i;
-	/* We add +1 for the final node */
-	int n_nodes = 1 + count_non_space_tokens(buffer, length, tokens->SPACE);
-	for (i = 0; i < n_nodes; i++) {
-		add_state(tfst->automaton);
-	}
-	set_initial_state(tfst->automaton->states[0]);
-	int final_node_index=n_nodes-1;
-	set_final_state(tfst->automaton->states[n_nodes - 1]);
-	struct info INFO;
-	INFO.tok = tokens;
-	INFO.buffer = buffer;
-	INFO.alph = alph;
-	INFO.SPACE = tokens->SPACE;
-	INFO.length_max = length;
-	int current_state = 0;
-	int is_not_unknown_token;
-	unichar inflected[4096];
-	/* Temp string used to build tags with bound control */
-	Ustring* foo = new_Ustring(1);
-	/* We compute the text and tokens of the sentence */
-	tfst->tokens = new_vector_int(length);
-	tfst->token_sizes = new_vector_int(length);
-	for (int il = 0; il < length; il++) {
-		vector_int_add(tfst->tokens, buffer[il]);
-		int l = u_strlen(tokens->token[buffer[il]]);
-		vector_int_add(tfst->token_sizes, l);
-		u_strcat(foo, tokens->token[buffer[il]], l);
-	}
-	tfst->text = u_strdup(foo->str);
+    int i;
+    /* We add +1 for the final node */
+    int n_nodes = 1 + count_non_space_tokens(buffer, length, tokens->SPACE);
+    for (i = 0; i < n_nodes; i++) {
+        add_state(tfst->automaton);
+    }
+    set_initial_state(tfst->automaton->states[0]);
+    int final_node_index=n_nodes-1;
+    set_final_state(tfst->automaton->states[n_nodes - 1]);
+    struct info INFO;
+    INFO.tok = tokens;
+    INFO.buffer = buffer;
+    INFO.alph = alph;
+    INFO.SPACE = tokens->SPACE;
+    INFO.length_max = length;
+    int current_state = 0;
+    int is_not_unknown_token;
+    unichar inflected[4096];
+    /* Temp string used to build tags with bound control */
+    Ustring* foo = new_Ustring(1);
+    /* We compute the text and tokens of the sentence */
+    tfst->tokens = new_vector_int(length);
+    tfst->token_sizes = new_vector_int(length);
+    for (int il = 0; il < length; il++) {
+        vector_int_add(tfst->tokens, buffer[il]);
+        int l = u_strlen(tokens->token[buffer[il]]);
+        vector_int_add(tfst->token_sizes, l);
+        u_strcat(foo, tokens->token[buffer[il]], l);
+    }
+    tfst->text = u_strdup(foo->str);
 
-	for (i = 0; i < length; i++) {
-		if (buffer[i] == tokens->SENTENCE_MARKER) {
-			fatal_error("build_sentence_automaton: unexpected {S} token\n");
-		}
-		if (buffer[i] != tokens->SPACE) {
-			/* We try to produce every transition from the current token */
-			is_not_unknown_token = 0;
-			unichar tag_buffer[4096];
-			explore_dictionary_tree(0, tokens->token[buffer[i]], inflected, 0,
-					DELA_tree->inflected_forms->root, DELA_tree, &INFO,
-					tfst->automaton->states[current_state], 1, current_state,
-					&is_not_unknown_token, i, i, tmp_tags, foo, language,
-					tag_buffer);
-			if (norm_tree != NULL) {
-				/* If there is a normalization tree, we explore it */
-				explore_normalization_tree(i, i, buffer[i], &INFO,
-						tfst->automaton, tmp_tags, norm_tree, current_state, 1,
-						foo, 0, language, korean);
-			}
-			if (!is_not_unknown_token) {
-				/* If the token was not matched in the dictionary, we put it as an unknown one */
-				u_sprintf(
-						foo,
-						"@STD\n@%S\n@%d.0.0-%d.%d.%d\n.\n",
-						tokens->token[buffer[i]],
-						i,
-						i,
-						tfst->token_sizes->tab[i] - 1,
-						get_length_in_jamo(
-								tokens->token[buffer[i]][tfst->token_sizes->tab[i]
-										- 1], korean) - 1);
-				int tag_number = get_value_index(foo->str, tmp_tags);
-				add_outgoing_transition(tfst->automaton->states[current_state],
-						tag_number, current_state + 1);
-			}
-			current_state++;
-		}
-	}
+    for (i = 0; i < length; i++) {
+        if (buffer[i] == tokens->SENTENCE_MARKER) {
+            fatal_error("build_sentence_automaton: unexpected {S} token\n");
+        }
+        if (buffer[i] != tokens->SPACE) {
+            /* We try to produce every transition from the current token */
+            is_not_unknown_token = 0;
+            unichar tag_buffer[4096];
+            explore_dictionary_tree(0, tokens->token[buffer[i]], inflected, 0,
+                    DELA_tree->inflected_forms->root, DELA_tree, &INFO,
+                    tfst->automaton->states[current_state], 1, current_state,
+                    &is_not_unknown_token, i, i, tmp_tags, foo, language,
+                    tag_buffer);
+            if (norm_tree != NULL) {
+                /* If there is a normalization tree, we explore it */
+                explore_normalization_tree(i, i, buffer[i], &INFO,
+                        tfst->automaton, tmp_tags, norm_tree, current_state, 1,
+                        foo, 0, language, korean);
+            }
+            if (!is_not_unknown_token) {
+                /* If the token was not matched in the dictionary, we put it as an unknown one */
+                u_sprintf(
+                        foo,
+                        "@STD\n@%S\n@%d.0.0-%d.%d.%d\n.\n",
+                        tokens->token[buffer[i]],
+                        i,
+                        i,
+                        tfst->token_sizes->tab[i] - 1,
+                        get_length_in_jamo(
+                                tokens->token[buffer[i]][tfst->token_sizes->tab[i]
+                                        - 1], korean) - 1);
+                int tag_number = get_value_index(foo->str, tmp_tags);
+                add_outgoing_transition(tfst->automaton->states[current_state],
+                        tag_number, current_state + 1);
+            }
+            current_state++;
+        }
+    }
 
-	/* Now, we insert the tag sequences found in the 'tags.ind' file, if any */
-	struct match_list* tmp;
-	while ((*tag_list) != NULL && (*tag_list)->m.start_pos_in_token
-			>= current_global_position_in_tokens
-			&& (*tag_list)->m.start_pos_in_token
-					<= current_global_position_in_tokens + length) {
-		if ((*tag_list)->m.end_pos_in_token > current_global_position_in_tokens
-				+ length) {
-			/* If we have a tag sequence that overlap two sentences, we must ignore it */
-			tmp = (*tag_list)->next;
-			free_match_list_element((*tag_list));
-			(*tag_list) = tmp;
-			continue;
-		}
-		/* We compute the local bounds of the tag sequence */
-		int start_index = (*tag_list)->m.start_pos_in_token
-				- current_global_position_in_tokens;
-		int end_index = (*tag_list)->m.end_pos_in_token
-				- current_global_position_in_tokens;
-		int start_pos_in_token = start_index;
-		int end_pos_in_token = end_index;
-		/* And we adjust them to our state indexes, because spaces
-		 * must be ignored */
-		for (int il = start_index; il >= 0; il--) {
-			if (buffer[il] == tokens->SPACE) {
-				start_index--;
-			}
-		}
-		for (int il = end_index; il >= 0; il--) {
-			if (buffer[il] == tokens->SPACE) {
-				end_index--;
-			}
-		}
-		if (end_index!=final_node_index) {
-			end_index+=1;
-		}
-		add_path_to_sentence_automaton(start_pos_in_token, end_pos_in_token,
-				start_index, INFO.alph, tfst->automaton, tmp_tags,
-				(*tag_list)->output, end_index, foo, &INFO, korean);
-		tmp = (*tag_list)->next;
-		free_match_list_element((*tag_list));
-		(*tag_list) = tmp;
-	}
+    /* Now, we insert the tag sequences found in the 'tags.ind' file, if any */
+    struct match_list* tmp;
+    while ((*tag_list) != NULL && (*tag_list)->m.start_pos_in_token
+            >= current_global_position_in_tokens
+            && (*tag_list)->m.start_pos_in_token
+                    <= current_global_position_in_tokens + length) {
+        if ((*tag_list)->m.end_pos_in_token > current_global_position_in_tokens
+                + length) {
+            /* If we have a tag sequence that overlap two sentences, we must ignore it */
+            tmp = (*tag_list)->next;
+            free_match_list_element((*tag_list));
+            (*tag_list) = tmp;
+            continue;
+        }
+        /* We compute the local bounds of the tag sequence */
+        int start_index = (*tag_list)->m.start_pos_in_token
+                - current_global_position_in_tokens;
+        int end_index = (*tag_list)->m.end_pos_in_token
+                - current_global_position_in_tokens;
+        int start_pos_in_token = start_index;
+        int end_pos_in_token = end_index;
+        /* And we adjust them to our state indexes, because spaces
+         * must be ignored */
+        for (int il = start_index; il >= 0; il--) {
+            if (buffer[il] == tokens->SPACE) {
+                start_index--;
+            }
+        }
+        for (int il = end_index; il >= 0; il--) {
+            if (buffer[il] == tokens->SPACE) {
+                end_index--;
+            }
+        }
+        if (end_index!=final_node_index) {
+            end_index+=1;
+        }
+        add_path_to_sentence_automaton(start_pos_in_token, end_pos_in_token,
+                start_index, INFO.alph, tfst->automaton, tmp_tags,
+                (*tag_list)->output, end_index, foo, &INFO, korean);
+        tmp = (*tag_list)->next;
+        free_match_list_element((*tag_list));
+        (*tag_list) = tmp;
+    }
 
-	if (we_must_clean) {
-		/* If necessary, we apply the "good paths" heuristic */
-		keep_best_paths(tfst->automaton, tmp_tags);
-	}
-	remove_epsilon_transitions(tfst->automaton, 0);
-	trim(tfst->automaton, NULL);
-	if (tfst->automaton->number_of_states == 0) {
-		/* Case 1: the automaton has been emptied because of the tagset filtering */
-		error("Sentence %d is empty\n", tfst->current_sentence);
-		SingleGraphState initial = add_state(tfst->automaton);
-		set_initial_state(initial);
-		free_vector_ptr(tfst->tags, (void(*)(void*)) free_TfstTag);
-		tfst->tags = new_vector_ptr(1);
-		vector_ptr_add(tfst->tags, new_TfstTag(T_EPSILON));
-		save_current_sentence(tfst, out_tfst, out_tind, NULL, 0, NULL);
-	} else {
-		/* Case 2: the automaton is not empty */
+    if (we_must_clean) {
+        /* If necessary, we apply the "good paths" heuristic */
+        keep_best_paths(tfst->automaton, tmp_tags);
+    }
+    remove_epsilon_transitions(tfst->automaton, 0);
+    trim(tfst->automaton, NULL);
+    if (tfst->automaton->number_of_states == 0) {
+        /* Case 1: the automaton has been emptied because of the tagset filtering */
+        error("Sentence %d is empty\n", tfst->current_sentence);
+        SingleGraphState initial = add_state(tfst->automaton);
+        set_initial_state(initial);
+        free_vector_ptr(tfst->tags, (void(*)(void*)) free_TfstTag);
+        tfst->tags = new_vector_ptr(1);
+        vector_ptr_add(tfst->tags, new_TfstTag(T_EPSILON));
+        save_current_sentence(tfst, out_tfst, out_tind, NULL, 0, NULL);
+    } else {
+        /* Case 2: the automaton is not empty */
 
-		/* We minimize the sentence automaton. It will remove the unused states and may
-		 * factorize suffixes introduced during the application of the normalization tree. */
-		minimize(tfst->automaton, 1);
-		/* We explore all the transitions of the automaton in order to renumber transitions */
-		for (i = 0; i < tfst->automaton->number_of_states; i++) {
-			Transition* trans =
-					tfst->automaton->states[i]->outgoing_transitions;
-			while (trans != NULL) {
-				/* For each tag of the graph that is actually used, we put it in the main
-				 * tags and we use this index in the tfst transition */
-				trans->tag_number = get_value_index(
-						tmp_tags->value[trans->tag_number], tags);
-				trans = trans->next;
-			}
-		}
-		save_current_sentence(tfst, out_tfst, out_tind, tags->value,
-				tags->size, form_frequencies);
-	}
-	close_text_automaton(tfst);
-	free_string_hash(tmp_tags);
-	free_string_hash(tags);
-	free_Ustring(foo);
+        /* We minimize the sentence automaton. It will remove the unused states and may
+         * factorize suffixes introduced during the application of the normalization tree. */
+        minimize(tfst->automaton, 1);
+        /* We explore all the transitions of the automaton in order to renumber transitions */
+        for (i = 0; i < tfst->automaton->number_of_states; i++) {
+            Transition* trans =
+                    tfst->automaton->states[i]->outgoing_transitions;
+            while (trans != NULL) {
+                /* For each tag of the graph that is actually used, we put it in the main
+                 * tags and we use this index in the tfst transition */
+                trans->tag_number = get_value_index(
+                        tmp_tags->value[trans->tag_number], tags);
+                trans = trans->next;
+            }
+        }
+        save_current_sentence(tfst, out_tfst, out_tind, tags->value,
+                tags->size, form_frequencies);
+    }
+    close_text_automaton(tfst);
+    free_string_hash(tmp_tags);
+    free_string_hash(tags);
+    free_Ustring(foo);
 }
 
 /**
@@ -1050,26 +1050,26 @@ void build_sentence_automaton(const int* buffer, int length,
  * - its inflected form otherwise
  */
 void get_tag_content(unichar* src, unichar* dest) {
-	if (src[0] != '{' || src[1] == '\0') {
-		u_strcpy(dest, src);
-		return;
-	}
-	struct dela_entry* e = tokenize_tag_token(src,1);
-	if (e == NULL) {
-		fatal_error("Invalid tag in get_tag_content: %S\n", src);
-	}
-	u_strcpy(dest, e->inflected);
-	free_dela_entry(e);
+    if (src[0] != '{' || src[1] == '\0') {
+        u_strcpy(dest, src);
+        return;
+    }
+    struct dela_entry* e = tokenize_tag_token(src,1);
+    if (e == NULL) {
+        fatal_error("Invalid tag in get_tag_content: %S\n", src);
+    }
+    u_strcpy(dest, e->inflected);
+    free_dela_entry(e);
 }
 
 int token_contains_Hangul_or_Chinese_chars(unichar* s, Alphabet* a) {
-	for (int i = 0; s[i] != '\0'; i++) {
-		if (u_is_Hangul(s[i]) || a->korean_equivalent_syllable[s[i]] != 0
-				|| (s[i] != 0x318D && u_is_Hangul_Compatility_Jamo(s[i]))) {
-			return 1;
-		}
-	}
-	return 0;
+    for (int i = 0; s[i] != '\0'; i++) {
+        if (u_is_Hangul(s[i]) || a->korean_equivalent_syllable[s[i]] != 0
+                || (s[i] != 0x318D && u_is_Hangul_Compatility_Jamo(s[i]))) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /**
@@ -1078,302 +1078,302 @@ int token_contains_Hangul_or_Chinese_chars(unichar* s, Alphabet* a) {
  * have been initialized with the current positions.
  */
 void compute_end_positions(unichar* jamo_tag, unichar* jamo_text,
-		int *pos_in_jamo_text, unichar* syllab_text, int *pos_in_syllab_text,
-		int *end_pos_token, int *end_pos_char, int *end_pos_letter,
-		int *new_pos_in_token, int *new_pos_in_char, int *new_pos_in_letter,
-		int* token_sizes, Alphabet* alphabet) {
-	int current_token = *end_pos_token;
-	int current_char = *end_pos_char;
-	int current_letter = *end_pos_letter;
-	if (/*u_is_korea_syllabe_letter(jamo_tag[0]) || alphabet->korean_equivalent_syllab[jamo_tag[0]]!=0*/
-	/*jamo_tag[0]!=0x318D && !u_is_Hangul_Jamo(jamo_tag[0])*/
-	token_contains_Hangul_or_Chinese_chars(jamo_tag, alphabet)) {
-		if ((*end_pos_letter) != 0
-		/* With this test, we deal with the case where a Jamo char was in the original text.
-		 * Then, we must update here the position in the text. It cannot be done
-		 * elsewhere, because this complicated case of "end of token even if there
-		 * is still Jamo char in the text" cannot be detected easily */
-		&& syllab_text[*pos_in_syllab_text] != jamo_tag[0]) {
-			fatal_error(
-					"compute_end_positions: cannot match a syllabic char when current_letter!=0\n"
-						"current_letter=%d  current token size=%d  tag=%S  syllab_text[%d]=%C  pos_in_jamo_text=%d\n"
-						"current token=%d\n", *end_pos_letter,
-					token_sizes[current_token], jamo_tag, *pos_in_syllab_text,
-					syllab_text[*pos_in_syllab_text], *pos_in_jamo_text,
-					current_token);
-		}
-		int was_a_Jamo_in_syllab_text = 0;
-		if (syllab_text[*pos_in_syllab_text] != 0x318D
-				&& u_is_Hangul_Compatility_Jamo(
-						syllab_text[*pos_in_syllab_text])) {
-			/* If necessary, we update the positions */
-			error("updating letter position for tag %S\n", jamo_tag);
-			current_letter = 0;
-			was_a_Jamo_in_syllab_text = 1;
-		}
-		for (int i = 0; jamo_tag[i] != '\0'; i++) {
-			if (jamo_tag[i] != syllab_text[*pos_in_syllab_text]) {
-				fatal_error(
-						"compute_end_positions: mismatch between text and tag syllabic character\n"
-							"tag[%d]=%C  text[%d]=%C\n", i, jamo_tag[i],
-						*pos_in_syllab_text, syllab_text[*pos_in_syllab_text]);
-			}
-			(*pos_in_syllab_text)++;
-			(*end_pos_char) = current_char;
-			current_char++;
-			/* We also must go on in the Jamo text */
-			if ((i > 0 || !was_a_Jamo_in_syllab_text)
-			/* The previous char was a Jamo ? */
-			&& *pos_in_jamo_text > 0 && u_is_Hangul_Jamo(
-					jamo_text[(*pos_in_jamo_text) - 1])
-			/* Not a Jamo syllable bound ? */
-			&& jamo_text[*pos_in_jamo_text] != 0x318D
-			/* Not a non Jamo letter ? */
-			&& !is_letter(jamo_text[*pos_in_jamo_text], alphabet)) {
-				fatal_error(
-						"compute_end_positions: should have found a syllable bound character\n"
-							"jamo_tag=%S pos_in_syllab_text=%d jamo_text[%d]=%C\n"
-							"i=%d  was a jamo in syllable text=%d\n", jamo_tag,
-						*pos_in_syllab_text, *pos_in_jamo_text,
-						jamo_text[*pos_in_jamo_text], i,
-						was_a_Jamo_in_syllab_text);
-			}
-			(*pos_in_jamo_text)++;
-			current_letter = 0;
-			if (!was_a_Jamo_in_syllab_text) {
-				/* If there was a Jamo char in the syllable text, then the (*pos_in_jamo_text)++; above
-				 * has already moved correctly the position in the Jamo text */
-				while (u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
-					/*error("pour le tag %S, on zappe le char %C a la position %d\n",jamo_tag,
-					 jamo_text[*pos_in_jamo_text],*pos_in_jamo_text);*/
-					(*end_pos_letter) = current_letter;
-					current_letter++;
-					(*pos_in_jamo_text)++;
-				}
-			}
-		}
-		if (current_char == token_sizes[current_token]) {
-			/* If we have reached the end of the current token */
-			current_token++;
-			current_char = 0;
-			current_letter = 0;
-		} else {
-			/* If not, we are supposed to have reached the end of a syllable */
-			current_letter = 0;
-		}
-		(*new_pos_in_token) = current_token;
-		(*new_pos_in_char) = current_char;
-		(*new_pos_in_letter) = current_letter;
-		return;
-	}
-	/* We have a tag made of any characters, except Korean syllabic ones */
-	for (int i = 0; jamo_tag[i] != '\0'; i++) {
-		if (jamo_tag[i] == 0x318D) {
-			/* We skip the sentence bound character in the tag */
-			continue;
-		}
-		if (!u_is_Hangul_Jamo(jamo_tag[i])) {
-			/* If the current character is not a Jamo letter, we must compare it to the
-			 * one in the text */
-			if (jamo_tag[i] != jamo_text[*pos_in_jamo_text]) {
-				fatal_error(
-						"compute_end_positions: mismatch between text and tag Jamo character\n"
-							"tag[%d]=%C  text[%d]=%C\n", i, jamo_tag[i],
-						*pos_in_jamo_text, jamo_text[*pos_in_jamo_text]);
-			}
-			(*pos_in_jamo_text)++;
-			/* A non Jamo character always corresponds to one character in the syllable text */
-			(*pos_in_syllab_text)++;
-			(*end_pos_token) = current_token;
-			(*end_pos_char) = current_char;
-			(*end_pos_letter) = current_letter;
-			if (current_char + 1 != token_sizes[current_token]) {
-				/* If we are not at the end of the current token */
-				current_char++;
-				current_letter = 0;
-			} else {
-				/* We have reached the end of the current token */
-				current_char = 0;
-				current_letter = 0;
-				current_token++;
-			}
-		} else {
-			/* We have a Jamo letter */
-			if (jamo_text[*pos_in_jamo_text] == 0x318D) {
-				/* If the text contains a syllable bound character, we must reset the letter position,
-				 * and that's all since char and syllable positions are modified when we reached the
-				 * end of a syllable (see below) */
-				current_letter = 0;
-				(*pos_in_jamo_text)++;
-				if (!u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
-					fatal_error(
-							"compute_end_positions: non Jamo letter after syllable bound character\n");
-				}
-			}
-			/* When we have a Jamo letter, we just have to compare it with the current one in
-			 * the text */
-			if (jamo_tag[i] != jamo_text[*pos_in_jamo_text]) {
-				fatal_error(
-						"compute_end_positions: mismatch #2 between text and tag character\n"
-							"jamo_tag[%d]=%C  jamo_text[%d]=%C\n", i,
-						jamo_tag[i], *pos_in_jamo_text,
-						jamo_text[*pos_in_jamo_text]);
-			}
-			(*pos_in_jamo_text)++;
-			(*end_pos_token) = current_token;
-			(*end_pos_char) = current_char;
-			(*end_pos_letter) = current_letter;
-			/*if (*pos_in_jamo_text==57) {
-			 error("pos_in_jamo_text==57  pour le tag %S\n",jamo_tag);
-			 error("  => current_char=%d  current token size=%d\n",current_char,token_sizes[current_token]);
-			 error("  => prochain char=%C (%X) jamo=%d\n",jamo_text[*pos_in_jamo_text],jamo_text[*pos_in_jamo_text],u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text]));
-			 error("for %C, syllable[%d]=%C\n",0x1105,*pos_in_syllab_text,syllab_text[(*pos_in_syllab_text)]);
-			 error("    is Jamo=%d  is Jamo compatible=%d\n",u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text)])
-			 ,u_is_Hangul_Compatility_Jamo(syllab_text[(*pos_in_syllab_text)]));
-			 error("current letter=%d\n",current_letter);
-			 }*/
+        int *pos_in_jamo_text, unichar* syllab_text, int *pos_in_syllab_text,
+        int *end_pos_token, int *end_pos_char, int *end_pos_letter,
+        int *new_pos_in_token, int *new_pos_in_char, int *new_pos_in_letter,
+        int* token_sizes, Alphabet* alphabet) {
+    int current_token = *end_pos_token;
+    int current_char = *end_pos_char;
+    int current_letter = *end_pos_letter;
+    if (/*u_is_korea_syllabe_letter(jamo_tag[0]) || alphabet->korean_equivalent_syllab[jamo_tag[0]]!=0*/
+    /*jamo_tag[0]!=0x318D && !u_is_Hangul_Jamo(jamo_tag[0])*/
+    token_contains_Hangul_or_Chinese_chars(jamo_tag, alphabet)) {
+        if ((*end_pos_letter) != 0
+        /* With this test, we deal with the case where a Jamo char was in the original text.
+         * Then, we must update here the position in the text. It cannot be done
+         * elsewhere, because this complicated case of "end of token even if there
+         * is still Jamo char in the text" cannot be detected easily */
+        && syllab_text[*pos_in_syllab_text] != jamo_tag[0]) {
+            fatal_error(
+                    "compute_end_positions: cannot match a syllabic char when current_letter!=0\n"
+                        "current_letter=%d  current token size=%d  tag=%S  syllab_text[%d]=%C  pos_in_jamo_text=%d\n"
+                        "current token=%d\n", *end_pos_letter,
+                    token_sizes[current_token], jamo_tag, *pos_in_syllab_text,
+                    syllab_text[*pos_in_syllab_text], *pos_in_jamo_text,
+                    current_token);
+        }
+        int was_a_Jamo_in_syllab_text = 0;
+        if (syllab_text[*pos_in_syllab_text] != 0x318D
+                && u_is_Hangul_Compatility_Jamo(
+                        syllab_text[*pos_in_syllab_text])) {
+            /* If necessary, we update the positions */
+            error("updating letter position for tag %S\n", jamo_tag);
+            current_letter = 0;
+            was_a_Jamo_in_syllab_text = 1;
+        }
+        for (int i = 0; jamo_tag[i] != '\0'; i++) {
+            if (jamo_tag[i] != syllab_text[*pos_in_syllab_text]) {
+                fatal_error(
+                        "compute_end_positions: mismatch between text and tag syllabic character\n"
+                            "tag[%d]=%C  text[%d]=%C\n", i, jamo_tag[i],
+                        *pos_in_syllab_text, syllab_text[*pos_in_syllab_text]);
+            }
+            (*pos_in_syllab_text)++;
+            (*end_pos_char) = current_char;
+            current_char++;
+            /* We also must go on in the Jamo text */
+            if ((i > 0 || !was_a_Jamo_in_syllab_text)
+            /* The previous char was a Jamo ? */
+            && *pos_in_jamo_text > 0 && u_is_Hangul_Jamo(
+                    jamo_text[(*pos_in_jamo_text) - 1])
+            /* Not a Jamo syllable bound ? */
+            && jamo_text[*pos_in_jamo_text] != 0x318D
+            /* Not a non Jamo letter ? */
+            && !is_letter(jamo_text[*pos_in_jamo_text], alphabet)) {
+                fatal_error(
+                        "compute_end_positions: should have found a syllable bound character\n"
+                            "jamo_tag=%S pos_in_syllab_text=%d jamo_text[%d]=%C\n"
+                            "i=%d  was a jamo in syllable text=%d\n", jamo_tag,
+                        *pos_in_syllab_text, *pos_in_jamo_text,
+                        jamo_text[*pos_in_jamo_text], i,
+                        was_a_Jamo_in_syllab_text);
+            }
+            (*pos_in_jamo_text)++;
+            current_letter = 0;
+            if (!was_a_Jamo_in_syllab_text) {
+                /* If there was a Jamo char in the syllable text, then the (*pos_in_jamo_text)++; above
+                 * has already moved correctly the position in the Jamo text */
+                while (u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
+                    /*error("pour le tag %S, on zappe le char %C a la position %d\n",jamo_tag,
+                     jamo_text[*pos_in_jamo_text],*pos_in_jamo_text);*/
+                    (*end_pos_letter) = current_letter;
+                    current_letter++;
+                    (*pos_in_jamo_text)++;
+                }
+            }
+        }
+        if (current_char == token_sizes[current_token]) {
+            /* If we have reached the end of the current token */
+            current_token++;
+            current_char = 0;
+            current_letter = 0;
+        } else {
+            /* If not, we are supposed to have reached the end of a syllable */
+            current_letter = 0;
+        }
+        (*new_pos_in_token) = current_token;
+        (*new_pos_in_char) = current_char;
+        (*new_pos_in_letter) = current_letter;
+        return;
+    }
+    /* We have a tag made of any characters, except Korean syllabic ones */
+    for (int i = 0; jamo_tag[i] != '\0'; i++) {
+        if (jamo_tag[i] == 0x318D) {
+            /* We skip the sentence bound character in the tag */
+            continue;
+        }
+        if (!u_is_Hangul_Jamo(jamo_tag[i])) {
+            /* If the current character is not a Jamo letter, we must compare it to the
+             * one in the text */
+            if (jamo_tag[i] != jamo_text[*pos_in_jamo_text]) {
+                fatal_error(
+                        "compute_end_positions: mismatch between text and tag Jamo character\n"
+                            "tag[%d]=%C  text[%d]=%C\n", i, jamo_tag[i],
+                        *pos_in_jamo_text, jamo_text[*pos_in_jamo_text]);
+            }
+            (*pos_in_jamo_text)++;
+            /* A non Jamo character always corresponds to one character in the syllable text */
+            (*pos_in_syllab_text)++;
+            (*end_pos_token) = current_token;
+            (*end_pos_char) = current_char;
+            (*end_pos_letter) = current_letter;
+            if (current_char + 1 != token_sizes[current_token]) {
+                /* If we are not at the end of the current token */
+                current_char++;
+                current_letter = 0;
+            } else {
+                /* We have reached the end of the current token */
+                current_char = 0;
+                current_letter = 0;
+                current_token++;
+            }
+        } else {
+            /* We have a Jamo letter */
+            if (jamo_text[*pos_in_jamo_text] == 0x318D) {
+                /* If the text contains a syllable bound character, we must reset the letter position,
+                 * and that's all since char and syllable positions are modified when we reached the
+                 * end of a syllable (see below) */
+                current_letter = 0;
+                (*pos_in_jamo_text)++;
+                if (!u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
+                    fatal_error(
+                            "compute_end_positions: non Jamo letter after syllable bound character\n");
+                }
+            }
+            /* When we have a Jamo letter, we just have to compare it with the current one in
+             * the text */
+            if (jamo_tag[i] != jamo_text[*pos_in_jamo_text]) {
+                fatal_error(
+                        "compute_end_positions: mismatch #2 between text and tag character\n"
+                            "jamo_tag[%d]=%C  jamo_text[%d]=%C\n", i,
+                        jamo_tag[i], *pos_in_jamo_text,
+                        jamo_text[*pos_in_jamo_text]);
+            }
+            (*pos_in_jamo_text)++;
+            (*end_pos_token) = current_token;
+            (*end_pos_char) = current_char;
+            (*end_pos_letter) = current_letter;
+            /*if (*pos_in_jamo_text==57) {
+             error("pos_in_jamo_text==57  pour le tag %S\n",jamo_tag);
+             error("  => current_char=%d  current token size=%d\n",current_char,token_sizes[current_token]);
+             error("  => prochain char=%C (%X) jamo=%d\n",jamo_text[*pos_in_jamo_text],jamo_text[*pos_in_jamo_text],u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text]));
+             error("for %C, syllable[%d]=%C\n",0x1105,*pos_in_syllab_text,syllab_text[(*pos_in_syllab_text)]);
+             error("    is Jamo=%d  is Jamo compatible=%d\n",u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text)])
+             ,u_is_Hangul_Compatility_Jamo(syllab_text[(*pos_in_syllab_text)]));
+             error("current letter=%d\n",current_letter);
+             }*/
 
-			if (current_char + 1 == token_sizes[current_token] &&
-			/* If we are on the last char of the current token */
-			(!u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])
-			/* and if 1) there is no more Jamo char in the Jamo text */
-			||
-			/* or 2) if there is a Jamo char but we are in the case were this char
-			 * comes from a Jamo char that was present in the original syllabic text */
-			u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text) + 1])
-					|| u_is_Hangul_Compatility_Jamo(
-							syllab_text[(*pos_in_syllab_text) + 1]))) {
-				if (u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text) + 1])
-						|| u_is_Hangul_Compatility_Jamo(
-								syllab_text[(*pos_in_syllab_text) + 1])) {
-					error(
-							"pos_in_jamo_text=%d:   end of token because of Jamo char %C in the syllabic text\n",
-							*pos_in_jamo_text,
-							syllab_text[(*pos_in_syllab_text) + 1]);
-				}
-				current_char = 0;
-				current_letter = 0;
-				current_token++;
-				(*pos_in_syllab_text)++;
-			} else {
-				/* We are not at the end of the current token */
-				if (u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
-					/* If the next character is a Jamo letter, then we just increase the
-					 * letter position */
-					current_letter++;
-				} else {
-					if (jamo_text[*pos_in_jamo_text] != 0x318D) {
-						fatal_error(
-								"compute_end_positions: syllable bound character expected but not found\n");
-					}
-					/* If the next character is not a Jamo letter, then we must reset the letter position
-					 * and increase the char position */
-					current_letter = 0;
-					current_char++;
-					(*pos_in_syllab_text)++;
-				}
-			}
-		}
-	}
-	/* Finally, we set the positions for the next move */
-	(*new_pos_in_token) = current_token;
-	(*new_pos_in_char) = current_char;
-	(*new_pos_in_letter) = current_letter;
+            if (current_char + 1 == token_sizes[current_token] &&
+            /* If we are on the last char of the current token */
+            (!u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])
+            /* and if 1) there is no more Jamo char in the Jamo text */
+            ||
+            /* or 2) if there is a Jamo char but we are in the case were this char
+             * comes from a Jamo char that was present in the original syllabic text */
+            u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text) + 1])
+                    || u_is_Hangul_Compatility_Jamo(
+                            syllab_text[(*pos_in_syllab_text) + 1]))) {
+                if (u_is_Hangul_Jamo(syllab_text[(*pos_in_syllab_text) + 1])
+                        || u_is_Hangul_Compatility_Jamo(
+                                syllab_text[(*pos_in_syllab_text) + 1])) {
+                    error(
+                            "pos_in_jamo_text=%d:   end of token because of Jamo char %C in the syllabic text\n",
+                            *pos_in_jamo_text,
+                            syllab_text[(*pos_in_syllab_text) + 1]);
+                }
+                current_char = 0;
+                current_letter = 0;
+                current_token++;
+                (*pos_in_syllab_text)++;
+            } else {
+                /* We are not at the end of the current token */
+                if (u_is_Hangul_Jamo(jamo_text[*pos_in_jamo_text])) {
+                    /* If the next character is a Jamo letter, then we just increase the
+                     * letter position */
+                    current_letter++;
+                } else {
+                    if (jamo_text[*pos_in_jamo_text] != 0x318D) {
+                        fatal_error(
+                                "compute_end_positions: syllable bound character expected but not found\n");
+                    }
+                    /* If the next character is not a Jamo letter, then we must reset the letter position
+                     * and increase the char position */
+                    current_letter = 0;
+                    current_char++;
+                    (*pos_in_syllab_text)++;
+                }
+            }
+        }
+    }
+    /* Finally, we set the positions for the next move */
+    (*new_pos_in_token) = current_token;
+    (*new_pos_in_char) = current_char;
+    (*new_pos_in_letter) = current_letter;
 }
 
 /* the function is the recursive work for explore_korean_automaton_for_positions
  with jamo_tag and syllab_tag private array of 256 unichar provided
  */
 void explore_korean_automaton_for_positions_with_buffer(Tfst* tfst, Fst2* jamo,
-		unichar* jamo_text, int current_state, int pos_in_token,
-		int pos_in_char, int pos_in_letter, int pos_in_syllab_text,
-		int pos_in_jamo_text, Alphabet* alphabet, unichar* jamo_tag,
-		unichar* syllab_tag) {
-	Transition* t =
-			tfst->automaton->states[current_state]->outgoing_transitions;
-	TfstTag* tag;
-	while (t != NULL) {
-		tag = (TfstTag*) (tfst->tags->tab[t->tag_number]);
-		if (tag->type != T_EPSILON && tag->m.end_pos_in_token == -1) {
-			/* We only process non epsilon tags that have not been explored */
-			if (!u_strcmp(tag->content, "<BL>")) {
-				/* The special <BL> tag was used to represent the space in a text automaton.
-				 * Now, we just increase our positions and then turn this tag into an
-				 * epsilon one, after some error checking */
-				if (jamo_text[pos_in_jamo_text] != ' ') {
-					fatal_error(
-							"explore_korean_automaton_for_positions_with_buffer: jamo_text <BL> error\n");
-				}
-				if (tfst->text[pos_in_syllab_text] != ' ') {
-					fatal_error(
-							"explore_korean_automaton_for_positions_with_buffer: syllab_text <BL> error\n"
-								"text[%d]=%C\n", pos_in_syllab_text,
-							tfst->text[pos_in_syllab_text]);
-				}
-				/* We set the tag number to 0 in order to replace this <BL> transition by an epsilon one */
-				t->tag_number = 0;
+        unichar* jamo_text, int current_state, int pos_in_token,
+        int pos_in_char, int pos_in_letter, int pos_in_syllab_text,
+        int pos_in_jamo_text, Alphabet* alphabet, unichar* jamo_tag,
+        unichar* syllab_tag) {
+    Transition* t =
+            tfst->automaton->states[current_state]->outgoing_transitions;
+    TfstTag* tag;
+    while (t != NULL) {
+        tag = (TfstTag*) (tfst->tags->tab[t->tag_number]);
+        if (tag->type != T_EPSILON && tag->m.end_pos_in_token == -1) {
+            /* We only process non epsilon tags that have not been explored */
+            if (!u_strcmp(tag->content, "<BL>")) {
+                /* The special <BL> tag was used to represent the space in a text automaton.
+                 * Now, we just increase our positions and then turn this tag into an
+                 * epsilon one, after some error checking */
+                if (jamo_text[pos_in_jamo_text] != ' ') {
+                    fatal_error(
+                            "explore_korean_automaton_for_positions_with_buffer: jamo_text <BL> error\n");
+                }
+                if (tfst->text[pos_in_syllab_text] != ' ') {
+                    fatal_error(
+                            "explore_korean_automaton_for_positions_with_buffer: syllab_text <BL> error\n"
+                                "text[%d]=%C\n", pos_in_syllab_text,
+                            tfst->text[pos_in_syllab_text]);
+                }
+                /* We set the tag number to 0 in order to replace this <BL> transition by an epsilon one */
+                t->tag_number = 0;
 
-				explore_korean_automaton_for_positions_with_buffer(tfst, jamo,
-						jamo_text, t->state_number,
-						/* We change of token */
-						pos_in_token + 1, 0, 0, pos_in_syllab_text + 1,
-						pos_in_jamo_text + 1, alphabet, jamo_tag, syllab_tag);
-			} else {
-				/* Non <BL> tag */
-				/* Remember that the original tag number was stored in 'start_pos_token' */
-				get_tag_content(jamo->tags[tag->m.start_pos_in_token]->input,
-						jamo_tag);
-				if (!u_strcmp(jamo_tag, "<E>")) {
-					/* If we have an empty surface form */
-					tag->m.start_pos_in_token = pos_in_token;
-					tag->m.end_pos_in_token = pos_in_token;
-					tag->m.start_pos_in_char = pos_in_char;
-					tag->m.end_pos_in_char = pos_in_char;
-					tag->m.start_pos_in_letter = pos_in_letter;
-					/* We note that we have a tag that correspond to the empty word in the text by
-					 * setting end_pos_letter to -1. We set all other fields with correct values in
-					 * order to know where this empty surface form occurs */
-					tag->m.end_pos_in_letter = -1;
-					explore_korean_automaton_for_positions_with_buffer(tfst,
-							jamo, jamo_text, t->state_number, pos_in_token,
-							pos_in_char, pos_in_letter, pos_in_syllab_text,
-							pos_in_jamo_text, alphabet, jamo_tag, syllab_tag);
-				} else {
-					/* Normal tag */
-					//get_tag_content(tag->content,syllab_tag);
-					/* The start positions are the current ones */
-					tag->m.start_pos_in_token = pos_in_token;
-					tag->m.start_pos_in_char = pos_in_char;
-					tag->m.start_pos_in_letter = pos_in_letter;
-					/* We also initialize the end positions with the current ones */
-					tag->m.end_pos_in_token = pos_in_token;
-					tag->m.end_pos_in_char = pos_in_char;
-					tag->m.end_pos_in_letter = pos_in_letter;
+                explore_korean_automaton_for_positions_with_buffer(tfst, jamo,
+                        jamo_text, t->state_number,
+                        /* We change of token */
+                        pos_in_token + 1, 0, 0, pos_in_syllab_text + 1,
+                        pos_in_jamo_text + 1, alphabet, jamo_tag, syllab_tag);
+            } else {
+                /* Non <BL> tag */
+                /* Remember that the original tag number was stored in 'start_pos_token' */
+                get_tag_content(jamo->tags[tag->m.start_pos_in_token]->input,
+                        jamo_tag);
+                if (!u_strcmp(jamo_tag, "<E>")) {
+                    /* If we have an empty surface form */
+                    tag->m.start_pos_in_token = pos_in_token;
+                    tag->m.end_pos_in_token = pos_in_token;
+                    tag->m.start_pos_in_char = pos_in_char;
+                    tag->m.end_pos_in_char = pos_in_char;
+                    tag->m.start_pos_in_letter = pos_in_letter;
+                    /* We note that we have a tag that correspond to the empty word in the text by
+                     * setting end_pos_letter to -1. We set all other fields with correct values in
+                     * order to know where this empty surface form occurs */
+                    tag->m.end_pos_in_letter = -1;
+                    explore_korean_automaton_for_positions_with_buffer(tfst,
+                            jamo, jamo_text, t->state_number, pos_in_token,
+                            pos_in_char, pos_in_letter, pos_in_syllab_text,
+                            pos_in_jamo_text, alphabet, jamo_tag, syllab_tag);
+                } else {
+                    /* Normal tag */
+                    //get_tag_content(tag->content,syllab_tag);
+                    /* The start positions are the current ones */
+                    tag->m.start_pos_in_token = pos_in_token;
+                    tag->m.start_pos_in_char = pos_in_char;
+                    tag->m.start_pos_in_letter = pos_in_letter;
+                    /* We also initialize the end positions with the current ones */
+                    tag->m.end_pos_in_token = pos_in_token;
+                    tag->m.end_pos_in_char = pos_in_char;
+                    tag->m.end_pos_in_letter = pos_in_letter;
 
-					int new_pos_in_token, new_pos_in_char, new_pos_in_letter;
-					int new_pos_in_jamo_text = pos_in_jamo_text;
-					int new_pos_in_syllab_text = pos_in_syllab_text;
-					compute_end_positions(jamo_tag, jamo_text,
-							&new_pos_in_jamo_text, tfst->text,
-							&new_pos_in_syllab_text,
-							&(tag->m.end_pos_in_token),
-							&(tag->m.end_pos_in_char),
-							&(tag->m.end_pos_in_letter), &new_pos_in_token,
-							&new_pos_in_char, &new_pos_in_letter,
-							tfst->token_sizes->tab, alphabet);
+                    int new_pos_in_token, new_pos_in_char, new_pos_in_letter;
+                    int new_pos_in_jamo_text = pos_in_jamo_text;
+                    int new_pos_in_syllab_text = pos_in_syllab_text;
+                    compute_end_positions(jamo_tag, jamo_text,
+                            &new_pos_in_jamo_text, tfst->text,
+                            &new_pos_in_syllab_text,
+                            &(tag->m.end_pos_in_token),
+                            &(tag->m.end_pos_in_char),
+                            &(tag->m.end_pos_in_letter), &new_pos_in_token,
+                            &new_pos_in_char, &new_pos_in_letter,
+                            tfst->token_sizes->tab, alphabet);
 
-					//error("\nafter tag %S, pos_token=%d pos_char=%d pos_letter=%d      pos_syllab=%d pos_jamo=%d\n",syllab_tag,
-					//      new_pos_in_token,new_pos_in_char,new_pos_in_letter,new_pos_in_syllab_text,new_pos_in_jamo_text);
-					explore_korean_automaton_for_positions_with_buffer(tfst,
-							jamo, jamo_text, t->state_number, new_pos_in_token,
-							new_pos_in_char, new_pos_in_letter,
-							new_pos_in_syllab_text, new_pos_in_jamo_text,
-							alphabet, jamo_tag, syllab_tag);
-				}
-			}
-		}
-		t = t->next;
-	}
+                    //error("\nafter tag %S, pos_token=%d pos_char=%d pos_letter=%d      pos_syllab=%d pos_jamo=%d\n",syllab_tag,
+                    //      new_pos_in_token,new_pos_in_char,new_pos_in_letter,new_pos_in_syllab_text,new_pos_in_jamo_text);
+                    explore_korean_automaton_for_positions_with_buffer(tfst,
+                            jamo, jamo_text, t->state_number, new_pos_in_token,
+                            new_pos_in_char, new_pos_in_letter,
+                            new_pos_in_syllab_text, new_pos_in_jamo_text,
+                            alphabet, jamo_tag, syllab_tag);
+                }
+            }
+        }
+        t = t->next;
+    }
 }
 
 /**
@@ -1384,15 +1384,15 @@ void explore_korean_automaton_for_positions_with_buffer(Tfst* tfst, Fst2* jamo,
  * know the number of the original tag).
  */
 void explore_korean_automaton_for_positions(Tfst* tfst, Fst2* jamo,
-		unichar* jamo_text, int current_state, int pos_in_token,
-		int pos_in_char, int pos_in_letter, int pos_in_syllab_text,
-		int pos_in_jamo_text, Alphabet* alphabet) {
-	unichar jamo_tag[256];
-	unichar syllab_tag[256];
-	explore_korean_automaton_for_positions_with_buffer(tfst, jamo, jamo_text,
-			current_state, pos_in_token, pos_in_char, pos_in_letter,
-			pos_in_syllab_text, pos_in_jamo_text, alphabet, jamo_tag,
-			syllab_tag);
+        unichar* jamo_text, int current_state, int pos_in_token,
+        int pos_in_char, int pos_in_letter, int pos_in_syllab_text,
+        int pos_in_jamo_text, Alphabet* alphabet) {
+    unichar jamo_tag[256];
+    unichar syllab_tag[256];
+    explore_korean_automaton_for_positions_with_buffer(tfst, jamo, jamo_text,
+            current_state, pos_in_token, pos_in_char, pos_in_letter,
+            pos_in_syllab_text, pos_in_jamo_text, alphabet, jamo_tag,
+            syllab_tag);
 }
 
 } // namespace unitex

--- a/BuildTextAutomaton.h
+++ b/BuildTextAutomaton.h
@@ -47,20 +47,20 @@ namespace unitex {
  * on the base of information taken from either the normalization fst2 or the tags.ind file.
  */
 struct output_info {
-	/* The output to a appear in the .tfst */
-	unichar* output;
-	/* The content of the tag. If the tag is of the form {xx,yyy.zzz},
-	 * it means xx; otherwise it is the same than 'output'. */
-	unichar* content;
-	/* Bounds of the sequence in the sentence, given in the form (X,Y) (W,Z) where
-	 * X is the start position in tokens, Y is the position in char in this token,
-	 * W is the end position in tokens, Z is the position in char in this token. */
-	int start_pos;
-	int end_pos;
-	int start_pos_char;
-	int end_pos_char;
-	int start_pos_letter;
-	int end_pos_letter;
+    /* The output to a appear in the .tfst */
+    unichar* output;
+    /* The content of the tag. If the tag is of the form {xx,yyy.zzz},
+     * it means xx; otherwise it is the same than 'output'. */
+    unichar* content;
+    /* Bounds of the sequence in the sentence, given in the form (X,Y) (W,Z) where
+     * X is the start position in tokens, Y is the position in char in this token,
+     * W is the end position in tokens, Z is the position in char in this token. */
+    int start_pos;
+    int end_pos;
+    int start_pos_char;
+    int end_pos_char;
+    int start_pos_letter;
+    int end_pos_letter;
 };
 
 #define MAX_TOKENS_IN_SENTENCE 2000
@@ -69,12 +69,12 @@ struct output_info {
  * This is an internal structure only used to give a set of parameters to some functions.
  */
 struct info {
-	const struct text_tokens* tok;
-	const int* buffer;
-	const Alphabet* alph;
-	int SPACE;
-	int TOKEN;
-	int length_max;
+    const struct text_tokens* tok;
+    const int* buffer;
+    const Alphabet* alph;
+    int SPACE;
+    int TOKEN;
+    int length_max;
 };
 
 void build_sentence_automaton(const int*,int,const struct text_tokens*,
@@ -88,26 +88,26 @@ void keep_best_paths(SingleGraph graph,struct string_hash* tmp_tags) ;
 int count_non_space_tokens(const int* buffer,int length,int SPACE);
 vector_ptr* tokenize_normalization_output(unichar* s, const Alphabet* alph);
 void free_output_info(struct output_info* x);
-void explore_dictionary_tree(int pos ,const unichar* token,	unichar* inflected,
-							int ,const struct string_hash_tree_node* ,
-							const struct DELA_tree* ,struct info* ,
-							SingleGraphState ,
-							int, int, int*, int, int, struct string_hash* ,
-							Ustring* ,language_t* ,unichar* tb);
+void explore_dictionary_tree(int pos ,const unichar* token, unichar* inflected,
+                            int ,const struct string_hash_tree_node* ,
+                            const struct DELA_tree* ,struct info* ,
+                            SingleGraphState ,
+                            int, int, int*, int, int, struct string_hash* ,
+                            Ustring* ,language_t* ,unichar* tb);
 
 void add_path_to_sentence_automaton(int start_pos, int end_pos,
-							int start_state_index, const Alphabet* alph,
-							SingleGraph graph,struct string_hash* tmp_tags,
-							unichar* s, int destination_state_index,
-							Ustring* foo, struct info* INFO, Korean* korean);
+                            int start_state_index, const Alphabet* alph,
+                            SingleGraph graph,struct string_hash* tmp_tags,
+                            unichar* s, int destination_state_index,
+                            Ustring* foo, struct info* INFO, Korean* korean);
 void explore_normalization_tree(int first_pos_in_buffer,
-							int current_pos_in_buffer, int token,
-							struct info* INFO,SingleGraph graph,
-							struct string_hash* tmp_tags,
-							struct normalization_tree* norm_tree_node,
-							int first_state_index,int shift, Ustring* foo,
-							int increment, language_t* language,
-							Korean* korean);
+                            int current_pos_in_buffer, int token,
+                            struct info* INFO,SingleGraph graph,
+                            struct string_hash* tmp_tags,
+                            struct normalization_tree* norm_tree_node,
+                            int first_state_index,int shift, Ustring* foo,
+                            int increment, language_t* language,
+                            Korean* korean);
 } // namespace unitex
 
 #endif

--- a/Cassys.cpp
+++ b/Cassys.cpp
@@ -1114,12 +1114,12 @@ int main_Cassys(int argc,char* const argv[]) {
         }
         case 'x': {
             if (options.vars()->optarg[0] != '\0') {
-		if(strcmp(options.vars()->optarg,"standoff")==0) {
+        if(strcmp(options.vars()->optarg,"standoff")==0) {
                     istex_param = 2;
-		}
-		else if(strcmp(options.vars()->optarg,"token")==0) {
+        }
+        else if(strcmp(options.vars()->optarg,"token")==0) {
                     istex_param = 1;
-		}
+        }
             }
             else {
                 error("You must specify an argument for istex\n");
@@ -1133,7 +1133,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 return USAGE_ERROR_CODE;
             }
             break;
-	}
+    }
         default :{
             error("Invalid option : %c\n",val);
             free_transducer_name_and_mode_linked_list(transducer_name_and_mode_linked_list_arg);
@@ -1807,12 +1807,12 @@ int cascade(const char* original_text, int in_place, int must_create_directory, 
                 (p_locate_perf_info + loop_display_perf)->name);
     }
 
-	if (p_locate_perf_info != NULL) {
-		for (unsigned int loop_display_perf = 0; loop_display_perf < nb_perf_info; loop_display_perf++) {
-			free((p_locate_perf_info + loop_display_perf)->name);
+    if (p_locate_perf_info != NULL) {
+        for (unsigned int loop_display_perf = 0; loop_display_perf < nb_perf_info; loop_display_perf++) {
+            free((p_locate_perf_info + loop_display_perf)->name);
         }
-		free(p_locate_perf_info);
-	}
+        free(p_locate_perf_info);
+    }
 
     return SUCCESS_RETURN_CODE;
 }

--- a/Cassys.cpp
+++ b/Cassys.cpp
@@ -338,7 +338,7 @@ grfInfo *extract_info(unichar **lines, int *num_annot, int total_lines, int *loc
                     infos[num_info].annotation[k] = lines[annot_pos][j];
                 infos[num_info].annotation[k] = '\0';
                 //end extract tag information
-                
+
                 num_info++;
             }
             num_lines++;
@@ -356,7 +356,7 @@ unichar **extract_entities(const char *token_list, const char *token_list_backup
         entity_string[i] = NULL;
     U_FILE *dico = u_fopen(vec, token_list, U_READ); //token list in the current _snt folder
     if(dico == NULL)
-        dico = u_fopen(vec, token_list_backup, U_READ);   //token list in the previous _snt folder 
+        dico = u_fopen(vec, token_list_backup, U_READ);   //token list in the previous _snt folder
     if(dico != NULL && infos != NULL) {
     int * num_entity = (int*)malloc(sizeof(int)*(num+1));
     for(int i = 0; i < num; i++)
@@ -379,7 +379,7 @@ unichar **extract_entities(const char *token_list, const char *token_list_backup
                 if(line[j]=='\\' && j+1<line_len) { //in case the annotation is protected
                     if(infos[k].annotation[i] == line[j+1])
                         j++;
-                } 
+                }
             }
             if(infos[k].annotation[i] == '\0') {
                 int reverse_i =  j; //We will go in reverse to find the entity
@@ -396,7 +396,7 @@ unichar **extract_entities(const char *token_list, const char *token_list_backup
                         num_paren++;
                     }
                     reverse_i--;
-                } 
+                }
                 int start = 0;
                 int end = 0;
                 int annot_start = 0;
@@ -731,7 +731,7 @@ int main_Cassys(int argc,char* const argv[]) {
         alloc_error("main_Cassys");
         free_vector_ptr(tokenize_additional_args, free);
         free(temp_work_dir);
-        free(textbuf);        
+        free(textbuf);
         return ALLOC_ERROR_CODE;
     }
 
@@ -741,7 +741,7 @@ int main_Cassys(int argc,char* const argv[]) {
         free_vector_ptr(locate_additional_args, free);
         free_vector_ptr(tokenize_additional_args, free);
         free(temp_work_dir);
-        free(textbuf);        
+        free(textbuf);
         return ALLOC_ERROR_CODE;
     }
 
@@ -758,7 +758,7 @@ int main_Cassys(int argc,char* const argv[]) {
                                           lopts_Cassys, &index))) {
         switch (val) {
         case 'V': only_verify_arguments = true;
-                  break;        
+                  break;
         case 'h': usage();
                   free_transducer_name_and_mode_linked_list(transducer_name_and_mode_linked_list_arg);
                   free_vector_ptr(concord_additional_args, free);
@@ -777,7 +777,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
@@ -790,7 +790,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -804,7 +804,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             }
 
             get_extension(options.vars()->optarg, textbuf->extension_text_name);
@@ -818,7 +818,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             }
 
             strcpy(textbuf->text_file_name, options.vars()->optarg);
@@ -836,7 +836,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             } else {
                 strcpy(textbuf->transducer_list_file_name, options.vars()->optarg);
                 has_transducer_list = true;
@@ -853,7 +853,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             } else {
                 strcpy(textbuf->transducer_filename_prefix, options.vars()->optarg);
                 has_transducer_list = true;
@@ -870,7 +870,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             } else {
                 transducer_name_and_mode_linked_list_arg=add_transducer_linked_list_new_name(transducer_name_and_mode_linked_list_arg,options.vars()->optarg);
             }
@@ -886,7 +886,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
             } else {
                 set_last_transducer_linked_list_mode_by_string(transducer_name_and_mode_linked_list_arg,options.vars()->optarg);
             }
@@ -956,7 +956,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              if ((strcmp(options.vars()->optarg,"minus")!=0) && (strcmp(options.vars()->optarg,"-")!=0) &&
                  (strcmp(options.vars()->optarg,"tilde")!=0) && (strcmp(options.vars()->optarg,"~")!=0))
@@ -1019,7 +1019,7 @@ int main_Cassys(int argc,char* const argv[]) {
                         free_vector_ptr(tokenize_additional_args, free);
                         free(morpho_dic);
                         free(textbuf);
-                        return ALLOC_ERROR_CODE;                      
+                        return ALLOC_ERROR_CODE;
                     }
 
             }
@@ -1037,7 +1037,7 @@ int main_Cassys(int argc,char* const argv[]) {
                         free_vector_ptr(tokenize_additional_args, free);
                         free(temp_work_dir);
                         free(textbuf);
-                        return ALLOC_ERROR_CODE; 
+                        return ALLOC_ERROR_CODE;
                     }
                 } else {
                     char* more_morpho_dics = (char*) realloc((void*) morpho_dic, strlen(
@@ -1053,7 +1053,7 @@ int main_Cassys(int argc,char* const argv[]) {
                         free(temp_work_dir);
                         free(morpho_dic);
                         free(textbuf);
-                        return ALLOC_ERROR_CODE; 
+                        return ALLOC_ERROR_CODE;
                     }
                     strcat(morpho_dic, ";");
                     strcat(morpho_dic, options.vars()->optarg);
@@ -1072,7 +1072,7 @@ int main_Cassys(int argc,char* const argv[]) {
                     free_vector_ptr(tokenize_additional_args, free);
                     free(temp_work_dir);
                     free(textbuf);
-                    return ALLOC_ERROR_CODE; 
+                    return ALLOC_ERROR_CODE;
                 }
                 vector_ptr_add(tokenize_additional_args, locate_arg);
             }
@@ -1089,7 +1089,7 @@ int main_Cassys(int argc,char* const argv[]) {
                     free_vector_ptr(tokenize_additional_args, free);
                     free(temp_work_dir);
                     free(textbuf);
-                    return ALLOC_ERROR_CODE; 
+                    return ALLOC_ERROR_CODE;
                 }
                 vector_ptr_add(locate_additional_args, locate_arg);
             }
@@ -1106,7 +1106,7 @@ int main_Cassys(int argc,char* const argv[]) {
                     free_vector_ptr(tokenize_additional_args, free);
                     free(temp_work_dir);
                     free(textbuf);
-                    return ALLOC_ERROR_CODE; 
+                    return ALLOC_ERROR_CODE;
                 }
                 vector_ptr_add(concord_additional_args, concord_arg);
             }
@@ -1130,7 +1130,7 @@ int main_Cassys(int argc,char* const argv[]) {
                 free(temp_work_dir);
                 free(morpho_dic);
                 free(textbuf);
-                return USAGE_ERROR_CODE;       				
+                return USAGE_ERROR_CODE;
             }
             break;
 	}
@@ -1164,7 +1164,7 @@ int main_Cassys(int argc,char* const argv[]) {
     }
 
     if(command_line_errors || only_verify_arguments) {
-        // freeing all allocated memory 
+        // freeing all allocated memory
         free_transducer_name_and_mode_linked_list(transducer_name_and_mode_linked_list_arg);
         free_vector_ptr(concord_additional_args, free);
         free_vector_ptr(locate_additional_args, free);
@@ -1172,13 +1172,13 @@ int main_Cassys(int argc,char* const argv[]) {
         free(temp_work_dir);
         free(morpho_dic);
         free(textbuf);
-        
+
         if (command_line_errors) {
           return USAGE_ERROR_CODE;
         }
 
-        return SUCCESS_RETURN_CODE;  
-    } 
+        return SUCCESS_RETURN_CODE;
+    }
 
     // Load the list of transducers from the file transducer list and stores it in a list
     //struct fifo *transducer_list = load_transducer(transducer_list_file_name);
@@ -1201,7 +1201,7 @@ int main_Cassys(int argc,char* const argv[]) {
     free(temp_work_dir);
     free(morpho_dic);
     free(textbuf);
-       
+
     return return_value;
 }
 
@@ -1495,7 +1495,7 @@ int cascade(const char* original_text, int in_place, int must_create_directory, 
                 free((p_locate_perf_info + loop_display_perf)->name);
             }
             free(p_locate_perf_info);
-            return DEFAULT_ERROR_CODE;           
+            return DEFAULT_ERROR_CODE;
         }
 
         for (iteration = 0; current_transducer->repeat_mode == INFINITY || iteration < current_transducer->repeat_mode; iteration++) {
@@ -1674,7 +1674,7 @@ int cascade(const char* original_text, int in_place, int must_create_directory, 
 
         transducer_number++;
     }
-    
+
     if(istex_param == 1) {
         int itr = iteration;
         if (iteration > 0)

--- a/Cassys.h
+++ b/Cassys.h
@@ -80,13 +80,13 @@ int main_Cassys(int argc,char* const argv[]);
  * return 0 if correct
  */
 int cascade(const char* text, int in_place, int must_create_directory, int must_do_cleanup, const char* tmp_work_dir,
-	fifo* transducer_list, const char *alphabet,
-	const char*name_input_offsets_file, int produce_offsets_file, const char* name_uima_offsets_file,
-	const char*negation_operator,
-	VersatileEncodingConfig*, 
-	const char *morpho_dic,
-	vector_ptr* tokenize_args, vector_ptr* locate_args, vector_ptr* concord_args,
-	int dump_graph, int realign_token_graph_pointer, int display_perf, int param);
+    fifo* transducer_list, const char *alphabet,
+    const char*name_input_offsets_file, int produce_offsets_file, const char* name_uima_offsets_file,
+    const char*negation_operator,
+    VersatileEncodingConfig*,
+    const char *morpho_dic,
+    vector_ptr* tokenize_args, vector_ptr* locate_args, vector_ptr* concord_args,
+    int dump_graph, int realign_token_graph_pointer, int display_perf, int param);
 
 
 

--- a/Cassys_concord.cpp
+++ b/Cassys_concord.cpp
@@ -221,11 +221,11 @@ void print_standoff(U_FILE *out,standOffInfo *infos, int num_info) {
         int count = 0;
         int capacity = infos[i].entList->capacity;
         if(infos[i].entList->number_of_elements > 0) {
-            u_fprintf(out,"<ns:listAnnotation type=\"%S\"",infos[i].type); 
+            u_fprintf(out,"<ns:listAnnotation type=\"%S\"",infos[i].type);
             if(infos[i].subtype != NULL)
-                u_fprintf(out," subtype=\"%S\"",infos[i].subtype); 
+                u_fprintf(out," subtype=\"%S\"",infos[i].subtype);
             u_fprintf(out,">\n");
-            for(int j=0; j<capacity 
+            for(int j=0; j<capacity
                     && count <infos[i].entList->number_of_elements; j++){
                 if(infos[i].entList->table[j] !=NULL) {
                     if(infos[i].entList->table[j]->ptr_key !=NULL) {
@@ -277,7 +277,7 @@ void getMetaInfo(unichar *e, unichar **s, unichar **t) {
             (*t)[i] = e[j];
         }
         (*t)[i] = '\0';
-        
+
         if(s_start>=0 && s_end>s_start) {
             *s = (unichar*) malloc(sizeof(unichar)* (s_end-s_start+1));
             i=0;
@@ -298,7 +298,7 @@ int findEntityList(standOffInfo *infos, int num,
                 found = i;
                 break;
             }
-            else if(s!=NULL && infos[i].subtype != NULL 
+            else if(s!=NULL && infos[i].subtype != NULL
                     && u_strcmp(s,infos[i].subtype) == 0) {
                     found = i;
                     break;
@@ -308,7 +308,7 @@ int findEntityList(standOffInfo *infos, int num,
     return found;
 }
 
-void construct_istex_standoff(const char *text_name, 
+void construct_istex_standoff(const char *text_name,
         VersatileEncodingConfig* vec, const char* original_file) {
     char text_name_without_extension[FILENAME_MAX];
     char result_file[FILENAME_MAX];
@@ -320,7 +320,7 @@ void construct_istex_standoff(const char *text_name,
     int num_info = 0;
     U_FILE *concord_file = u_fopen(vec, text_name, U_READ);
     if(concord_file != NULL) {
-        while(u_fgets_dynamic_buffer(&line, &size_buffer_line, 
+        while(u_fgets_dynamic_buffer(&line, &size_buffer_line,
                 concord_file) != EOF) {
             int limit = u_strlen(line);
             if(line != NULL && limit > 2 &&
@@ -392,7 +392,7 @@ void construct_istex_token(const char *text_name, VersatileEncodingConfig* vec,
     sprintf(result_file,"%s_token.txt",text_name_without_extension);
     U_FILE *out_file = u_fopen(vec, result_file, U_WRITE);
     if(token_file != NULL && out_file != NULL) {
-        while(u_fgets_dynamic_buffer(&line, 
+        while(u_fgets_dynamic_buffer(&line,
                 &size_buffer_line, token_file) != EOF) {
             if(line !=NULL && line[0] == '{') {
                 int limit = u_strlen(line) - 1;

--- a/Cassys_concord.cpp
+++ b/Cassys_concord.cpp
@@ -38,13 +38,13 @@
 namespace unitex {
 
 void display_lu(struct list_ustring *l){
-	struct list_ustring *u;
+    struct list_ustring *u;
 
-	u_printf("begin\n");
-	for(u=l; u!=NULL; u=u->next){
-		u_printf("%S\n",u->string);
-	}
-	u_printf("\n");
+    u_printf("begin\n");
+    for(u=l; u!=NULL; u=u->next){
+        u_printf("%S\n",u->string);
+    }
+    u_printf("\n");
 }
 
 
@@ -57,51 +57,51 @@ void display_lu(struct list_ustring *l){
  * stored in a locate_pos structure
  */
 struct fifo *read_concord_file(const char *concord_file_name, const VersatileEncodingConfig* vec){
-	unichar* line = NULL;
-	size_t size_buffer_line = 0;
+    unichar* line = NULL;
+    size_t size_buffer_line = 0;
 
-	struct fifo *f = new_fifo();
+    struct fifo *f = new_fifo();
 
-	U_FILE *concord_desc_file;
-	concord_desc_file = u_fopen(vec,concord_file_name,U_READ);
-	if( concord_desc_file == NULL){
-		fatal_error("Cannot open file %s\n",concord_file_name);
-		exit(1);
-	}
+    U_FILE *concord_desc_file;
+    concord_desc_file = u_fopen(vec,concord_file_name,U_READ);
+    if( concord_desc_file == NULL){
+        fatal_error("Cannot open file %s\n",concord_file_name);
+        exit(1);
+    }
 
-	if (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord_desc_file) == EOF){
-		fatal_error("Malformed concordance file %s",concord_file_name);
-	}
+    if (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord_desc_file) == EOF){
+        fatal_error("Malformed concordance file %s",concord_file_name);
+    }
 
-	while (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord_desc_file) != EOF){
-		locate_pos *l = read_concord_line(line);
-		put_ptr(f,l);
-	}
-	if (line != NULL) {
-		free(line);
-	}
-	u_fclose(concord_desc_file);
-	return f;
+    while (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord_desc_file) != EOF){
+        locate_pos *l = read_concord_line(line);
+        put_ptr(f,l);
+    }
+    if (line != NULL) {
+        free(line);
+    }
+    u_fclose(concord_desc_file);
+    return f;
 }
 
 
 
 int count_concordance(const char *concord_file_name, const VersatileEncodingConfig* vec){
 
-	struct fifo *stage_concord = read_concord_file(concord_file_name, vec);
+    struct fifo *stage_concord = read_concord_file(concord_file_name, vec);
 
-	int number_of_concordance = 0;
-	while (!is_empty(stage_concord)) {
+    int number_of_concordance = 0;
+    while (!is_empty(stage_concord)) {
 
-		locate_pos *l = (locate_pos*) take_ptr(stage_concord);
-		free(l->label);
-		free(l);
+        locate_pos *l = (locate_pos*) take_ptr(stage_concord);
+        free(l->label);
+        free(l);
 
-		number_of_concordance ++;
-	}
-	free_fifo(stage_concord);
+        number_of_concordance ++;
+    }
+    free_fifo(stage_concord);
 
-	return number_of_concordance;
+    return number_of_concordance;
 }
 
 
@@ -109,45 +109,45 @@ int count_concordance(const char *concord_file_name, const VersatileEncodingConf
 
 void protect_lexical_tag_in_concord(const char *concord_file_name, const OutputPolicy op, const VersatileEncodingConfig *vec) {
 
-	struct fifo *stage_concord = read_concord_file(concord_file_name, vec);
+    struct fifo *stage_concord = read_concord_file(concord_file_name, vec);
 
-	U_FILE *concord_xml_desc = u_fopen(vec, concord_file_name, U_WRITE);
-	if (concord_xml_desc == NULL) {
-		fatal_error("Cannot open file %s\n", concord_file_name);
-		exit(1);
-	}
-	switch (op) {
-		case MERGE_OUTPUTS: {
-			u_fprintf(concord_xml_desc, "#M\n");
-			break;
-		}
-		case REPLACE_OUTPUTS: {
-			u_fprintf(concord_xml_desc, "#R\n");
-			break;
-		}
-		default:
-			fatal_error("Only Replace and merge output are currently allowed with transducers\n");
-			break;
-	}
+    U_FILE *concord_xml_desc = u_fopen(vec, concord_file_name, U_WRITE);
+    if (concord_xml_desc == NULL) {
+        fatal_error("Cannot open file %s\n", concord_file_name);
+        exit(1);
+    }
+    switch (op) {
+        case MERGE_OUTPUTS: {
+            u_fprintf(concord_xml_desc, "#M\n");
+            break;
+        }
+        case REPLACE_OUTPUTS: {
+            u_fprintf(concord_xml_desc, "#R\n");
+            break;
+        }
+        default:
+            fatal_error("Only Replace and merge output are currently allowed with transducers\n");
+            break;
+    }
 
 
-	while (!is_empty(stage_concord)) {
+    while (!is_empty(stage_concord)) {
 
-		locate_pos *l = (locate_pos*) take_ptr(stage_concord);
+        locate_pos *l = (locate_pos*) take_ptr(stage_concord);
 
-		unichar *protected_line = protect_lexical_tag(l->label, false);
+        unichar *protected_line = protect_lexical_tag(l->label, false);
 
-		u_fprintf(concord_xml_desc, "%ld.%ld.%ld %ld.%ld.%ld %S\n",
-				l->token_start_offset, l->character_start_offset,
-				l->logical_start_offset, l->token_end_offset,
-				l->character_end_offset, l->logical_end_offset, protected_line);
+        u_fprintf(concord_xml_desc, "%ld.%ld.%ld %ld.%ld.%ld %S\n",
+                l->token_start_offset, l->character_start_offset,
+                l->logical_start_offset, l->token_end_offset,
+                l->character_end_offset, l->logical_end_offset, protected_line);
 
-		free(protected_line);
-		free(l->label);
-		free(l);
-	}
-	u_fclose(concord_xml_desc);
-	free_fifo(stage_concord);
+        free(protected_line);
+        free(l->label);
+        free(l);
+    }
+    u_fclose(concord_xml_desc);
+    free_fifo(stage_concord);
 }
 
 
@@ -163,44 +163,44 @@ void protect_lexical_tag_in_concord(const char *concord_file_name, const OutputP
  */
 locate_pos *read_concord_line(const unichar *line) {
 
-	locate_pos *l;
-	l = (locate_pos*) malloc(sizeof(locate_pos) * 1);
-	if (l == NULL) {
-		fatal_alloc_error("read_concord_line");
-		exit(1);
-	}
-	l->label = (unichar*) malloc(sizeof(unichar) * (u_strlen(line) + 1));
-	if (l->label == NULL) {
-		fatal_alloc_error("read_concord_line");
-		exit(1);
-	}
+    locate_pos *l;
+    l = (locate_pos*) malloc(sizeof(locate_pos) * 1);
+    if (l == NULL) {
+        fatal_alloc_error("read_concord_line");
+        exit(1);
+    }
+    l->label = (unichar*) malloc(sizeof(unichar) * (u_strlen(line) + 1));
+    if (l->label == NULL) {
+        fatal_alloc_error("read_concord_line");
+        exit(1);
+    }
 
-	// format of a line : n.n.n n.n.n t where n are integers and t is string
-	const unichar **next;
+    // format of a line : n.n.n n.n.n t where n are integers and t is string
+    const unichar **next;
 
-	const unichar *current = line;
-	next = &line; // make next not NULL
-	l->token_start_offset = (long)u_parse_int(current, next);
+    const unichar *current = line;
+    next = &line; // make next not NULL
+    l->token_start_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	l->character_start_offset = (long)u_parse_int(current, next);
+    current = (*next)+1;
+    l->character_start_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	l->logical_start_offset = (long)u_parse_int(current, next);
+    current = (*next)+1;
+    l->logical_start_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	l->token_end_offset = (long)u_parse_int(current, next);
+    current = (*next)+1;
+    l->token_end_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	l-> character_end_offset = (long)u_parse_int(current, next);
+    current = (*next)+1;
+    l-> character_end_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	l-> logical_end_offset = (long)u_parse_int(current, next);
+    current = (*next)+1;
+    l-> logical_end_offset = (long)u_parse_int(current, next);
 
-	current = (*next)+1;
-	u_strcpy(l->label,current);
+    current = (*next)+1;
+    u_strcpy(l->label,current);
 
-	return l;
+    return l;
 }
 
 struct standOffInfo {
@@ -421,118 +421,118 @@ void construct_istex_token(const char *text_name, VersatileEncodingConfig* vec,
 
 
 void construct_cascade_concord(cassys_tokens_list *list, const char *text_name,
-		int number_of_transducer, int iteration,
+        int number_of_transducer, int iteration,
     VersatileEncodingConfig* vec){
 
-	u_printf("Construct cascade concord\n");
+    u_printf("Construct cascade concord\n");
 
-	struct snt_files *snt_file = new_snt_files(text_name);
+    struct snt_files *snt_file = new_snt_files(text_name);
 
-	U_FILE *concord_desc_file = u_fopen(vec, snt_file->concord_ind,U_WRITE);
-	if( concord_desc_file == NULL){
-		fatal_error("Cannot open file %s\n",snt_file->concord_ind);
-		exit(1);
-	}
+    U_FILE *concord_desc_file = u_fopen(vec, snt_file->concord_ind,U_WRITE);
+    if( concord_desc_file == NULL){
+        fatal_error("Cannot open file %s\n",snt_file->concord_ind);
+        exit(1);
+    }
 
-	u_printf("Concord File %s successfully opened\n",snt_file->concord_ind);
+    u_printf("Concord File %s successfully opened\n",snt_file->concord_ind);
 
-	if (list == NULL) {
-		fatal_error("empty text");
-	}
+    if (list == NULL) {
+        fatal_error("empty text");
+    }
 
-	u_fprintf(concord_desc_file,"#M\n");
+    u_fprintf(concord_desc_file,"#M\n");
 
-	cassys_tokens_list *current_pos_in_original_text = list;
+    cassys_tokens_list *current_pos_in_original_text = list;
 
-	cassys_tokens_list *output=get_output(list, number_of_transducer, iteration);
-	struct list_ustring *sentence = NULL;
-	struct list_ustring *latest_on_sentence = NULL;
-	bool output_detected = false;
-	long token_position=0;
+    cassys_tokens_list *output=get_output(list, number_of_transducer, iteration);
+    struct list_ustring *sentence = NULL;
+    struct list_ustring *latest_on_sentence = NULL;
+    bool output_detected = false;
+    long token_position=0;
 
-	while(current_pos_in_original_text != NULL){
-		if (output == NULL) {
-			u_printf("output = NULL\n");
-		}
+    while(current_pos_in_original_text != NULL){
+        if (output == NULL) {
+            u_printf("output = NULL\n");
+        }
 
-		if(output == NULL || output -> transducer_id == 0){
-			if(output_detected){
-				int start_position = (int)token_position;
-				int last_token_length = 0;
-				while(current_pos_in_original_text != output){
-					token_position ++;
-					last_token_length = u_strlen(current_pos_in_original_text -> token)-1;
-					current_pos_in_original_text = current_pos_in_original_text -> next_token;
-				}
+        if(output == NULL || output -> transducer_id == 0){
+            if(output_detected){
+                int start_position = (int)token_position;
+                int last_token_length = 0;
+                while(current_pos_in_original_text != output){
+                    token_position ++;
+                    last_token_length = u_strlen(current_pos_in_original_text -> token)-1;
+                    current_pos_in_original_text = current_pos_in_original_text -> next_token;
+                }
 
-				// token position pointe sur le token suivant�
-				int end_position=(int)(token_position-1);
+                // token position pointe sur le token suivant�
+                int end_position=(int)(token_position-1);
 
-				if(sentence == NULL){
-					fatal_error("construct_cassys_concordance : Phrase de remplacement vide\n");
-				}
+                if(sentence == NULL){
+                    fatal_error("construct_cassys_concordance : Phrase de remplacement vide\n");
+                }
 
-				struct list_ustring *iterator = sentence;
+                struct list_ustring *iterator = sentence;
 
-				/*
-				// remove code not useful...
-				while(iterator -> next != NULL){
-					iterator = iterator -> next;
-				}
+                /*
+                // remove code not useful...
+                while(iterator -> next != NULL){
+                    iterator = iterator -> next;
+                }
 
-				iterator = sentence;
-				*/
+                iterator = sentence;
+                */
 
-				u_fprintf(concord_desc_file, "%d.0.0 %d.%d.0 ",start_position,end_position,last_token_length);
-				while(iterator != NULL){
-					u_fputs(iterator->string,concord_desc_file);
-					//u_printf("ccc iter = %S\n",iterator->string);
-					//u_fprintf(concord_desc_file,"concord.ind : %S %S %S\n",iterator->string, previous_pos_in_original_text->token, current_pos_in_original_text->token);
-					iterator = iterator -> next;
-				}
-				u_fprintf(concord_desc_file,"\n");
+                u_fprintf(concord_desc_file, "%d.0.0 %d.%d.0 ",start_position,end_position,last_token_length);
+                while(iterator != NULL){
+                    u_fputs(iterator->string,concord_desc_file);
+                    //u_printf("ccc iter = %S\n",iterator->string);
+                    //u_fprintf(concord_desc_file,"concord.ind : %S %S %S\n",iterator->string, previous_pos_in_original_text->token, current_pos_in_original_text->token);
+                    iterator = iterator -> next;
+                }
+                u_fprintf(concord_desc_file,"\n");
 
-				free_list_ustring(sentence);
-				sentence = NULL;
-				latest_on_sentence = NULL;
+                free_list_ustring(sentence);
+                sentence = NULL;
+                latest_on_sentence = NULL;
 
-				if(current_pos_in_original_text==NULL){
-					break;
-				}
+                if(current_pos_in_original_text==NULL){
+                    break;
+                }
 
-				current_pos_in_original_text = current_pos_in_original_text -> next_token;
-				output = get_output(current_pos_in_original_text, number_of_transducer, iteration);
-				token_position++;
+                current_pos_in_original_text = current_pos_in_original_text -> next_token;
+                output = get_output(current_pos_in_original_text, number_of_transducer, iteration);
+                token_position++;
 
 
 
-				output_detected = false;
-			} else {
-				if (current_pos_in_original_text == NULL) {
-					break;
-				}
+                output_detected = false;
+            } else {
+                if (current_pos_in_original_text == NULL) {
+                    break;
+                }
 
-				current_pos_in_original_text = current_pos_in_original_text -> next_token;
-				output = get_output(current_pos_in_original_text,number_of_transducer, iteration);
-				token_position++;
-			}
-		}
-		else {
-			//u_printf("insert new sentence\n");
+                current_pos_in_original_text = current_pos_in_original_text -> next_token;
+                output = get_output(current_pos_in_original_text,number_of_transducer, iteration);
+                token_position++;
+            }
+        }
+        else {
+            //u_printf("insert new sentence\n");
 
-			sentence = insert_at_end_of_list_with_latest(output->token, sentence, &latest_on_sentence);
-			output = output -> next_token;
-			output = get_output(output, number_of_transducer, iteration);
-			output_detected = true;
-			//display_lu(sentence);
-		}
+            sentence = insert_at_end_of_list_with_latest(output->token, sentence, &latest_on_sentence);
+            output = output -> next_token;
+            output = get_output(output, number_of_transducer, iteration);
+            output_detected = true;
+            //display_lu(sentence);
+        }
 
-	}
+    }
 
-	free_list_ustring(sentence);
+    free_list_ustring(sentence);
 
-	u_fclose(concord_desc_file);
-	free(snt_file);
+    u_fclose(concord_desc_file);
+    free(snt_file);
 
 }
 
@@ -540,14 +540,14 @@ void construct_cascade_concord(cassys_tokens_list *list, const char *text_name,
 
 void construct_xml_concord(const char *text_name, VersatileEncodingConfig* vec){
 
-	u_printf("Building xml concord\n");
+    u_printf("Building xml concord\n");
 
-	struct snt_files *snt_file = new_snt_files(text_name);
+    struct snt_files *snt_file = new_snt_files(text_name);
 
-	xmlizeConcordFile(snt_file->concord_ind, vec);
+    xmlizeConcordFile(snt_file->concord_ind, vec);
 
 
-	free(snt_file);
+    free(snt_file);
 }
 
 

--- a/Cassys_concord.h
+++ b/Cassys_concord.h
@@ -45,36 +45,36 @@ namespace unitex {
  */
 typedef struct locate_pos{
 
-	/**
-	 * position in token of the first token located by a transducer
-	 */
-	long token_start_offset;
+    /**
+     * position in token of the first token located by a transducer
+     */
+    long token_start_offset;
 
-	/**
-	 * position in character of the first character in the first token located by a transducer
-	 */
-	long character_start_offset;
+    /**
+     * position in character of the first character in the first token located by a transducer
+     */
+    long character_start_offset;
 
-	/**
-	 * used for thai. Not used by cassys
-	 */
-	long logical_start_offset;
+    /**
+     * used for thai. Not used by cassys
+     */
+    long logical_start_offset;
 
-	/**
-	 * position in token of the last token located by a transducer
-	 */
-	long token_end_offset;
+    /**
+     * position in token of the last token located by a transducer
+     */
+    long token_end_offset;
 
-	/**
-	 * position in character of the last character in the last token located by a transducer
-	 */
-	long character_end_offset;
+    /**
+     * position in character of the last character in the last token located by a transducer
+     */
+    long character_end_offset;
 
-	/**
-	 * used for thai. Not used by cassys
-	 */
-	long logical_end_offset;
-	unichar *label;
+    /**
+     * used for thai. Not used by cassys
+     */
+    long logical_end_offset;
+    unichar *label;
 }locate_pos;
 
 

--- a/Cassys_external_program.cpp
+++ b/Cassys_external_program.cpp
@@ -41,8 +41,8 @@ namespace unitex {
 /**
  * \brief Calls the tokenize program in Cassys
  *
- *	Tokenize is called with target text_name and options --word_by_word, --alphabet=alphabet_name, --token=token_txt_name if
- *	if token_txt_name is not NULL. For more information about tokenize, see the unitex manual.
+ *  Tokenize is called with target text_name and options --word_by_word, --alphabet=alphabet_name, --token=token_txt_name if
+ *  if token_txt_name is not NULL. For more information about tokenize, see the unitex manual.
  *
  * \param [in/out] text_name the name of the text
  * \param [in] alphabet the name of the alphabet
@@ -54,30 +54,30 @@ namespace unitex {
  */
 
 static int cassys_invoke(ProgramInvoker *invoker, int display_perf, unsigned int* time_elapsed) {
-	hTimeElapsed htmWork = NULL;
-	unsigned int time_elapsed_invoke = 0;
-	char* line_command = build_command_line_alloc(invoker, 0, 1);
-	u_printf("%s\n", line_command);
+    hTimeElapsed htmWork = NULL;
+    unsigned int time_elapsed_invoke = 0;
+    char* line_command = build_command_line_alloc(invoker, 0, 1);
+    u_printf("%s\n", line_command);
 
-	if (display_perf || time_elapsed) {
-		htmWork = SyncBuidTimeMarkerObject();
-	}
-	int result = invoke(invoker);
+    if (display_perf || time_elapsed) {
+        htmWork = SyncBuidTimeMarkerObject();
+    }
+    int result = invoke(invoker);
 
-	if (display_perf || time_elapsed) {
-		time_elapsed_invoke = SyncGetMSecElapsed(htmWork);
+    if (display_perf || time_elapsed) {
+        time_elapsed_invoke = SyncGetMSecElapsed(htmWork);
 
-		const char* name_tool = (const char*)(invoker->args->tab[0]);
-		if ((strlen(name_tool) > 5) && (memcmp(name_tool, "main_", 5) == 0)) name_tool += 5;
-		if (display_perf) {
-			u_printf("Running %s take %.3f sec\n", name_tool, (time_elapsed_invoke / 1000.));
-		}
-		if (time_elapsed)
-			*time_elapsed += time_elapsed_invoke;
-	}
-	free_command_line_alloc(line_command);
+        const char* name_tool = (const char*)(invoker->args->tab[0]);
+        if ((strlen(name_tool) > 5) && (memcmp(name_tool, "main_", 5) == 0)) name_tool += 5;
+        if (display_perf) {
+            u_printf("Running %s take %.3f sec\n", name_tool, (time_elapsed_invoke / 1000.));
+        }
+        if (time_elapsed)
+            *time_elapsed += time_elapsed_invoke;
+    }
+    free_command_line_alloc(line_command);
 
-	return result;
+    return result;
 }
 
 
@@ -85,14 +85,14 @@ int launch_tokenize_in_Cassys(const char *text_name, const char *alphabet_name, 
     VersatileEncodingConfig* vec,
     vector_ptr* additional_args, int display_perf, unsigned int* time_elapsed) {
 
-	u_printf("Launch tokenize in Cassys \n");
-	ProgramInvoker *invoker = new_ProgramInvoker(main_Tokenize,"main_Tokenize");
+    u_printf("Launch tokenize in Cassys \n");
+    ProgramInvoker *invoker = new_ProgramInvoker(main_Tokenize,"main_Tokenize");
 
-	char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
-	if (tmp == NULL) {
-		fatal_alloc_error("launch_tokenize_in_Cassys");
-		exit(1);
-	}
+    char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
+    if (tmp == NULL) {
+        fatal_alloc_error("launch_tokenize_in_Cassys");
+        exit(1);
+    }
 
     {
         tmp[0]=0;
@@ -110,40 +110,40 @@ int launch_tokenize_in_Cassys(const char *text_name, const char *alphabet_name, 
         }
     }
 
-	// add the alphabet
-	sprintf(tmp, "--alphabet=%s", alphabet_name);
-	add_argument(invoker, tmp);
+    // add the alphabet
+    sprintf(tmp, "--alphabet=%s", alphabet_name);
+    add_argument(invoker, tmp);
 
-	// Tokenize word by word
-	add_argument(invoker, "--word_by_word");
+    // Tokenize word by word
+    add_argument(invoker, "--word_by_word");
 
-	// add the target text file
-	add_argument(invoker,text_name);
+    // add the target text file
+    add_argument(invoker,text_name);
 
-	// if a token.txt file already exists, use it
-	if(token_txt_name != NULL){
-		sprintf(tmp,"--tokens=%s",token_txt_name);
-		add_argument(invoker,tmp);
-	}
+    // if a token.txt file already exists, use it
+    if(token_txt_name != NULL){
+        sprintf(tmp,"--tokens=%s",token_txt_name);
+        add_argument(invoker,tmp);
+    }
 
 
-	for (int i = 0; i<((additional_args == NULL) ? 0 : (additional_args->nbelems)); i++) {
-		add_argument(invoker, (const char*)additional_args->tab[i]);
-	}
+    for (int i = 0; i<((additional_args == NULL) ? 0 : (additional_args->nbelems)); i++) {
+        add_argument(invoker, (const char*)additional_args->tab[i]);
+    }
 
-	int result = cassys_invoke(invoker, display_perf, time_elapsed);
+    int result = cassys_invoke(invoker, display_perf, time_elapsed);
 
-	free_ProgramInvoker(invoker);
+    free_ProgramInvoker(invoker);
 
-	free(tmp);
-	return result;
+    free(tmp);
+    return result;
 }
 
 
 /**
  * \brief Calls the Locate program in Cassys
  *
- *	Locate is called with target the transducer file name of transudcer and options
+ *  Locate is called with target the transducer file name of transudcer and options
  *  --text=text_name, --alphabet=alphabet_name, --longest_matches, --all and --merge or --replace
  *  depending of the output policy of the transducer.
  *
@@ -160,13 +160,13 @@ int launch_locate_in_Cassys(const char *text_name, const transducer *transducer,
     const char *morpho_dic,
     vector_ptr* additional_args, int display_perf, unsigned int* time_elapsed) {
 
-	ProgramInvoker *invoker = new_ProgramInvoker(main_Locate, "main_Locate");
+    ProgramInvoker *invoker = new_ProgramInvoker(main_Locate, "main_Locate");
 
     char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
-	if (tmp == NULL) {
-		fatal_alloc_error("launch__in_Cassys");
-		exit(1);
-	}
+    if (tmp == NULL) {
+        fatal_alloc_error("launch__in_Cassys");
+        exit(1);
+    }
 
     {
         tmp[0]=0;
@@ -186,31 +186,31 @@ int launch_locate_in_Cassys(const char *text_name, const transducer *transducer,
 
     add_argument(invoker, transducer->transducer_file_name);
 
-	// add the text
-	sprintf(tmp,"--text=%s",text_name);
-	add_argument(invoker, tmp);
+    // add the text
+    sprintf(tmp,"--text=%s",text_name);
+    add_argument(invoker, tmp);
 
-	// add the merge or replace option
-	switch (transducer ->output_policy) {
-	   case MERGE_OUTPUTS: add_argument(invoker,"--merge"); break;
-	   case REPLACE_OUTPUTS: add_argument(invoker,"--replace"); break;
-	   default: add_argument(invoker,"--ignore"); break;
-	}
+    // add the merge or replace option
+    switch (transducer ->output_policy) {
+       case MERGE_OUTPUTS: add_argument(invoker,"--merge"); break;
+       case REPLACE_OUTPUTS: add_argument(invoker,"--replace"); break;
+       default: add_argument(invoker,"--ignore"); break;
+    }
 
-	// add the alphabet
-	sprintf(tmp,"--alphabet=%s",alphabet_name);
-	add_argument(invoker, tmp);
+    // add the alphabet
+    sprintf(tmp,"--alphabet=%s",alphabet_name);
+    add_argument(invoker, tmp);
 
-	// look for the longest match argument
-	add_argument(invoker, "--longest_matches");
+    // look for the longest match argument
+    add_argument(invoker, "--longest_matches");
 
-	// look for all the occurrences
-	add_argument(invoker, "--all");
+    // look for all the occurrences
+    add_argument(invoker, "--all");
 
-	if(morpho_dic != NULL){
-		sprintf(tmp,"--morpho=%s",morpho_dic);
-		add_argument(invoker,tmp);
-	}
+    if(morpho_dic != NULL){
+        sprintf(tmp,"--morpho=%s",morpho_dic);
+        add_argument(invoker,tmp);
+    }
 
     if ((*negation_operator) != 0) {
         sprintf(tmp,"--negation_operator=%s",negation_operator);
@@ -218,17 +218,17 @@ int launch_locate_in_Cassys(const char *text_name, const transducer *transducer,
     }
 
 
-	for (int i = 0; i<((additional_args == NULL) ? 0 : (additional_args->nbelems)); i++) {
-		add_argument(invoker, (const char*)additional_args->tab[i]);
-	}
+    for (int i = 0; i<((additional_args == NULL) ? 0 : (additional_args->nbelems)); i++) {
+        add_argument(invoker, (const char*)additional_args->tab[i]);
+    }
 
 
-	int result = cassys_invoke(invoker, display_perf, time_elapsed);
+    int result = cassys_invoke(invoker, display_perf, time_elapsed);
 
-	free_ProgramInvoker(invoker);
+    free_ProgramInvoker(invoker);
 
-	free(tmp);
-	return result;
+    free(tmp);
+    return result;
 }
 
 
@@ -248,44 +248,44 @@ int launch_locate_in_Cassys(const char *text_name, const transducer *transducer,
 int launch_grf2fst2_in_Cassys(const char *text_name, const char *alphabet_name, VersatileEncodingConfig *vec, int display_perf, unsigned int* time_elapsed) {
     ProgramInvoker *invoker = new_ProgramInvoker(main_Grf2Fst2, "main_Grf2Fst2");
 
-	char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
-	if (tmp == NULL) {
-		fatal_alloc_error("launch__in_Cassys");
-		exit(1);
-	}
+    char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
+    if (tmp == NULL) {
+        fatal_alloc_error("launch__in_Cassys");
+        exit(1);
+    }
 
-	{
-	    tmp[0] = 0;
-	    get_reading_encoding_text(tmp, SIZE_TMP_BUFFER, vec->mask_encoding_compatibility_input);
-	    if(tmp[0] != '\0') {
-		add_argument(invoker,"-k");
-		add_argument(invoker,tmp);
-	    }
-	    tmp[0] = 0;
-	    get_writing_encoding_text(tmp, SIZE_TMP_BUFFER, vec->encoding_output, vec->bom_output);
-	    if(tmp[0] != '\0') {
-		add_argument(invoker,"-q");
-		add_argument(invoker,tmp);
-	    }
-	}
+    {
+        tmp[0] = 0;
+        get_reading_encoding_text(tmp, SIZE_TMP_BUFFER, vec->mask_encoding_compatibility_input);
+        if(tmp[0] != '\0') {
+        add_argument(invoker,"-k");
+        add_argument(invoker,tmp);
+        }
+        tmp[0] = 0;
+        get_writing_encoding_text(tmp, SIZE_TMP_BUFFER, vec->encoding_output, vec->bom_output);
+        if(tmp[0] != '\0') {
+        add_argument(invoker,"-q");
+        add_argument(invoker,tmp);
+        }
+    }
 
-	add_argument(invoker,text_name);
-	add_argument(invoker,"-y");
+    add_argument(invoker,text_name);
+    add_argument(invoker,"-y");
 
-	sprintf(tmp,"--alphabet=%s",alphabet_name);
-	add_argument(invoker,tmp);
+    sprintf(tmp,"--alphabet=%s",alphabet_name);
+    add_argument(invoker,tmp);
 
-	int result = cassys_invoke(invoker, display_perf, time_elapsed);
-	free_ProgramInvoker(invoker);
+    int result = cassys_invoke(invoker, display_perf, time_elapsed);
+    free_ProgramInvoker(invoker);
 
-	free(tmp);
-	return result;
+    free(tmp);
+    return result;
 }
 
 /**
  * \brief Calls the Concord program in Cassys
  *
- *	Concord is called with target index_file and options
+ *  Concord is called with target index_file and options
  *  --merge=text_name, --alphabet=alphabet_name.
  *
  *  For more information about Concord, see the unitex manual.
@@ -296,53 +296,53 @@ int launch_grf2fst2_in_Cassys(const char *text_name, const char *alphabet_name, 
  *
  */
 int launch_concord_in_Cassys(const char *text_name, const char *index_file, const char *alphabet_name,
-	const char *input_offsets_name, const char *uima_name, const char *output_offsets_name,
-	VersatileEncodingConfig* vec,
-	vector_ptr* additional_args, int display_perf, unsigned int* time_elapsed) {
-	ProgramInvoker *invoker = new_ProgramInvoker(main_Concord, "main_Concord");
+    const char *input_offsets_name, const char *uima_name, const char *output_offsets_name,
+    VersatileEncodingConfig* vec,
+    vector_ptr* additional_args, int display_perf, unsigned int* time_elapsed) {
+    ProgramInvoker *invoker = new_ProgramInvoker(main_Concord, "main_Concord");
 
-	char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
-	if (tmp == NULL) {
-		fatal_alloc_error("launch__in_Cassys");
-		exit(1);
-	}
+    char *tmp = (char*)malloc(SIZE_TMP_BUFFER + 1);
+    if (tmp == NULL) {
+        fatal_alloc_error("launch__in_Cassys");
+        exit(1);
+    }
 
-	// verify the braces in concordance
-			U_FILE *concord;
-			unichar* line = NULL;
-			size_t size_buffer_line = 0;
-			int brace_level;
-			int i;
-			int l;
+    // verify the braces in concordance
+            U_FILE *concord;
+            unichar* line = NULL;
+            size_t size_buffer_line = 0;
+            int brace_level;
+            int i;
+            int l;
 
-			concord = u_fopen(vec, index_file, U_READ);
-			if( concord == NULL){
-				fatal_error("Cannot open file %s\n",index_file);
-				exit(1);
-			}
-			while (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord) != EOF) {
+            concord = u_fopen(vec, index_file, U_READ);
+            if( concord == NULL){
+                fatal_error("Cannot open file %s\n",index_file);
+                exit(1);
+            }
+            while (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord) != EOF) {
 
 
-				brace_level = 0;
-				i=0;
-				l=u_strlen(line);
-				while(i<l) {
-					if(line[i]=='{')
-						brace_level++;
-					else if(line[i]=='}')
-						brace_level--;
-					i++;
-				}
-				if( brace_level!=0){
-					error("File %s\nProblem of brackets in line %S\n", index_file, line);
-					error("cassys_tokenize_word_by_word : correct the current graph if possible.\n");
-				}
-			}
-			u_fclose(concord);
+                brace_level = 0;
+                i=0;
+                l=u_strlen(line);
+                while(i<l) {
+                    if(line[i]=='{')
+                        brace_level++;
+                    else if(line[i]=='}')
+                        brace_level--;
+                    i++;
+                }
+                if( brace_level!=0){
+                    error("File %s\nProblem of brackets in line %S\n", index_file, line);
+                    error("cassys_tokenize_word_by_word : correct the current graph if possible.\n");
+                }
+            }
+            u_fclose(concord);
 
-	// end of veifying braces
+    // end of veifying braces
 
-	add_argument(invoker,index_file);
+    add_argument(invoker,index_file);
 
 
     {
@@ -361,43 +361,43 @@ int launch_concord_in_Cassys(const char *text_name, const char *index_file, cons
         }
     }
 
-	if ((uima_name != NULL) && (uima_name[0] != '\0')) {
-		sprintf(tmp, "--uima=%s", uima_name);
-		add_argument(invoker, tmp);
-	}
+    if ((uima_name != NULL) && (uima_name[0] != '\0')) {
+        sprintf(tmp, "--uima=%s", uima_name);
+        add_argument(invoker, tmp);
+    }
 
-	sprintf(tmp,"--merge=%s",text_name);
-	add_argument(invoker,tmp);
-
-
-	if ((input_offsets_name != NULL) && (input_offsets_name[0] != '\0')) {
-		sprintf(tmp, "--input_offsets=%s", input_offsets_name);
-		add_argument(invoker, tmp);
-	}
-
-	if ((output_offsets_name != NULL) && (output_offsets_name[0] != '\0')) {
-		sprintf(tmp, "--output_offsets=%s", output_offsets_name);
-		add_argument(invoker, tmp);
-	}
+    sprintf(tmp,"--merge=%s",text_name);
+    add_argument(invoker,tmp);
 
 
-	sprintf(tmp,"--alphabet=%s",alphabet_name);
-	add_argument(invoker, tmp);
+    if ((input_offsets_name != NULL) && (input_offsets_name[0] != '\0')) {
+        sprintf(tmp, "--input_offsets=%s", input_offsets_name);
+        add_argument(invoker, tmp);
+    }
 
-	for (int arg = 0; arg<((additional_args == NULL) ? 0 : (additional_args->nbelems)); arg++) {
-		add_argument(invoker, (const char*)additional_args->tab[arg]);
-	}
+    if ((output_offsets_name != NULL) && (output_offsets_name[0] != '\0')) {
+        sprintf(tmp, "--output_offsets=%s", output_offsets_name);
+        add_argument(invoker, tmp);
+    }
 
 
-	int result = cassys_invoke(invoker, display_perf, time_elapsed);
+    sprintf(tmp,"--alphabet=%s",alphabet_name);
+    add_argument(invoker, tmp);
 
-	free_ProgramInvoker(invoker);
-	if (line != NULL) {
-		free(line);
-	}
+    for (int arg = 0; arg<((additional_args == NULL) ? 0 : (additional_args->nbelems)); arg++) {
+        add_argument(invoker, (const char*)additional_args->tab[arg]);
+    }
 
-	free(tmp);
-	return result;
+
+    int result = cassys_invoke(invoker, display_perf, time_elapsed);
+
+    free_ProgramInvoker(invoker);
+    if (line != NULL) {
+        free(line);
+    }
+
+    free(tmp);
+    return result;
 }
 
 

--- a/Cassys_external_program.cpp
+++ b/Cassys_external_program.cpp
@@ -274,7 +274,7 @@ int launch_grf2fst2_in_Cassys(const char *text_name, const char *alphabet_name, 
 
 	sprintf(tmp,"--alphabet=%s",alphabet_name);
 	add_argument(invoker,tmp);
-        
+
 	int result = cassys_invoke(invoker, display_perf, time_elapsed);
 	free_ProgramInvoker(invoker);
 
@@ -321,7 +321,7 @@ int launch_concord_in_Cassys(const char *text_name, const char *index_file, cons
 				exit(1);
 			}
 			while (u_fgets_dynamic_buffer(&line, &size_buffer_line, concord) != EOF) {
-				
+
 
 				brace_level = 0;
 				i=0;
@@ -344,7 +344,7 @@ int launch_concord_in_Cassys(const char *text_name, const char *index_file, cons
 
 	add_argument(invoker,index_file);
 
-    
+
     {
         tmp[0]=0;
         get_reading_encoding_text(tmp, SIZE_TMP_BUFFER,vec->mask_encoding_compatibility_input);

--- a/Cassys_external_program.h
+++ b/Cassys_external_program.h
@@ -39,8 +39,8 @@ namespace unitex {
 /**
  * \brief Calls the 'locate' program
  *
- *	The locate program is called with the options '--longest_match' and '--all'. References of to the occurrences
- *	found are saved in a file 'concord.ind'
+ *  The locate program is called with the options '--longest_match' and '--all'. References of to the occurrences
+ *  found are saved in a file 'concord.ind'
  *
  * \param text_name target text
  * \param transducer transducer to apply
@@ -84,9 +84,9 @@ int launch_concord_in_Cassys(const char *text_name,
 /**
  * \brief Calls the program 'tokenize'
  *
- *	The program is called with the option 'word_by_word. The results of this program are the two files
- *	'tokens.txt' which contains all the tokens of 'text' and 'tokens.cod' which contains the text coded with
- *	'tokens.txt'.
+ *  The program is called with the option 'word_by_word. The results of this program are the two files
+ *  'tokens.txt' which contains all the tokens of 'text' and 'tokens.cod' which contains the text coded with
+ *  'tokens.txt'.
  *
  * \param text_name target text
  * \param file name of the alphabet of the target text

--- a/Cassys_io.cpp
+++ b/Cassys_io.cpp
@@ -44,7 +44,7 @@ namespace unitex {
 
 
 int make_cassys_directory(const char *path){
-	return mkDirPortable(path);
+    return mkDirPortable(path);
 }
 
 
@@ -64,35 +64,35 @@ static int copy_directory_snt_item(const char*dest_snt_dir,const char*src_snd_di
 
 static void remove_file_in_path(char* path, const char* filename, int mandatory)
 {
-	if (!path)
-		return;
-	char * end_path = path + strlen(path);
-	strcpy(end_path, filename);
-	if (mandatory || fexists(path))
-		af_remove(path);
-	*end_path = '\0';
+    if (!path)
+        return;
+    char * end_path = path + strlen(path);
+    strcpy(end_path, filename);
+    if (mandatory || fexists(path))
+        af_remove(path);
+    *end_path = '\0';
 }
 
 void cleanup_work_directory_content(char* path)
 {
-	if (path == NULL)
-		return;
-	remove_file_in_path(path, "concord.ind", 0);
-	remove_file_in_path(path, "concord.n", 0);
-	remove_file_in_path(path, "concord.txt", 0);
-	remove_file_in_path(path, "dlc", 0);
-	remove_file_in_path(path, "dlf", 0);
-	remove_file_in_path(path, "enter.pos", 1);
-	remove_file_in_path(path, "err", 0);
-	remove_file_in_path(path, "stat_dic.n", 0);
-	remove_file_in_path(path, "stats.n", 0);
-	remove_file_in_path(path, "tags.ind", 0);
-	remove_file_in_path(path, "text.cod", 1);
-	remove_file_in_path(path, "tok_by_alph.txt", 0);
-	remove_file_in_path(path, "tok_by_freq.txt", 0);
-	remove_file_in_path(path, "tokens.txt", 1);
-	remove_file_in_path(path, "snt_offsets.pos", 0);
-	rmDirPortable(path);
+    if (path == NULL)
+        return;
+    remove_file_in_path(path, "concord.ind", 0);
+    remove_file_in_path(path, "concord.n", 0);
+    remove_file_in_path(path, "concord.txt", 0);
+    remove_file_in_path(path, "dlc", 0);
+    remove_file_in_path(path, "dlf", 0);
+    remove_file_in_path(path, "enter.pos", 1);
+    remove_file_in_path(path, "err", 0);
+    remove_file_in_path(path, "stat_dic.n", 0);
+    remove_file_in_path(path, "stats.n", 0);
+    remove_file_in_path(path, "tags.ind", 0);
+    remove_file_in_path(path, "text.cod", 1);
+    remove_file_in_path(path, "tok_by_alph.txt", 0);
+    remove_file_in_path(path, "tok_by_freq.txt", 0);
+    remove_file_in_path(path, "tokens.txt", 1);
+    remove_file_in_path(path, "snt_offsets.pos", 0);
+    rmDirPortable(path);
 }
 
 
@@ -122,229 +122,229 @@ int copy_directory_snt_content(const char*dest_snt_dir, const char*src_snd_dir, 
 
 void get_csc_path(const char* filename, char* result) {
 
-	get_path(filename, result);
-	remove_path_and_extension(filename, result + strlen(result));
+    get_path(filename, result);
+    remove_path_and_extension(filename, result + strlen(result));
 
-	strcat(result, CASSYS_DIRECTORY_EXTENSION);
+    strcat(result, CASSYS_DIRECTORY_EXTENSION);
 
-	strcat(result, PATH_SEPARATOR_STRING);
+    strcat(result, PATH_SEPARATOR_STRING);
 }
 
 void get_csc_wd_path(const char* filename, char* result) {
-	char canonical_name[FILENAME_MAX];
-	remove_path_and_extension(filename, canonical_name);
+    char canonical_name[FILENAME_MAX];
+    remove_path_and_extension(filename, canonical_name);
 
-	char extension[FILENAME_MAX];
-	get_extension(filename, extension);
+    char extension[FILENAME_MAX];
+    get_extension(filename, extension);
 
-	get_path(filename, result);
-	remove_path_and_extension(filename, result + strlen(result));
+    get_path(filename, result);
+    remove_path_and_extension(filename, result + strlen(result));
 
-	strcat(result, CASSYS_DIRECTORY_EXTENSION);
+    strcat(result, CASSYS_DIRECTORY_EXTENSION);
 
-	strcat(result, PATH_SEPARATOR_STRING);
-	sprintf(result+strlen(result), "%s_0_0%s",canonical_name,extension);
+    strcat(result, PATH_SEPARATOR_STRING);
+    sprintf(result+strlen(result), "%s_0_0%s",canonical_name,extension);
 }
 
 int initialize_working_directory_before_tokenize(const char*text, int must_create_directory)
 {
-	char snt_dir[FILENAME_MAX];
-	get_snt_path(text, snt_dir);
-	if (must_create_directory != 0) {
-		make_cassys_directory(snt_dir);
-	}
+    char snt_dir[FILENAME_MAX];
+    get_snt_path(text, snt_dir);
+    if (must_create_directory != 0) {
+        make_cassys_directory(snt_dir);
+    }
 
-	return 0;
+    return 0;
 }
 
 int initialize_working_directory(const char *text,int must_create_directory){
-	char path[FILENAME_MAX];
-	get_path(text,path);
+    char path[FILENAME_MAX];
+    get_path(text,path);
 
-	char canonical_name[FILENAME_MAX];
-	remove_path_and_extension(text, canonical_name);
+    char canonical_name[FILENAME_MAX];
+    remove_path_and_extension(text, canonical_name);
 
-	char extension[FILENAME_MAX];
-	get_extension(text,extension);
+    char extension[FILENAME_MAX];
+    get_extension(text,extension);
 
-	char working_directory[FILENAME_MAX];
-	sprintf(working_directory, "%s%s%s%c",path, canonical_name, CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR);
+    char working_directory[FILENAME_MAX];
+    sprintf(working_directory, "%s%s%s%c",path, canonical_name, CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR);
 
-	if (must_create_directory != 0) {
-		make_cassys_directory(working_directory);
-    }
-
-	char text_in_wd[FILENAME_MAX];
-	sprintf(text_in_wd, "%s%s_0_0%s",working_directory,canonical_name,extension );
-	copy_file(text_in_wd,text);
-
-	char snt_dir_text_in_wd[FILENAME_MAX];
-	get_snt_path(text_in_wd, snt_dir_text_in_wd);
     if (must_create_directory != 0) {
-		make_cassys_directory(snt_dir_text_in_wd);
+        make_cassys_directory(working_directory);
     }
 
-	char original_snt_dir[FILENAME_MAX];
-	get_snt_path(text,original_snt_dir);
-	copy_directory_snt_content(snt_dir_text_in_wd, original_snt_dir,1);
+    char text_in_wd[FILENAME_MAX];
+    sprintf(text_in_wd, "%s%s_0_0%s",working_directory,canonical_name,extension );
+    copy_file(text_in_wd,text);
 
-	return 0;
+    char snt_dir_text_in_wd[FILENAME_MAX];
+    get_snt_path(text_in_wd, snt_dir_text_in_wd);
+    if (must_create_directory != 0) {
+        make_cassys_directory(snt_dir_text_in_wd);
+    }
+
+    char original_snt_dir[FILENAME_MAX];
+    get_snt_path(text,original_snt_dir);
+    copy_directory_snt_content(snt_dir_text_in_wd, original_snt_dir,1);
+
+    return 0;
 }
 
 
 //char* create_labeled_files_and_directory(const char *text, int next_transducer_label,int must_create_directory,int must_copy_file) {
 char* create_labeled_files_and_directory(
-		const char *text,
-		int previous_transducer_label,
-		int next_transducer_label,
-		int previous_iteration,
-		int next_iteration,
-		int must_create_directory,
-		int must_copy_file) {
+        const char *text,
+        int previous_transducer_label,
+        int next_transducer_label,
+        int previous_iteration,
+        int next_iteration,
+        int must_create_directory,
+        int must_copy_file) {
 
-	char path[FILENAME_MAX];
-	get_path(text, path);
+    char path[FILENAME_MAX];
+    get_path(text, path);
 
-	char canonical_text_name[FILENAME_MAX];
-	remove_path_and_extension(text, canonical_text_name);
+    char canonical_text_name[FILENAME_MAX];
+    remove_path_and_extension(text, canonical_text_name);
 
-	char extension[FILENAME_MAX];
-	get_extension(text, extension);
+    char extension[FILENAME_MAX];
+    get_extension(text, extension);
 
-	char working_directory[FILENAME_MAX];
-	sprintf(working_directory, "%s%s%s%c", path, canonical_text_name,
-			CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR);
+    char working_directory[FILENAME_MAX];
+    sprintf(working_directory, "%s%s%s%c", path, canonical_text_name,
+            CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR);
 
-	// copy the text label i- to i
-	char old_labeled_text_name[FILENAME_MAX];
-	sprintf(old_labeled_text_name, "%s%s_%d_%d%s", working_directory,
-			canonical_text_name, previous_transducer_label, previous_iteration, extension);
+    // copy the text label i- to i
+    char old_labeled_text_name[FILENAME_MAX];
+    sprintf(old_labeled_text_name, "%s%s_%d_%d%s", working_directory,
+            canonical_text_name, previous_transducer_label, previous_iteration, extension);
 
-	char new_labeled_text_name[FILENAME_MAX];
-	sprintf(new_labeled_text_name, "%s%s_%d_%d%s", working_directory,
-			canonical_text_name, next_transducer_label, next_iteration, extension);
+    char new_labeled_text_name[FILENAME_MAX];
+    sprintf(new_labeled_text_name, "%s%s_%d_%d%s", working_directory,
+            canonical_text_name, next_transducer_label, next_iteration, extension);
 
-	char new_labeled_snt_directory[FILENAME_MAX];
-	get_snt_path(new_labeled_text_name, new_labeled_snt_directory);
+    char new_labeled_snt_directory[FILENAME_MAX];
+    get_snt_path(new_labeled_text_name, new_labeled_snt_directory);
     if (must_create_directory != 0) {
-		make_cassys_directory(new_labeled_snt_directory);
+        make_cassys_directory(new_labeled_snt_directory);
     }
 
     if (must_copy_file != 0)
     {
-	    copy_file(new_labeled_text_name, old_labeled_text_name);
+        copy_file(new_labeled_text_name, old_labeled_text_name);
 
-	    // create snt directory labeled i
-	    char old_labeled_snt_directory[FILENAME_MAX];
-	    get_snt_path(old_labeled_text_name, old_labeled_snt_directory);
+        // create snt directory labeled i
+        char old_labeled_snt_directory[FILENAME_MAX];
+        get_snt_path(old_labeled_text_name, old_labeled_snt_directory);
 
 
-	    // copy dictionary files in the new snt directory
-	    struct snt_files *old_snt_ = new_snt_files(old_labeled_text_name);
-	    struct snt_files *new_snt_ = new_snt_files(new_labeled_text_name);
+        // copy dictionary files in the new snt directory
+        struct snt_files *old_snt_ = new_snt_files(old_labeled_text_name);
+        struct snt_files *new_snt_ = new_snt_files(new_labeled_text_name);
 
-	    if (fexists(old_snt_->dlc)) {
-		    copy_file(new_snt_->dlc, old_snt_->dlc);
-	    }
-	    if (fexists(old_snt_-> dlf)) {
-		    copy_file(new_snt_->dlf, old_snt_->dlf);
-	    }
-	    if (fexists(old_snt_-> err)) {
-		    copy_file(new_snt_->err, old_snt_->err);
-	    }
-	    if (fexists(old_snt_->dlc_n)) {
-		    copy_file(new_snt_->dlc_n, old_snt_->dlc_n);
-	    }
-	    if (fexists(old_snt_->dlf_n)) {
-		    copy_file(new_snt_->dlf_n, old_snt_->dlf_n);
-	    }
-	    if (fexists(old_snt_-> err_n)) {
-		    copy_file(new_snt_->err_n, old_snt_->err_n);
-	    }
-	    if (fexists(old_snt_->stat_dic_n)) {
-		    copy_file(new_snt_->stat_dic_n, old_snt_->stat_dic_n);
-	    }
-	    free_snt_files(old_snt_);
-	    free_snt_files(new_snt_);
+        if (fexists(old_snt_->dlc)) {
+            copy_file(new_snt_->dlc, old_snt_->dlc);
+        }
+        if (fexists(old_snt_-> dlf)) {
+            copy_file(new_snt_->dlf, old_snt_->dlf);
+        }
+        if (fexists(old_snt_-> err)) {
+            copy_file(new_snt_->err, old_snt_->err);
+        }
+        if (fexists(old_snt_->dlc_n)) {
+            copy_file(new_snt_->dlc_n, old_snt_->dlc_n);
+        }
+        if (fexists(old_snt_->dlf_n)) {
+            copy_file(new_snt_->dlf_n, old_snt_->dlf_n);
+        }
+        if (fexists(old_snt_-> err_n)) {
+            copy_file(new_snt_->err_n, old_snt_->err_n);
+        }
+        if (fexists(old_snt_->stat_dic_n)) {
+            copy_file(new_snt_->stat_dic_n, old_snt_->stat_dic_n);
+        }
+        free_snt_files(old_snt_);
+        free_snt_files(new_snt_);
     }
-	char *labeled_text_name;
-	labeled_text_name = (char*)malloc(sizeof(char)*(strlen(new_labeled_text_name)+1));
-	if(labeled_text_name == NULL){
-		fatal_alloc_error("create_labeled_files_and_directory");
-		exit(1);
-	}
-	strcpy(labeled_text_name, new_labeled_text_name);
-	return labeled_text_name;
+    char *labeled_text_name;
+    labeled_text_name = (char*)malloc(sizeof(char)*(strlen(new_labeled_text_name)+1));
+    if(labeled_text_name == NULL){
+        fatal_alloc_error("create_labeled_files_and_directory");
+        exit(1);
+    }
+    strcpy(labeled_text_name, new_labeled_text_name);
+    return labeled_text_name;
 }
 
 
 char* create_updated_graph_filename(const char *text,
-	int next_transducer_label,
-	int next_iteration,
-	const char* graph_name,
-	const char* ext)
+    int next_transducer_label,
+    int next_iteration,
+    const char* graph_name,
+    const char* ext)
 {
-	char path[FILENAME_MAX];
-	get_path(text, path);
+    char path[FILENAME_MAX];
+    get_path(text, path);
 
-	char canonical_text_name[FILENAME_MAX];
-	remove_path_and_extension(text, canonical_text_name);
+    char canonical_text_name[FILENAME_MAX];
+    remove_path_and_extension(text, canonical_text_name);
 
-	char working[FILENAME_MAX];
-	sprintf(working, "%s%s%s%c%s_%d_%d_snt%c", path, canonical_text_name,
-		CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR,
-		canonical_text_name, next_transducer_label, next_iteration, PATH_SEPARATOR_CHAR);
-
-
-
-	strcat(working, graph_name);
-	strcat(working, ext);
+    char working[FILENAME_MAX];
+    sprintf(working, "%s%s%s%c%s_%d_%d_snt%c", path, canonical_text_name,
+        CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR,
+        canonical_text_name, next_transducer_label, next_iteration, PATH_SEPARATOR_CHAR);
 
 
-	char* full_graph_name = (char*)malloc(sizeof(char)*(strlen(working) + 1));
-	if (graph_name == NULL) {
-		fatal_alloc_error("create_updated_graph_filename");
-		exit(1);
-	}
-	strcpy(full_graph_name, working);
-	return full_graph_name;
+
+    strcat(working, graph_name);
+    strcat(working, ext);
+
+
+    char* full_graph_name = (char*)malloc(sizeof(char)*(strlen(working) + 1));
+    if (graph_name == NULL) {
+        fatal_alloc_error("create_updated_graph_filename");
+        exit(1);
+    }
+    strcpy(full_graph_name, working);
+    return full_graph_name;
 }
 
 char* get_file_in_current_snt(const char *text,
-	int next_transducer_label,
-	int next_iteration,
-	const char* file_name,
-	const char* ext)
+    int next_transducer_label,
+    int next_iteration,
+    const char* file_name,
+    const char* ext)
 {
     return create_updated_graph_filename(text,next_transducer_label,next_iteration,file_name,ext);
 }
 
 void protect_text(const char *fileName, const VersatileEncodingConfig* vec){
 
-	U_FILE *file_reader = u_fopen(vec, fileName, U_READ);
-	if(file_reader == NULL){
-		fatal_error("u_fopen");
-	}
+    U_FILE *file_reader = u_fopen(vec, fileName, U_READ);
+    if(file_reader == NULL){
+        fatal_error("u_fopen");
+    }
 
-	unichar *text = read_file(file_reader);
+    unichar *text = read_file(file_reader);
 
-	unichar *protected_text = protect_lexical_tag(text, false);
+    unichar *protected_text = protect_lexical_tag(text, false);
 
-	free(text);
-	u_fclose(file_reader);
+    free(text);
+    u_fclose(file_reader);
 
-	U_FILE *file_write = u_fopen(vec, fileName, U_WRITE);
-	if(file_write == NULL){
-		fatal_error("u_fopen");
-	}
+    U_FILE *file_write = u_fopen(vec, fileName, U_WRITE);
+    if(file_write == NULL){
+        fatal_error("u_fopen");
+    }
 
-	int written = u_fwrite(protected_text, u_strlen(protected_text),file_write);
-	if(written != (int)u_strlen(protected_text)){
-		fatal_error("u_fwrite");
-	}
+    int written = u_fwrite(protected_text, u_strlen(protected_text),file_write);
+    if(written != (int)u_strlen(protected_text)){
+        fatal_error("u_fwrite");
+    }
 
-	u_fclose(file_write);
-	free(protected_text);
+    u_fclose(file_write);
+    free(protected_text);
 
 }
 
@@ -357,36 +357,36 @@ void protect_text(const char *fileName, const VersatileEncodingConfig* vec){
 
 unichar* read_file(U_FILE *f){
 
-	unichar *text = NULL;
+    unichar *text = NULL;
 
-	text = (unichar *)malloc(sizeof(unichar));
-	if(text==NULL){
-		fatal_alloc_error("malloc");
-	}
-	text[0]='\0';
+    text = (unichar *)malloc(sizeof(unichar));
+    if(text==NULL){
+        fatal_alloc_error("malloc");
+    }
+    text[0]='\0';
 
-	int total_read = 0;
-	int read;
-	do {
-		unichar buffer[READ_FILE_BUFFER_SIZE+1];
-		memset(buffer,0,sizeof(unichar)*(READ_FILE_BUFFER_SIZE+1));
+    int total_read = 0;
+    int read;
+    do {
+        unichar buffer[READ_FILE_BUFFER_SIZE+1];
+        memset(buffer,0,sizeof(unichar)*(READ_FILE_BUFFER_SIZE+1));
 
-		int ok=1;
+        int ok=1;
 
-		read = u_fread(buffer,READ_FILE_BUFFER_SIZE,f,&ok);
+        read = u_fread(buffer,READ_FILE_BUFFER_SIZE,f,&ok);
 
-		total_read += u_strlen(buffer);
-		text = (unichar *)realloc(text,sizeof(unichar)*(total_read+1));
-		if(text==NULL){
-				fatal_alloc_error("realloc");
-		}
-		u_strcat(text,buffer);
+        total_read += u_strlen(buffer);
+        text = (unichar *)realloc(text,sizeof(unichar)*(total_read+1));
+        if(text==NULL){
+                fatal_alloc_error("realloc");
+        }
+        u_strcat(text,buffer);
 
-	} while (read == READ_FILE_BUFFER_SIZE);
+    } while (read == READ_FILE_BUFFER_SIZE);
 
-	text[total_read]='\0';
+    text[total_read]='\0';
 
-	return text;
+    return text;
 }
 
 

--- a/Cassys_io.cpp
+++ b/Cassys_io.cpp
@@ -124,7 +124,7 @@ void get_csc_path(const char* filename, char* result) {
 
 	get_path(filename, result);
 	remove_path_and_extension(filename, result + strlen(result));
-	
+
 	strcat(result, CASSYS_DIRECTORY_EXTENSION);
 
 	strcat(result, PATH_SEPARATOR_STRING);
@@ -139,7 +139,7 @@ void get_csc_wd_path(const char* filename, char* result) {
 
 	get_path(filename, result);
 	remove_path_and_extension(filename, result + strlen(result));
-	
+
 	strcat(result, CASSYS_DIRECTORY_EXTENSION);
 
 	strcat(result, PATH_SEPARATOR_STRING);
@@ -292,7 +292,7 @@ char* create_updated_graph_filename(const char *text,
 
 	char working[FILENAME_MAX];
 	sprintf(working, "%s%s%s%c%s_%d_%d_snt%c", path, canonical_text_name,
-		CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR, 
+		CASSYS_DIRECTORY_EXTENSION, PATH_SEPARATOR_CHAR,
 		canonical_text_name, next_transducer_label, next_iteration, PATH_SEPARATOR_CHAR);
 
 

--- a/Cassys_io.h
+++ b/Cassys_io.h
@@ -99,13 +99,13 @@ void get_csc_wd_path(const char* filename, char* result);
  * \param[in] next_transducer_label
  */
 char* create_labeled_files_and_directory(
-		const char *text,
-		int previous_transducer_label,
-		int next_transducer_label,
-		int previous_iteration,
-		int next_iteration,
-		int must_create_directory,
-		int must_copy_file) ;
+        const char *text,
+        int previous_transducer_label,
+        int next_transducer_label,
+        int previous_iteration,
+        int next_iteration,
+        int must_create_directory,
+        int must_copy_file) ;
 
 
 //int copy_directory_snt_item(const char*dest_snt_dir,const char*src_snd_dir,const char*filename,int mandatory);
@@ -123,15 +123,15 @@ int copy_directory_snt_content(const char *dest, const char *src, int contain_ma
 
 
 char* create_updated_graph_filename(const char *text,
-	int next_transducer_label,
-	int next_iteration,
-	const char* graph_name,
-	const char* ext);
+    int next_transducer_label,
+    int next_iteration,
+    const char* graph_name,
+    const char* ext);
 
 char* get_file_in_current_snt(const char *text,
-	int next_transducer_label,
-	int next_iteration,
-	const char* file_name,
+    int next_transducer_label,
+    int next_iteration,
+    const char* file_name,
         const char* ext);
 
 /**

--- a/Cassys_lexical_tags.cpp
+++ b/Cassys_lexical_tags.cpp
@@ -40,60 +40,60 @@ namespace unitex {
 
 
 unichar *protect_lexical_tag(const unichar *text, bool is_substring = false) {
-	unichar *result = NULL;
+    unichar *result = NULL;
 
-	list_ustring *tokens = cassys_tokenize(text);
-
-
-	int size = 0;
-	result = (unichar*)malloc(sizeof(unichar)*(size+1));
-	if(result==NULL){
-		fatal_alloc_error("malloc");
-	}
-	result[size]='\0';
-
-	for (list_ustring *ite = tokens; ite != NULL; ite = ite->next) {
-		unichar *s=NULL;
-
-		if (is_lexical_token(ite->string)) {
-			cassys_pattern *cp = load_cassys_pattern(ite->string);
-
-			unichar *protected_s = protect_lexical_tag( cp->form, true);
-			free(cp->form);
-
-			cp->form=(unichar*)malloc(sizeof(unichar)*(u_strlen(protected_s)+1));
-			if(cp->form == NULL){
-				fatal_alloc_error("malloc");
-			}
-			u_strcpy(cp->form, protected_s);
-			free(protected_s);
-
-			s = cassys_pattern_2_lexical_tag(cp, is_substring);
-			free_cassys_pattern(cp);
-
-			size += u_strlen(s);
-			result = (unichar*)realloc(result, sizeof(unichar)*(size+1));
-			if(result==NULL){
-				fatal_alloc_error("malloc");
-			}
-			u_strcat(result,s);
-			free(s);
+    list_ustring *tokens = cassys_tokenize(text);
 
 
-		} else {
-			size += + u_strlen(ite->string);
-			result = (unichar*) realloc(result, sizeof(unichar) * (size+1));
-			if (result == NULL) {
-				fatal_alloc_error("malloc");
-			}
-			u_strcat(result, ite->string);
-		}
+    int size = 0;
+    result = (unichar*)malloc(sizeof(unichar)*(size+1));
+    if(result==NULL){
+        fatal_alloc_error("malloc");
+    }
+    result[size]='\0';
 
-	}
+    for (list_ustring *ite = tokens; ite != NULL; ite = ite->next) {
+        unichar *s=NULL;
 
-	free_list_ustring(tokens);
+        if (is_lexical_token(ite->string)) {
+            cassys_pattern *cp = load_cassys_pattern(ite->string);
 
-	return result;
+            unichar *protected_s = protect_lexical_tag( cp->form, true);
+            free(cp->form);
+
+            cp->form=(unichar*)malloc(sizeof(unichar)*(u_strlen(protected_s)+1));
+            if(cp->form == NULL){
+                fatal_alloc_error("malloc");
+            }
+            u_strcpy(cp->form, protected_s);
+            free(protected_s);
+
+            s = cassys_pattern_2_lexical_tag(cp, is_substring);
+            free_cassys_pattern(cp);
+
+            size += u_strlen(s);
+            result = (unichar*)realloc(result, sizeof(unichar)*(size+1));
+            if(result==NULL){
+                fatal_alloc_error("malloc");
+            }
+            u_strcat(result,s);
+            free(s);
+
+
+        } else {
+            size += + u_strlen(ite->string);
+            result = (unichar*) realloc(result, sizeof(unichar) * (size+1));
+            if (result == NULL) {
+                fatal_alloc_error("malloc");
+            }
+            u_strcat(result, ite->string);
+        }
+
+    }
+
+    free_list_ustring(tokens);
+
+    return result;
 }
 
 
@@ -102,63 +102,63 @@ unichar *protect_lexical_tag(const unichar *text, bool is_substring = false) {
  */
 list_ustring *cassys_tokenize(const unichar* text) {
 
-	list_ustring *result = NULL;
-	list_ustring *latest_on_result = NULL;
+    list_ustring *result = NULL;
+    list_ustring *latest_on_result = NULL;
 
-	int position = 0;
-	int last_position = 0;
+    int position = 0;
+    int last_position = 0;
 
-	enum {TEXT_MODE, LEXICAL_TAG_MODE};
+    enum {TEXT_MODE, LEXICAL_TAG_MODE};
 
-	int mode = TEXT_MODE;
-//	if(text[0] == '{'){
-//		mode = LEXICAL_TAG_MODE;
-//	}
+    int mode = TEXT_MODE;
+//  if(text[0] == '{'){
+//      mode = LEXICAL_TAG_MODE;
+//  }
 
-	while(text[position]!='\0'){
-		int offset=0;
+    while(text[position]!='\0'){
+        int offset=0;
 
-		if (text[position] == '{') {
-			mode = LEXICAL_TAG_MODE;
-		}
+        if (text[position] == '{') {
+            mode = LEXICAL_TAG_MODE;
+        }
 
-		last_position = position;
-		if(mode==TEXT_MODE){
-			offset = begin_of_lexical_tag(text+position);
-			position += offset;
+        last_position = position;
+        if(mode==TEXT_MODE){
+            offset = begin_of_lexical_tag(text+position);
+            position += offset;
 
-			mode = LEXICAL_TAG_MODE;
-		} else if(mode==LEXICAL_TAG_MODE){
-			offset = end_of_lexical_tag(text+position);
-			if(offset == -1){
-				error("%S : Expected '}' character in cassys_tokenize", text+position);
-				return result;
-			}
-			offset++; // add the } character
-			position+=offset;
+            mode = LEXICAL_TAG_MODE;
+        } else if(mode==LEXICAL_TAG_MODE){
+            offset = end_of_lexical_tag(text+position);
+            if(offset == -1){
+                error("%S : Expected '}' character in cassys_tokenize", text+position);
+                return result;
+            }
+            offset++; // add the } character
+            position+=offset;
 
-			mode=TEXT_MODE;
-		}
+            mode=TEXT_MODE;
+        }
 
-		int token_size = offset ;// We take also the closing bracket
+        int token_size = offset ;// We take also the closing bracket
 
-		#define DEFAULT_TOKEN_BUFFER_SIZE (0x40)
+        #define DEFAULT_TOKEN_BUFFER_SIZE (0x40)
 
-		unichar default_token_buffer[DEFAULT_TOKEN_BUFFER_SIZE];
+        unichar default_token_buffer[DEFAULT_TOKEN_BUFFER_SIZE];
 
-		unichar *token = ((token_size + 1) < DEFAULT_TOKEN_BUFFER_SIZE) ? default_token_buffer : (unichar*)malloc(sizeof(unichar)*(token_size+1));
-		if(token == NULL){
-			fatal_error("malloc cassys_tokenize\n");
-		}
-		if(token_size > 0){
-			u_strncpy(token,text+last_position, token_size);
-		}
-		token[token_size]='\0';
-		result = insert_at_end_of_list_with_latest(token, result, &latest_on_result);
-		if (!((token_size + 1) < DEFAULT_TOKEN_BUFFER_SIZE)) free(token);
-	}
+        unichar *token = ((token_size + 1) < DEFAULT_TOKEN_BUFFER_SIZE) ? default_token_buffer : (unichar*)malloc(sizeof(unichar)*(token_size+1));
+        if(token == NULL){
+            fatal_error("malloc cassys_tokenize\n");
+        }
+        if(token_size > 0){
+            u_strncpy(token,text+last_position, token_size);
+        }
+        token[token_size]='\0';
+        result = insert_at_end_of_list_with_latest(token, result, &latest_on_result);
+        if (!((token_size + 1) < DEFAULT_TOKEN_BUFFER_SIZE)) free(token);
+    }
 
-	return result;
+    return result;
 }
 
 /**
@@ -167,29 +167,29 @@ list_ustring *cassys_tokenize(const unichar* text) {
  */
 int begin_of_lexical_tag(const unichar *text){
 
-	bool protected_character = false;
-	int i=0;
-	while(text[i]!='\0'){
-		i++;
-	}
+    bool protected_character = false;
+    int i=0;
+    while(text[i]!='\0'){
+        i++;
+    }
 
-	for(i=0;text[i]!='\0';i++){
+    for(i=0;text[i]!='\0';i++){
 
-		if(protected_character){
-			protected_character = false;
-			continue;
-		}
+        if(protected_character){
+            protected_character = false;
+            continue;
+        }
 
-		if (text[i] == '\\') {
-			protected_character = true;
-		}
+        if (text[i] == '\\') {
+            protected_character = true;
+        }
 
-		if (text[i] == '{') {
-			return i;
-		}
-	}
+        if (text[i] == '{') {
+            return i;
+        }
+    }
 
-	return i;
+    return i;
 
 }
 
@@ -199,36 +199,36 @@ int begin_of_lexical_tag(const unichar *text){
  * if no closing bracket is found
  */
 int end_of_lexical_tag(const unichar *text){
-	int i=0;
+    int i=0;
 
-	if(text[0]!='{'){
-		return -1;
-	}
+    if(text[0]!='{'){
+        return -1;
+    }
 
-	bool protected_char = false;
-	int brace_depth =1;
-	for(i=1; text[i]!='\0' && brace_depth > 0;i++){
+    bool protected_char = false;
+    int brace_depth =1;
+    for(i=1; text[i]!='\0' && brace_depth > 0;i++){
 
-		if(protected_char){
-			protected_char = false;
-			continue;
-		}
-		if(text[i]=='\\'){
-			protected_char=true;
-		}
-		if(text[i]=='}'){
-			brace_depth--;
-		}
-		if(text[i]=='{'){
-			brace_depth++;
-		}
-		if (brace_depth == 0) {
-			return i;
-		}
-	}
+        if(protected_char){
+            protected_char = false;
+            continue;
+        }
+        if(text[i]=='\\'){
+            protected_char=true;
+        }
+        if(text[i]=='}'){
+            brace_depth--;
+        }
+        if(text[i]=='{'){
+            brace_depth++;
+        }
+        if (brace_depth == 0) {
+            return i;
+        }
+    }
 
 
-	return -1;
+    return -1;
 
 }
 
@@ -237,60 +237,60 @@ int end_of_lexical_tag(const unichar *text){
  */
 unichar *unprotect_lexical_tag(const unichar *text){
 
-	int text_size = u_strlen(text);
+    int text_size = u_strlen(text);
 
-	unichar *result = (unichar*)malloc(sizeof(unichar)*(text_size+1));
-	if(result==NULL){
-		fatal_alloc_error("unprotect_lexical_tag\n");
-	}
-	int i;
-	for(i=0;i<=text_size;i++){
-		result[i]='\0';
-	}
+    unichar *result = (unichar*)malloc(sizeof(unichar)*(text_size+1));
+    if(result==NULL){
+        fatal_alloc_error("unprotect_lexical_tag\n");
+    }
+    int i;
+    for(i=0;i<=text_size;i++){
+        result[i]='\0';
+    }
 
-	if(text[0]!='{'){
-		fatal_error("lexical tag should begin with {\n");
-	}
+    if(text[0]!='{'){
+        fatal_error("lexical tag should begin with {\n");
+    }
 
-	int brace_depth =0;
+    int brace_depth =0;
 
-	i=0;
-	int j=0;
-	bool protected_char = false;
-	for(i=0; text[i]!='\0';i++){
-		if (protected_char) {
-			result[j++] = text[i];
-			protected_char = false;
-			continue;
-		}
+    i=0;
+    int j=0;
+    bool protected_char = false;
+    for(i=0; text[i]!='\0';i++){
+        if (protected_char) {
+            result[j++] = text[i];
+            protected_char = false;
+            continue;
+        }
 
-		if(text[i]=='\\'){
-			protected_char = true;
-			continue;
-		}
+        if(text[i]=='\\'){
+            protected_char = true;
+            continue;
+        }
 
-		result[j++] = text[i];
+        result[j++] = text[i];
 
-		if(text[i]=='{'){
-			brace_depth++;
-		}
+        if(text[i]=='{'){
+            brace_depth++;
+        }
 
-		if(text[i]=='}'){
-			brace_depth--;
-		}
+        if(text[i]=='}'){
+            brace_depth--;
+        }
 
-		if(brace_depth==0){
-			break;
-		}
+        if(brace_depth==0){
+            break;
+        }
 
-	}
+    }
 
 
-	if(text[i]=='\0'){
-		fatal_error("unprotect_lexical_tag : unexpected end of string\n");
-	}
+    if(text[i]=='\0'){
+        fatal_error("unprotect_lexical_tag : unexpected end of string\n");
+    }
 
-	return result;
+    return result;
 
 }
 
@@ -299,292 +299,292 @@ unichar *unprotect_lexical_tag(const unichar *text){
  * all special characters ('+','{','}',':','.',',') are protected with '\'. The form element is always protected.
  */
 unichar* cassys_pattern_2_lexical_tag(struct cassys_pattern *cp,
-		bool to_protect) {
+        bool to_protect) {
 
-	unichar *result = NULL;
+    unichar *result = NULL;
 
-	// First we compute an upper bound on the needed size of unichar string and allocate the necessary memory
-	int result_size = 4; // opening and closing bracket
+    // First we compute an upper bound on the needed size of unichar string and allocate the necessary memory
+    int result_size = 4; // opening and closing bracket
 
-	list_ustring *ite = cp->inflection;
-	while (ite != NULL) {
-		result_size += u_strlen(ite->string) +2 ; // size of string + a separator char
-		ite = ite->next;
-	}
+    list_ustring *ite = cp->inflection;
+    while (ite != NULL) {
+        result_size += u_strlen(ite->string) +2 ; // size of string + a separator char
+        ite = ite->next;
+    }
 
-	ite = cp->code;
-	while (ite != NULL) {
-		result_size += u_strlen(ite->string) + 2; // size of string + a separator char
-		ite = ite->next;
-	}
+    ite = cp->code;
+    while (ite != NULL) {
+        result_size += u_strlen(ite->string) + 2; // size of string + a separator char
+        ite = ite->next;
+    }
 
-	result_size += u_strlen(cp->form)*2 +2; // size of string  * 2 + a separator char. Multiply by to protect the form element
+    result_size += u_strlen(cp->form)*2 +2; // size of string  * 2 + a separator char. Multiply by to protect the form element
 
-	if(cp->lem != NULL){
-		result_size += u_strlen(cp->lem) +2;
-	}
+    if(cp->lem != NULL){
+        result_size += u_strlen(cp->lem) +2;
+    }
 
-	result = (unichar *)malloc(sizeof(unichar)*(result_size+1));
-	if(result == NULL){
-		fatal_alloc_error("cassys_pattern_2_lexical_tag");
-	}
-	int i;
-	for(i=0; i<result_size+1;i++){
-		result[i]='\0';
-	}
-
-
-	// Now we build the string
-
-	int position = 0;
-	if(to_protect){
-		result[position++]='\\';
-	}
-	result[position++]='{';
-
-	unichar *protected_form = protect_form(cp->form);
-	u_strcat(result, protected_form);
-	position+= u_strlen(protected_form);
-	free(protected_form);
+    result = (unichar *)malloc(sizeof(unichar)*(result_size+1));
+    if(result == NULL){
+        fatal_alloc_error("cassys_pattern_2_lexical_tag");
+    }
+    int i;
+    for(i=0; i<result_size+1;i++){
+        result[i]='\0';
+    }
 
 
-	if(cp->lem == NULL){
-		if (to_protect) {
-				result[position++] = '\\';
-			}
-			result[position++] = '}';
-			result[position++] = '\0';
-		return result;
-	}
+    // Now we build the string
 
-	if (cp->lem[0] != '\0' || length(cp->code) > 0 || length(cp->inflection)
-			> 0) {
-		if (to_protect) {
-			result[position++] = '\\';
-		}
-		result[position++] = ',';
+    int position = 0;
+    if(to_protect){
+        result[position++]='\\';
+    }
+    result[position++]='{';
 
-		u_strcat(result, cp->lem);
-		position += u_strlen(cp->lem);
+    unichar *protected_form = protect_form(cp->form);
+    u_strcat(result, protected_form);
+    position+= u_strlen(protected_form);
+    free(protected_form);
 
-		if (length(cp->code) > 0 || length(cp->inflection) > 0) {
-			if (to_protect) {
-				result[position++] = '\\';
-			}
-			result[position++] = '.';
 
-			// add the code
-			ite = cp->code;
-			while (ite != NULL) {
-				u_strcat(result, ite->string);
-				position += u_strlen(ite->string);
-				ite = ite->next;
+    if(cp->lem == NULL){
+        if (to_protect) {
+                result[position++] = '\\';
+            }
+            result[position++] = '}';
+            result[position++] = '\0';
+        return result;
+    }
 
-				if (ite != NULL) {
-					if (to_protect) {
-						result[position++] = '\\';
-					}
-					result[position++] = '+';
-				}
-			}
+    if (cp->lem[0] != '\0' || length(cp->code) > 0 || length(cp->inflection)
+            > 0) {
+        if (to_protect) {
+            result[position++] = '\\';
+        }
+        result[position++] = ',';
 
-			// add the inflection
-			ite = cp->inflection;
-			while (ite != NULL) {
-				if (to_protect) {
-					result[position++] = '\\';
-				}
-				result[position++] = ':';
+        u_strcat(result, cp->lem);
+        position += u_strlen(cp->lem);
 
-				u_strcat(result, ite->string);
-				position += u_strlen(ite->string);
-				ite = ite->next;
-			}
-		}
-	}
+        if (length(cp->code) > 0 || length(cp->inflection) > 0) {
+            if (to_protect) {
+                result[position++] = '\\';
+            }
+            result[position++] = '.';
 
-	if (to_protect) {
-		result[position++] = '\\';
-	}
-	result[position++] = '}';
-	result[position++] = '\0';
+            // add the code
+            ite = cp->code;
+            while (ite != NULL) {
+                u_strcat(result, ite->string);
+                position += u_strlen(ite->string);
+                ite = ite->next;
 
-	return result;
+                if (ite != NULL) {
+                    if (to_protect) {
+                        result[position++] = '\\';
+                    }
+                    result[position++] = '+';
+                }
+            }
+
+            // add the inflection
+            ite = cp->inflection;
+            while (ite != NULL) {
+                if (to_protect) {
+                    result[position++] = '\\';
+                }
+                result[position++] = ':';
+
+                u_strcat(result, ite->string);
+                position += u_strlen(ite->string);
+                ite = ite->next;
+            }
+        }
+    }
+
+    if (to_protect) {
+        result[position++] = '\\';
+    }
+    result[position++] = '}';
+    result[position++] = '\0';
+
+    return result;
 }
 
 
 
 unichar *protect_form(unichar *string){
-	int i;
+    int i;
 
-	int size = u_strlen(string);
-	int number_of_special_character = 0;
-	for(i=0; i<size; i++){
-		if(string[i]==',' || string[i]==':' || string[i]=='.' || string[i]=='+'){
-			number_of_special_character++;
-		}
-		if (string[i] == '\\' ) {
-			if(string[i+1]=='\0'){
-				number_of_special_character++;
-				error("Unexpected end of string in string of length %d : %S\n", size, string);
-			}
-			i++;
-			if(string[i] == ',' || string[i]==':' || string[i] == '.' || string[i]=='+' || string[i]=='\\' || string[i]=='{' || string[i]=='}'){
+    int size = u_strlen(string);
+    int number_of_special_character = 0;
+    for(i=0; i<size; i++){
+        if(string[i]==',' || string[i]==':' || string[i]=='.' || string[i]=='+'){
+            number_of_special_character++;
+        }
+        if (string[i] == '\\' ) {
+            if(string[i+1]=='\0'){
+                number_of_special_character++;
+                error("Unexpected end of string in string of length %d : %S\n", size, string);
+            }
+            i++;
+            if(string[i] == ',' || string[i]==':' || string[i] == '.' || string[i]=='+' || string[i]=='\\' || string[i]=='{' || string[i]=='}'){
 
-			} else {
-				number_of_special_character++;
-			}
-		}
+            } else {
+                number_of_special_character++;
+            }
+        }
 
-	}
+    }
 
-	unichar *result = (unichar*)malloc(sizeof(unichar)*(size+number_of_special_character+1));
-	if(result==NULL){
-		fatal_alloc_error("malloc");
-	}
-	for(i=0; i<size+number_of_special_character;i++){
-		result[i]='\0';
-	}
+    unichar *result = (unichar*)malloc(sizeof(unichar)*(size+number_of_special_character+1));
+    if(result==NULL){
+        fatal_alloc_error("malloc");
+    }
+    for(i=0; i<size+number_of_special_character;i++){
+        result[i]='\0';
+    }
 
-	int j=0;
-	for (i = 0; i < size; i++) {
-		if (string[i] == ',' || string[i] == ':' || string[i] == '.' || string[i]=='+') {
-			result[i+j]='\\';
-			j++;
-			result[i+j]=string[i];
-			continue;
-		}
-		if (string[i] == '\\') {
-			result[i+j]='\\';
-			if (string[i + 1] == '\0') {
-				error("Unexpected end of string!\n");
-			}
-			i++;
-			if (string[i]==',' || string[i]==':' || string[i]=='.' || string[i]=='+' || string[i]=='\\' || string[i]=='{' || string[i]=='}') {
-				result[i+j] = string[i];
-			} else {
-				result[i+j]='\\';
-				j++;
-				result[i+j]=string[i];
-			}
-			continue;
-		}
-		result[i+j]=string[i];
+    int j=0;
+    for (i = 0; i < size; i++) {
+        if (string[i] == ',' || string[i] == ':' || string[i] == '.' || string[i]=='+') {
+            result[i+j]='\\';
+            j++;
+            result[i+j]=string[i];
+            continue;
+        }
+        if (string[i] == '\\') {
+            result[i+j]='\\';
+            if (string[i + 1] == '\0') {
+                error("Unexpected end of string!\n");
+            }
+            i++;
+            if (string[i]==',' || string[i]==':' || string[i]=='.' || string[i]=='+' || string[i]=='\\' || string[i]=='{' || string[i]=='}') {
+                result[i+j] = string[i];
+            } else {
+                result[i+j]='\\';
+                j++;
+                result[i+j]=string[i];
+            }
+            continue;
+        }
+        result[i+j]=string[i];
 
-	}
-	result[i+j]='\0';
-	return result;
+    }
+    result[i+j]='\0';
+    return result;
 }
 
 
 struct cassys_pattern* load_cassys_pattern(unichar *string){
 
-	struct cassys_pattern *cp = NULL;
+    struct cassys_pattern *cp = NULL;
 
-	cp = (struct cassys_pattern*) malloc(sizeof(struct cassys_pattern));
-	if (cp == NULL) {
-		fatal_alloc_error("malloc");
-	}
-	cp->form = NULL;
-	cp->lem = NULL;
-	cp->code=NULL;
-	cp->inflection=NULL;
+    cp = (struct cassys_pattern*) malloc(sizeof(struct cassys_pattern));
+    if (cp == NULL) {
+        fatal_alloc_error("malloc");
+    }
+    cp->form = NULL;
+    cp->lem = NULL;
+    cp->code=NULL;
+    cp->inflection=NULL;
 
-	unichar *result = (unichar *)malloc(sizeof(unichar)*(u_strlen(string)+1));
-	if(result == NULL){
-		fatal_alloc_error("malloc");
-	}
+    unichar *result = (unichar *)malloc(sizeof(unichar)*(u_strlen(string)+1));
+    if(result == NULL){
+        fatal_alloc_error("malloc");
+    }
 
-	int string_size = u_strlen(string);
-	int form_lemma_separator_position = get_form_lemma_separator_position(string);
+    int string_size = u_strlen(string);
+    int form_lemma_separator_position = get_form_lemma_separator_position(string);
 
-	//u_printf("string = %S\n",string);
+    //u_printf("string = %S\n",string);
 
-	if (form_lemma_separator_position == 0) {
-		/*
-		 * No comma so this lexical tag only contains form
-		 */
-		cp->form = (unichar*) malloc(sizeof(unichar) * (string_size /*- 2*/ + 1)); // -2 to exclude { and }, but in comment to prevent less than 1 if error
-		if (cp->form == NULL) {
-			fatal_alloc_error("malloc");
-		}
-		cp->form[0] = '\0';
-		if (string_size > 2) {
-			u_strncpy(cp->form, string + 1, string_size - 2); // we copy string without brackets so begin at position 1 and lenght -2
-			cp->form[string_size - 2] = '\0';
-		}
+    if (form_lemma_separator_position == 0) {
+        /*
+         * No comma so this lexical tag only contains form
+         */
+        cp->form = (unichar*) malloc(sizeof(unichar) * (string_size /*- 2*/ + 1)); // -2 to exclude { and }, but in comment to prevent less than 1 if error
+        if (cp->form == NULL) {
+            fatal_alloc_error("malloc");
+        }
+        cp->form[0] = '\0';
+        if (string_size > 2) {
+            u_strncpy(cp->form, string + 1, string_size - 2); // we copy string without brackets so begin at position 1 and lenght -2
+            cp->form[string_size - 2] = '\0';
+        }
 
-		free(result);
+        free(result);
 
-		return cp;
-	}
+        return cp;
+    }
 
-	int form_size = form_lemma_separator_position - 1; // -1 to exclude {
-	cp->form = (unichar*) malloc(sizeof(unichar) * (form_size + 1));
-	if (cp->form == NULL) {
-		fatal_alloc_error("malloc");
-	}
-	if (form_size>0) u_strncpy(cp->form, string + 1, form_size); // we copy string without brackets so begin at position 1
-	cp->form[form_size] = '\0';
+    int form_size = form_lemma_separator_position - 1; // -1 to exclude {
+    cp->form = (unichar*) malloc(sizeof(unichar) * (form_size + 1));
+    if (cp->form == NULL) {
+        fatal_alloc_error("malloc");
+    }
+    if (form_size>0) u_strncpy(cp->form, string + 1, form_size); // we copy string without brackets so begin at position 1
+    cp->form[form_size] = '\0';
 
 
-	int position = 0;
+    int position = 0;
 
-	// put the annotation in the string with same name
-	int annotation_size = string_size - form_size - 3; // -3 to exclude { and } and ,
-	unichar *annotation = (unichar *) malloc(sizeof(unichar)
-			* (annotation_size + 1));
-	if (annotation == NULL) {
-		fatal_alloc_error("malloc");
-	}
+    // put the annotation in the string with same name
+    int annotation_size = string_size - form_size - 3; // -3 to exclude { and } and ,
+    unichar *annotation = (unichar *) malloc(sizeof(unichar)
+            * (annotation_size + 1));
+    if (annotation == NULL) {
+        fatal_alloc_error("malloc");
+    }
 
-	if (annotation_size>0) u_strncpy(annotation, string + form_lemma_separator_position + 1, annotation_size); // again +1 to exclude comma
-	annotation[annotation_size]='\0';
+    if (annotation_size>0) u_strncpy(annotation, string + form_lemma_separator_position + 1, annotation_size); // again +1 to exclude comma
+    annotation[annotation_size]='\0';
 
-	position = 0;
-	if (parse_string(annotation, &position, result, P_DOT) != P_OK) {
-		error("%S : malformed cassys pattern!\n",annotation);
-		*result='\0';
-	}
-	cp->lem = (unichar*) malloc(sizeof(unichar) * (u_strlen(result)+ 1));
-	if (cp->lem == NULL) {
-		fatal_alloc_error("malloc");
-	}
-	u_strcpy(cp->lem,result);
+    position = 0;
+    if (parse_string(annotation, &position, result, P_DOT) != P_OK) {
+        error("%S : malformed cassys pattern!\n",annotation);
+        *result='\0';
+    }
+    cp->lem = (unichar*) malloc(sizeof(unichar) * (u_strlen(result)+ 1));
+    if (cp->lem == NULL) {
+        fatal_alloc_error("malloc");
+    }
+    u_strcpy(cp->lem,result);
 
-	enum {CODE,INFLEXION};
-	int state = CODE;
-	while(annotation[position] != '\0'){
-		const unichar P_PLUS_CLOSING_ROUND_BRACE[]= { '+', '}', ':', 0 };
-		position++;
-		if (parse_string(annotation, &position, result,
-				P_PLUS_CLOSING_ROUND_BRACE) != P_OK) {
-			error("%S : malformed cassys pattern!!\n",annotation);
-			*result = '\0';
-		}
-		if(u_strlen(result) >0){
-			unichar *token = (unichar *)malloc(sizeof(unichar)*(u_strlen(result)+1));
-			if(token==NULL){
-				fatal_error("malloc");
-			}
-			u_strcpy(token, result);
-			if(state == CODE){
-				cp->code = insert_at_end_of_list(token, cp->code);
-			}
-			if(state == INFLEXION){
-				cp->inflection = insert_at_end_of_list(token, cp->inflection);
-			}
+    enum {CODE,INFLEXION};
+    int state = CODE;
+    while(annotation[position] != '\0'){
+        const unichar P_PLUS_CLOSING_ROUND_BRACE[]= { '+', '}', ':', 0 };
+        position++;
+        if (parse_string(annotation, &position, result,
+                P_PLUS_CLOSING_ROUND_BRACE) != P_OK) {
+            error("%S : malformed cassys pattern!!\n",annotation);
+            *result = '\0';
+        }
+        if(u_strlen(result) >0){
+            unichar *token = (unichar *)malloc(sizeof(unichar)*(u_strlen(result)+1));
+            if(token==NULL){
+                fatal_error("malloc");
+            }
+            u_strcpy(token, result);
+            if(state == CODE){
+                cp->code = insert_at_end_of_list(token, cp->code);
+            }
+            if(state == INFLEXION){
+                cp->inflection = insert_at_end_of_list(token, cp->inflection);
+            }
 
-			if(annotation[position] == ':'){
-				state = INFLEXION;
-			}
-			free(token);
-		}
-	}
-	free(annotation);
-	free(result);
+            if(annotation[position] == ':'){
+                state = INFLEXION;
+            }
+            free(token);
+        }
+    }
+    free(annotation);
+    free(result);
 
-	return cp;
+    return cp;
 }
 
 
@@ -602,12 +602,12 @@ struct cassys_pattern* load_cassys_pattern(unichar *string){
 
 bool is_lexical_token(unichar *token){
 
-	int size = u_strlen(token);
+    int size = u_strlen(token);
 
-	if(token[0] == '{' && token[size-1] == '}'){
-		return true;
-	}
-	return false;
+    if(token[0] == '{' && token[size-1] == '}'){
+        return true;
+    }
+    return false;
 
 }
 
@@ -619,94 +619,94 @@ list_ustring *cassys_tokenize_word_by_word(const unichar* text,const Alphabet* a
 #define CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER 4096
 #define CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN 0x10
 
-	list_ustring *result = NULL;
-	list_ustring *latest_on_result = NULL;
-	unichar token_default_buffer[CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER];
-	unichar braced_token_default_buffer[CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER];
-	unichar *token=token_default_buffer;
-	unichar *braced_token=braced_token_default_buffer;
-	int heap_buffer=0;
+    list_ustring *result = NULL;
+    list_ustring *latest_on_result = NULL;
+    unichar token_default_buffer[CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER];
+    unichar braced_token_default_buffer[CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER];
+    unichar *token=token_default_buffer;
+    unichar *braced_token=braced_token_default_buffer;
+    int heap_buffer=0;
 
-	int i=0,j=0;
-	int text_len=u_strlen(text);
-	if ((text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN) > CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER)
-	{
-		heap_buffer=1;
-		token = (unichar*)malloc(sizeof(unichar)*(text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN));
-		if (token == NULL) {
-			fatal_alloc_error("malloc in cassys_tokenize_word_by_word");
-		}
-		braced_token=(unichar*)malloc(sizeof(unichar)*(text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN));
-		if (braced_token == NULL) {
-			fatal_alloc_error("malloc in cassys_tokenize_word_by_word");
-		}
-	}
-	int opened_bracket = 0;
-	bool protected_char = false;
-	bool token_found = false;
+    int i=0,j=0;
+    int text_len=u_strlen(text);
+    if ((text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN) > CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER)
+    {
+        heap_buffer=1;
+        token = (unichar*)malloc(sizeof(unichar)*(text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN));
+        if (token == NULL) {
+            fatal_alloc_error("malloc in cassys_tokenize_word_by_word");
+        }
+        braced_token=(unichar*)malloc(sizeof(unichar)*(text_len + CASSYS_TOKENIZE_WORD_BY_WORD_DEFAULT_BUFFER_MARGIN));
+        if (braced_token == NULL) {
+            fatal_alloc_error("malloc in cassys_tokenize_word_by_word");
+        }
+    }
+    int opened_bracket = 0;
+    bool protected_char = false;
+    bool token_found = false;
 
-	//u_printf("Cassys_tokenize : \n");
-	//u_printf("chaine = %S\n",text);
+    //u_printf("Cassys_tokenize : \n");
+    //u_printf("chaine = %S\n",text);
 
-	while(text[i]!='\0'){
-		if (!opened_bracket) {
-			token[j++]=text[i];
-			if (is_letter(text[i], alphabet)) {
-				if (!is_letter(text[i + 1], alphabet)) {
-					token_found = true;
+    while(text[i]!='\0'){
+        if (!opened_bracket) {
+            token[j++]=text[i];
+            if (is_letter(text[i], alphabet)) {
+                if (!is_letter(text[i + 1], alphabet)) {
+                    token_found = true;
 
-				}
-			}
-			else {
-				if(text[i]=='{'){
-					opened_bracket ++;
-					j=0;
-				}
-				else {
-					token_found = true;
-				}
-			}
+                }
+            }
+            else {
+                if(text[i]=='{'){
+                    opened_bracket ++;
+                    j=0;
+                }
+                else {
+                    token_found = true;
+                }
+            }
 
-		}
-		else {
-			braced_token[j++] = text[i];
+        }
+        else {
+            braced_token[j++] = text[i];
 
-			if(protected_char){
-				protected_char = false;
-			}
-			else {
-				if(text[i]=='\\'){
-					protected_char = true;
-				}
-				if (text[i] == '}'){
-					opened_bracket --;
-					if(!opened_bracket){
-						token_found = true;
-						braced_token[--j]='\0';
-						u_sprintf(token,"{%S}",braced_token);
-						j=u_strlen(token);
-					}
-				}
-				if (text[i] == '{'){
-					opened_bracket ++;
-				}
-			}
-		}
-		if(token_found){
-			token[j] = '\0';
-			result = insert_at_end_of_list_with_latest(token,result,&latest_on_result);
-			j=0;
-			token_found = false;
-			//u_printf("token = %S\n",token);
-		}
-		i++;
-	}
+            if(protected_char){
+                protected_char = false;
+            }
+            else {
+                if(text[i]=='\\'){
+                    protected_char = true;
+                }
+                if (text[i] == '}'){
+                    opened_bracket --;
+                    if(!opened_bracket){
+                        token_found = true;
+                        braced_token[--j]='\0';
+                        u_sprintf(token,"{%S}",braced_token);
+                        j=u_strlen(token);
+                    }
+                }
+                if (text[i] == '{'){
+                    opened_bracket ++;
+                }
+            }
+        }
+        if(token_found){
+            token[j] = '\0';
+            result = insert_at_end_of_list_with_latest(token,result,&latest_on_result);
+            j=0;
+            token_found = false;
+            //u_printf("token = %S\n",token);
+        }
+        i++;
+    }
 
-	if (heap_buffer != 0) {
-		free(token);
-		free(braced_token);
-	}
-	return result;
+    if (heap_buffer != 0) {
+        free(token);
+        free(braced_token);
+    }
+    return result;
 }
 
 
@@ -715,51 +715,51 @@ list_ustring *cassys_tokenize_word_by_word(const unichar* text,const Alphabet* a
  */
 int get_form_lemma_separator_position(unichar *text){
 
-	/*
-	 * The form lemma separator is the position of the last comma of a lexical tag
-	 */
+    /*
+     * The form lemma separator is the position of the last comma of a lexical tag
+     */
 
-	int size = u_strlen(text);
+    int size = u_strlen(text);
 
-	int i;
-	int brace_level = 0;
-	for(i=size-1; i>0; i--){
+    int i;
+    int brace_level = 0;
+    for(i=size-1; i>0; i--){
 
-		/**
-		 * Comma are only looked for outside of { }. It does not matter whether these brackets are protected
-		 *
-		 */
-		if(text[i]=='}'){
-			brace_level++;
-		}
-		if(text[i]=='{'){
-			brace_level--;
-		}
+        /**
+         * Comma are only looked for outside of { }. It does not matter whether these brackets are protected
+         *
+         */
+        if(text[i]=='}'){
+            brace_level++;
+        }
+        if(text[i]=='{'){
+            brace_level--;
+        }
 
-		// Since a lexical tag is supposed to be given as argument, a closing bracket should be the las character of
-		// string. So brace_level is 1 and not 0.
-		if(text[i]==',' && brace_level == 1 && i+1<size-1 && text[i+1]=='.'){
-			break;
-		}
-	}
-	return i;
+        // Since a lexical tag is supposed to be given as argument, a closing bracket should be the las character of
+        // string. So brace_level is 1 and not 0.
+        if(text[i]==',' && brace_level == 1 && i+1<size-1 && text[i+1]=='.'){
+            break;
+        }
+    }
+    return i;
 
 }
 
 
 void free_cassys_pattern(cassys_pattern *cp){
 
-	if(cp!=NULL){
-		if(cp->form!=NULL){
-			free(cp->form);
-		}
-		if(cp->lem!=NULL){
-			free(cp->lem);
-		}
-		free_list_ustring(cp->code);
-		free_list_ustring(cp->inflection);
-		free(cp);
-	}
+    if(cp!=NULL){
+        if(cp->form!=NULL){
+            free(cp->form);
+        }
+        if(cp->lem!=NULL){
+            free(cp->lem);
+        }
+        free_list_ustring(cp->code);
+        free_list_ustring(cp->inflection);
+        free(cp);
+    }
 
 
 }

--- a/Cassys_lexical_tags.cpp
+++ b/Cassys_lexical_tags.cpp
@@ -145,7 +145,7 @@ list_ustring *cassys_tokenize(const unichar* text) {
 		#define DEFAULT_TOKEN_BUFFER_SIZE (0x40)
 
 		unichar default_token_buffer[DEFAULT_TOKEN_BUFFER_SIZE];
-		
+
 		unichar *token = ((token_size + 1) < DEFAULT_TOKEN_BUFFER_SIZE) ? default_token_buffer : (unichar*)malloc(sizeof(unichar)*(token_size+1));
 		if(token == NULL){
 			fatal_error("malloc cassys_tokenize\n");

--- a/Cassys_lexical_tags.h
+++ b/Cassys_lexical_tags.h
@@ -41,10 +41,10 @@ namespace unitex {
 
 
 struct cassys_pattern {
-	unichar *form;
-	unichar *lem;
-	list_ustring *code;
-	list_ustring *inflection;
+    unichar *form;
+    unichar *lem;
+    list_ustring *code;
+    list_ustring *inflection;
 };
 
 
@@ -73,7 +73,7 @@ int end_of_lexical_tag(const unichar *text);
 list_ustring *cassys_tokenize(const unichar* text);
 
 unichar* cassys_pattern_2_lexical_tag(struct cassys_pattern *cp,
-		bool to_protect) ;
+        bool to_protect) ;
 unichar *unprotect_lexical_tag(const unichar *text);
 
 unichar *protect_lexical_tag(const unichar *text, bool b);

--- a/Cassys_tokens.cpp
+++ b/Cassys_tokens.cpp
@@ -95,7 +95,7 @@ void cassys_tokens_2_graph_walk_for_subgraph(cassys_tokens_list *c, U_FILE *u, c
 
 				u_fprintf(u, "\t_%08x -> _%08x [style=invis]\n", (unsigned int)(count++), 0);
 			}
-		
+
 
 		}
 
@@ -271,7 +271,7 @@ unichar *unprotect_lexical_tags(unichar *u){
 }
 
 
-cassys_tokens_list *cassys_load_text(const VersatileEncodingConfig* vec, const char *tokens_text_name, const char *text_cod_name, 
+cassys_tokens_list *cassys_load_text(const VersatileEncodingConfig* vec, const char *tokens_text_name, const char *text_cod_name,
          struct text_tokens **tokens, const vector_int* uima_offset, cassys_tokens_allocation_tool * allocation_tool) {
 
 	DISCARD_UNUSED_PARAMETER(uima_offset)

--- a/Cassys_tokens.cpp
+++ b/Cassys_tokens.cpp
@@ -39,162 +39,162 @@ namespace unitex {
 
 void cassys_tokens_2_graph(cassys_tokens_list *c,const char *fileName, int realign_token_graph_pointer){
 
-	U_FILE *dot_desc_file = u_fopen(ASCII, fileName, U_WRITE);
-	if (dot_desc_file == NULL) {
-		fatal_error("Cannot open file \n");
-		exit(1);
-	}
+    U_FILE *dot_desc_file = u_fopen(ASCII, fileName, U_WRITE);
+    if (dot_desc_file == NULL) {
+        fatal_error("Cannot open file \n");
+        exit(1);
+    }
 
-	u_fprintf(dot_desc_file,"digraph text {\n");
-	//u_fprintf(dot_desc_file,"\trankdir=\"LR\"");   //pour changer l'orientation, decommenter
-	u_fprintf(dot_desc_file,"\tbgcolor=lightblue1\n");
-	u_fprintf(dot_desc_file,"node [color=lightblue2, style=filled]\n");
+    u_fprintf(dot_desc_file,"digraph text {\n");
+    //u_fprintf(dot_desc_file,"\trankdir=\"LR\"");   //pour changer l'orientation, decommenter
+    u_fprintf(dot_desc_file,"\tbgcolor=lightblue1\n");
+    u_fprintf(dot_desc_file,"node [color=lightblue2, style=filled]\n");
 
-	//u_fprintf(dot_desc_file,"\tbgcolor=antiqueblue\n");
-	cassys_tokens_2_graph_subgraph(c, dot_desc_file, realign_token_graph_pointer);
+    //u_fprintf(dot_desc_file,"\tbgcolor=antiqueblue\n");
+    cassys_tokens_2_graph_subgraph(c, dot_desc_file, realign_token_graph_pointer);
 
-	cassys_tokens_2_graph_walk_for_subgraph(c, dot_desc_file, NULL, realign_token_graph_pointer);
+    cassys_tokens_2_graph_walk_for_subgraph(c, dot_desc_file, NULL, realign_token_graph_pointer);
 
-	u_fprintf(dot_desc_file, "\tNULL[label=\"END\" shape=Mdiamond]\n");
-	u_fprintf(dot_desc_file,"}\n");
+    u_fprintf(dot_desc_file, "\tNULL[label=\"END\" shape=Mdiamond]\n");
+    u_fprintf(dot_desc_file,"}\n");
 
-	u_fclose(dot_desc_file);
+    u_fclose(dot_desc_file);
 }
 
 void cassys_tokens_2_graph_walk_for_subgraph(cassys_tokens_list *c, U_FILE *u, cassys_tokens_list *predecessor, int realign_token_graph_pointer){
 
-	cassys_tokens_list *i;
-	cassys_tokens_list *p = predecessor;
-	unsigned int count = 0;
+    cassys_tokens_list *i;
+    cassys_tokens_list *p = predecessor;
+    unsigned int count = 0;
 
-	for(i=c; i != NULL && i->transducer_id == c->transducer_id; i = i->next_token) {
+    for(i=c; i != NULL && i->transducer_id == c->transducer_id; i = i->next_token) {
 
-		if(i->output != NULL) {
-			cassys_tokens_2_graph_subgraph(i->output, u, realign_token_graph_pointer);
-			cassys_tokens_2_graph_walk_for_subgraph(i->output, u, p, realign_token_graph_pointer);
-
-
-			if (realign_token_graph_pointer == 0) {
-				if (p != NULL){
-					u_fprintf(u, "\t_%p -> _%p\n", p, i->output);
-				}
-				else {
-					u_fprintf(u, "\tstart -> _%p\n", i->output);
-				}
-
-				u_fprintf(u, "\t_%p -> _%p [style=invis]\n", i, i->output);
-			}
-			else
-			{
-				if (p != NULL){
-					u_fprintf(u, "\t_%08x -> _%08x\n", (unsigned int)0, 0);
-				}
-				else {
-					u_fprintf(u, "\tstart -> _%08x\n", 0);
-				}
-
-				u_fprintf(u, "\t_%08x -> _%08x [style=invis]\n", (unsigned int)(count++), 0);
-			}
+        if(i->output != NULL) {
+            cassys_tokens_2_graph_subgraph(i->output, u, realign_token_graph_pointer);
+            cassys_tokens_2_graph_walk_for_subgraph(i->output, u, p, realign_token_graph_pointer);
 
 
-		}
+            if (realign_token_graph_pointer == 0) {
+                if (p != NULL){
+                    u_fprintf(u, "\t_%p -> _%p\n", p, i->output);
+                }
+                else {
+                    u_fprintf(u, "\tstart -> _%p\n", i->output);
+                }
 
-		p = i;
-	}
+                u_fprintf(u, "\t_%p -> _%p [style=invis]\n", i, i->output);
+            }
+            else
+            {
+                if (p != NULL){
+                    u_fprintf(u, "\t_%08x -> _%08x\n", (unsigned int)0, 0);
+                }
+                else {
+                    u_fprintf(u, "\tstart -> _%08x\n", 0);
+                }
+
+                u_fprintf(u, "\t_%08x -> _%08x [style=invis]\n", (unsigned int)(count++), 0);
+            }
+
+
+        }
+
+        p = i;
+    }
 }
 
 void cassys_tokens_2_graph_subgraph(cassys_tokens_list *c, U_FILE *u, int realign_token_graph_pointer){
 
-	static int cluster_number = 0;
-	cassys_tokens_list *i;
-	unsigned int count = 0;
-	u_fprintf(u, "\tsubgraph cluster%d {\n", cluster_number);
-	u_fprintf(u,"\tbgcolor=cornflowerblue\n");
-	u_fprintf(u, "\tlabel = \"transducer %d_%d\"\n", c->transducer_id, c->iteration);
+    static int cluster_number = 0;
+    cassys_tokens_list *i;
+    unsigned int count = 0;
+    u_fprintf(u, "\tsubgraph cluster%d {\n", cluster_number);
+    u_fprintf(u,"\tbgcolor=cornflowerblue\n");
+    u_fprintf(u, "\tlabel = \"transducer %d_%d\"\n", c->transducer_id, c->iteration);
 
-	if(c->transducer_id==0){
-		u_fprintf(u,"\tstart[shape=Mdiamond]\n");
-		if(c!=NULL){
-			if (realign_token_graph_pointer == 0) {
-				u_fprintf(u, "\tstart -> _%p\n", c);
-			}
-			else {
-				u_fprintf(u, "\tstart -> _%08x\n", 0);
-			}
-		}
-	}
+    if(c->transducer_id==0){
+        u_fprintf(u,"\tstart[shape=Mdiamond]\n");
+        if(c!=NULL){
+            if (realign_token_graph_pointer == 0) {
+                u_fprintf(u, "\tstart -> _%p\n", c);
+            }
+            else {
+                u_fprintf(u, "\tstart -> _%08x\n", 0);
+            }
+        }
+    }
 
-	for (i = c; i != NULL && i->transducer_id == c->transducer_id; i = i->next_token) {
+    for (i = c; i != NULL && i->transducer_id == c->transducer_id; i = i->next_token) {
 
-		if(is_lexical_token(i->token)){
+        if(is_lexical_token(i->token)){
 
-			cassys_pattern *cp = load_cassys_pattern(i->token);
-			unichar *unprotected_form = unprotect_lexical_tags(cp->form);
-			unichar *form = protect_from_record(unprotected_form);
+            cassys_pattern *cp = load_cassys_pattern(i->token);
+            unichar *unprotected_form = unprotect_lexical_tags(cp->form);
+            unichar *form = protect_from_record(unprotected_form);
 
-			//u_fprintf(u, "\t\t_%p[label=\"%S\" shape=record ]\n",i,form);
+            //u_fprintf(u, "\t\t_%p[label=\"%S\" shape=record ]\n",i,form);
 
-			u_fprintf(u, "\t\t_%p[fillcolor=steelblue1 label=\"",i);
-			u_fprintf(u,"{ %S",form);
-			u_fprintf(u,"| ");
-			if(cp->lem!=NULL && cp->lem[0]!='\0'){
-				unichar *lem = protect_from_record(cp->lem);
-				u_fprintf(u," %S \\n",lem);
-				free(lem);
-			}
-			u_fprintf(u,"| ");
-			if(cp->code!=NULL){
-				list_ustring *lu=cp->code;
-				while(lu!=NULL){
-					u_fprintf(u," %S \\n",lu->string);
-					lu=lu->next;
-				}
-			}
-			u_fprintf(u,"| ");
-			if (cp->inflection != NULL) {
-				list_ustring *lu = cp->inflection;
-				while (lu != NULL) {
-					u_fprintf(u, " %S \\n", lu->string);
-					lu = lu->next;
-				}
-			}
-			u_fprintf(u, "}\" shape=Mrecord ]\n");
+            u_fprintf(u, "\t\t_%p[fillcolor=steelblue1 label=\"",i);
+            u_fprintf(u,"{ %S",form);
+            u_fprintf(u,"| ");
+            if(cp->lem!=NULL && cp->lem[0]!='\0'){
+                unichar *lem = protect_from_record(cp->lem);
+                u_fprintf(u," %S \\n",lem);
+                free(lem);
+            }
+            u_fprintf(u,"| ");
+            if(cp->code!=NULL){
+                list_ustring *lu=cp->code;
+                while(lu!=NULL){
+                    u_fprintf(u," %S \\n",lu->string);
+                    lu=lu->next;
+                }
+            }
+            u_fprintf(u,"| ");
+            if (cp->inflection != NULL) {
+                list_ustring *lu = cp->inflection;
+                while (lu != NULL) {
+                    u_fprintf(u, " %S \\n", lu->string);
+                    lu = lu->next;
+                }
+            }
+            u_fprintf(u, "}\" shape=Mrecord ]\n");
 
-			free(unprotected_form);
-			free(form);
-			free_cassys_pattern(cp);
-		} else {
-			unichar *label = protect_quote(i->token);
+            free(unprotected_form);
+            free(form);
+            free_cassys_pattern(cp);
+        } else {
+            unichar *label = protect_quote(i->token);
 
-			if (realign_token_graph_pointer == 0) {
-				u_fprintf(u, "\t\t_%p[fillcolor=steelblue label=\"%S\"]\n", i, label);
-			}
-			else {
-				u_fprintf(u, "\t\t_%08x[fillcolor=steelblue label=\"%S\"]\n", (unsigned int)(count++), label);
-			}
-			free(label);
-		}
+            if (realign_token_graph_pointer == 0) {
+                u_fprintf(u, "\t\t_%p[fillcolor=steelblue label=\"%S\"]\n", i, label);
+            }
+            else {
+                u_fprintf(u, "\t\t_%08x[fillcolor=steelblue label=\"%S\"]\n", (unsigned int)(count++), label);
+            }
+            free(label);
+        }
 
-		if (realign_token_graph_pointer == 0) {
-			if (i->next_token != NULL) {
-				u_fprintf(u, "\t\t_%p -> _%p\n", i, i->next_token);
-			}
-			else {
-				u_fprintf(u, "\t\t_%p -> NULL\n", i);
-			}
-		}
-		else {
+        if (realign_token_graph_pointer == 0) {
+            if (i->next_token != NULL) {
+                u_fprintf(u, "\t\t_%p -> _%p\n", i, i->next_token);
+            }
+            else {
+                u_fprintf(u, "\t\t_%p -> NULL\n", i);
+            }
+        }
+        else {
 
-			if (i->next_token != NULL) {
-				u_fprintf(u, "\t\t_%08x -> _%08x\n", (unsigned int)(count++), 0);
-			}
-			else {
-				u_fprintf(u, "\t\t_%08x -> NULL\n", (unsigned int)(count++));
-			}
-		}
-	}
-	u_fprintf(u,"\t}\n");
-	cluster_number++;
+            if (i->next_token != NULL) {
+                u_fprintf(u, "\t\t_%08x -> _%08x\n", (unsigned int)(count++), 0);
+            }
+            else {
+                u_fprintf(u, "\t\t_%08x -> NULL\n", (unsigned int)(count++));
+            }
+        }
+    }
+    u_fprintf(u,"\t}\n");
+    cluster_number++;
 }
 
 
@@ -202,115 +202,115 @@ void cassys_tokens_2_graph_subgraph(cassys_tokens_list *c, U_FILE *u, int realig
 
 unichar *protect_from_record(const unichar *u){
 
-	int size = u_strlen(u);
-	unichar *r=(unichar *)malloc(sizeof(unichar)*size*2+1);
-	if(r == NULL){
-		fatal_alloc_error("malloc");
-	}
+    int size = u_strlen(u);
+    unichar *r=(unichar *)malloc(sizeof(unichar)*size*2+1);
+    if(r == NULL){
+        fatal_alloc_error("malloc");
+    }
 
-	int i,j;
-	for(i=0, j=0; i<=size; i++){
-		if(u[i]=='"' || u[i]=='<' || u[i]=='>' || u[i]=='{'||u[i]=='}'||u[i]=='|'){
-			r[i+j]='\\';
-			j++;
-		}
-		r[i+j]=u[i];
-	}
+    int i,j;
+    for(i=0, j=0; i<=size; i++){
+        if(u[i]=='"' || u[i]=='<' || u[i]=='>' || u[i]=='{'||u[i]=='}'||u[i]=='|'){
+            r[i+j]='\\';
+            j++;
+        }
+        r[i+j]=u[i];
+    }
 
-	return r;
+    return r;
 }
 
 
 unichar *protect_quote(const unichar *u){
 
-	int size = u_strlen(u);
-	unichar *r=(unichar *)malloc(sizeof(unichar)*(size*2+1));
-	if(r == NULL){
-		fatal_alloc_error("malloc");
-	}
+    int size = u_strlen(u);
+    unichar *r=(unichar *)malloc(sizeof(unichar)*(size*2+1));
+    if(r == NULL){
+        fatal_alloc_error("malloc");
+    }
 
-	int i,j;
-	for(i=0, j=0; i<=size; i++){
-		if(u[i]=='"'){
-			r[i+j]='\\';
-			j++;
-		}
-		r[i+j]=u[i];
-	}
+    int i,j;
+    for(i=0, j=0; i<=size; i++){
+        if(u[i]=='"'){
+            r[i+j]='\\';
+            j++;
+        }
+        r[i+j]=u[i];
+    }
 
-	return r;
+    return r;
 }
 
 
 unichar *unprotect_lexical_tags(unichar *u){
 
-	int size = u_strlen(u);
+    int size = u_strlen(u);
 
-	unichar *result=(unichar *)malloc(sizeof(unichar)*(size+1));
-	if (result == NULL) {
-		fatal_alloc_error("malloc");
-	}
-	int i, j;
-	for(i=0;i<=size;i++){
-		result[i]='\0';
-	}
+    unichar *result=(unichar *)malloc(sizeof(unichar)*(size+1));
+    if (result == NULL) {
+        fatal_alloc_error("malloc");
+    }
+    int i, j;
+    for(i=0;i<=size;i++){
+        result[i]='\0';
+    }
 
 
 
-	for (i = 0, j = 0; i <= size; i++) {
-		if (u[i] == '\\') {
-			if(u[i+1]=='.'|| u[i+1]=='+'|| u[i+1]==':' || u[i+1]=='{' ||  u[i+1]=='}'|| u[i+1]=='\\'){
-				j++;
-				continue;
-			}
-		}
-		result[i-j] = u[i];
-	}
+    for (i = 0, j = 0; i <= size; i++) {
+        if (u[i] == '\\') {
+            if(u[i+1]=='.'|| u[i+1]=='+'|| u[i+1]==':' || u[i+1]=='{' ||  u[i+1]=='}'|| u[i+1]=='\\'){
+                j++;
+                continue;
+            }
+        }
+        result[i-j] = u[i];
+    }
 
-	return result;
+    return result;
 }
 
 
 cassys_tokens_list *cassys_load_text(const VersatileEncodingConfig* vec, const char *tokens_text_name, const char *text_cod_name,
          struct text_tokens **tokens, const vector_int* uima_offset, cassys_tokens_allocation_tool * allocation_tool) {
 
-	DISCARD_UNUSED_PARAMETER(uima_offset)
+    DISCARD_UNUSED_PARAMETER(uima_offset)
 
-	*tokens = load_text_tokens(vec, tokens_text_name);
-	if ((*tokens) == NULL)
-		return NULL;
+    *tokens = load_text_tokens(vec, tokens_text_name);
+    if ((*tokens) == NULL)
+        return NULL;
 
-	ABSTRACTMAPFILE* map_text_cod = af_open_mapfile(text_cod_name, MAPFILE_OPTION_READ, 0);
+    ABSTRACTMAPFILE* map_text_cod = af_open_mapfile(text_cod_name, MAPFILE_OPTION_READ, 0);
 
-	if (map_text_cod == NULL){
-		fatal_error("Cannot open file %s\n", text_cod_name);
-		exit(1);
-	}
-	const int* text_cod_buf = (const int*)af_get_mapfile_pointer(map_text_cod);
-	unsigned int text_cod_size_nb_int = (unsigned int)(af_get_mapfile_size(map_text_cod) / sizeof(int));
-
-
-
-	cassys_tokens_list *list = NULL;
-	cassys_tokens_list *temp = list;
+    if (map_text_cod == NULL){
+        fatal_error("Cannot open file %s\n", text_cod_name);
+        exit(1);
+    }
+    const int* text_cod_buf = (const int*)af_get_mapfile_pointer(map_text_cod);
+    unsigned int text_cod_size_nb_int = (unsigned int)(af_get_mapfile_size(map_text_cod) / sizeof(int));
 
 
-	for (unsigned int i = 0; i<text_cod_size_nb_int; i++) {
-		int token_id = *(text_cod_buf + i);
-		if (list == NULL){
-			list = new_element((*tokens)->token[token_id], 0, 0, allocation_tool);
-			temp = list;
-		}
-		else {
-			temp->next_token = new_element((*tokens)->token[token_id], 0, 0, allocation_tool);
-			temp = temp->next_token;
-		}
-	}
 
-	af_release_mapfile_pointer(map_text_cod, text_cod_buf);
-	af_close_mapfile(map_text_cod);
+    cassys_tokens_list *list = NULL;
+    cassys_tokens_list *temp = list;
 
-	return list;
+
+    for (unsigned int i = 0; i<text_cod_size_nb_int; i++) {
+        int token_id = *(text_cod_buf + i);
+        if (list == NULL){
+            list = new_element((*tokens)->token[token_id], 0, 0, allocation_tool);
+            temp = list;
+        }
+        else {
+            temp->next_token = new_element((*tokens)->token[token_id], 0, 0, allocation_tool);
+            temp = temp->next_token;
+        }
+    }
+
+    af_release_mapfile_pointer(map_text_cod, text_cod_buf);
+    af_close_mapfile(map_text_cod);
+
+    return list;
 }
 
 
@@ -319,85 +319,85 @@ cassys_tokens_list *cassys_load_text(const VersatileEncodingConfig* vec, const c
  *
  */
 cassys_tokens_list *add_replaced_text(
-			const char *text, cassys_tokens_list *list,
-			int previous_transducer, int previous_iteration,
-			int transducer_id, int iteration,
-			const char *alphabet_name,
-			const VersatileEncodingConfig* vec, cassys_tokens_allocation_tool * allocation_tool) {
+            const char *text, cassys_tokens_list *list,
+            int previous_transducer, int previous_iteration,
+            int transducer_id, int iteration,
+            const char *alphabet_name,
+            const VersatileEncodingConfig* vec, cassys_tokens_allocation_tool * allocation_tool) {
 
-	locate_pos *prev_l=NULL;
-	Alphabet *alphabet = load_alphabet(vec,alphabet_name);
+    locate_pos *prev_l=NULL;
+    Alphabet *alphabet = load_alphabet(vec,alphabet_name);
 
-	struct snt_files *snt_text_files = new_snt_files(text);
+    struct snt_files *snt_text_files = new_snt_files(text);
 
-	struct fifo *stage_concord = read_concord_file(snt_text_files->concord_ind,vec);
+    struct fifo *stage_concord = read_concord_file(snt_text_files->concord_ind,vec);
 
-	// performance enhancement
-	cassys_tokens_list *current_list_position = list;
-	long current_token_position = 0;
-	while (!is_empty(stage_concord)) {
+    // performance enhancement
+    cassys_tokens_list *current_list_position = list;
+    long current_token_position = 0;
+    while (!is_empty(stage_concord)) {
 
-		locate_pos *l=(locate_pos*)take_ptr(stage_concord);
+        locate_pos *l=(locate_pos*)take_ptr(stage_concord);
 
-		if(prev_l!=NULL){ // manage the fact that when writing a text merging the concord.ind,
-			// and when there is more than one pattern beginning at the same position in the text,
-			// the behavior of concord.exe is to take the first of those patterns.
-			// when we create the concordance of a cascade, it is needed to chose the same path (the first)
-			// as in concord.exe
-			if(prev_l->token_start_offset==l->token_start_offset){
-				while(prev_l!=NULL && l!=NULL && prev_l->token_start_offset==l->token_start_offset){
-					free(prev_l->label);
-					free(prev_l);
-					prev_l=l;
-					if(!is_empty(stage_concord))
-						l=(locate_pos*)take_ptr(stage_concord);
-					else l=NULL;
-				}
-			}
-			else {
-				free(prev_l->label);
-				free(prev_l);
-				prev_l=NULL;
-			}
-		}
-		if(l!=NULL){
-			struct list_ustring *new_sentence_lu = cassys_tokenize_word_by_word(l->label, alphabet);
-			cassys_tokens_list *new_sentence_ctl =
-				new_list(new_sentence_lu, transducer_id, iteration, allocation_tool);
+        if(prev_l!=NULL){ // manage the fact that when writing a text merging the concord.ind,
+            // and when there is more than one pattern beginning at the same position in the text,
+            // the behavior of concord.exe is to take the first of those patterns.
+            // when we create the concordance of a cascade, it is needed to chose the same path (the first)
+            // as in concord.exe
+            if(prev_l->token_start_offset==l->token_start_offset){
+                while(prev_l!=NULL && l!=NULL && prev_l->token_start_offset==l->token_start_offset){
+                    free(prev_l->label);
+                    free(prev_l);
+                    prev_l=l;
+                    if(!is_empty(stage_concord))
+                        l=(locate_pos*)take_ptr(stage_concord);
+                    else l=NULL;
+                }
+            }
+            else {
+                free(prev_l->label);
+                free(prev_l);
+                prev_l=NULL;
+            }
+        }
+        if(l!=NULL){
+            struct list_ustring *new_sentence_lu = cassys_tokenize_word_by_word(l->label, alphabet);
+            cassys_tokens_list *new_sentence_ctl =
+                new_list(new_sentence_lu, transducer_id, iteration, allocation_tool);
 
-			// performance enhancement :
-			// Since matches are sorted, we begin the search from the last known position in the list.
-			// We have to substract from the text position the current token position.
-			cassys_tokens_list *list_position = get_element_at(current_list_position, previous_transducer, previous_iteration,
-				(int)(l->token_start_offset - current_token_position));
+            // performance enhancement :
+            // Since matches are sorted, we begin the search from the last known position in the list.
+            // We have to substract from the text position the current token position.
+            cassys_tokens_list *list_position = get_element_at(current_list_position, previous_transducer, previous_iteration,
+                (int)(l->token_start_offset - current_token_position));
 
-			int replaced_sentence_length = (int)(l->token_end_offset - l->token_start_offset+1);
-			int new_sentence_length = length(new_sentence_lu);
+            int replaced_sentence_length = (int)(l->token_end_offset - l->token_start_offset+1);
+            int new_sentence_length = length(new_sentence_lu);
 
-			add_output(list_position, new_sentence_ctl, previous_transducer, previous_iteration, transducer_id, iteration,
-				replaced_sentence_length, new_sentence_length-1);
+            add_output(list_position, new_sentence_ctl, previous_transducer, previous_iteration, transducer_id, iteration,
+                replaced_sentence_length, new_sentence_length-1);
 
-			// performance enhancement
-			current_list_position = list_position;
-			current_token_position = l->token_start_offset;
+            // performance enhancement
+            current_list_position = list_position;
+            current_token_position = l->token_start_offset;
 
-			if (prev_l != NULL){
-				free(prev_l->label);
-				free(prev_l);
-			}
-			prev_l=l;
-			free_list_ustring(new_sentence_lu);
-		}
-	}
-	if (prev_l != NULL){
-		free(prev_l->label);
-		free(prev_l);
-	}
-	free_fifo(stage_concord);
-	free_snt_files(snt_text_files);
-	free_alphabet(alphabet);
+            if (prev_l != NULL){
+                free(prev_l->label);
+                free(prev_l);
+            }
+            prev_l=l;
+            free_list_ustring(new_sentence_lu);
+        }
+    }
+    if (prev_l != NULL){
+        free(prev_l->label);
+        free(prev_l);
+    }
+    free_fifo(stage_concord);
+    free_snt_files(snt_text_files);
+    free_alphabet(alphabet);
 
-	return list;
+    return list;
 }
 
 
@@ -405,128 +405,128 @@ cassys_tokens_list *add_replaced_text(
 
 
 cassys_tokens_list *next_element(cassys_tokens_list *list, int transducer_id, int iteration){
-	if(list->next_token == NULL){
-		return NULL;
-	}
+    if(list->next_token == NULL){
+        return NULL;
+    }
 
-	cassys_tokens_list *temp = list->next_token;
-	temp = get_output(temp,transducer_id, iteration);
+    cassys_tokens_list *temp = list->next_token;
+    temp = get_output(temp,transducer_id, iteration);
 
-	return temp;
+    return temp;
 }
 
 
 const unichar *next_token(cassys_tokens_list *list, int transducer_id, int iteration){
-	cassys_tokens_list *temp = next_element(list,transducer_id, iteration);
+    cassys_tokens_list *temp = next_element(list,transducer_id, iteration);
 
-	if(temp == NULL){
-		return NULL;
-	}
-	return temp -> token;
+    if(temp == NULL){
+        return NULL;
+    }
+    return temp -> token;
 }
 
 
 cassys_tokens_list *get_output(cassys_tokens_list *list, int transducer_id, int iteration){
-	cassys_tokens_list *temp = list;
+    cassys_tokens_list *temp = list;
 
-	if(list == NULL){
-		return NULL;
-	}
+    if(list == NULL){
+        return NULL;
+    }
 
-	while (temp -> output != NULL && ((temp -> output -> transducer_id
-			== transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
-		temp = temp -> output;
-	}
+    while (temp -> output != NULL && ((temp -> output -> transducer_id
+            == transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
+        temp = temp -> output;
+    }
 
-	return temp;
+    return temp;
 }
 
 
 cassys_tokens_list *get_element_at(cassys_tokens_list *list, int transducer_id, int iteration, int position){
-	int current_position = 0;
-	cassys_tokens_list *temp = list;
+    int current_position = 0;
+    cassys_tokens_list *temp = list;
 
     if (temp==NULL)
         return NULL;
 
     while (temp -> output != NULL && ((temp -> output -> transducer_id
-			== transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
-		temp = temp -> output;
-	}
+            == transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
+        temp = temp -> output;
+    }
 
- 	while(current_position < position){
+    while(current_position < position){
         if(temp->next_token != NULL)
         {
             temp=temp->next_token;
 
-	        while (temp -> output != NULL && ((temp -> output -> transducer_id
-			        == transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
-	            temp = temp -> output;
-	        }
+            while (temp -> output != NULL && ((temp -> output -> transducer_id
+                    == transducer_id && temp->output->iteration <= iteration)|| temp -> output -> transducer_id< transducer_id)) {
+                temp = temp -> output;
+            }
         }
         else
         {
             return NULL;
         }
 
-		current_position++;
-	}
+        current_position++;
+    }
 
-	return temp;
+    return temp;
 }
 
 
 cassys_tokens_list *add_output(cassys_tokens_list *list,
-		cassys_tokens_list *output, int previous_transducer, int previous_iteration,
-		int transducer_id, int iteration,
-		int number_of_tokens_replaced, int number_of_output_tokens) {
+        cassys_tokens_list *output, int previous_transducer, int previous_iteration,
+        int transducer_id, int iteration,
+        int number_of_tokens_replaced, int number_of_output_tokens) {
 
 
-	DISCARD_UNUSED_PARAMETER(transducer_id)
-	DISCARD_UNUSED_PARAMETER(iteration)
+    DISCARD_UNUSED_PARAMETER(transducer_id)
+    DISCARD_UNUSED_PARAMETER(iteration)
 
-	if (list == NULL) {
-		return NULL;
-	}
+    if (list == NULL) {
+        return NULL;
+    }
 
     list ->output = output;
-	cassys_tokens_list *replacement_end = get_element_at(list, previous_transducer, previous_iteration, number_of_tokens_replaced);
-	cassys_tokens_list *output_end =NULL;
-	if(list->output!=NULL)
-		output_end = get_element_at(list->output, list->output->transducer_id, list->output->iteration, number_of_output_tokens);
-	if (output_end == NULL) {
-		return NULL;
-	}
+    cassys_tokens_list *replacement_end = get_element_at(list, previous_transducer, previous_iteration, number_of_tokens_replaced);
+    cassys_tokens_list *output_end =NULL;
+    if(list->output!=NULL)
+        output_end = get_element_at(list->output, list->output->transducer_id, list->output->iteration, number_of_output_tokens);
+    if (output_end == NULL) {
+        return NULL;
+    }
 
-	output_end -> next_token = replacement_end;
+    output_end -> next_token = replacement_end;
 
-	return list;
+    return list;
 }
 
 
 cassys_tokens_list *new_list(list_ustring *l_u, int transducer_id, int iteration, cassys_tokens_allocation_tool * allocation_tool){
-	cassys_tokens_list *head = NULL;
+    cassys_tokens_list *head = NULL;
 
-	if(l_u!=NULL){
-		head = new_element(l_u -> string, transducer_id, iteration, allocation_tool);
-		l_u=l_u->next;
-	}
+    if(l_u!=NULL){
+        head = new_element(l_u -> string, transducer_id, iteration, allocation_tool);
+        l_u=l_u->next;
+    }
 
-	cassys_tokens_list *current = head;
+    cassys_tokens_list *current = head;
 
-	while(l_u!=NULL){
-		// free ajout� pour lib�rer next_token : verifier son utilit� !
-		free(current->next_token);
-		current -> next_token = new_element(l_u -> string, transducer_id, iteration, allocation_tool);
+    while(l_u!=NULL){
+        // free ajout� pour lib�rer next_token : verifier son utilit� !
+        free(current->next_token);
+        current -> next_token = new_element(l_u -> string, transducer_id, iteration, allocation_tool);
 
 
-		current = current ->next_token;
+        current = current ->next_token;
 
-		list_ustring *l_u_next = l_u->next;
-		l_u= l_u_next;
-	}
+        list_ustring *l_u_next = l_u->next;
+        l_u= l_u_next;
+    }
 
-	return head;
+    return head;
 }
 
 
@@ -535,32 +535,32 @@ cassys_tokens_list *new_list(list_ustring *l_u, int transducer_id, int iteration
 
 cassys_tokens_allocation_tool *build_cassys_tokens_allocation_tool()
 {
-	cassys_tokens_allocation_tool *allocation_tool = (cassys_tokens_allocation_tool*)malloc(sizeof(cassys_tokens_allocation_tool));
-	if (allocation_tool == NULL){
-		fatal_alloc_error("build_cassys_tokens_allocation_tool");
-		exit(1);
-	}
-	allocation_tool->first_item = NULL;
-	allocation_tool->allocator_tokens_list = create_abstract_allocator("build_cassys_tokens_allocation_tool", AllocatorCreationFlagAutoFreePrefered);
-	allocation_tool->must_free_tokens_list = (get_allocator_cb_flag(allocation_tool->allocator_tokens_list) & AllocatorGetFlagAutoFreePresent) ? 0 : 1;
-	return allocation_tool;
+    cassys_tokens_allocation_tool *allocation_tool = (cassys_tokens_allocation_tool*)malloc(sizeof(cassys_tokens_allocation_tool));
+    if (allocation_tool == NULL){
+        fatal_alloc_error("build_cassys_tokens_allocation_tool");
+        exit(1);
+    }
+    allocation_tool->first_item = NULL;
+    allocation_tool->allocator_tokens_list = create_abstract_allocator("build_cassys_tokens_allocation_tool", AllocatorCreationFlagAutoFreePrefered);
+    allocation_tool->must_free_tokens_list = (get_allocator_cb_flag(allocation_tool->allocator_tokens_list) & AllocatorGetFlagAutoFreePresent) ? 0 : 1;
+    return allocation_tool;
 }
 
 
 void free_cassys_tokens_allocation_tool(cassys_tokens_allocation_tool * allocation_tool)
 {
-	struct cassys_tokens_allocation_tool_item* item = allocation_tool->first_item;
-	while (item != NULL)
-	{
-		struct cassys_tokens_allocation_tool_item* next_item = item->next;
-		free_cb(item->tokens_list_item->token, allocation_tool->allocator_tokens_list);
-		free_cb(item->tokens_list_item, allocation_tool->allocator_tokens_list);
-		free(item);
-		item = next_item;
-	}
+    struct cassys_tokens_allocation_tool_item* item = allocation_tool->first_item;
+    while (item != NULL)
+    {
+        struct cassys_tokens_allocation_tool_item* next_item = item->next;
+        free_cb(item->tokens_list_item->token, allocation_tool->allocator_tokens_list);
+        free_cb(item->tokens_list_item, allocation_tool->allocator_tokens_list);
+        free(item);
+        item = next_item;
+    }
 
-	close_abstract_allocator(allocation_tool->allocator_tokens_list);
-	free(allocation_tool);
+    close_abstract_allocator(allocation_tool->allocator_tokens_list);
+    free(allocation_tool);
 }
 
 
@@ -568,110 +568,110 @@ void free_cassys_tokens_allocation_tool(cassys_tokens_allocation_tool * allocati
 
 cassys_tokens_list *new_element(const unichar *u, int transducer_id, int iteration, cassys_tokens_allocation_tool * allocation_tool){
 
-	cassys_tokens_list *l = (cassys_tokens_list*)malloc_cb(sizeof(cassys_tokens_list) * 1, allocation_tool->allocator_tokens_list);
-	if(l == NULL){
-		fatal_alloc_error("new_element");
-		exit(1);
-	}
-	if (allocation_tool->must_free_tokens_list) {
-		cassys_tokens_allocation_tool_item* allocation_item = (cassys_tokens_allocation_tool_item*)malloc(sizeof(cassys_tokens_allocation_tool_item));
-		if (allocation_item == NULL){
-			fatal_alloc_error("new_element");
-			exit(1);
-		}
+    cassys_tokens_list *l = (cassys_tokens_list*)malloc_cb(sizeof(cassys_tokens_list) * 1, allocation_tool->allocator_tokens_list);
+    if(l == NULL){
+        fatal_alloc_error("new_element");
+        exit(1);
+    }
+    if (allocation_tool->must_free_tokens_list) {
+        cassys_tokens_allocation_tool_item* allocation_item = (cassys_tokens_allocation_tool_item*)malloc(sizeof(cassys_tokens_allocation_tool_item));
+        if (allocation_item == NULL){
+            fatal_alloc_error("new_element");
+            exit(1);
+        }
 
-		allocation_item->tokens_list_item = l;
-		allocation_item->next = allocation_tool->first_item;
-		allocation_tool->first_item = allocation_item;
-	}
+        allocation_item->tokens_list_item = l;
+        allocation_item->next = allocation_tool->first_item;
+        allocation_tool->first_item = allocation_item;
+    }
 
-	l->transducer_id = transducer_id;
-	l->iteration = iteration;
-	l->output = NULL;
-	l->next_token = NULL;
-	l->token=u_strdup(u, allocation_tool->allocator_tokens_list);
-	return l;
+    l->transducer_id = transducer_id;
+    l->iteration = iteration;
+    l->output = NULL;
+    l->next_token = NULL;
+    l->token=u_strdup(u, allocation_tool->allocator_tokens_list);
+    return l;
 }
 /*
 void free_cassys_tokens_list(cassys_tokens_list *l){
-	while(l!=NULL){
+    while(l!=NULL){
         cassys_tokens_list *l_next_token=NULL;
-		free(l->token);
-		free_cassys_tokens_list(l->output);
-		if(l->next_token!=NULL  && l->transducer_id == l->next_token -> transducer_id){
-			l_next_token = l->next_token;
-		}
-		free(l);
+        free(l->token);
+        free_cassys_tokens_list(l->output);
+        if(l->next_token!=NULL  && l->transducer_id == l->next_token -> transducer_id){
+            l_next_token = l->next_token;
+        }
+        free(l);
         l=l_next_token;
-	}
+    }
 }*/
 
 void display_text(cassys_tokens_list *l, int transducer_id, int iteration){
-	u_printf("cassys_token_list = ");
-	while(l!=NULL){
-		u_printf("%S",l->token);
-		l=next_element(l,transducer_id, iteration);
-	}
-	u_printf("\n");
+    u_printf("cassys_token_list = ");
+    while(l!=NULL){
+        u_printf("%S",l->token);
+        l=next_element(l,transducer_id, iteration);
+    }
+    u_printf("\n");
 }
 
 bool u_isspace(const unichar *u){
-	if ( u[0] == ' ' || u[0] == '\t' || u[0] == 0x0d|| u[0] == 0x0a) {
-		return true;
-	}
-	else {
-		return false;
-	}
+    if ( u[0] == ' ' || u[0] == '\t' || u[0] == 0x0d|| u[0] == 0x0a) {
+        return true;
+    }
+    else {
+        return false;
+    }
 }
 
 
 cassys_tokens_list* cassys_trim(cassys_tokens_list *l, unichar *string_before, unichar *string_next, cassys_tokens_allocation_tool * allocation_tool){
 
-	cassys_tokens_list *last = NULL;
-	// We deal with successive spaces in the new concordance
-	for(cassys_tokens_list *ite_base = l; ite_base !=NULL; ite_base=ite_base->next_token){
-		if (u_isspace(ite_base->token)) {
+    cassys_tokens_list *last = NULL;
+    // We deal with successive spaces in the new concordance
+    for(cassys_tokens_list *ite_base = l; ite_base !=NULL; ite_base=ite_base->next_token){
+        if (u_isspace(ite_base->token)) {
 
-			cassys_tokens_list *ite_space = ite_base->next_token;
-			while( ite_space !=NULL ){
-				if (u_isspace(ite_space->token)) {
-					// suppress the node in the graph
-					ite_base -> next_token = ite_space->next_token;
+            cassys_tokens_list *ite_space = ite_base->next_token;
+            while( ite_space !=NULL ){
+                if (u_isspace(ite_space->token)) {
+                    // suppress the node in the graph
+                    ite_base -> next_token = ite_space->next_token;
 
-					cassys_tokens_list *to_be_freed = ite_space;
-					ite_space=ite_space->next_token;
-					free_cb(to_be_freed->token, allocation_tool->allocator_tokens_list);
-					free_cb(to_be_freed, allocation_tool->allocator_tokens_list);
-				} else {
-					// not a space character
-					break;
-				}
-			}
-		}
+                    cassys_tokens_list *to_be_freed = ite_space;
+                    ite_space=ite_space->next_token;
+                    free_cb(to_be_freed->token, allocation_tool->allocator_tokens_list);
+                    free_cb(to_be_freed, allocation_tool->allocator_tokens_list);
+                } else {
+                    // not a space character
+                    break;
+                }
+            }
+        }
 
-		// We remind the last token of the list to trim it with string_next
-		if(ite_base->next_token==NULL){
-			last = ite_base;
-		}
-	}
+        // We remind the last token of the list to trim it with string_next
+        if(ite_base->next_token==NULL){
+            last = ite_base;
+        }
+    }
 
-	if(string_before !=NULL){
-		if(u_isspace(string_before)&& u_isspace(l->token)){
-			cassys_tokens_list *to_be_freed = l;
-			l=l->next_token;
-			free_cb(to_be_freed->token, allocation_tool->allocator_tokens_list);
-			free_cb(to_be_freed, allocation_tool->allocator_tokens_list);
-		}
-	}
-	if(string_next !=NULL){
-		if(u_isspace(string_next)&& u_isspace(last->token)){
-			free_cb(last->token, allocation_tool->allocator_tokens_list);
-			free_cb(last, allocation_tool->allocator_tokens_list);
-			last=NULL;
-		}
-	}
+    if(string_before !=NULL){
+        if(u_isspace(string_before)&& u_isspace(l->token)){
+            cassys_tokens_list *to_be_freed = l;
+            l=l->next_token;
+            free_cb(to_be_freed->token, allocation_tool->allocator_tokens_list);
+            free_cb(to_be_freed, allocation_tool->allocator_tokens_list);
+        }
+    }
+    if(string_next !=NULL){
+        if(u_isspace(string_next)&& u_isspace(last->token)){
+            free_cb(last->token, allocation_tool->allocator_tokens_list);
+            free_cb(last, allocation_tool->allocator_tokens_list);
+            last=NULL;
+        }
+    }
 
-	return l;
+    return l;
 }
 
 

--- a/Cassys_tokens.h
+++ b/Cassys_tokens.h
@@ -44,30 +44,30 @@ namespace unitex {
  *
  */
 typedef struct cassys_tokens_list{
-	/**
-	 * Current token of the text
-	 */
-	unichar *token;
+    /**
+     * Current token of the text
+     */
+    unichar *token;
 
-	/**
-	 * The label of the transducer that added the token to the text. The id 0 means token from the initial text.
-	 */
-	int transducer_id;
+    /**
+     * The label of the transducer that added the token to the text. The id 0 means token from the initial text.
+     */
+    int transducer_id;
 
-	/**
-	 * The iteration that added the token to the text
-	 */
-	int iteration;
+    /**
+     * The iteration that added the token to the text
+     */
+    int iteration;
 
-	/**
-	 * The next token of the text.
-	 */
-	struct cassys_tokens_list *next_token;
+    /**
+     * The next token of the text.
+     */
+    struct cassys_tokens_list *next_token;
 
-	/**
-	 * If not NULL, beginning of an output found by a transducer.
-	 */
-	struct cassys_tokens_list *output;
+    /**
+     * If not NULL, beginning of an output found by a transducer.
+     */
+    struct cassys_tokens_list *output;
 }cassys_tokens_list;
 
 
@@ -78,14 +78,14 @@ typedef struct cassys_tokens_list{
 */
 
 typedef struct cassys_tokens_allocation_tool_item{
-	cassys_tokens_list* tokens_list_item;
-	struct cassys_tokens_allocation_tool_item* next;
+    cassys_tokens_list* tokens_list_item;
+    struct cassys_tokens_allocation_tool_item* next;
 }cassys_tokens_allocation_tool_item;
 
 typedef struct cassys_tokens_allocation_tool{
-	struct cassys_tokens_allocation_tool_item* first_item;
-	Abstract_allocator allocator_tokens_list;
-	int must_free_tokens_list;
+    struct cassys_tokens_allocation_tool_item* first_item;
+    Abstract_allocator allocator_tokens_list;
+    int must_free_tokens_list;
 } cassys_tokens_allocation_tool;
 
 /**
@@ -115,7 +115,7 @@ cassys_tokens_list *cassys_load_text(const VersatileEncodingConfig*,const char *
          struct text_tokens **tokens, const vector_int* uima_offset, cassys_tokens_allocation_tool * allocation_tool);
 
 cassys_tokens_list *add_replaced_text(const char *text, cassys_tokens_list *list, int previous_transducer, int previous_iteration,
-		 int transducer_id, int iteration, const char *alphabet, const VersatileEncodingConfig*, cassys_tokens_allocation_tool * allocation_tool);
+         int transducer_id, int iteration, const char *alphabet, const VersatileEncodingConfig*, cassys_tokens_allocation_tool * allocation_tool);
 
 //void free_cassys_tokens_list(cassys_tokens_list *l);
 

--- a/Cassys_transducer.cpp
+++ b/Cassys_transducer.cpp
@@ -116,7 +116,7 @@ int extract_cassys_generic_mark(const char *line) {
             if(line[i] != '\0' && line[i] == '@')
                 return 1;
         }
-        
+
         return 0;
 
 }
@@ -181,7 +181,7 @@ void translate_path_separator_to_native_in_filename(char* filename) {
 		walk++;
 	}
 }
- 
+
 
 struct transducer_name_and_mode_linked_list *load_transducer_list_file(const char *transducer_list_name, int translate_path_separator_to_native) {
 

--- a/Cassys_transducer.cpp
+++ b/Cassys_transducer.cpp
@@ -44,15 +44,15 @@ namespace unitex {
  * 'set_last_transducer_linked_list_mode' function
  */
 struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name(
-			struct transducer_name_and_mode_linked_list *current_list,
-			const char*filename,
-			int repeat_mode, int generic_graph)
+            struct transducer_name_and_mode_linked_list *current_list,
+            const char*filename,
+            int repeat_mode, int generic_graph)
 {
     struct transducer_name_and_mode_linked_list* new_item=(struct transducer_name_and_mode_linked_list*)malloc(sizeof(struct transducer_name_and_mode_linked_list));
     if (new_item==NULL) {
-		fatal_alloc_error("add_transducer_linked_list_new_name");
-		exit(1);
-	}
+        fatal_alloc_error("add_transducer_linked_list_new_name");
+        exit(1);
+    }
 
     new_item->transducer_filename = strdup(filename);
     new_item->transducer_mode=IGNORE_OUTPUTS;
@@ -60,9 +60,9 @@ struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name
     new_item->generic_graph = generic_graph;
     new_item->next=NULL;
     if (new_item->transducer_filename==NULL) {
-		fatal_alloc_error("add_transducer_linked_list_new_name");
-		exit(1);
-	}
+        fatal_alloc_error("add_transducer_linked_list_new_name");
+        exit(1);
+    }
 
     if (current_list==NULL)
         return new_item;
@@ -77,41 +77,41 @@ struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name
 
 int extract_cassys_generic_mark(const char *line) {
 
-	int i = 0;
-	// filename
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (isspace(line[i])) {
-		i++;
-	}
+    int i = 0;
+    // filename
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	// merge or replace policy
-	while (isalpha(line[i])) {
-		i++;
-	}
-	while (isspace(line[i])) {
-		i++;
-	}
+    // merge or replace policy
+    while (isalpha(line[i])) {
+        i++;
+    }
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	// disabled or enabled
-	while (isalpha(line[i])) {
-		i++;
-	}
-	while (isspace(line[i])) {
-		i++;
-	}
+    // disabled or enabled
+    while (isalpha(line[i])) {
+        i++;
+    }
+    while (isspace(line[i])) {
+        i++;
+    }
         //fix until
-	i++;
-	//generic graph
+    i++;
+    //generic graph
         if(line[i] != '\0') {
             while (line[i] != '\0' && isspace(line[i])) {
-		i++;
+        i++;
             }
             if(line[i] != '\0' && line[i] == '@')
                 return 1;
@@ -122,10 +122,10 @@ int extract_cassys_generic_mark(const char *line) {
 }
 
 struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name(
-			struct transducer_name_and_mode_linked_list *current_list,
-			const char*filename)
+            struct transducer_name_and_mode_linked_list *current_list,
+            const char*filename)
 {
-	return add_transducer_linked_list_new_name(current_list, filename, 1,0);
+    return add_transducer_linked_list_new_name(current_list, filename, 1,0);
 }
 
 
@@ -142,15 +142,15 @@ void set_last_transducer_linked_list_mode(struct transducer_name_and_mode_linked
 
 OutputPolicy GetOutputPolicyFromString(const char*option_name)
 {
-	if (strcmp(option_name, "M") == 0 || strcmp(option_name, "MERGE") == 0 || strcmp(
-			option_name, "Merge") == 0) {
-		return MERGE_OUTPUTS;
-	}
-	if (strcmp(option_name, "R") == 0 || strcmp(option_name, "REPLACE") == 0
-			|| strcmp(option_name, "Replace") == 0) {
-		return REPLACE_OUTPUTS;
-	}
-	return IGNORE_OUTPUTS;
+    if (strcmp(option_name, "M") == 0 || strcmp(option_name, "MERGE") == 0 || strcmp(
+            option_name, "Merge") == 0) {
+        return MERGE_OUTPUTS;
+    }
+    if (strcmp(option_name, "R") == 0 || strcmp(option_name, "REPLACE") == 0
+            || strcmp(option_name, "Replace") == 0) {
+        return REPLACE_OUTPUTS;
+    }
+    return IGNORE_OUTPUTS;
 }
 
 
@@ -172,75 +172,75 @@ void free_transducer_name_and_mode_linked_list(struct transducer_name_and_mode_l
 
 
 void translate_path_separator_to_native_in_filename(char* filename) {
-	char * walk = filename;
-	while ((*walk) != '\0') {
-		char c = *walk;
-		if ((c == '\\') || (c == '/')) {
-			*walk = PATH_SEPARATOR_CHAR;
-		}
-		walk++;
-	}
+    char * walk = filename;
+    while ((*walk) != '\0') {
+        char c = *walk;
+        if ((c == '\\') || (c == '/')) {
+            *walk = PATH_SEPARATOR_CHAR;
+        }
+        walk++;
+    }
 }
 
 
 struct transducer_name_and_mode_linked_list *load_transducer_list_file(const char *transducer_list_name, int translate_path_separator_to_native) {
 
-	U_FILE *file_transducer_list;
+    U_FILE *file_transducer_list;
     struct transducer_name_and_mode_linked_list * res=NULL;
 
-	file_transducer_list = u_fopen(ASCII, transducer_list_name,U_READ);
-	if( file_transducer_list == NULL){
-		fatal_error("Cannot open file %s\n",transducer_list_name);
-		exit(1);
-	}
+    file_transducer_list = u_fopen(ASCII, transducer_list_name,U_READ);
+    if( file_transducer_list == NULL){
+        fatal_error("Cannot open file %s\n",transducer_list_name);
+        exit(1);
+    }
 
     char line[1024];
     int i=1;
-	while (cassys_fgets(line,1024,file_transducer_list) != NULL){
-		char *transducer_file_name;
-		char *enabled_policy;
-		int repeat_policy;
-		int generic_graph;
+    while (cassys_fgets(line,1024,file_transducer_list) != NULL){
+        char *transducer_file_name;
+        char *enabled_policy;
+        int repeat_policy;
+        int generic_graph;
 
-		OutputPolicy transducer_policy;
+        OutputPolicy transducer_policy;
 
-		remove_cassys_comments(line);
+        remove_cassys_comments(line);
 
-		transducer_file_name = extract_cassys_transducer_name(line);
-		if ((translate_path_separator_to_native != 0) && (transducer_file_name != NULL)) {
-			translate_path_separator_to_native_in_filename(transducer_file_name);
+        transducer_file_name = extract_cassys_transducer_name(line);
+        if ((translate_path_separator_to_native != 0) && (transducer_file_name != NULL)) {
+            translate_path_separator_to_native_in_filename(transducer_file_name);
 
-		}
+        }
 
-		//u_printf("transducer name read =%s\n",transducer_file_name);
+        //u_printf("transducer name read =%s\n",transducer_file_name);
 
-		transducer_policy = extract_cassys_transducer_policy(line);
-		enabled_policy = extract_cassys_disabled(line);
-		repeat_policy = extract_cassys_tranducer_star(line);
-		generic_graph = extract_cassys_generic_mark(line);
-		if (transducer_file_name != NULL && transducer_policy != IGNORE_OUTPUTS && (strcmp("",enabled_policy)==0 || strcmp("Enabled",enabled_policy)==0)) {
-			res=add_transducer_linked_list_new_name(res,transducer_file_name, repeat_policy, generic_graph);
+        transducer_policy = extract_cassys_transducer_policy(line);
+        enabled_policy = extract_cassys_disabled(line);
+        repeat_policy = extract_cassys_tranducer_star(line);
+        generic_graph = extract_cassys_generic_mark(line);
+        if (transducer_file_name != NULL && transducer_policy != IGNORE_OUTPUTS && (strcmp("",enabled_policy)==0 || strcmp("Enabled",enabled_policy)==0)) {
+            res=add_transducer_linked_list_new_name(res,transducer_file_name, repeat_policy, generic_graph);
             set_last_transducer_linked_list_mode(res,transducer_policy);
-		}
-		else {
-			if (transducer_file_name == NULL) {
-				u_printf("Line %d : Empty line\n",i);
-			} else if (transducer_policy == IGNORE_OUTPUTS) {
-				u_printf("Line %d : Transducer policy not recognized\n",i);
-			}
-			if(strcmp("Disabled",enabled_policy)!=0){
-				u_printf("Line %d : Could not recognize whether transducer is enabled\n",i);
-			} else {
-				u_printf("transducer %s is Disabled\n",transducer_file_name);
-			}
-		}
-		free(enabled_policy);
+        }
+        else {
+            if (transducer_file_name == NULL) {
+                u_printf("Line %d : Empty line\n",i);
+            } else if (transducer_policy == IGNORE_OUTPUTS) {
+                u_printf("Line %d : Transducer policy not recognized\n",i);
+            }
+            if(strcmp("Disabled",enabled_policy)!=0){
+                u_printf("Line %d : Could not recognize whether transducer is enabled\n",i);
+            } else {
+                u_printf("transducer %s is Disabled\n",transducer_file_name);
+            }
+        }
+        free(enabled_policy);
         free(transducer_file_name);
-		i++;
-	}
+        i++;
+    }
     u_fclose(file_transducer_list);
 
-	return res;
+    return res;
 }
 
 
@@ -248,82 +248,82 @@ struct transducer_name_and_mode_linked_list *load_transducer_list_file(const cha
  *  (by example, replace 'c:\folder\sub\file' by 'folder\sub\file')
  */
 static const char*skip_absolute_prefix(const char* filename) {
-	// if Windows filename begin with 'c:', we skip two char
-	if ((*(filename)) != '\0')
-		if ((*(filename + 1)) == ':')
-			filename += 2;
-	if (((*filename) == '\\') | ((*filename) == '/'))
-		filename++;
-	return filename;
+    // if Windows filename begin with 'c:', we skip two char
+    if ((*(filename)) != '\0')
+        if ((*(filename + 1)) == ':')
+            filename += 2;
+    if (((*filename) == '\\') | ((*filename) == '/'))
+        filename++;
+    return filename;
 }
 
 
 struct fifo *load_transducer_from_linked_list(const struct transducer_name_and_mode_linked_list *list,const char* transducer_filename_prefix){
-	struct fifo *transducer_fifo = new_fifo();
+    struct fifo *transducer_fifo = new_fifo();
 
-	int i=1;
-	while (list != NULL){
-		char *transducer_file_name;
-		OutputPolicy transducer_policy;
-		transducer *t;
-		int repeat_policy;
+    int i=1;
+    while (list != NULL){
+        char *transducer_file_name;
+        OutputPolicy transducer_policy;
+        transducer *t;
+        int repeat_policy;
                 int generic_graph;
 
         transducer_file_name = list->transducer_filename;
-		//u_printf("transducer name read =%s\n",transducer_file_name);
+        //u_printf("transducer name read =%s\n",transducer_file_name);
 
         transducer_policy = list->transducer_mode;
         repeat_policy = list->repeat_mode;
         generic_graph = list->generic_graph;
 
-		if (transducer_file_name != NULL && transducer_policy != IGNORE_OUTPUTS) {
-			//u_printf("transducer to be loaded\n");
-			t = (transducer*) malloc(sizeof(transducer) * 1);
-			if (t == NULL) {
-				fatal_alloc_error("load_transducer_from_linked_list");
-				exit(1);
-			}
+        if (transducer_file_name != NULL && transducer_policy != IGNORE_OUTPUTS) {
+            //u_printf("transducer to be loaded\n");
+            t = (transducer*) malloc(sizeof(transducer) * 1);
+            if (t == NULL) {
+                fatal_alloc_error("load_transducer_from_linked_list");
+                exit(1);
+            }
             size_t transducer_filename_prefix_len = 0;
             if (transducer_filename_prefix != NULL)
                 transducer_filename_prefix_len = strlen(transducer_filename_prefix);
-			t->transducer_file_name = (char*)malloc(sizeof(char)*(transducer_filename_prefix_len+strlen(transducer_file_name)+1));
-			if(t->transducer_file_name == NULL){
-				fatal_alloc_error("load_transducer_from_linked_list");
-				exit(1);
-			}
+            t->transducer_file_name = (char*)malloc(sizeof(char)*(transducer_filename_prefix_len+strlen(transducer_file_name)+1));
+            if(t->transducer_file_name == NULL){
+                fatal_alloc_error("load_transducer_from_linked_list");
+                exit(1);
+            }
 
             t->transducer_file_name[0] = '\0';
             if (transducer_filename_prefix != NULL)
                 strcpy(t->transducer_file_name, transducer_filename_prefix);
 
-			const char* transducer_file_name_to_add = (transducer_filename_prefix_len > 0) ? skip_absolute_prefix(transducer_file_name) : transducer_file_name;
-			strcat(t->transducer_file_name, transducer_file_name_to_add);
+            const char* transducer_file_name_to_add = (transducer_filename_prefix_len > 0) ? skip_absolute_prefix(transducer_file_name) : transducer_file_name;
+            strcat(t->transducer_file_name, transducer_file_name_to_add);
 
-			t->output_policy = transducer_policy;
-			t->repeat_mode = repeat_policy;
+            t->output_policy = transducer_policy;
+            t->repeat_mode = repeat_policy;
                         t->generic_graph = generic_graph;
 
-			struct any value;
-			value._ptr = t;
-			put_any(transducer_fifo,value);
-			if (!is_empty(transducer_fifo)) {
-				u_printf("transducer %s successfully loaded\n",
-						t->transducer_file_name);
-			}
-		}
-		else {
-			if (transducer_file_name == NULL) {
-				u_printf("Transducer %d : Empty filename\n",i);
-			} else if (transducer_policy == IGNORE_OUTPUTS) {
-				u_printf("Transducer %d : Transducer mode not recognized\n",i);
-			}
-		}
-		i++;
+            struct any value;
+            value._ptr = t;
+            put_any(transducer_fifo,value);
+            if (!is_empty(transducer_fifo)) {
+                u_printf("transducer %s successfully loaded\n",
+                        t->transducer_file_name);
+            }
+        }
+        else {
+            if (transducer_file_name == NULL) {
+                u_printf("Transducer %d : Empty filename\n",i);
+            } else if (transducer_policy == IGNORE_OUTPUTS) {
+                u_printf("Transducer %d : Transducer mode not recognized\n",i);
+            }
+        }
+        i++;
         list=list->next;
-	}
+    }
 
 
-	return transducer_fifo;
+    return transducer_fifo;
 }
 
 
@@ -331,11 +331,11 @@ struct fifo *load_transducer_from_linked_list(const struct transducer_name_and_m
  * \brief Suppress Cassys comment line.
  */
 void remove_cassys_comments(char *line){
-	int i=0;
-	while(line[i] != '\0' && line[i] != '#'){
-		i++;
-	}
-	line[i]='\0';
+    int i=0;
+    while(line[i] != '\0' && line[i] != '#'){
+        i++;
+    }
+    line[i]='\0';
 }
 
 
@@ -351,21 +351,21 @@ void remove_cassys_comments(char *line){
  * @return NULL if no character has been read before \c EOF has been encountered, \c line otherwise
  */
 char *cassys_fgets(char *line, int n, U_FILE *u) {
-	int i = 0;
-	int c;
+    int i = 0;
+    int c;
 
-	c = u_fgetc(u);
-	if (c == EOF) {
-		return NULL;
-	}
-	while (c != EOF && c != '\n' && i < n) {
-		line[i] = (char) c;
-		c=u_fgetc(u);
-		i++;
-	}
-	line[i] = '\0';
-	//u_printf("fgets result =%s\n",line);
-	return line;
+    c = u_fgetc(u);
+    if (c == EOF) {
+        return NULL;
+    }
+    while (c != EOF && c != '\n' && i < n) {
+        line[i] = (char) c;
+        c=u_fgetc(u);
+        i++;
+    }
+    line[i] = '\0';
+    //u_printf("fgets result =%s\n",line);
+    return line;
 }
 
 
@@ -373,174 +373,174 @@ char *cassys_fgets(char *line, int n, U_FILE *u) {
  *
  */
 char* extract_cassys_transducer_name(const char *line){
-	char *transducer_name;
-	int i=0;
-	while(line[i]!='"' && line[i] != '\0'){
-		i++;
-	}
-	if(line[i] == '\0'){
-		return NULL;
-	}
-	i++;
-	int j=i;
-	while(line[i]!='"' && line[i] != '\0'){
-			i++;
-		}
-	if(line[i] == '\0'){
-			return NULL;
-		}
+    char *transducer_name;
+    int i=0;
+    while(line[i]!='"' && line[i] != '\0'){
+        i++;
+    }
+    if(line[i] == '\0'){
+        return NULL;
+    }
+    i++;
+    int j=i;
+    while(line[i]!='"' && line[i] != '\0'){
+            i++;
+        }
+    if(line[i] == '\0'){
+            return NULL;
+        }
 
-	transducer_name = (char*)malloc(sizeof(char)*((i-j)+1));
-	if(transducer_name == NULL){
-		fatal_alloc_error("extract_cassys_transducer_name");
-		exit(1);
-	}
-	strncpy(transducer_name,line+j,(i-j));
-	transducer_name[i-j]='\0';
+    transducer_name = (char*)malloc(sizeof(char)*((i-j)+1));
+    if(transducer_name == NULL){
+        fatal_alloc_error("extract_cassys_transducer_name");
+        exit(1);
+    }
+    strncpy(transducer_name,line+j,(i-j));
+    transducer_name[i-j]='\0';
 
-	return transducer_name;
+    return transducer_name;
 }
 
 
 int extract_cassys_tranducer_star(const char *line) {
 
-	int i = 0;
-	// filename
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (isspace(line[i])) {
-		i++;
-	}
+    int i = 0;
+    // filename
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	// merge or replace policy
-	while (isalpha(line[i])) {
-		i++;
-	}
-	while (isspace(line[i])) {
-		i++;
-	}
+    // merge or replace policy
+    while (isalpha(line[i])) {
+        i++;
+    }
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	// disabled or enabled
-	while (isalpha(line[i])) {
-		i++;
-	}
-	while (isspace(line[i])) {
-		i++;
-	}
+    // disabled or enabled
+    while (isalpha(line[i])) {
+        i++;
+    }
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	if(line[i]=='*'){
-		return INFINITY;
-	}
+    if(line[i]=='*'){
+        return INFINITY;
+    }
 
-	return 1;
+    return 1;
 
 }
 
 
 char *extract_cassys_disabled(const char *line){
-	char *enabled_policy;
+    char *enabled_policy;
 
-	int i = 0;
-	// filename
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (isspace(line[i])) {
-		i++;
-	}
+    int i = 0;
+    // filename
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	// merge or replace policy
-	while (isalpha(line[i])) {
-		i++;
-	}
-	while (isspace(line[i])) {
-		i++;
-	}
+    // merge or replace policy
+    while (isalpha(line[i])) {
+        i++;
+    }
+    while (isspace(line[i])) {
+        i++;
+    }
 
-	int j=0;
-	char option_name[FILENAME_MAX];
-	while(isalpha(line[i])){
-		option_name[j]=line[i];
-		i++;j++;
-	}
-	option_name[j]='\0';
+    int j=0;
+    char option_name[FILENAME_MAX];
+    while(isalpha(line[i])){
+        option_name[j]=line[i];
+        i++;j++;
+    }
+    option_name[j]='\0';
 
-	enabled_policy = (char *)malloc(sizeof(char)*strlen(option_name)+1);
-	if (enabled_policy == NULL) {
-		fatal_alloc_error("extract_cassys_disabled memory allocation\n");
-		exit(1);
-	}
-	strcpy(enabled_policy,option_name);
+    enabled_policy = (char *)malloc(sizeof(char)*strlen(option_name)+1);
+    if (enabled_policy == NULL) {
+        fatal_alloc_error("extract_cassys_disabled memory allocation\n");
+        exit(1);
+    }
+    strcpy(enabled_policy,option_name);
 
-	return enabled_policy;
+    return enabled_policy;
 }
 
 
 OutputPolicy extract_cassys_transducer_policy(const char *line) {
-	int i = 0;
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while (line[i] != '"' && line[i] != '\0') {
-		i++;
-	}
-	i++;
-	while(isspace(line[i])){
-		i++;
-	}
+    int i = 0;
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while (line[i] != '"' && line[i] != '\0') {
+        i++;
+    }
+    i++;
+    while(isspace(line[i])){
+        i++;
+    }
 
-	char option_name[FILENAME_MAX];
-	int j=0;
-	while(isalpha(line[i])){
-		option_name[j]=line[i];
-		i++;j++;
-	}
+    char option_name[FILENAME_MAX];
+    int j=0;
+    while(isalpha(line[i])){
+        option_name[j]=line[i];
+        i++;j++;
+    }
 
-	option_name[j]='\0';
+    option_name[j]='\0';
 
-	//u_printf("extract option =%s\n",option_name);
+    //u_printf("extract option =%s\n",option_name);
 
-	if (strcmp(option_name, "M") == 0 || strcmp(option_name, "MERGE") == 0 || strcmp(
-			option_name, "Merge") == 0) {
-		return MERGE_OUTPUTS;
-	}
-	if (strcmp(option_name, "R") == 0 || strcmp(option_name, "REPLACE") == 0
-			|| strcmp(option_name, "Replace") == 0) {
-		return REPLACE_OUTPUTS;
-	}
-	return IGNORE_OUTPUTS;
+    if (strcmp(option_name, "M") == 0 || strcmp(option_name, "MERGE") == 0 || strcmp(
+            option_name, "Merge") == 0) {
+        return MERGE_OUTPUTS;
+    }
+    if (strcmp(option_name, "R") == 0 || strcmp(option_name, "REPLACE") == 0
+            || strcmp(option_name, "Replace") == 0) {
+        return REPLACE_OUTPUTS;
+    }
+    return IGNORE_OUTPUTS;
 }
 
 
 bool is_debug_mode(transducer *t, const VersatileEncodingConfig* vec) {
 
-	U_FILE *graph_file;
-	graph_file = u_fopen(vec, t->transducer_file_name, U_READ);
-	if (graph_file == NULL) {
-		return false;
-	}
+    U_FILE *graph_file;
+    graph_file = u_fopen(vec, t->transducer_file_name, U_READ);
+    if (graph_file == NULL) {
+        return false;
+    }
 
-	unichar c = (unichar)u_fgetc(graph_file);
+    unichar c = (unichar)u_fgetc(graph_file);
 
-	u_fclose(graph_file);
+    u_fclose(graph_file);
 
-	if(c=='d'){
-		return true;
-	} else {
-		return false;
-	}
+    if(c=='d'){
+        return true;
+    } else {
+        return false;
+    }
 }
 
 

--- a/Cassys_transducer.h
+++ b/Cassys_transducer.h
@@ -61,40 +61,40 @@ struct transducer_name_and_mode_linked_list
  */
 
 typedef struct transducer{
-	char *transducer_file_name;
-	OutputPolicy output_policy;
-	int repeat_mode;
-	int generic_graph;
+    char *transducer_file_name;
+    OutputPolicy output_policy;
+    int repeat_mode;
+    int generic_graph;
 }transducer;
 
 
 struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name(
-			struct transducer_name_and_mode_linked_list *current_list,
-			const char*filename);
+            struct transducer_name_and_mode_linked_list *current_list,
+            const char*filename);
 
 struct transducer_name_and_mode_linked_list* add_transducer_linked_list_new_name(
-		struct transducer_name_and_mode_linked_list *current_list,
-		const char*filename,
-		int repeat_mode,
-		int generic_graph);
+        struct transducer_name_and_mode_linked_list *current_list,
+        const char*filename,
+        int repeat_mode,
+        int generic_graph);
 
 void set_last_transducer_linked_list_mode(
-		struct transducer_name_and_mode_linked_list *current_list,
-		OutputPolicy mode);
+        struct transducer_name_and_mode_linked_list *current_list,
+        OutputPolicy mode);
 
 void set_last_transducer_linked_list_mode_by_string(
-		struct transducer_name_and_mode_linked_list *current_list,
-		const char*option_name);
+        struct transducer_name_and_mode_linked_list *current_list,
+        const char*option_name);
 
 void free_transducer_name_and_mode_linked_list(
-		struct transducer_name_and_mode_linked_list *list);
+        struct transducer_name_and_mode_linked_list *list);
 
 struct transducer_name_and_mode_linked_list *load_transducer_list_file(
-		const char *transducer_list_name, int translate_path_separator_to_native);
+        const char *transducer_list_name, int translate_path_separator_to_native);
 
 struct fifo *load_transducer_from_linked_list(
-		const struct transducer_name_and_mode_linked_list *list,
-		const char*transducer_filename_prefix);
+        const struct transducer_name_and_mode_linked_list *list,
+        const char*transducer_filename_prefix);
 
 /**
  * \brief returns a fifo containing the list of transducers to be applied in the cascade

--- a/Cassys_xml_output.cpp
+++ b/Cassys_xml_output.cpp
@@ -43,98 +43,98 @@ namespace unitex {
 
 void xmlizeConcordFile(const char *concordBracketFileName, const VersatileEncodingConfig *vec) {
 
-	//char concordXmlFileName[FILENAME_MAX]="";
+    //char concordXmlFileName[FILENAME_MAX]="";
 
-//	remove_extension(concordBracketFileName, concordXmlFileName);
-//	strcat(concordXmlFileName,".xml");
+//  remove_extension(concordBracketFileName, concordXmlFileName);
+//  strcat(concordXmlFileName,".xml");
 
-	struct fifo *stage_concord = read_concord_file(concordBracketFileName, vec);
+    struct fifo *stage_concord = read_concord_file(concordBracketFileName, vec);
 
 
-	U_FILE *concord_xml_desc = u_fopen(vec, concordBracketFileName, U_WRITE);
-		if (concord_xml_desc == NULL) {
-			fatal_error("Cannot open file %s\n", concordBracketFileName);
-			exit(1);
-		}
-	u_fprintf(concord_xml_desc,"#M\n");
+    U_FILE *concord_xml_desc = u_fopen(vec, concordBracketFileName, U_WRITE);
+        if (concord_xml_desc == NULL) {
+            fatal_error("Cannot open file %s\n", concordBracketFileName);
+            exit(1);
+        }
+    u_fprintf(concord_xml_desc,"#M\n");
 
-	while (!is_empty(stage_concord)) {
+    while (!is_empty(stage_concord)) {
 
-		locate_pos *l=(locate_pos*)take_ptr(stage_concord);
+        locate_pos *l=(locate_pos*)take_ptr(stage_concord);
 
-		//u_printf("string = %S\n",l->label);
+        //u_printf("string = %S\n",l->label);
 
-		unichar *xml_line = xmlizeConcordLine(l->label);
+        unichar *xml_line = xmlizeConcordLine(l->label);
 
-		u_fprintf(concord_xml_desc,"%ld.%ld.%ld %ld.%ld.%ld %S\n",
-				l->token_start_offset,
-				l->character_start_offset,
-				l->logical_start_offset,
-				l->token_end_offset,
-				l->character_end_offset,
-				l->logical_end_offset,
-				xml_line);
+        u_fprintf(concord_xml_desc,"%ld.%ld.%ld %ld.%ld.%ld %S\n",
+                l->token_start_offset,
+                l->character_start_offset,
+                l->logical_start_offset,
+                l->token_end_offset,
+                l->character_end_offset,
+                l->logical_end_offset,
+                xml_line);
 
-		free(xml_line);
-		free(l->label);
-		free(l);
-	}
-	u_fclose(concord_xml_desc);
-	free_fifo(stage_concord);
+        free(xml_line);
+        free(l->label);
+        free(l);
+    }
+    u_fclose(concord_xml_desc);
+    free_fifo(stage_concord);
 }
 
 
 
 unichar* xmlizeConcordLine(const unichar *line){
 
-	list_ustring *lu = cassys_tokenize(line);
+    list_ustring *lu = cassys_tokenize(line);
 
-	int size = u_strlen(line);
-	unichar *result = (unichar*) malloc(sizeof(unichar) * (size+1));
-	if (result == NULL) {
-		fatal_alloc_error("malloc\n");
-	}
-	result[0] = '\0';
+    int size = u_strlen(line);
+    unichar *result = (unichar*) malloc(sizeof(unichar) * (size+1));
+    if (result == NULL) {
+        fatal_alloc_error("malloc\n");
+    }
+    result[0] = '\0';
 
-	for(list_ustring *ite = lu; ite!=NULL; ite=ite->next){
-		if(is_lexical_token(ite->string)){
+    for(list_ustring *ite = lu; ite!=NULL; ite=ite->next){
+        if(is_lexical_token(ite->string)){
 
-			unichar *unprotected = unprotect_lexical_tag(ite->string);
+            unichar *unprotected = unprotect_lexical_tag(ite->string);
 
-			unichar *xml_string = xmlize(unprotected);
-			size = size - u_strlen(ite->string) + u_strlen(xml_string);
+            unichar *xml_string = xmlize(unprotected);
+            size = size - u_strlen(ite->string) + u_strlen(xml_string);
 
-			result = (unichar*)realloc(result, sizeof(unichar) * (size +1));
-			if (result == NULL) {
-				fatal_alloc_error("realloc");
-			}
-			u_strcat(result, xml_string);
-			free(unprotected);
-			free(xml_string);
+            result = (unichar*)realloc(result, sizeof(unichar) * (size +1));
+            if (result == NULL) {
+                fatal_alloc_error("realloc");
+            }
+            u_strcat(result, xml_string);
+            free(unprotected);
+            free(xml_string);
 
-		} else {
-			u_strcat(result,ite->string);
-		}
+        } else {
+            u_strcat(result,ite->string);
+        }
 
-	}
-	free_list_ustring(lu);
-	return result;
+    }
+    free_list_ustring(lu);
+    return result;
 
 }
 
 
 unichar* xmlize(unichar *lexical_token){
 
-	struct cassys_pattern *cp = load_cassys_pattern(lexical_token);
+    struct cassys_pattern *cp = load_cassys_pattern(lexical_token);
 
-	unichar *form = xmlizeConcordLine(cp->form);
-	free(cp->form);
-	cp->form = form;
+    unichar *form = xmlizeConcordLine(cp->form);
+    free(cp->form);
+    cp->form = form;
 
-	unichar *result = xmlize(cp);
-	free_cassys_pattern(cp);
+    unichar *result = xmlize(cp);
+    free_cassys_pattern(cp);
 
-	return result;
+    return result;
 }
 
 /**
@@ -143,33 +143,33 @@ unichar* xmlize(unichar *lexical_token){
 unichar* xmlize(struct cassys_pattern *cp){
 
 
-	unichar *xml_form = xmlize_element(cp->form, FORM_OPENING, FORM_CLOSING);
-	unichar *xml_lem = xmlize_element(cp->lem, LEM_OPENING, LEM_CLOSING);
-	unichar *xml_code = xmlize_element(cp->code, CODE_OPENING, CODE_CLOSING);
-	unichar *xml_inflex = xmlize_element(cp->inflection, INFLECTION_OPENING, INFLECTION_CLOSING);
+    unichar *xml_form = xmlize_element(cp->form, FORM_OPENING, FORM_CLOSING);
+    unichar *xml_lem = xmlize_element(cp->lem, LEM_OPENING, LEM_CLOSING);
+    unichar *xml_code = xmlize_element(cp->code, CODE_OPENING, CODE_CLOSING);
+    unichar *xml_inflex = xmlize_element(cp->inflection, INFLECTION_OPENING, INFLECTION_CLOSING);
 
-	int size = u_strlen(LEXICAL_OPENING) + u_strlen(xml_form) + u_strlen(xml_lem)
-			+ u_strlen(xml_code) + u_strlen(xml_inflex) + u_strlen(LEXICAL_CLOSING);
-	unichar *result = (unichar*)malloc(sizeof(unichar)*(size+1));
-	if(result==NULL) {
-		fatal_alloc_error("malloc");
-	}
-	result[0]='\0';
+    int size = u_strlen(LEXICAL_OPENING) + u_strlen(xml_form) + u_strlen(xml_lem)
+            + u_strlen(xml_code) + u_strlen(xml_inflex) + u_strlen(LEXICAL_CLOSING);
+    unichar *result = (unichar*)malloc(sizeof(unichar)*(size+1));
+    if(result==NULL) {
+        fatal_alloc_error("malloc");
+    }
+    result[0]='\0';
 
 
-	u_strcat(result, LEXICAL_OPENING);
-	u_strcat(result, xml_form);
-	u_strcat(result, xml_lem);
-	u_strcat(result, xml_code);
-	u_strcat(result, xml_inflex);
-	u_strcat(result, LEXICAL_CLOSING);
+    u_strcat(result, LEXICAL_OPENING);
+    u_strcat(result, xml_form);
+    u_strcat(result, xml_lem);
+    u_strcat(result, xml_code);
+    u_strcat(result, xml_inflex);
+    u_strcat(result, LEXICAL_CLOSING);
 
-	free(xml_form);
-	free(xml_code);
-	free(xml_lem);
-	free(xml_inflex);
+    free(xml_form);
+    free(xml_code);
+    free(xml_lem);
+    free(xml_inflex);
 
-	return result;
+    return result;
 }
 
 /**
@@ -181,19 +181,19 @@ unichar *xmlize_element(const unichar *text, const unichar *opening_xml, const u
 int size = 0;
 
 if(text != NULL && text[0]!='\0') {
-	size = u_strlen(opening_xml)+u_strlen(closing_xml)+ u_strlen(text);
+    size = u_strlen(opening_xml)+u_strlen(closing_xml)+ u_strlen(text);
 }
 
 unichar *result = (unichar*)malloc(sizeof(unichar)*(size+1));
 if(result==NULL) {
-	fatal_alloc_error("malloc");
+    fatal_alloc_error("malloc");
 }
 result[0]='\0';
 
 if(text != NULL && text[0]!='\0') {
-	u_strcat(result, opening_xml);
-	u_strcat(result, text);
-	u_strcat(result, closing_xml);
+    u_strcat(result, opening_xml);
+    u_strcat(result, text);
+    u_strcat(result, closing_xml);
 }
 
 return result;
@@ -207,29 +207,29 @@ return result;
  */
 unichar *xmlize_element(list_ustring *u, const unichar *opening_xml, const unichar *closing_xml){
 
-	int size = 0;
-	list_ustring *ite = u;
+    int size = 0;
+    list_ustring *ite = u;
 
-	while(ite!=NULL){
-		size += u_strlen(ite->string) + u_strlen(opening_xml) + u_strlen(closing_xml);
-		ite = ite->next;
-	}
+    while(ite!=NULL){
+        size += u_strlen(ite->string) + u_strlen(opening_xml) + u_strlen(closing_xml);
+        ite = ite->next;
+    }
 
-	unichar *result = (unichar*)malloc(sizeof(unichar)*(size+1));
-	if(result==NULL) {
-		fatal_alloc_error("malloc");
-	}
-	result[0]='\0';
+    unichar *result = (unichar*)malloc(sizeof(unichar)*(size+1));
+    if(result==NULL) {
+        fatal_alloc_error("malloc");
+    }
+    result[0]='\0';
 
-	ite = u;
-	while(ite!=NULL){
-		unichar *single_element = xmlize_element(ite->string, opening_xml, closing_xml);
-		u_strcat(result, single_element);
-		free(single_element);
-		ite = ite->next;
-	}
+    ite = u;
+    while(ite!=NULL){
+        unichar *single_element = xmlize_element(ite->string, opening_xml, closing_xml);
+        u_strcat(result, single_element);
+        free(single_element);
+        ite = ite->next;
+    }
 
-	return result;
+    return result;
 }
 
 

--- a/CheckDic.cpp
+++ b/CheckDic.cpp
@@ -106,8 +106,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_CheckDic,lopts_CheckDic,
    case 'f': is_a_DELAF=1; break;
    case 's': is_a_DELAF=0; break;
    case 'V': only_verify_arguments = true;
-             break;   
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 'r': strict_unprotected=1; break;
    case 't': strict_unprotected=0; break;
@@ -147,7 +147,7 @@ if (is_a_DELAF==-1 || options.vars()->optind!=argc-1) {
 }
 
 if (only_verify_arguments) {
-  // freeing all allocated memory 
+  // freeing all allocated memory
   return SUCCESS_RETURN_CODE;
 }
 
@@ -238,7 +238,7 @@ u_fclose(dic);
 u_fprintf(out,"-----------------------------------\n");
 u_fprintf(out,"-------------  Stats  -------------\n");
 u_fprintf(out,"-----------------------------------\n");
-if (skip_path != 0) { 
+if (skip_path != 0) {
     char filename_without_path[FILENAME_MAX];
     remove_path(argv[options.vars()->optind],filename_without_path);
     u_fprintf(out,"File: %s\n",filename_without_path);

--- a/CodePages.cpp
+++ b/CodePages.cpp
@@ -66,14 +66,14 @@ namespace unitex {
 
 
 struct encodings_context {
-	/* Array of all encodings */
-	struct encoding** encodings;
-	/* Size of in 'encodings' */
-	int number_of_encodings;
-	/* Root of the encoding name tree */
-	struct search_tree_node* encoding_names;
-	/* context of html function */
-	void* character_context;
+    /* Array of all encodings */
+    struct encoding** encodings;
+    /* Size of in 'encodings' */
+    int number_of_encodings;
+    /* Root of the encoding name tree */
+    struct search_tree_node* encoding_names;
+    /* context of html function */
+    void* character_context;
 } ;
 
 /**
@@ -811,10 +811,10 @@ unicode[0xff]=0x0138;
 void init_uni2asc_code_page_array(unsigned char* ascii_dest,unichar* unicode_dest) {
 int i;
 for (i=0;i<MAX_NUMBER_OF_UNICODE_CHARS;i++) {
-	ascii_dest[i]='?';
+    ascii_dest[i]='?';
 }
 for (i=0;i<256;i++) {
-	ascii_dest[unicode_dest[i]]=(unsigned char)i;
+    ascii_dest[unicode_dest[i]]=(unsigned char)i;
 }
 }
 
@@ -1171,13 +1171,13 @@ return (int)af_fwrite(&c,1,1,f);
 
 int write_one_char(unichar c,const void* encoding_ctx,ABSTRACTFILE* f,const struct encoding* encoding,unsigned char* ascii_dest) {
 if (encoding->type==E_ONE_BYTE_ENCODING) {
-	return write_1_byte_character(ascii_dest[c],f);
+    return write_1_byte_character(ascii_dest[c],f);
 } else {
-	if (encoding->output_function != NULL) {
-	  return encoding->output_function(c,f);
-	}
-	else {
-		return encoding->output_function_ctx(c,f,encoding_ctx);
+    if (encoding->output_function != NULL) {
+      return encoding->output_function(c,f);
+    }
+    else {
+        return encoding->output_function_ctx(c,f,encoding_ctx);
     }
 }
 }
@@ -1192,8 +1192,8 @@ if (encoding->type==E_ONE_BYTE_ENCODING) {
  */
 void write_integer(int n,const void* encoding_ctx,ABSTRACTFILE* f,const struct encoding* encoding,unsigned char* ascii_dest) {
 if (n<10) {
-	write_one_char((unichar)('0'+n),encoding_ctx,f,encoding,ascii_dest);
-	return;
+    write_one_char((unichar)('0'+n),encoding_ctx,f,encoding,ascii_dest);
+    return;
 }
 write_integer(n/10,encoding_ctx,f,encoding,ascii_dest);
 write_one_char('0'+n%10,encoding_ctx,f,encoding,ascii_dest);
@@ -1209,53 +1209,53 @@ write_one_char('0'+n%10,encoding_ctx,f,encoding,ascii_dest);
  *
  */
 void html_characters_encoding(unichar c,const void* encoding_ctx,const struct encoding* encoding,ABSTRACTFILE* f,
-			int encode_all_characters,int encode_HTML_control_characters,
-			unsigned char* ascii_dest) {
+            int encode_all_characters,int encode_HTML_control_characters,
+            unsigned char* ascii_dest) {
 /* First, we check if we have an HTML control character */
 if (is_HTML_control_character(c)) {
-	/* If necessary, we encode it in HTML */
-	if (encode_HTML_control_characters) {
-		write_one_char('&',encoding_ctx,f,encoding,ascii_dest);
-		switch (c) {
-			case '<': write_one_char('l',encoding_ctx,f,encoding,ascii_dest);
-			          write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
-			          break;
-			case '>': write_one_char('g',encoding_ctx,f,encoding,ascii_dest);
-			          write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
-			          break;
-			case '&': write_one_char('a',encoding_ctx,f,encoding,ascii_dest);
-			          write_one_char('m',encoding_ctx,f,encoding,ascii_dest);
-			          write_one_char('p',encoding_ctx,f,encoding,ascii_dest);
-			          break;
-			case '\'': write_one_char('q',encoding_ctx,f,encoding,ascii_dest);
-			           write_one_char('u',encoding_ctx,f,encoding,ascii_dest);
-			           write_one_char('o',encoding_ctx,f,encoding,ascii_dest);
-			           write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
-			           break;
-			default: error("Internal error in html_characters_encoding:\n");
-					fatal_error("inconsistency about HTML characters\n");
-		}
-		write_one_char(';',encoding_ctx,f,encoding,ascii_dest);
-		return;
-	}
-	/* Otherwise, we just print it, but only if it is supported by the encoding */
-	if (encoding->can_be_encoded_function(c,ascii_dest)) {
-	   write_one_char(c,encoding_ctx,f,encoding,ascii_dest);
-	} else {
-		/* If the control character can not be encoded as it, we
-		 * print the default character '?' */
-		write_one_char('?',encoding_ctx,f,encoding,ascii_dest);
-	}
-	return;
+    /* If necessary, we encode it in HTML */
+    if (encode_HTML_control_characters) {
+        write_one_char('&',encoding_ctx,f,encoding,ascii_dest);
+        switch (c) {
+            case '<': write_one_char('l',encoding_ctx,f,encoding,ascii_dest);
+                      write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
+                      break;
+            case '>': write_one_char('g',encoding_ctx,f,encoding,ascii_dest);
+                      write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
+                      break;
+            case '&': write_one_char('a',encoding_ctx,f,encoding,ascii_dest);
+                      write_one_char('m',encoding_ctx,f,encoding,ascii_dest);
+                      write_one_char('p',encoding_ctx,f,encoding,ascii_dest);
+                      break;
+            case '\'': write_one_char('q',encoding_ctx,f,encoding,ascii_dest);
+                       write_one_char('u',encoding_ctx,f,encoding,ascii_dest);
+                       write_one_char('o',encoding_ctx,f,encoding,ascii_dest);
+                       write_one_char('t',encoding_ctx,f,encoding,ascii_dest);
+                       break;
+            default: error("Internal error in html_characters_encoding:\n");
+                    fatal_error("inconsistency about HTML characters\n");
+        }
+        write_one_char(';',encoding_ctx,f,encoding,ascii_dest);
+        return;
+    }
+    /* Otherwise, we just print it, but only if it is supported by the encoding */
+    if (encoding->can_be_encoded_function(c,ascii_dest)) {
+       write_one_char(c,encoding_ctx,f,encoding,ascii_dest);
+    } else {
+        /* If the control character can not be encoded as it, we
+         * print the default character '?' */
+        write_one_char('?',encoding_ctx,f,encoding,ascii_dest);
+    }
+    return;
 }
 /* Here, we have to deal with a normal character */
 if (!encoding->can_be_encoded_function(c,ascii_dest) && encode_all_characters) {
-	/* If the character can not be encoded as it, we encode it like &#1200; */
-	write_one_char('&',encoding_ctx,f,encoding,ascii_dest);
-	write_one_char('#',encoding_ctx,f,encoding,ascii_dest);
-	write_integer(c,encoding_ctx,f,encoding,ascii_dest);
-	write_one_char(';',encoding_ctx,f,encoding,ascii_dest);
-	return;
+    /* If the character can not be encoded as it, we encode it like &#1200; */
+    write_one_char('&',encoding_ctx,f,encoding,ascii_dest);
+    write_one_char('#',encoding_ctx,f,encoding,ascii_dest);
+    write_integer(c,encoding_ctx,f,encoding,ascii_dest);
+    write_one_char(';',encoding_ctx,f,encoding,ascii_dest);
+    return;
 }
 /* Otherwise, we just print the character */
 write_one_char(c,encoding_ctx,f,encoding,ascii_dest);
@@ -1287,14 +1287,14 @@ html_characters_encoding(c,encoding_ctx,encoding,f,1,1,ascii_dest);
  */
 int read_one_char(const void* encoding_ctx,ABSTRACTFILE* input,const struct encoding* encoding,unichar* unicode_src) {
 if (encoding->type==E_ONE_BYTE_ENCODING) {
-	return read_1_byte_character(input,unicode_src);
+    return read_1_byte_character(input,unicode_src);
 
 } else {
-	if (encoding->input_function != NULL) {
-	  return encoding->input_function(input);
-	}
-	else {
-		return encoding->input_function_ctx(input,encoding_ctx);
+    if (encoding->input_function != NULL) {
+      return encoding->input_function(input);
+    }
+    else {
+        return encoding->input_function_ctx(input,encoding_ctx);
     }
 }
 }
@@ -1305,62 +1305,62 @@ if (encoding->type==E_ONE_BYTE_ENCODING) {
  * with the output encoder. All other chars are UTF16LE encoded.
  */
 int transliterate_delaf(const void* encoding_ctx,ABSTRACTFILE* input,ABSTRACTFILE* output,
-		    const struct encoding* input_encoding,
-			const struct encoding* output_encoding,
-			unichar* unicode_src) {
+            const struct encoding* input_encoding,
+            const struct encoding* output_encoding,
+            unichar* unicode_src) {
 int c;
 for (;;) {
-	while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!=',') {
-		if (c=='\n') {
-			break;
-		}
-		if (c=='\\') {
-			u_fputc_UTF16LE('\\',output);
-			c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
-			if (c==EOF) break;
-			if (c=='\n') {
-				/* It would be an error */
-				break;
-			}
-		}
-		/* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
-		write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
-	}
-	if (c==EOF) break;
-	if (c=='\n') {
-		u_fputc_UTF16LE('\n',output);
-		break;
-	}
-	u_fputc_UTF16LE(',',output);
-	/* Now, we look for the lemma */
-	while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!='.') {
-		if (c=='\n') {
-			break;
-		}
-		if (c=='\\') {
-			u_fputc_UTF16LE('\\',output);
-			c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
-			if (c==EOF) break;
-			if (c=='\n') {
-				/* It would be an error */
-				break;
-			}
-		}
-		/* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
-		write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
-	}
-	if (c==EOF) break;
-	if (c=='\n') {
-		u_fputc_UTF16LE('\n',output);
-		break;
-	}
-	u_fputc_UTF16LE('.',output);
-	/* And we just copy the remaining chars */
-	while ((c=u_fgetc_UTF16LE(input))!=EOF) {
-		u_fputc_UTF16LE((unichar)c,output);
-		if (c=='\n') break;
-	}
-	if (c==EOF) break;
+    while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!=',') {
+        if (c=='\n') {
+            break;
+        }
+        if (c=='\\') {
+            u_fputc_UTF16LE('\\',output);
+            c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
+            if (c==EOF) break;
+            if (c=='\n') {
+                /* It would be an error */
+                break;
+            }
+        }
+        /* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
+        write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
+    }
+    if (c==EOF) break;
+    if (c=='\n') {
+        u_fputc_UTF16LE('\n',output);
+        break;
+    }
+    u_fputc_UTF16LE(',',output);
+    /* Now, we look for the lemma */
+    while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!='.') {
+        if (c=='\n') {
+            break;
+        }
+        if (c=='\\') {
+            u_fputc_UTF16LE('\\',output);
+            c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
+            if (c==EOF) break;
+            if (c=='\n') {
+                /* It would be an error */
+                break;
+            }
+        }
+        /* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
+        write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
+    }
+    if (c==EOF) break;
+    if (c=='\n') {
+        u_fputc_UTF16LE('\n',output);
+        break;
+    }
+    u_fputc_UTF16LE('.',output);
+    /* And we just copy the remaining chars */
+    while ((c=u_fgetc_UTF16LE(input))!=EOF) {
+        u_fputc_UTF16LE((unichar)c,output);
+        if (c=='\n') break;
+    }
+    if (c==EOF) break;
 }
 return CONVERSION_OK;
 }
@@ -1371,41 +1371,41 @@ return CONVERSION_OK;
  * with the output encoder. All other chars are UTF16LE encoded.
  */
 int transliterate_delas(const void* encoding_ctx,ABSTRACTFILE* input,ABSTRACTFILE* output,
-		    const struct encoding* input_encoding,
-			const struct encoding* output_encoding,
-			unichar* unicode_src) {
-	int c;
-	for (;;) {
-		while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!=',') {
-			if (c=='\n') {
-				break;
-			}
-			if (c=='\\') {
-				u_fputc_UTF16LE('\\',output);
-				c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
-				if (c==EOF) break;
-				if (c=='\n') {
-					/* It would be an error */
-					break;
-				}
-			}
-			/* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
-			write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
-		}
-		if (c==EOF) break;
-		if (c=='\n') {
-			u_fputc_UTF16LE('\n',output);
-			break;
-		}
-		u_fputc_UTF16LE(',',output);
-		/* And we just copy the remaining chars */
-		while ((c=u_fgetc_UTF16LE(input))!=EOF) {
-			u_fputc_UTF16LE((unichar)c,output);
-			if (c=='\n') break;
-		}
-		if (c==EOF) break;
-	}
-	return CONVERSION_OK;
+            const struct encoding* input_encoding,
+            const struct encoding* output_encoding,
+            unichar* unicode_src) {
+    int c;
+    for (;;) {
+        while ((c=read_one_char(encoding_ctx,input,input_encoding,unicode_src))!=EOF && c!=',') {
+            if (c=='\n') {
+                break;
+            }
+            if (c=='\\') {
+                u_fputc_UTF16LE('\\',output);
+                c=read_one_char(encoding_ctx,input,input_encoding,unicode_src);
+                if (c==EOF) break;
+                if (c=='\n') {
+                    /* It would be an error */
+                    break;
+                }
+            }
+            /* Last parameter is NULL since transliteration is supposed to produce UTF16LE */
+            write_one_char((unichar)c,encoding_ctx,output,output_encoding,NULL);
+        }
+        if (c==EOF) break;
+        if (c=='\n') {
+            u_fputc_UTF16LE('\n',output);
+            break;
+        }
+        u_fputc_UTF16LE(',',output);
+        /* And we just copy the remaining chars */
+        while ((c=u_fgetc_UTF16LE(input))!=EOF) {
+            u_fputc_UTF16LE((unichar)c,output);
+            if (c=='\n') break;
+        }
+        if (c==EOF) break;
+    }
+    return CONVERSION_OK;
 }
 
 
@@ -1429,7 +1429,7 @@ int transliterate_delas(const void* encoding_ctx,ABSTRACTFILE* input,ABSTRACTFIL
  *      of being encoded as any other character
  */
 int convert(const void* encoding_ctx,U_FILE* input,U_FILE* output,const struct encoding* input_encoding,
-			const struct encoding* output_encoding,
+            const struct encoding* output_encoding,
             int decode_HTML_normal_characters,int decode_HTML_control_characters,
             int encode_all_characters,int encode_HTML_control_characters,
             int format) {
@@ -1443,30 +1443,30 @@ unichar unicode_dest[256];
 unsigned char ascii_dest[MAX_NUMBER_OF_UNICODE_CHARS];
 const struct encodings_context* ectx=(const struct encodings_context*)encoding_ctx;
 switch(input_encoding->type) {
-	/* For UTF, we need to read the 2 or 3 BYTE ORDER MASK header */
+    /* For UTF, we need to read the 2 or 3 BYTE ORDER MASK header */
     /* for E_UTF_xx, we accept if there is no BOM */
     /* for E_UTF_xx_BOM, we don't accept if there is no BOM */
-	case E_UTF16_LE:
+    case E_UTF16_LE:
     case E_UTF16_LE_BOM:
-		tmp=u_fgetc_UTF16LE(input->f);
-		if (tmp!=U_BYTE_ORDER_MARK) {
+        tmp=u_fgetc_UTF16LE(input->f);
+        if (tmp!=U_BYTE_ORDER_MARK) {
             if (input_encoding->type == E_UTF16_LE_BOM)
-			  return INPUT_FILE_NOT_IN_UTF16_LE;
+              return INPUT_FILE_NOT_IN_UTF16_LE;
             else
               af_fseek(input->f,0,0);
-		}
-		break;
+        }
+        break;
 
-	case E_UTF16_BE:
+    case E_UTF16_BE:
     case E_UTF16_BE_BOM:
-		tmp=u_fgetc_UTF16BE(input->f);
-		if (tmp!=U_BYTE_ORDER_MARK) {
+        tmp=u_fgetc_UTF16BE(input->f);
+        if (tmp!=U_BYTE_ORDER_MARK) {
             if (input_encoding->type == E_UTF16_BE_BOM)
-			  return INPUT_FILE_NOT_IN_UTF16_BE;
+              return INPUT_FILE_NOT_IN_UTF16_BE;
             else
               af_fseek(input->f,0,0);
-		}
-		break;
+        }
+        break;
 
     case E_UTF8_BOM:
     case E_UTF8:
@@ -1481,14 +1481,14 @@ switch(input_encoding->type) {
             if (bom_present==0)
             {
             if (input_encoding->type == E_UTF8_BOM)
-			  return INPUT_FILE_NOT_IN_UTF8;
+              return INPUT_FILE_NOT_IN_UTF8;
             else
                 af_fseek(input->f,0,0);
             }
-		}
-		break;
-	case E_ONE_BYTE_ENCODING: input_encoding->init_function(unicode_src);
-		break;
+        }
+        break;
+    case E_ONE_BYTE_ENCODING: input_encoding->init_function(unicode_src);
+        break;
 }
 /*
  * If necessary, we write the UTF16 2-byte header to the destination file.
@@ -1497,104 +1497,104 @@ switch(input_encoding->type) {
  */
 switch(output_encoding->type) {
     case E_UTF16_LE_BOM:
-	case E_UTF16_LE: u_fputc_UTF16LE(U_BYTE_ORDER_MARK,output->f); break;
+    case E_UTF16_LE: u_fputc_UTF16LE(U_BYTE_ORDER_MARK,output->f); break;
     case E_UTF16_BE_BOM:
-	case E_UTF16_BE: u_fputc_UTF16BE(U_BYTE_ORDER_MARK,output->f); break;
+    case E_UTF16_BE: u_fputc_UTF16BE(U_BYTE_ORDER_MARK,output->f); break;
     case E_UTF8_BOM: u_fputc_UTF8(U_BYTE_ORDER_MARK,output->f); break;
-	case E_ONE_BYTE_ENCODING: output_encoding->init_function(unicode_dest);
-							init_uni2asc_code_page_array(ascii_dest,unicode_dest);
-							break;
+    case E_ONE_BYTE_ENCODING: output_encoding->init_function(unicode_dest);
+                            init_uni2asc_code_page_array(ascii_dest,unicode_dest);
+                            break;
 }
 if (format==CONV_DELAF_FILE) {
-	return transliterate_delaf(encoding_ctx,input->f,output->f,input_encoding,output_encoding,unicode_src);
+    return transliterate_delaf(encoding_ctx,input->f,output->f,input_encoding,output_encoding,unicode_src);
 }
 if (format==CONV_DELAS_FILE) {
-	return transliterate_delas(encoding_ctx,input->f,output->f,input_encoding,output_encoding,unicode_src);
+    return transliterate_delas(encoding_ctx,input->f,output->f,input_encoding,output_encoding,unicode_src);
 }
 /* We choose the function that will be used to encode HTML characters
  * if necessary */
 if (encode_all_characters)
-	if (encode_HTML_control_characters)
-		z=f11;
-	else z=f10;
+    if (encode_HTML_control_characters)
+        z=f11;
+    else z=f10;
 else if (encode_HTML_control_characters)
-		z=f01;
-	else z=f00;
+        z=f01;
+    else z=f00;
 /* Then we read all the characters from the input file and we encode them */
 while ((tmp=read_one_char(encoding_ctx,input->f,input_encoding,unicode_src))!=EOF) {
    if (!decode_HTML_normal_characters || tmp!='&') {
-		/* If we do not need to decode HTML normal characters like &#eacute;
-		 * or if we do not have '&', we can print the character to the output */
-		z((unichar)tmp,encoding_ctx,output_encoding,output->f,ascii_dest);
-	} else {
-		/* We read everything until we find the ';' character */
-		char temp[257];
-		int i=0;
-		do {
-			tmp=read_one_char(encoding_ctx,input->f,input_encoding,unicode_src);
-			if (tmp==EOF) {
-				/* If we find an unexpected end of file, we raise an error */
-				return ERROR_IN_HTML_CHARACTER_NAME;
-			}
-			if (tmp>0x7F) {
-				/* If the character is not an ascii one, it is an error */
-				i=-1;
-				break;
-			}
-			temp[i++]=(char)tmp;
-		} while (tmp!=';' && i<256);
-		if (i==-1) {
-			/* If the character declaration contains a non ascii character,
-			 * we print an error message and we write '?' to the output. */
-			error("Non ASCII character in a HTML character declaration of the form &......;\n");
-			z('?',encoding_ctx,output_encoding,output->f,ascii_dest);
-		} else if (i==1) {
-			/* If we have an empty code '&;' we print an error message and
-			 * we print nothing to the output. */
-			 error("Empty HTML code &;\n");
-		}
-		else if (tmp!=';' && i==256) {
-			/* If the HTML character if too long, we print an error message
-			 * and print '?' in the output. */
-			 error("Too long HTML character of the form &........;\n");
-			 z('?',encoding_ctx,output_encoding,output->f,ascii_dest);
-		} else {
-			temp[i-1]='\0';
-			/* Now, temp contains "#228" or "eacute". We look for the associated
-			 * code and we print it to the output if any; otherwise, we print
-			 * the '?' character. */
-			i=get_HTML_character(ectx->character_context,temp,decode_HTML_control_characters);
-			switch (i) {
-				case UNKNOWN_CHARACTER: z('?',encoding_ctx,output_encoding,output->f,ascii_dest); break;
-				case MALFORMED_HTML_CODE: error("Malformed HTML character declaration &%s;\n",temp);
-									z('?',encoding_ctx,output_encoding,output->f,ascii_dest); break;
-				case DO_NOT_DECODE_CHARACTER:
-					/* If we have a control character that we must not decode like '&gt;',
-					 * we print it as it to the output */
-					 z('&',encoding_ctx,output_encoding,output->f,ascii_dest);
-					 for (int j=0;temp[j]!='\0';j++) {
-					 	z(temp[j],encoding_ctx,output_encoding,output->f,ascii_dest);
-					 }
-					 z(';',encoding_ctx,output_encoding,output->f,ascii_dest);
-					 break;
-				default: if (!is_HTML_control_character((unichar)i) || decode_HTML_control_characters) {
-							/* If we have a normal character or if we can
-							 * encode control characters, then we print it */
-							z((unichar)i,encoding_ctx,output_encoding,output->f,ascii_dest);
-						} else {
-							/* If we have a control character and if we can not decode it,
-							 * then we copy the string representation that was in
-							 * the input */
-							z('&',encoding_ctx,output_encoding,output->f,ascii_dest);
-							for (int j=0;temp[j]!='\0';j++) {
-								z(temp[j],encoding_ctx,output_encoding,output->f,ascii_dest);
-							}
-							z(';',encoding_ctx,output_encoding,output->f,ascii_dest);
-					 		break;
-						}
-			}
-		}
-	}
+        /* If we do not need to decode HTML normal characters like &#eacute;
+         * or if we do not have '&', we can print the character to the output */
+        z((unichar)tmp,encoding_ctx,output_encoding,output->f,ascii_dest);
+    } else {
+        /* We read everything until we find the ';' character */
+        char temp[257];
+        int i=0;
+        do {
+            tmp=read_one_char(encoding_ctx,input->f,input_encoding,unicode_src);
+            if (tmp==EOF) {
+                /* If we find an unexpected end of file, we raise an error */
+                return ERROR_IN_HTML_CHARACTER_NAME;
+            }
+            if (tmp>0x7F) {
+                /* If the character is not an ascii one, it is an error */
+                i=-1;
+                break;
+            }
+            temp[i++]=(char)tmp;
+        } while (tmp!=';' && i<256);
+        if (i==-1) {
+            /* If the character declaration contains a non ascii character,
+             * we print an error message and we write '?' to the output. */
+            error("Non ASCII character in a HTML character declaration of the form &......;\n");
+            z('?',encoding_ctx,output_encoding,output->f,ascii_dest);
+        } else if (i==1) {
+            /* If we have an empty code '&;' we print an error message and
+             * we print nothing to the output. */
+             error("Empty HTML code &;\n");
+        }
+        else if (tmp!=';' && i==256) {
+            /* If the HTML character if too long, we print an error message
+             * and print '?' in the output. */
+             error("Too long HTML character of the form &........;\n");
+             z('?',encoding_ctx,output_encoding,output->f,ascii_dest);
+        } else {
+            temp[i-1]='\0';
+            /* Now, temp contains "#228" or "eacute". We look for the associated
+             * code and we print it to the output if any; otherwise, we print
+             * the '?' character. */
+            i=get_HTML_character(ectx->character_context,temp,decode_HTML_control_characters);
+            switch (i) {
+                case UNKNOWN_CHARACTER: z('?',encoding_ctx,output_encoding,output->f,ascii_dest); break;
+                case MALFORMED_HTML_CODE: error("Malformed HTML character declaration &%s;\n",temp);
+                                    z('?',encoding_ctx,output_encoding,output->f,ascii_dest); break;
+                case DO_NOT_DECODE_CHARACTER:
+                    /* If we have a control character that we must not decode like '&gt;',
+                     * we print it as it to the output */
+                     z('&',encoding_ctx,output_encoding,output->f,ascii_dest);
+                     for (int j=0;temp[j]!='\0';j++) {
+                        z(temp[j],encoding_ctx,output_encoding,output->f,ascii_dest);
+                     }
+                     z(';',encoding_ctx,output_encoding,output->f,ascii_dest);
+                     break;
+                default: if (!is_HTML_control_character((unichar)i) || decode_HTML_control_characters) {
+                            /* If we have a normal character or if we can
+                             * encode control characters, then we print it */
+                            z((unichar)i,encoding_ctx,output_encoding,output->f,ascii_dest);
+                        } else {
+                            /* If we have a control character and if we can not decode it,
+                             * then we copy the string representation that was in
+                             * the input */
+                            z('&',encoding_ctx,output_encoding,output->f,ascii_dest);
+                            for (int j=0;temp[j]!='\0';j++) {
+                                z(temp[j],encoding_ctx,output_encoding,output->f,ascii_dest);
+                            }
+                            z(';',encoding_ctx,output_encoding,output->f,ascii_dest);
+                            break;
+                        }
+            }
+        }
+    }
 }
 return CONVERSION_OK;
 }
@@ -1668,7 +1668,7 @@ return 0;
 void strtolower(char* s) {
 if (s==NULL) return;
 for (int i=0;s[i];i++) {
-	if (s[i]>='A' && s[i]<='Z') s[i]=s[i]+32; /* 32 = 'a'-'A' */
+    if (s[i]>='A' && s[i]<='Z') s[i]=s[i]+32; /* 32 = 'a'-'A' */
 }
 }
 
@@ -1694,35 +1694,35 @@ if (name==NULL) {
 struct encoding* encoding=new_encoding();
 encoding->type=E_ONE_BYTE_ENCODING;
 if ((encoding->name=strdup(name))==NULL) {
-	fatal_alloc_error("install_one_byte_encoding");
+    fatal_alloc_error("install_one_byte_encoding");
 }
 strtolower(encoding->name);
 if (init_function==NULL) {
-	fatal_error("NULL init_function error in install_one_byte_encoding\n");
+    fatal_error("NULL init_function error in install_one_byte_encoding\n");
 }
 encoding->init_function=init_function;
 if (usage_function==NULL) {
-	fatal_error("NULL usage_function error in install_one_byte_encoding\n");
+    fatal_error("NULL usage_function error in install_one_byte_encoding\n");
 }
 encoding->usage_function=usage_function;
 encoding->can_be_encoded_function=can_encode;
 encoding->input_function=NULL;
 encoding->output_function=NULL;
 if (aliases==NULL) {
-	/* If there is no aliases, we can return */
+    /* If there is no aliases, we can return */
 }
 int i=0;
 while (aliases[i]!=NULL) {
-	encoding->aliases=(char**)realloc(encoding->aliases,(i+1)*sizeof(char*));
-	if (encoding->aliases==NULL) {
-	   fatal_alloc_error("install_one_byte_encoding");
-	}
-	encoding->aliases[i]=strdup(aliases[i]);
-	strtolower(encoding->aliases[i]);
-	if (encoding->aliases[i]==NULL) {
-	   fatal_alloc_error("install_one_byte_encoding");
-	}
-	i++;
+    encoding->aliases=(char**)realloc(encoding->aliases,(i+1)*sizeof(char*));
+    if (encoding->aliases==NULL) {
+       fatal_alloc_error("install_one_byte_encoding");
+    }
+    encoding->aliases[i]=strdup(aliases[i]);
+    strtolower(encoding->aliases[i]);
+    if (encoding->aliases[i]==NULL) {
+       fatal_alloc_error("install_one_byte_encoding");
+    }
+    i++;
 }
 encoding->number_of_aliases=i;
 /* Now, we install this encoding, enlarging the encoding array */
@@ -1736,12 +1736,12 @@ ectx->encodings[ectx->number_of_encodings]=encoding;
  * operation will raise a fatal error if the given encoding name is already
  * in the encoding name tree. */
 if (!insert_string(&ectx->encoding_names,name,ectx->number_of_encodings)) {
-	fatal_error("Internal error in install_multi_bytes_encoding: encoding name %s already used\n",name);
+    fatal_error("Internal error in install_multi_bytes_encoding: encoding name %s already used\n",name);
 }
 for (i=0;i<encoding->number_of_aliases;i++) {
-	if (!insert_string(&ectx->encoding_names,encoding->aliases[i],ectx->number_of_encodings)) {
-		fatal_error("Internal error in install_multi_bytes_encoding: encoding name %s already used\n",encoding->aliases[i]);
-	}
+    if (!insert_string(&ectx->encoding_names,encoding->aliases[i],ectx->number_of_encodings)) {
+        fatal_error("Internal error in install_multi_bytes_encoding: encoding name %s already used\n",encoding->aliases[i]);
+    }
 }
 /* And finally, we do not forget to increase the number of encodings */
 ectx->number_of_encodings++;
@@ -1761,12 +1761,12 @@ ectx->number_of_encodings++;
  * We consider that a multi-bytes encoding can encode any character.
  */
 void install_multi_bytes_encoding_ctxfunc(void* ctx,const char* name,int type,
-								int (*input_function)(ABSTRACTFILE*),
-								int (*input_function_ctx)(ABSTRACTFILE*,const void*),
-								int (*output_function)(unichar,ABSTRACTFILE*),
-								int (*output_function_ctx)(unichar,ABSTRACTFILE*,const void*),
-								void (*usage_function)(void),
-								const char** aliases) {
+                                int (*input_function)(ABSTRACTFILE*),
+                                int (*input_function_ctx)(ABSTRACTFILE*,const void*),
+                                int (*output_function)(unichar,ABSTRACTFILE*),
+                                int (*output_function_ctx)(unichar,ABSTRACTFILE*,const void*),
+                                void (*usage_function)(void),
+                                const char** aliases) {
 struct encodings_context* ectx=(struct encodings_context*)ctx;
 if (name==NULL) {
    fatal_error("NULL name error in install_multi_bytes_encoding\n");
@@ -1775,23 +1775,23 @@ if (name==NULL) {
 struct encoding* encoding=new_encoding();
 encoding->type=type;
 if ((encoding->name=strdup(name))==NULL) {
-	fatal_alloc_error("install_multi_bytes_encoding");
+    fatal_alloc_error("install_multi_bytes_encoding");
 }
 strtolower(encoding->name);
 if ((input_function==NULL) && (input_function_ctx==NULL)) {
-	fatal_error("NULL input_function error in install_multi_bytes_encoding_ctxfunc\n");
+    fatal_error("NULL input_function error in install_multi_bytes_encoding_ctxfunc\n");
 }
 encoding->input_function=input_function;
 encoding->input_function_ctx=input_function_ctx;
 
 if ((output_function==NULL) && (output_function_ctx==NULL)) {
-	fatal_error("NULL output_function error in install_multi_bytes_encoding_ctxfunc\n");
+    fatal_error("NULL output_function error in install_multi_bytes_encoding_ctxfunc\n");
 }
 encoding->output_function=output_function;
 encoding->output_function_ctx=output_function_ctx;
 
 if (usage_function==NULL) {
-	fatal_error("NULL usage_function error in install_multi_bytes_encoding_ctxfunc\n");
+    fatal_error("NULL usage_function error in install_multi_bytes_encoding_ctxfunc\n");
 }
 encoding->usage_function=usage_function;
 /*
@@ -1800,19 +1800,19 @@ encoding->usage_function=usage_function;
 encoding->can_be_encoded_function=can_always_encode;
 int i=0;
 if (aliases!=NULL) {
-	/* If there are aliases, we take care of them */
-	while (aliases[i]!=NULL) {
-		encoding->aliases=(char**)realloc(encoding->aliases,(i+1)*sizeof(char*));
-		if (encoding->aliases==NULL) {
-		fatal_alloc_error("install_multi_bytes_encoding_ctxfunc");
-		}
-		encoding->aliases[i]=strdup(aliases[i]);
-		strtolower(encoding->aliases[i]);
-		if (encoding->aliases[i]==NULL) {
-		fatal_alloc_error("install_multi_bytes_encoding_ctxfunc");
-		}
-		i++;
-	}
+    /* If there are aliases, we take care of them */
+    while (aliases[i]!=NULL) {
+        encoding->aliases=(char**)realloc(encoding->aliases,(i+1)*sizeof(char*));
+        if (encoding->aliases==NULL) {
+        fatal_alloc_error("install_multi_bytes_encoding_ctxfunc");
+        }
+        encoding->aliases[i]=strdup(aliases[i]);
+        strtolower(encoding->aliases[i]);
+        if (encoding->aliases[i]==NULL) {
+        fatal_alloc_error("install_multi_bytes_encoding_ctxfunc");
+        }
+        i++;
+    }
 }
 encoding->number_of_aliases=i;
 /* Now, we install this encoding, enlarging the encoding array */
@@ -1826,12 +1826,12 @@ ectx->encodings[ectx->number_of_encodings]=encoding;
  * operation will raise a fatal error if the given encoding name is already
  * in the encoding name tree. */
 if (!insert_string(&ectx->encoding_names,name,ectx->number_of_encodings)) {
-	fatal_error("Internal error in install_multi_bytes_encoding_ctxfunc: encoding name %s already used\n",name);
+    fatal_error("Internal error in install_multi_bytes_encoding_ctxfunc: encoding name %s already used\n",name);
 }
 for (i=0;i<encoding->number_of_aliases;i++) {
-	if (!insert_string(&ectx->encoding_names,encoding->aliases[i],ectx->number_of_encodings)) {
-		fatal_error("Internal error in install_multi_bytes_encoding_ctxfunc: encoding name %s already used\n",encoding->aliases[i]);
-	}
+    if (!insert_string(&ectx->encoding_names,encoding->aliases[i],ectx->number_of_encodings)) {
+        fatal_error("Internal error in install_multi_bytes_encoding_ctxfunc: encoding name %s already used\n",encoding->aliases[i]);
+    }
 }
 /* And finally, we do not forget to increase the number of encodings */
 ectx->number_of_encodings++;
@@ -1841,15 +1841,15 @@ ectx->number_of_encodings++;
 /* same as install_multi_bytes_encoding_ctxfunc but without specify context in/out function
  */
 void install_multi_bytes_encoding(void*encoding_ctx,const char* name,int type,
-								int (*input_function)(ABSTRACTFILE*),
-								int (*output_function)(unichar,ABSTRACTFILE*),
-								void (*usage_function)(void),
-								const char** aliases)
+                                int (*input_function)(ABSTRACTFILE*),
+                                int (*output_function)(unichar,ABSTRACTFILE*),
+                                void (*usage_function)(void),
+                                const char** aliases)
 {
     install_multi_bytes_encoding_ctxfunc(encoding_ctx,name,type,
-								input_function,NULL,
-								output_function,NULL,
-								usage_function,aliases);
+                                input_function,NULL,
+                                output_function,NULL,
+                                usage_function,aliases);
 }
 
 
@@ -1932,8 +1932,8 @@ install_one_byte_encoding(ctx,"ms-windows-1250",init_windows_1250,usage_windows_
 const char* aliases_windows_1251[4]={"windows-1251","windows1251","cyrillic",NULL};
 install_one_byte_encoding(ctx,"ms-windows-1251",init_windows_1251,usage_windows_1251,aliases_windows_1251);
 const char* aliases_windows_1252[10]={"windows-1252","windows1252","french","english",
-								"german","spanish","portuguese","italian",
-								"norwegian",NULL};
+                                "german","spanish","portuguese","italian",
+                                "norwegian",NULL};
 install_one_byte_encoding(ctx,"ms-windows-1252",init_windows_1252,usage_windows_1252,aliases_windows_1252);
 const char* aliases_windows_1253[4]={"windows-1253","windows1253","greek",NULL};
 install_one_byte_encoding(ctx,"ms-windows-1253",init_windows_1253,usage_windows_1253,aliases_windows_1253);
@@ -1981,7 +1981,7 @@ free(ectx);
 void print_encoding_main_names(const void* encoding_ctx) {
 const struct encodings_context* ectx=(const struct encodings_context*)encoding_ctx;
 for (int i=0;i<ectx->number_of_encodings;i++) {
-	u_printf("%s\n",ectx->encodings[i]->name);
+    u_printf("%s\n",ectx->encodings[i]->name);
 }
 }
 
@@ -1993,9 +1993,9 @@ for (int i=0;i<ectx->number_of_encodings;i++) {
 void print_encoding_aliases(const void* encoding_ctx) {
 const struct encodings_context* ectx=(const struct encodings_context*)encoding_ctx;
 for (int i=0;i<ectx->number_of_encodings;i++) {
-	for (int j=0;j<ectx->encodings[i]->number_of_aliases;j++) {
-		u_printf("%s\n",ectx->encodings[i]->aliases[j]);
-	}
+    for (int j=0;j<ectx->encodings[i]->number_of_aliases;j++) {
+        u_printf("%s\n",ectx->encodings[i]->aliases[j]);
+    }
 }
 }
 
@@ -2006,11 +2006,11 @@ for (int i=0;i<ectx->number_of_encodings;i++) {
 void print_encoding_infos(const struct encoding* encoding) {
 u_printf("Main name = %s\n",encoding->name);
 if (encoding->number_of_aliases>0) {
-	u_printf("Alias%s =",(encoding->number_of_aliases==1)?"":"es");
-	for (int i=0;i<encoding->number_of_aliases;i++) {
-		u_printf(" %s",encoding->aliases[i]);
-	}
-	u_printf("\n");
+    u_printf("Alias%s =",(encoding->number_of_aliases==1)?"":"es");
+    for (int i=0;i<encoding->number_of_aliases;i++) {
+        u_printf(" %s",encoding->aliases[i]);
+    }
+    u_printf("\n");
 }
 encoding->usage_function();
 }
@@ -2024,8 +2024,8 @@ encoding->usage_function();
 void print_encoding_infos(const void* encoding_ctx,const char* name) {
 const struct encoding* encoding=get_encoding(encoding_ctx,name);
 if (encoding==NULL) {
-	error("%s is not a valid encoding name\n",name);
-	return;
+    error("%s is not a valid encoding name\n",name);
+    return;
 }
 print_encoding_infos(encoding);
 }
@@ -2037,8 +2037,8 @@ print_encoding_infos(encoding);
 void print_information_for_all_encodings(const void* encoding_ctx) {
 const struct encodings_context* ectx=(const struct encodings_context*)encoding_ctx;
 for (int i=0;i<ectx->number_of_encodings;i++) {
-	print_encoding_infos(ectx->encodings[i]);
-	u_printf("\n");
+    print_encoding_infos(ectx->encodings[i]);
+    u_printf("\n");
 }
 }
 
@@ -2054,7 +2054,7 @@ strcpy(name_in_lower,name);
 strtolower(name_in_lower);
 int encoding_number;
 if (!get_string_number(ectx->encoding_names,name_in_lower,&encoding_number)) {
-	return NULL;
+    return NULL;
 }
 return ectx->encodings[encoding_number];
 }

--- a/CodePages.cpp
+++ b/CodePages.cpp
@@ -1469,7 +1469,7 @@ switch(input_encoding->type) {
 		break;
 
     case E_UTF8_BOM:
-    case E_UTF8: 
+    case E_UTF8:
         {
             unsigned char utf8_bom[3];
             int bom_present=0;
@@ -1729,7 +1729,7 @@ encoding->number_of_aliases=i;
 ectx->encodings=(struct encoding**)realloc(ectx->encodings,(ectx->number_of_encodings+1)*sizeof(struct encoding*));
 if (ectx->encodings==NULL) {
    fatal_alloc_error("install_one_byte_encoding");
-} 
+}
 ectx->encodings[ectx->number_of_encodings]=encoding;
 /* Then we insert the encoding name and its aliases in the encoding name tree,
  * associating them to the corresponding index in 'encodings'. The insertion

--- a/CodePages.h
+++ b/CodePages.h
@@ -63,33 +63,33 @@ namespace unitex {
  * This structure represents a one byte encoding.
  */
 struct encoding {
-	/* The type defines if we have a one byte encoding,
-	 * a UTF-16 one, a UTF-8 one, etc. */
-	int type;
-	/* Main name of the encoding ("iso-8859-1") */
-	char* name;
-	/* Other names for this encoding ("latin1","latin-1") */
-	char** aliases;
-	/* Size of 'aliases' */
-	int number_of_aliases;
+    /* The type defines if we have a one byte encoding,
+     * a UTF-16 one, a UTF-8 one, etc. */
+    int type;
+    /* Main name of the encoding ("iso-8859-1") */
+    char* name;
+    /* Other names for this encoding ("latin1","latin-1") */
+    char** aliases;
+    /* Size of 'aliases' */
+    int number_of_aliases;
 
-	/* The code page initialization function for this encoding.
-	 * This function is used only if the encoding type is ON_BYTE_ENCODING */
-	void (*init_function)(unichar*);
-	/*
-	 * If the encoding type is not ON_BYTE_ENCODING, we must define
-	 * an input and output function.
-	 */
-	int (*input_function)(ABSTRACTFILE*);
-	int (*output_function)(unichar,ABSTRACTFILE*);
+    /* The code page initialization function for this encoding.
+     * This function is used only if the encoding type is ON_BYTE_ENCODING */
+    void (*init_function)(unichar*);
+    /*
+     * If the encoding type is not ON_BYTE_ENCODING, we must define
+     * an input and output function.
+     */
+    int (*input_function)(ABSTRACTFILE*);
+    int (*output_function)(unichar,ABSTRACTFILE*);
 
-	int (*input_function_ctx)(ABSTRACTFILE*,const void*);
-	int (*output_function_ctx)(unichar,ABSTRACTFILE*,const void*);
+    int (*input_function_ctx)(ABSTRACTFILE*,const void*);
+    int (*output_function_ctx)(unichar,ABSTRACTFILE*,const void*);
 
-	/* The usage function for this encoding */
-	void (*usage_function)(void);
-	/* This function returns 1 if the given char can be encoded with this encoding */
-	int (*can_be_encoded_function)(unichar,const unsigned char*);
+    /* The usage function for this encoding */
+    void (*usage_function)(void);
+    /* This function returns 1 if the given char can be encoded with this encoding */
+    int (*can_be_encoded_function)(unichar,const unsigned char*);
 };
 
 

--- a/CompoundWordHashTable.cpp
+++ b/CompoundWordHashTable.cpp
@@ -74,7 +74,7 @@ if (hash_table==NULL) {
 }
 hash_table->size = 1;
 while (hash_table->size < size)
-	hash_table->size *= 2;
+    hash_table->size *= 2;
 
 hash_table->hash_blocks=(struct tct_hash_block*)malloc(get_tct_hash_block_item_size_array(size));
 hash_table->token_array_standard_base_memory_nb_item_for_each_block=tct_hash_block_size;
@@ -163,7 +163,7 @@ if ((block->size) == token_array_base_memory_nb_item_size) {
   if (factor < 4) factor=4;
   int* new_array=(int*)malloc(block->size*sizeof(int)*factor);
   for (int i=0;i<block->length;i++) {
-	  new_array[i]=block->token_array[i];
+      new_array[i]=block->token_array[i];
   }
   block->token_array=new_array;
 }
@@ -230,7 +230,7 @@ while (i<block_length) {
     * to put 'i' on the first cell after the -1 and priority of the previous
     * token sequence. */
    while (i<block_length && tokens[i]!=-1) {
-	   i++;
+       i++;
    }
    i=i+2;
    if (i==block_length) return -1;

--- a/CompoundWordHashTable.cpp
+++ b/CompoundWordHashTable.cpp
@@ -48,7 +48,7 @@ int size=hash_table->size;
 if (hash_table->hash_blocks==NULL) {
   fatal_alloc_error("initialize_hash_blocks");
 }
-   
+
 if (hash_table->token_array_base_memory_alloc==NULL) {
   fatal_alloc_error("initialize_hash_blocks");
 }
@@ -57,7 +57,7 @@ for (int i=0;i<size;i++) {
    block=(hash_table->hash_blocks+i);
    block->size=block_size;
    block->token_array=(hash_table->token_array_base_memory_alloc) + (i*hash_table->token_array_standard_base_memory_nb_item_for_each_block);
-   block->length=0;   
+   block->length=0;
 }
 }
 
@@ -125,7 +125,7 @@ free(hash_table);
 int tct_length(int* token_sequence) {
 int i;
 for (i=0;token_sequence[i]!=-1;i++) {}
-return i+1; 
+return i+1;
 }
 
 
@@ -181,7 +181,7 @@ if (block->token_array==NULL) {
  * Adds a token sequence ended by -1 to the given hash table.
  * An integer representing the given priority is added after the -1 in
  * the token sequence stored in the hash table.
- * 
+ *
  * Example: (574,1,5,1,575,-1) 2 => the (574,1,5,1,575,-1,2) array will be stored
  */
 void add_tct_token_sequence(int* token_seq,struct tct_hash* hash_table,int priority) {
@@ -218,11 +218,11 @@ int tct_match(struct tct_hash_block* block,int* token_sequence) {
 int i=0;
 int j=0;
 int block_length=block->length;
-int* tokens=block->token_array; 
+int* tokens=block->token_array;
 while (i<block_length) {
    j=0;
    while (i+j<block_length && tokens[i+j]==token_sequence[j]) {
-      if (token_sequence[j]==-1) return i; 
+      if (token_sequence[j]==-1) return i;
       j++;
    }
    /* If the current sequence in the token array has not matched,
@@ -234,7 +234,7 @@ while (i<block_length) {
    }
    i=i+2;
    if (i==block_length) return -1;
-} 
+}
 return -1;
 }
 
@@ -264,9 +264,9 @@ return 0;
  * the given text tokens. The result is an integer sequence that is
  * stored in 'token_sequence'. Each integer represents a token number,
  * and the sequence is ended by -1.
- * 
+ *
  * Example: "sans raison" may be turned into (121,1,1643,-1)
- * 
+ *
  * WARNING: every token of the compound word is supposed to be present
  *          in the given text tokens.
  */

--- a/CompoundWordHashTable.h
+++ b/CompoundWordHashTable.h
@@ -23,14 +23,14 @@
 #define CompoundWordHashTableH
 
 /**
- * 
+ *
  * This library provides functions for manipulating compound words seen as
  * token sequences. Such compound words are stored into a hash table.
- * 
+ *
  * Author: Alexis Neme
  * Modified by: Sébastien Paumier
  */
- 
+
 #include "Unicode.h"
 
 #ifndef HAS_UNITEX_NAMESPACE
@@ -51,7 +51,7 @@ namespace unitex {
  * For instance, if a block contains sequences for the compound words
  * "black box" and "black humor", respectively with priorities 2 and 3, the
  * token array may be:
- * 
+ *
  * (40,2,13,-1,2,40,2,125,-1,3)
  */
 struct tct_hash_block {
@@ -67,16 +67,16 @@ struct tct_hash_block {
 struct tct_hash {
    /* The size of the table, i.e. the size of the 'hash_blocks' array */
    int size;
-   
+
    /* The array of hash blocks */
-   struct tct_hash_block*	hash_blocks;
+   struct tct_hash_block*   hash_blocks;
    int* token_array_base_memory_alloc;
    int token_array_standard_base_memory_nb_item_for_each_block;
 };
 
 
-struct tct_hash* new_tct_hash();  
-struct tct_hash* new_tct_hash(int,int);  
+struct tct_hash* new_tct_hash();
+struct tct_hash* new_tct_hash(int,int);
 void free_tct_hash(struct tct_hash*);
 int was_already_in_tct_hash(int*,struct tct_hash*,int);
 int build_token_sequence(unichar*,struct text_tokens*,int*);

--- a/CompoundWordTree.cpp
+++ b/CompoundWordTree.cpp
@@ -45,7 +45,7 @@ struct DLC_tree_node* new_DLC_tree_node() {
 struct DLC_tree_node* n;
 n=(struct DLC_tree_node*)malloc(sizeof(struct DLC_tree_node));
 if (n==NULL) {
-	fatal_alloc_error("new_DLC_tree_node");
+    fatal_alloc_error("new_DLC_tree_node");
 }
 n->patterns=NULL;
 n->number_of_patterns=0;
@@ -66,7 +66,7 @@ struct DLC_tree_transition* new_DLC_tree_transition() {
 struct DLC_tree_transition* t;
 t=(struct DLC_tree_transition*)malloc(sizeof(struct DLC_tree_transition));
 if (t==NULL) {
-	fatal_alloc_error("new_DLC_tree_transition");
+    fatal_alloc_error("new_DLC_tree_transition");
 }
 t->token_sequence=NULL;
 t->node=NULL;
@@ -86,7 +86,7 @@ return t;
 struct DLC_tree_info* new_DLC_tree(int number_of_tokens) {
 struct DLC_tree_info* DLC_tree=(struct DLC_tree_info*)malloc(sizeof(struct DLC_tree_info));
 if (DLC_tree==NULL) {
-	fatal_alloc_error("new_DLC_tree");
+    fatal_alloc_error("new_DLC_tree");
 }
 DLC_tree->root=new_DLC_tree_node();
 DLC_tree->index=(struct DLC_tree_node**)malloc(number_of_tokens*sizeof(struct DLC_tree_node*));
@@ -94,7 +94,7 @@ if (DLC_tree->index==NULL) {
    fatal_alloc_error("new_DLC_tree");
 }
 for (int i=0;i<number_of_tokens;i++) {
-	DLC_tree->index[i]=NULL;
+    DLC_tree->index[i]=NULL;
 }
 return DLC_tree;
 }
@@ -107,11 +107,11 @@ return DLC_tree;
 void free_DLC_tree_transitions(struct DLC_tree_transition* transitions) {
 struct DLC_tree_transition* tmp;
 while (transitions!=NULL) {
-	decrement_reference_DLC_tree_node(transitions->node);
-	if (transitions->token_sequence!=NULL) free(transitions->token_sequence);
-	tmp=transitions->next;
-	free(transitions);
-	transitions=tmp;
+    decrement_reference_DLC_tree_node(transitions->node);
+    if (transitions->token_sequence!=NULL) free(transitions->token_sequence);
+    tmp=transitions->next;
+    free(transitions);
+    transitions=tmp;
 }
 }
 
@@ -142,9 +142,9 @@ free_DLC_tree_transitions(node->transitions);
 if (node->destination_tokens!=NULL) free(node->destination_tokens);
 if (node->destination_nodes!=NULL) {
     for (int i=0;i<node->number_of_transitions;i++) {
-				decrement_reference_DLC_tree_node(node->destination_nodes[i]);
-	}
-	free(node->destination_nodes);
+                decrement_reference_DLC_tree_node(node->destination_nodes[i]);
+    }
+    free(node->destination_nodes);
 }
 free(node);
 }
@@ -250,10 +250,10 @@ int stop=0;
 /* We parse the list until we have found the pattern or the place
  * to insert the pattern */
 while (!stop && previous->next!=NULL) {
-	/* If we find the pattern in the list, we have nothing to do */
-	if (previous->next->n==pattern) return;
-	else if (previous->next->n<pattern) previous=previous->next;
-	else stop=1;
+    /* If we find the pattern in the list, we have nothing to do */
+    if (previous->next->n==pattern) return;
+    else if (previous->next->n<pattern) previous=previous->next;
+    else stop=1;
 }
 /* If must insert the pattern */
 previous->next=head_insert(pattern,previous->next);
@@ -310,11 +310,11 @@ int stop=0;
 /* We parse the list until we have found the node or the place
  * to insert the node */
 while (!stop && previous->next!=NULL) {
-	/* If we find the node, we return it */
+    /* If we find the node, we return it */
    compare=compare_IntSequence(previous->next->token_sequence,token_sequence);
-	if (compare==0) return previous->next->node;
-	else if (compare<0) previous=previous->next;
-	else stop=1;
+    if (compare==0) return previous->next->node;
+    else if (compare<0) previous=previous->next;
+    else stop=1;
 }
 /* We return if the function must not create the node */
 if (!create_if_necessary) return NULL;
@@ -350,7 +350,7 @@ return l->node;
  * 'DLC_tree' represents the tree and the compound word index.
  */
 void associate_pattern_to_compound_word(int* token_list,int pos,struct DLC_tree_node* node,
-				int pattern,struct DLC_tree_info* DLC_tree) {
+                int pattern,struct DLC_tree_info* DLC_tree) {
 if (token_list[pos]==END_TOKEN_LIST) {
    /* If we are at the end of the token list, we
     * add the pattern number to the current node */
@@ -390,9 +390,9 @@ associate_pattern_to_compound_word(token_list,pos,ptr,pattern,DLC_tree);
  * for any compound word, regardless the pattern, with <DIC> or <CDIC>.
  */
 void add_compound_word_with_no_pattern(const unichar* word,const Alphabet* alph,struct string_hash* tok,
-							struct DLC_tree_info* DLC_tree,TokenizationPolicy tokenization_mode) {
+                            struct DLC_tree_info* DLC_tree,TokenizationPolicy tokenization_mode) {
 add_compound_word_with_pattern(word,COMPOUND_WORD_PATTERN,alph,tok,DLC_tree,
-							tokenization_mode);
+                            tokenization_mode);
 }
 
 
@@ -401,7 +401,7 @@ add_compound_word_with_pattern(word,COMPOUND_WORD_PATTERN,alph,tok,DLC_tree,
  * number 'pattern'.
  */
 void add_compound_word_with_pattern(const unichar* word,int pattern,const Alphabet* alph,struct string_hash* tok,
-							struct DLC_tree_info* DLC_tree,TokenizationPolicy tokenization_mode) {
+                            struct DLC_tree_info* DLC_tree,TokenizationPolicy tokenization_mode) {
 int token_list[MAX_TOKEN_IN_A_COMPOUND_WORD];
 tokenize_compound_word(word,token_list,alph,tok,tokenization_mode);
 associate_pattern_to_compound_word(token_list,0,DLC_tree->root,pattern,DLC_tree);
@@ -447,7 +447,7 @@ return 0;
  * 'DLC_tree' represents the tree and the compound word index.
  */
 int conditional_insertion_in_DLC_tree_node(int* token_list,int pos,struct DLC_tree_node* node,
-										int pattern1,int pattern2) {
+                                        int pattern1,int pattern2) {
 if (token_list[pos]==END_TOKEN_LIST) {
    /* If we are at the end of the token list */
    return conditional_pattern_insertion(node,pattern1,pattern2);
@@ -488,7 +488,7 @@ return 0;
  * non-zero value.
  */
 int conditional_insertion_in_DLC_tree(unichar* word,int pattern1,int pattern2,const Alphabet* alph,
-						struct string_hash* tok,struct DLC_tree_info* infos,TokenizationPolicy tokenization_mode) {
+                        struct string_hash* tok,struct DLC_tree_info* infos,TokenizationPolicy tokenization_mode) {
 int token_list[MAX_TOKEN_IN_A_COMPOUND_WORD];
 tokenize_compound_word(word,token_list,alph,tok,tokenization_mode);
 return conditional_insertion_in_DLC_tree_node(token_list,0,infos->root,pattern1,pattern2);

--- a/CompoundWordTree.cpp
+++ b/CompoundWordTree.cpp
@@ -123,7 +123,7 @@ node->count_reference++;
 }
 
 /**
- * Decrement the counter usage of a pointer to a node 
+ * Decrement the counter usage of a pointer to a node
  *  (a compound word tree whose root is 'node'.)
  * Frees the object from memory if counter became 0
  *
@@ -611,7 +611,7 @@ for (;;) {
       tmp=array[i];
       array[i]=array[j];
       array[j]=tmp;
-   } else 
+   } else
        break;
 }
 return j;

--- a/CompoundWordTree.h
+++ b/CompoundWordTree.h
@@ -72,10 +72,10 @@ namespace unitex {
  * Once we have replaced tokens by all their case equivalents, we obtain the following
  * arrays:
  *
- * destination_tokens	destination_nodes
- * THE					   47,129
- * The					   47,129
- * the					   47
+ * destination_tokens   destination_nodes
+ * THE                     47,129
+ * The                     47,129
+ * the                     47
  */
 struct DLC_tree_node {
     /*
@@ -86,41 +86,41 @@ struct DLC_tree_node {
      */
 
     unsigned int count_reference;
-	/*
-	 * 'patterns' is the list of the numbers of all the patterns that
-	 * can match the compound words corresponding to this node.
-	 */
-	struct list_int* patterns;
-	/*
-	 * 'number_of_patterns' is the length of the list 'patterns'
-	 */
-	int number_of_patterns;
-	/*
-	 * For optimization reasons, the list 'patterns' is replaced
-	 * by the sorted array 'array_of_patterns' before being used
-	 * in the locate.
-	 */
-	int* array_of_patterns;
-	/*
-	 * 'transitions' is the list of transitions that outgo from
-	 * this node. NOTE: transitions are supposed to be sorted
-	 * by token numbers.
-	 */
-	struct DLC_tree_transition* transitions;
-	/*
-	 * WARNING: 'number_of_transitions' is NOT the length of the list
+    /*
+     * 'patterns' is the list of the numbers of all the patterns that
+     * can match the compound words corresponding to this node.
+     */
+    struct list_int* patterns;
+    /*
+     * 'number_of_patterns' is the length of the list 'patterns'
+     */
+    int number_of_patterns;
+    /*
+     * For optimization reasons, the list 'patterns' is replaced
+     * by the sorted array 'array_of_patterns' before being used
+     * in the locate.
+     */
+    int* array_of_patterns;
+    /*
+     * 'transitions' is the list of transitions that outgo from
+     * this node. NOTE: transitions are supposed to be sorted
+     * by token numbers.
+     */
+    struct DLC_tree_transition* transitions;
+    /*
+     * WARNING: 'number_of_transitions' is NOT the length of the list
     *          'transitions', but the size of the 'destination_tokens'
     *          and 'destination_nodes' arrays.
-	 */
-	int number_of_transitions;
-	/*
-	 * Sorted array of tokens, including case equivalents. See comment above.
-	 */
-	int* destination_tokens;
-	/*
-	 * Sorted array of nodes. See comment above.
-	 */
-	struct DLC_tree_node** destination_nodes;
+     */
+    int number_of_transitions;
+    /*
+     * Sorted array of tokens, including case equivalents. See comment above.
+     */
+    int* destination_tokens;
+    /*
+     * Sorted array of nodes. See comment above.
+     */
+    struct DLC_tree_node** destination_nodes;
 };
 
 
@@ -135,12 +135,12 @@ typedef int* IntSequence;
  * This structure represent a list of transitions in a compound word tree.
  */
 struct DLC_tree_transition {
-	/* The number of the token */
-	IntSequence token_sequence;
-	/* The destination node */
-	struct DLC_tree_node* node;
-	/* The following element of the list */
-	struct DLC_tree_transition* next;
+    /* The number of the token */
+    IntSequence token_sequence;
+    /* The destination node */
+    struct DLC_tree_node* node;
+    /* The following element of the list */
+    struct DLC_tree_transition* next;
 };
 
 
@@ -150,8 +150,8 @@ struct DLC_tree_transition {
  * words that begin by a given token.
  */
 struct DLC_tree_info {
-	struct DLC_tree_node* root;
-	struct DLC_tree_node** index;
+    struct DLC_tree_node* root;
+    struct DLC_tree_node** index;
 };
 
 

--- a/Compress.cpp
+++ b/Compress.cpp
@@ -43,7 +43,7 @@
 #endif
 
 namespace unitex {
-                            
+
 const char* usage_Compress =
 "Usage:\n"
 "  Compress [options] DICTIONARY\n"
@@ -118,7 +118,7 @@ static void usage() {
 static const size_t step_filename_buffer =
                     ((((DIC_WORD_SIZE * sizeof(unichar)) / 0x10) + 1) * 0x10);
 
-// function used to minimize a dictionary tree, i.e. to construct a minimal ADFA 
+// function used to minimize a dictionary tree, i.e. to construct a minimal ADFA
 typedef void(*minimize_func)(struct dictionary_node* root,
                              struct bit_array* used_inf_values,
                              Abstract_allocator prv_alloc);
@@ -150,9 +150,9 @@ static void write_INF_file_header(const VersatileEncodingConfig* vec,
 /**
  * @brief Builds a tree representation of a DELAF dictionary
  *
- * Builds a tree representation of a DELAF dictionary pointed by \a filename. 
- * The output \root structure represents the starting node of the dictionary 
- * being loaded. This function returns a succeed status if at least one entry 
+ * Builds a tree representation of a DELAF dictionary pointed by \a filename.
+ * The output \root structure represents the starting node of the dictionary
+ * being loaded. This function returns a succeed status if at least one entry
  * was processed, this is true even if the dictionary contains invalid entries
  *
  * @param[in] vec encoding I/O Configuration
@@ -165,7 +165,7 @@ static void write_INF_file_header(const VersatileEncodingConfig* vec,
  * @param[out] n_entries total entries processed without comments
  * @param[out] n_lines total lines scanned including comments
  * @param[out] n_line_errors total lines errors including comments
- * @param[out] n_file_includes total files included from \a filename 
+ * @param[out] n_file_includes total files included from \a filename
  * @return SUCCESS_RETURN_CODE or other status code. See Error.h for details
  * @author Cristian Martinez (based in a previous version of Sébastien Paumier)
  */
@@ -203,7 +203,7 @@ static int build_tree_from_dictionary(
     free(heap_buffer);
     return DEFAULT_ERROR_CODE;
   }
-  
+
   // filename is a directory not a plain text file
   if(is_directory(filename_as_char)) {
     error("%S: Is a directory\n", filename);
@@ -342,7 +342,7 @@ static int build_tree_from_dictionary(
 
       default:
         // if we have a line, we tokenize it
-        
+
         // reinitialize entry to NULL, in this way if replace_special_equal_signs()
         // fails, an error will be threw
         entry = NULL;
@@ -361,7 +361,7 @@ static int build_tree_from_dictionary(
                                        compress_tokenize_abstract_allocator);
         }
 
-        // if the entry is not well-formed throw an error indicating 
+        // if the entry is not well-formed throw an error indicating
         // the file name and the line number where the error happened
         if (entry == NULL) {
           error("%s:%d\n",
@@ -370,8 +370,8 @@ static int build_tree_from_dictionary(
           (*n_line_errors)++;
           // breaks switch
           break;
-        } 
-        
+        }
+
         // if the entry is well-formed
         // The unescaped = that were not in the inflected or lemma form must
         // be restored as real = character
@@ -521,7 +521,7 @@ static int build_tree_from_dictionary(
  * @param[out] n_lines total lines scanned including commentaries
  * @param[out] n_entries total entries processed without file commentaries
  * @return SUCCESS_RETURN_CODE or other status code. See Error.h for details
- * @author Cristian Martinez 
+ * @author Cristian Martinez
  */
 static int build_tree_from_dictionary_list(
                      const VersatileEncodingConfig* vec,
@@ -538,13 +538,13 @@ static int build_tree_from_dictionary_list(
                      Abstract_allocator compress_tokenize_abstract_allocator) {
   // number of entries that were processed in the file that is being read
   int current_file_total_entries      = 0;
-  
+
   // number of lines that were scanned in the file that is being read
   int current_file_total_lines        = 0;
-  
+
   // number of lines that were scanned in the file that is being read
   int current_file_total_line_errors  = 0;
-  
+
   // number of files that were included in the file that is being read
   int current_file_total_includes     = 0;
 
@@ -578,29 +578,29 @@ static int build_tree_from_dictionary_list(
        &current_file_total_includes,           // total includes
        compress_abstract_allocator,
        compress_tokenize_abstract_allocator);
-    
+
     // throw an error if there are not entries to process in this dictionary
-    if (return_value == SUCCESS_RETURN_CODE && 
-        current_file_total_includes == 0    && 
+    if (return_value == SUCCESS_RETURN_CODE &&
+        current_file_total_includes == 0    &&
         current_file_total_entries  == 0) {
       error("%S: Empty dictionary\n", current_dictionary->string);
-    }    
-    
+    }
+
     // update counters
     (*n_entries)     += current_file_total_entries;
     (*n_lines)       += current_file_total_lines;
     (*n_line_errors) += current_file_total_line_errors;
     (*n_files)++;
-    
+
     // get the next filename to be processed
     current_dictionary = current_dictionary->next;
   }  // while (current_dictionary != NULL)
-  
+
   // succeed only if there are entries to process
   if(return_value == SUCCESS_RETURN_CODE && *n_entries <= 0) {
     return DEFAULT_ERROR_CODE;
   }
-  
+
   return return_value;
 }
 
@@ -680,7 +680,7 @@ static int create_and_save_inf(const VersatileEncodingConfig* vec,
 }
 
 /**
- * @brief Minimizes and save a DELAF dictionary tree into a classic bin file 
+ * @brief Minimizes and save a DELAF dictionary tree into a classic bin file
  *
  * @param[in] vec encoding I/O Configuration for the \a output_inf file
  * @param[in] bin_filename null-terminated string, with the output .bin filename
@@ -894,12 +894,12 @@ while (EOF != (val = options.parse_long(argc, argv, optstring_Compress, lopts_Co
     case  1 : // this is according to the "Standards for Command Line Interfaces"
               // https://goo.gl/7UgLC8
               u_printf("Compress (Unitex) %s\n",get_unitex_semver_string());
-              return SUCCESS_RETURN_CODE;          
-    case  2 : new_style_bin = 1; bin_type = BIN_BIN2;    break;    
+              return SUCCESS_RETURN_CODE;
+    case  2 : new_style_bin = 1; bin_type = BIN_BIN2;    break;
     case  3 : new_style_bin = 0; bin_type = BIN_CLASSIC; break;
     case  4 : new_style_bin = 1; bin_type = BIN_CLASSIC; break;
     case 'V': only_verify_arguments = true;
-              break;    
+              break;
     case 'h': usage();
               free(buffer_filename);
               return SUCCESS_RETURN_CODE;
@@ -909,7 +909,7 @@ while (EOF != (val = options.parse_long(argc, argv, optstring_Compress, lopts_Co
                 return USAGE_ERROR_CODE;
               }
               strcpy(output_type, options.vars()->optarg);
-              break;              
+              break;
     case 'o': if (options.vars()->optarg[0] == '\0') {
                 error("You must specify a non empty output\n");
                 free(buffer_filename);
@@ -940,7 +940,7 @@ while (EOF != (val = options.parse_long(argc, argv, optstring_Compress, lopts_Co
                error("Missing argument for option -%c\n",  options.vars()->optopt) :
                error("Missing argument for option --%s\n", lopts_Compress[index].name);
               free(buffer_filename);
-              return USAGE_ERROR_CODE;              
+              return USAGE_ERROR_CODE;
     case '?': index == -1 ? error("Invalid option -%c\n", options.vars()->optopt) :
                             error("Invalid option --%s\n", options.vars()->optarg);
               free(buffer_filename);
@@ -967,7 +967,7 @@ if (options.vars()->optind != argc-1 && bin_filename[0] == '\0') {
 if (output_type[0] != '\0') {
   if      (strcmp(output_type,"bin1") == 0) {
     new_style_bin = 1;
-    bin_type = BIN_CLASSIC;  
+    bin_type = BIN_CLASSIC;
   }
   else if (strcmp(output_type,"bin2") == 0) {
     new_style_bin = 1;
@@ -1006,7 +1006,7 @@ list_ustring_ptr dictionary_list = NULL;
 
 // insert in the list all filenames that were passed as argument
 for (; options.vars()->optind != argc; (options.vars()->optind)++) {
-  // to prevent including a file repeatedly, we only stored resolved filenames 
+  // to prevent including a file repeatedly, we only stored resolved filenames
   // @see get_real_path for more information
   if (get_real_path(argv[options.vars()->optind],
                    resolved_filename) == SUCCESS_RETURN_CODE) {
@@ -1094,7 +1094,7 @@ if (return_value == SUCCESS_RETURN_CODE) {
                        &bin_size,        // size of the resulting .bin file
                        compress_abstract_allocator);
       break;
-    // .bin2 style, with outputs included in the transducer 
+    // .bin2 style, with outputs included in the transducer
     case BIN_BIN2:
       return_value = minimize_and_save_tree_as_bin_two(
                        bin_filename,     // output .bin filename

--- a/CompressedDic.cpp
+++ b/CompressedDic.cpp
@@ -43,16 +43,16 @@ static int read_bin_header(Dictionary*);
  */
 int isDictionaryNeedInf(const unsigned char* binData, size_t binSize)
 {
-	if (binSize<5) {
-		return 0;
-	}
-	Dictionary d;
-	d.bin=binData;
-	d.bin_size=(long)binSize;
-	if (!read_bin_header(&d)) {
-		return 0;
-	}
-	return  (d.type==BIN_CLASSIC) ? 1 : 0;
+    if (binSize<5) {
+        return 0;
+    }
+    Dictionary d;
+    d.bin=binData;
+    d.bin_size=(long)binSize;
+    if (!read_bin_header(&d)) {
+        return 0;
+    }
+    return  (d.type==BIN_CLASSIC) ? 1 : 0;
 }
 
 
@@ -62,36 +62,36 @@ int isDictionaryNeedInf(const unsigned char* binData, size_t binSize)
 Dictionary* new_Dictionary(const VersatileEncodingConfig* vec,const char* bin,const char* inf,Abstract_allocator prv_alloc) {
 void* ptr=get_persistent_structure(bin);
 if (ptr!=NULL) {
-	return (Dictionary*)ptr;
+    return (Dictionary*)ptr;
 }
 Dictionary* d=(Dictionary*)malloc_cb(sizeof(Dictionary),prv_alloc);
 if (d==NULL) {
-	fatal_alloc_error("new_Dictionary");
+    fatal_alloc_error("new_Dictionary");
 }
 d->bin=load_abstract_BIN_file(bin,&d->bin_size,&d->bin_free);
 if (d->bin==NULL) {
-	free_cb(d,prv_alloc);
-	return NULL;
+    free_cb(d,prv_alloc);
+    return NULL;
 }
 if (!read_bin_header(d)) {
-	free_abstract_BIN(d->bin,&d->bin_free);
-	free_cb(d,prv_alloc);
-	return NULL;
+    free_abstract_BIN(d->bin,&d->bin_free);
+    free_cb(d,prv_alloc);
+    return NULL;
 }
 d->inf=NULL;
 if (d->type==BIN_CLASSIC) {
-	if (inf==NULL) {
-		error("NULL .inf file in new_Dictionary\n");
-		free_abstract_BIN(d->bin,&d->bin_free);
-		free_cb(d,prv_alloc);
-		return NULL;
-	}
-	d->inf=load_abstract_INF_file(vec,inf,&d->inf_free);
-	if (d->inf==NULL) {
-		free_abstract_BIN(d->bin,&d->bin_free);
-		free_cb(d,prv_alloc);
-		return NULL;
-	}
+    if (inf==NULL) {
+        error("NULL .inf file in new_Dictionary\n");
+        free_abstract_BIN(d->bin,&d->bin_free);
+        free_cb(d,prv_alloc);
+        return NULL;
+    }
+    d->inf=load_abstract_INF_file(vec,inf,&d->inf_free);
+    if (d->inf==NULL) {
+        free_abstract_BIN(d->bin,&d->bin_free);
+        free_cb(d,prv_alloc);
+        return NULL;
+    }
 }
 return d;
 }
@@ -116,7 +116,7 @@ void free_Dictionary(Dictionary* d,Abstract_allocator prv_alloc) {
 if (d==NULL || is_persistent_structure(d)) return;
 if (d->bin!=NULL) free_abstract_BIN(d->bin,&d->bin_free);
 if (d->inf!=NULL) {
-	free_abstract_INF(d->inf,&d->inf_free);
+    free_abstract_INF(d->inf,&d->inf_free);
 }
 free_cb(d,prv_alloc);
 }
@@ -165,15 +165,15 @@ const unsigned char* bindata=bin+(*offset);
 unsigned char c0=bindata[0];
 if ((c0 & 0x80)==0)
 {
-	(*offset)++;
-	return (c0);
+    (*offset)++;
+    return (c0);
 }
 
 (*offset)+=(c0>>5)-2;
 return ((c0 & 0x80) == 0) ? ((int)c0) :
-		(int)(((c0 & 0x1f) | (((unsigned int)bindata[1])<<5) | (((unsigned int)bindata[2])<<13) |
-		                     (((unsigned int)bindata[3])<<21) | (((unsigned int)bindata[4])<<29))
-		  & mask_from_sizebits[c0>>5]);
+        (int)(((c0 & 0x1f) | (((unsigned int)bindata[1])<<5) | (((unsigned int)bindata[2])<<13) |
+                             (((unsigned int)bindata[3])<<21) | (((unsigned int)bindata[4])<<29))
+          & mask_from_sizebits[c0>>5]);
 }
 
 
@@ -184,16 +184,16 @@ return ((c0 & 0x80) == 0) ? ((int)c0) :
 int bin_get_value_variable_length(int value) {
 unsigned int uivalue=(unsigned int)value;
 if (uivalue == ((uivalue) & 0x7f)) {
-	return 1;
+    return 1;
 }
 if (uivalue == ((uivalue) & 0x1fff)) {
-	return 2;
+    return 2;
 }
 if (uivalue == ((uivalue) & 0x1fffff)) {
-	return 3;
+    return 3;
 }
 if (uivalue == ((uivalue) & 0x1fffffff)) {
-	return 4;
+    return 4;
 }
 return 5;
 }
@@ -203,30 +203,30 @@ static void bin_write_variable_length(unsigned char* bin,int value,int *offset) 
 unsigned char* bindata=bin+(*offset);
 unsigned int uivalue=(unsigned int)value;
 if (uivalue == ((uivalue) & 0x7f)) {
-	bindata[0]=(unsigned char)((uivalue));
-	(*offset)+=1;
-	return;
+    bindata[0]=(unsigned char)((uivalue));
+    (*offset)+=1;
+    return;
 }
 if (uivalue == ((uivalue) & 0x1fff)) {
-	bindata[1]=(unsigned char)((uivalue>>5));
-	bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0x80));
-	(*offset)+=2;
-	return;
+    bindata[1]=(unsigned char)((uivalue>>5));
+    bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0x80));
+    (*offset)+=2;
+    return;
 }
 if (uivalue == ((uivalue) & 0x1fffff)) {
-	bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0xa0));
-	bindata[1]=(unsigned char)((uivalue>>5));
-	bindata[2]=(unsigned char)((uivalue>>13));
-	(*offset)+=3;
-	return;
+    bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0xa0));
+    bindata[1]=(unsigned char)((uivalue>>5));
+    bindata[2]=(unsigned char)((uivalue>>13));
+    (*offset)+=3;
+    return;
 }
 if (uivalue == ((uivalue) & 0x1fffffff)) {
-	bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0xc0));
-	bindata[1]=(unsigned char)((uivalue>>5));
-	bindata[2]=(unsigned char)((uivalue>>13));
-	bindata[3]=(unsigned char)((uivalue>>21));
-	(*offset)+=4;
-	return;
+    bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0xc0));
+    bindata[1]=(unsigned char)((uivalue>>5));
+    bindata[2]=(unsigned char)((uivalue>>13));
+    bindata[3]=(unsigned char)((uivalue>>21));
+    (*offset)+=4;
+    return;
 }
 bindata[0]=(unsigned char)((uivalue & 0x1f)| ((unsigned char)0xe0));
 bindata[1]=(unsigned char)((uivalue>>5));
@@ -311,15 +311,15 @@ return NULL;
  */
 int read_dictionary_state(const Dictionary* d,int pos,int *final,int *n_transitions,int *code) {
 if (d->state_encoding==BIN_CLASSIC_STATE) {
-	*final=!(d->bin[pos] & 128);
-	*n_transitions=((d->bin[pos] & 127)<<8) | (d->bin[pos+1]);
-	pos=pos+2;
-	if (*final) {
-		*code=(d->inf_number_read_bin_func)(d->bin,&pos);
-	} else {
-		*code=-1;
-	}
-	return pos;
+    *final=!(d->bin[pos] & 128);
+    *n_transitions=((d->bin[pos] & 127)<<8) | (d->bin[pos+1]);
+    pos=pos+2;
+    if (*final) {
+        *code=(d->inf_number_read_bin_func)(d->bin,&pos);
+    } else {
+        *code=-1;
+    }
+    return pos;
 }
 
 if ((d->state_encoding==BIN_NEW_STATE) || (d->state_encoding==BIN_BIN2_STATE)) {
@@ -327,9 +327,9 @@ int value=bin_read_variable_length(d->bin,&pos);
 *final=value & 1;
 *n_transitions=value>>1;
 if (*final && d->state_encoding==BIN_NEW_STATE) {
-	*code=(d->inf_number_read_bin_func)(d->bin,&pos);
+    *code=(d->inf_number_read_bin_func)(d->bin,&pos);
 } else {
-	*code=-1;
+    *code=-1;
 }
 return pos;
 }
@@ -343,24 +343,24 @@ return 0;
  * finality and number of outgoing transitions. Updates the position.
  */
 void write_dictionary_state(unsigned char* bin,BinStateEncoding state_encoding,
-							t_fnc_bin_write_bytes inf_number_write_function,int *pos,int final,int n_transitions,int code) {
+                            t_fnc_bin_write_bytes inf_number_write_function,int *pos,int final,int n_transitions,int code) {
 if (state_encoding==BIN_CLASSIC_STATE) {
-	int value=n_transitions & ((1<<15)-1);
-	if (!final) value=value | (1<<15);
-	bin_write_2bytes(bin,value,pos);
-	if (final) {
-		(*inf_number_write_function)(bin,code,pos);
-	}
-	return;
+    int value=n_transitions & ((1<<15)-1);
+    if (!final) value=value | (1<<15);
+    bin_write_2bytes(bin,value,pos);
+    if (final) {
+        (*inf_number_write_function)(bin,code,pos);
+    }
+    return;
 }
 if (state_encoding!=BIN_NEW_STATE && state_encoding!=BIN_BIN2_STATE) {
-	fatal_error("read_dictionary_state: unsupported state encoding\n");
+    fatal_error("read_dictionary_state: unsupported state encoding\n");
 }
 int value=(n_transitions<<1);
 if (final) value=value | 1;
 bin_write_variable_length(bin,value,pos);
 if (final && state_encoding==BIN_NEW_STATE) {
-	(*inf_number_write_function)(bin,code,pos);
+    (*inf_number_write_function)(bin,code,pos);
 }
 }
 
@@ -374,15 +374,15 @@ int read_dictionary_transition(const Dictionary* d,int pos,unichar *c,int *dest,
 *dest=(d->offset_read_bin_func)(d->bin,&pos);
 if (d->type==BIN_CLASSIC) return pos;
 if (d->type==BIN_BIN2) {
-	int is_output=(*dest) & 1;
-	(*dest)=(*dest)>>1;
-	if (is_output) {
-		int tmp;
-		while ((tmp=((d->char_read_bin_func)(d->bin,&pos)))!='\0') {
-			u_strcat(output,(unichar)tmp);
-		}
-	}
-	return pos;
+    int is_output=(*dest) & 1;
+    (*dest)=(*dest)>>1;
+    if (is_output) {
+        int tmp;
+        while ((tmp=((d->char_read_bin_func)(d->bin,&pos)))!='\0') {
+            u_strcat(output,(unichar)tmp);
+        }
+    }
+    return pos;
 }
 fatal_error("read_dictionary_state: unsupported dictionary type\n");
 return 0;
@@ -393,25 +393,25 @@ return 0;
  * Updates the position.
  */
 void write_dictionary_transition(unsigned char* bin,int *pos,t_fnc_bin_write_bytes char_write_function,
-								t_fnc_bin_write_bytes offset_write_function,unichar c,int dest,
-								BinType bin_type,unichar* output) {
+                                t_fnc_bin_write_bytes offset_write_function,unichar c,int dest,
+                                BinType bin_type,unichar* output) {
 (*char_write_function)(bin,c,pos);
 if (bin_type==BIN_CLASSIC) {
-	(*offset_write_function)(bin,dest,pos);
-	return;
+    (*offset_write_function)(bin,dest,pos);
+    return;
 }
 /* For .bin2, we have a bit to indicate whether there is an output or not */
 dest=dest<<1;
 if (output!=NULL && output[0]!='\0') {
-	dest=dest|1;
+    dest=dest|1;
 }
 (*offset_write_function)(bin,dest,pos);
 if (dest & 1) {
-	int i=-1;
-	do {
-		i++;
-		(*char_write_function)(bin,output[i],pos);
-	} while (output[i]!='\0');
+    int i=-1;
+    do {
+        i++;
+        (*char_write_function)(bin,output[i],pos);
+    } while (output[i]!='\0');
 }
 }
 
@@ -450,8 +450,8 @@ return -1;
 int bin_get_string_length(unichar* s,BinEncoding char_encoding) {
 int n=0,i=-1;
 do {
-	i++;
-	n+=bin_get_value_length(s[i],char_encoding);
+    i++;
+    n+=bin_get_value_length(s[i],char_encoding);
 } while (s[i]!='\0');
 return n;
 }
@@ -459,16 +459,16 @@ return n;
 int bin_get_string_length(unichar* s,t_fnc_bin_write_bytes char_encoding_func) {
 int n=0,i=-1;
 do {
-	i++;
-	n+=bin_get_value_length(s[i],char_encoding_func);
+    i++;
+    n+=bin_get_value_length(s[i],char_encoding_func);
 } while (s[i]!='\0');
 return n;
 }
 
 static void select_bin_read_function(Dictionary* d) {
-	d->inf_number_read_bin_func=get_bin_read_function_for_encoding(d->inf_number_encoding);
-	d->char_read_bin_func=get_bin_read_function_for_encoding(d->char_encoding);
-	d->offset_read_bin_func=get_bin_read_function_for_encoding(d->offset_encoding);
+    d->inf_number_read_bin_func=get_bin_read_function_for_encoding(d->inf_number_encoding);
+    d->char_read_bin_func=get_bin_read_function_for_encoding(d->char_encoding);
+    d->offset_read_bin_func=get_bin_read_function_for_encoding(d->offset_encoding);
 }
 
 /**
@@ -478,45 +478,45 @@ static void select_bin_read_function(Dictionary* d) {
  */
 static int read_bin_header(Dictionary* d) {
 if (d->bin[0]==0) {
-	/* Type 1: old style .bin/.inf dictionary */
-	d->initial_state_offset=4;
-	if (d->bin_size<d->initial_state_offset+2) {
-		/* The minimal empty dictionary is made of the header plus a 2 bytes empty state */
-		error("Invalid .bin size\n");
-		return 0;
-	}
-	/* If we have an old style .bin */
-	d->type=BIN_CLASSIC;
-	d->state_encoding=BIN_CLASSIC_STATE;
-	d->inf_number_encoding=BIN_3BYTES;
-	d->char_encoding=BIN_2BYTES;
-	d->offset_encoding=BIN_3BYTES;
-	select_bin_read_function(d);
-	return 1;
+    /* Type 1: old style .bin/.inf dictionary */
+    d->initial_state_offset=4;
+    if (d->bin_size<d->initial_state_offset+2) {
+        /* The minimal empty dictionary is made of the header plus a 2 bytes empty state */
+        error("Invalid .bin size\n");
+        return 0;
+    }
+    /* If we have an old style .bin */
+    d->type=BIN_CLASSIC;
+    d->state_encoding=BIN_CLASSIC_STATE;
+    d->inf_number_encoding=BIN_3BYTES;
+    d->char_encoding=BIN_2BYTES;
+    d->offset_encoding=BIN_3BYTES;
+    select_bin_read_function(d);
+    return 1;
 }
 if (d->bin[0]==1) {
-	/* Type 2: modern style .bin/.inf dictionary with no limit on .bin size */
-	d->type=BIN_CLASSIC;
-	d->state_encoding=(BinStateEncoding)d->bin[1];
-	d->inf_number_encoding=(BinEncoding)d->bin[2];
-	d->char_encoding=(BinEncoding)d->bin[3];
-	d->offset_encoding=(BinEncoding)d->bin[4];
-	select_bin_read_function(d);
-	int offset=5;
-	d->initial_state_offset=bin_read_4bytes(d->bin,&offset);
-	return 1;
+    /* Type 2: modern style .bin/.inf dictionary with no limit on .bin size */
+    d->type=BIN_CLASSIC;
+    d->state_encoding=(BinStateEncoding)d->bin[1];
+    d->inf_number_encoding=(BinEncoding)d->bin[2];
+    d->char_encoding=(BinEncoding)d->bin[3];
+    d->offset_encoding=(BinEncoding)d->bin[4];
+    select_bin_read_function(d);
+    int offset=5;
+    d->initial_state_offset=bin_read_4bytes(d->bin,&offset);
+    return 1;
 }
 if (d->bin[0]==2) {
-	/* Type 3: .bin2 dictionary */
-	d->type=BIN_BIN2;
-	d->state_encoding=(BinStateEncoding)d->bin[1];
-	d->inf_number_encoding=(BinEncoding)d->bin[2];
-	d->char_encoding=(BinEncoding)d->bin[3];
-	d->offset_encoding=(BinEncoding)d->bin[4];
-	select_bin_read_function(d);
-	int offset=5;
-	d->initial_state_offset=bin_read_4bytes(d->bin,&offset);
-	return 1;
+    /* Type 3: .bin2 dictionary */
+    d->type=BIN_BIN2;
+    d->state_encoding=(BinStateEncoding)d->bin[1];
+    d->inf_number_encoding=(BinEncoding)d->bin[2];
+    d->char_encoding=(BinEncoding)d->bin[3];
+    d->offset_encoding=(BinEncoding)d->bin[4];
+    select_bin_read_function(d);
+    int offset=5;
+    d->initial_state_offset=bin_read_4bytes(d->bin,&offset);
+    return 1;
 }
 error("Unknown dictionary type: %d\n",d->bin[0]);
 return 0;
@@ -527,8 +527,8 @@ return 0;
  * Writes the .bin header for a v2 .bin or a .bin2
  */
 void write_new_bin_header(BinType bin_type,unsigned char* bin,int *pos,BinStateEncoding state_encoding,
-		BinEncoding char_encoding,BinEncoding inf_number_encoding,
-		BinEncoding offset_encoding,int initial_state_offset) {
+        BinEncoding char_encoding,BinEncoding inf_number_encoding,
+        BinEncoding offset_encoding,int initial_state_offset) {
 bin[(*pos)++]=(bin_type==BIN_CLASSIC)?1:2;
 bin[(*pos)++]=(unsigned char)state_encoding;
 bin[(*pos)++]=(unsigned char)inf_number_encoding;
@@ -552,8 +552,8 @@ return s->len;
  */
 void restore_output(int n,Ustring* s) {
 if (s!=NULL && n!=-1) {
-	s->len=n;
-	s->str[n]='\0';
+    s->len=n;
+    s->str[n]='\0';
 }
 }
 
@@ -564,19 +564,19 @@ if (s!=NULL && n!=-1) {
  * if *inf_codes should be freed (.bin2), 0 if not (.bin).
  */
 int get_inf_codes(Dictionary* d,int inf_number,Ustring* output,struct list_ustring* *inf_codes,
-				int base) {
+                int base) {
 *inf_codes=NULL;
 if (d->type==BIN_CLASSIC) {
-	if (inf_number!=-1) {
-		*inf_codes=d->inf->codes[inf_number];
-	}
-	return 0;
+    if (inf_number!=-1) {
+        *inf_codes=d->inf->codes[inf_number];
+    }
+    return 0;
 }
 if (d->type!=BIN_BIN2) {
-	fatal_error("get_inf_codes: unsupported dictionary type\n");
+    fatal_error("get_inf_codes: unsupported dictionary type\n");
 }
 if (output!=NULL && output->str[base]!='\0') {
-	*inf_codes=tokenize_compressed_info(output->str+base);
+    *inf_codes=tokenize_compressed_info(output->str+base);
 }
 return 1;
 }

--- a/CompressedDic.h
+++ b/CompressedDic.h
@@ -42,23 +42,23 @@ namespace unitex {
  * in the transducer:
  */
 typedef enum {
-	BIN_2BYTES,   /* 2 bytes in big-endian */
-	BIN_3BYTES,   /* 3 bytes in big-endian */
-	BIN_4BYTES,   /* 4 bytes in big-endian */
-	BIN_VARIABLE  /* variable length encoding */
+    BIN_2BYTES,   /* 2 bytes in big-endian */
+    BIN_3BYTES,   /* 3 bytes in big-endian */
+    BIN_4BYTES,   /* 4 bytes in big-endian */
+    BIN_VARIABLE  /* variable length encoding */
 } BinEncoding;
 
 
 typedef enum {
-	BIN_CLASSIC,   /* old style .bin/.inf dictionary */
-	BIN_BIN2       /* .bin2 dictionary style, with outputs included in the transducer */
+    BIN_CLASSIC,   /* old style .bin/.inf dictionary */
+    BIN_BIN2       /* .bin2 dictionary style, with outputs included in the transducer */
 } BinType;
 
 
 typedef enum {
-	BIN_CLASSIC_STATE,   /* old style .bin state encoding on 2 bytes */
-	BIN_NEW_STATE,       /* variable length state encoding */
-	BIN_BIN2_STATE       /* .bin2 state encoding */
+    BIN_CLASSIC_STATE,   /* old style .bin state encoding on 2 bytes */
+    BIN_NEW_STATE,       /* variable length state encoding */
+    BIN_BIN2_STATE       /* .bin2 state encoding */
 } BinStateEncoding;
 
 
@@ -74,27 +74,27 @@ typedef void (*t_fnc_bin_write_bytes)(unsigned char* bin,int value,int *offset) 
  * This structure represents a compressed dictionary.
  */
 typedef struct {
-	BinType type;
-	int initial_state_offset;
-	long bin_size;
+    BinType type;
+    int initial_state_offset;
+    long bin_size;
 
-	/* Encodings used to store data in the transducer */
-	BinStateEncoding state_encoding;
-	BinEncoding inf_number_encoding;
-	BinEncoding char_encoding;
-	BinEncoding offset_encoding;
+    /* Encodings used to store data in the transducer */
+    BinStateEncoding state_encoding;
+    BinEncoding inf_number_encoding;
+    BinEncoding char_encoding;
+    BinEncoding offset_encoding;
 
-	//t_fnc_bin_read_bytes state_read_bin_func;
-	t_fnc_bin_read_bytes inf_number_read_bin_func;
-	t_fnc_bin_read_bytes char_read_bin_func;
-	t_fnc_bin_read_bytes offset_read_bin_func;
+    //t_fnc_bin_read_bytes state_read_bin_func;
+    t_fnc_bin_read_bytes inf_number_read_bin_func;
+    t_fnc_bin_read_bytes char_read_bin_func;
+    t_fnc_bin_read_bytes offset_read_bin_func;
 
-	/* The binary transducer */
-	const unsigned char* bin;
-	struct BIN_free_info bin_free;
-	/* The codes contained in the .inf file */
-	const struct INF_codes* inf;
-	struct INF_free_info inf_free;
+    /* The binary transducer */
+    const unsigned char* bin;
+    struct BIN_free_info bin_free;
+    /* The codes contained in the .inf file */
+    const struct INF_codes* inf;
+    struct INF_free_info inf_free;
 } Dictionary;
 
 
@@ -106,19 +106,19 @@ void free_Dictionary(Dictionary* d,Abstract_allocator prv_alloc=STANDARD_ALLOCAT
 int read_dictionary_state(const Dictionary*,int,int*,int*,int*);
 t_fnc_bin_write_bytes get_bin_write_function_for_encoding(BinEncoding e) ;
 void write_dictionary_state(unsigned char* bin,BinStateEncoding state_encoding,
-							t_fnc_bin_write_bytes inf_number_write_function,int *pos,int final,int n_transitions,int code);
+                            t_fnc_bin_write_bytes inf_number_write_function,int *pos,int final,int n_transitions,int code);
 int read_dictionary_transition(const Dictionary*,int,unichar*,int*,Ustring*);
 void write_dictionary_transition(unsigned char* bin,int *pos,t_fnc_bin_write_bytes char_write_function,
-								t_fnc_bin_write_bytes offset_write_function,unichar c,int dest,
-								BinType bin_type,unichar* output);
+                                t_fnc_bin_write_bytes offset_write_function,unichar c,int dest,
+                                BinType bin_type,unichar* output);
 int bin_get_value_length(int,BinEncoding);
 int bin_get_value_length(int v,t_fnc_bin_write_bytes func);
 int bin_get_string_length(unichar* s,BinEncoding char_encoding);
 int bin_get_string_length(unichar* s,t_fnc_bin_write_bytes char_encoding_func);
 void bin_write_4bytes(unsigned char* bin,int value,int *offset);
 void write_new_bin_header(BinType bin_type,unsigned char* bin,int *pos,BinStateEncoding state_encoding,
-		BinEncoding char_encoding,BinEncoding inf_number_encoding,
-		BinEncoding offset_encoding,int initial_state_offset);
+        BinEncoding char_encoding,BinEncoding inf_number_encoding,
+        BinEncoding offset_encoding,int initial_state_offset);
 
 int save_output(Ustring*);
 void restore_output(int,Ustring*);

--- a/ConcorDiff.cpp
+++ b/ConcorDiff.cpp
@@ -75,8 +75,8 @@ const struct option_TS lopts_ConcorDiff[]= {
 
 int main_ConcorDiff(int argc,char* const argv[]) {
 if (argc==1) {
-	usage();
-	return SUCCESS_RETURN_CODE;
+    usage();
+    return SUCCESS_RETURN_CODE;
 }
 
 int val,index=-1;

--- a/ConcorDiff.cpp
+++ b/ConcorDiff.cpp
@@ -108,7 +108,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_ConcorDiff,lopts_ConcorD
                 error("You must specify a non empty font name\n");
                 free(font);
                 free(out);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              font=strdup(options.vars()->optarg);
              if (font==NULL) {
@@ -129,7 +129,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_ConcorDiff,lopts_ConcorD
              break;
    case 'd': diff_only=1; break;
    case 'V': only_verify_arguments = true;
-             break;   
+             break;
    case 'h': usage();
              free(font);
              free(out);
@@ -156,7 +156,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_ConcorDiff,lopts_ConcorD
                error("Empty output_encoding argument\n");
                free(font);
                free(out);
-               return USAGE_ERROR_CODE;                
+               return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -172,7 +172,7 @@ if (out==NULL) {
 if (font==NULL) {
    error("You must specify the font to use\n");
    free(out);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 if (size==0) {
    error("You must specify the font size to use\n");
@@ -193,7 +193,7 @@ if (only_verify_arguments) {
   free(font);
   free(out);
   return SUCCESS_RETURN_CODE;
-}             
+}
 
 diff(&vec,argv[options.vars()->optind],argv[options.vars()->optind+1],out,font,size,diff_only);
 

--- a/ConcorDiff.h
+++ b/ConcorDiff.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef ConcorDiffH
 #define ConcorDiffH
 

--- a/Concord.cpp
+++ b/Concord.cpp
@@ -290,7 +290,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
              if (ret==0 || ret==3 || (ret==2 && foo!='s') || concord_options->left_context<0) {
                 error("Invalid left context argument: %s\n",options.vars()->optarg);
                 free_conc_opt(concord_options);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              if (ret==2) {
                 concord_options->left_context_until_eos=1;
@@ -300,7 +300,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
              if (ret==0 || ret==3 || (ret==2 && foo!='s') || concord_options->right_context<0) {
                 error("Invalid right context argument: %s\n",options.vars()->optarg);
                 free_conc_opt(concord_options);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              if (ret==2) {
                 concord_options->right_context_until_eos=1;
@@ -343,26 +343,26 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
              if (options.vars()->optarg[0]=='\0') {
                 error("Empty glossanet script argument\n");
                 free_conc_opt(concord_options);
-                return USAGE_ERROR_CODE;                   
+                return USAGE_ERROR_CODE;
              }
              concord_options->script=strdup(options.vars()->optarg);
              if (concord_options->script==NULL) {
                 alloc_error("main_Concord");
                 free_conc_opt(concord_options);
-                return ALLOC_ERROR_CODE;                   
+                return ALLOC_ERROR_CODE;
              }
              break;
    case 'p': concord_options->result_mode=SCRIPT_;
              if (options.vars()->optarg[0]=='\0') {
                 error("Empty script argument\n");
                 free_conc_opt(concord_options);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              concord_options->script=strdup(options.vars()->optarg);
              if (concord_options->script==NULL) {
                 alloc_error("main_Concord");
                 free_conc_opt(concord_options);
-                return ALLOC_ERROR_CODE;                 
+                return ALLOC_ERROR_CODE;
              }
              break;
    case 'i': concord_options->result_mode=INDEX_; break;
@@ -378,7 +378,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
                 concord_options->original_file_offsets=1;
              }
              break;
-   case 'w': concord_options->result_mode=XML_WITH_HEADER_; 
+   case 'w': concord_options->result_mode=XML_WITH_HEADER_;
              if (options.vars()->optarg!=NULL) {
                 strcpy(offset_file, options.vars()->optarg);
                 concord_options->original_file_offsets = 1;
@@ -411,7 +411,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
    case 'a': if (options.vars()->optarg[0]=='\0') {
                 error("Empty alphabet argument\n");
                 free_conc_opt(concord_options);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              concord_options->sort_alphabet=strdup(options.vars()->optarg);
              if (concord_options->sort_alphabet==NULL) {
@@ -428,9 +428,9 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Concord,lopts_Concord,&i
              strcpy(concord_options->working_directory,options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': usage();
-             free_conc_opt(concord_options); 
+             free_conc_opt(concord_options);
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Concord[index].name);
@@ -467,7 +467,7 @@ if (concord_options->fontname==NULL || concord_options->fontsize<=0) {
    if (concord_options->result_mode==HTML_ || concord_options->result_mode==GLOSSANET_) {
       error("The specified output mode is an HTML file: you must specify font parameters\n");
       free_conc_opt(concord_options);
-      return USAGE_ERROR_CODE;      
+      return USAGE_ERROR_CODE;
    }
 }
 
@@ -481,7 +481,7 @@ U_FILE* concor=u_fopen(&vec,argv[options.vars()->optind],U_READ);
 if (concor==NULL) {
    error("Cannot open concordance index file %s\n",argv[options.vars()->optind]);
    free_conc_opt(concord_options);
-   return DEFAULT_ERROR_CODE;   
+   return DEFAULT_ERROR_CODE;
 }
 
 if (concord_options->working_directory[0]=='\0') {
@@ -529,7 +529,7 @@ else {
     free_snt_files(snt_files);
     u_fclose(concor);
     free_conc_opt(concord_options);
-    return ALLOC_ERROR_CODE;     
+    return ALLOC_ERROR_CODE;
   }
   n_enter_char=(int)fread(enter_pos,sizeof(int),size/sizeof(int),f_enter);
   if (n_enter_char!=(int)(size/sizeof(int))) {
@@ -545,7 +545,7 @@ else {
   }
   u_fclose(f_enter);
 }
-if (concord_options->result_mode==INDEX_ || concord_options->result_mode==UIMA_ || 
+if (concord_options->result_mode==INDEX_ || concord_options->result_mode==UIMA_ ||
     concord_options->result_mode==XML_ || concord_options->result_mode==XML_WITH_HEADER_ ||
     concord_options->result_mode==AXIS_) {
    /* We force some options for index, uima and axis files */
@@ -563,26 +563,26 @@ if (concord_options->result_mode==HTML_ || concord_options->result_mode==DIFF_ |
   concord_options->snt_offsets=load_snt_offsets(snt_files->snt_offsets_pos);
   if (concord_options->snt_offsets==NULL) {
     error("Cannot read snt offset file %s\n",snt_files->snt_offsets_pos);
-    free(enter_pos);    
+    free(enter_pos);
     free_text_tokens(tok);
     af_close_mapfile(text);
     free_snt_files(snt_files);
     u_fclose(concor);
     free_conc_opt(concord_options);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 if (offset_file[0]!='\0') {
   concord_options->uima_offsets=load_uima_offsets(&vec,offset_file);
   if (concord_options->uima_offsets==NULL) {
     error("Cannot read offset file %s\n",offset_file);
-    free(enter_pos); 
+    free(enter_pos);
     free_text_tokens(tok);
     af_close_mapfile(text);
     free_snt_files(snt_files);
     u_fclose(concor);
     free_conc_opt(concord_options);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 if (PRLG[0]!='\0') {
@@ -595,7 +595,7 @@ if (PRLG[0]!='\0') {
     free_snt_files(snt_files);
     u_fclose(concor);
     free_conc_opt(concord_options);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 if (concord_options->result_mode==CSV_) {

--- a/Concord.h
+++ b/Concord.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef ConcordH
 #define ConcordH
 

--- a/Concordance.cpp
+++ b/Concordance.cpp
@@ -1201,16 +1201,16 @@ while (matches!=NULL) {
 	}
 	position_in_chars=start_pos_char;
 	position_in_tokens=start_pos;
-	
+
 	if (matches->m.start_pos_in_token<matches->m.end_pos_in_token) {
-	   /* If the match is made of several tokens, we must set end_pos_in_char 
+	   /* If the match is made of several tokens, we must set end_pos_in_char
 	    * to the beginning of the next token */
 	   int start_of_first_token=start_pos_char;
 	   start_pos_char=start_of_first_token+matches->m.start_pos_in_char;
-	   
+
 	   end_pos_char=start_of_first_token;
 	   end_from_eos=start_from_eos;
-	   
+
 	   /* We update 'end_pos_char' in the same way */
 	   for (int z=start_pos;z<end_pos;z++) {
 	      int token_size=0;
@@ -1223,13 +1223,13 @@ while (matches!=NULL) {
 	   end_pos_char=end_pos_char+matches->m.end_pos_in_char+1;
 	   end_from_eos=end_from_eos+matches->m.end_pos_in_char+1;
 	} else {
-	   /* If we work on just one token, we can set directly start_pos_in_char 
+	   /* If we work on just one token, we can set directly start_pos_in_char
 	    * and end_pos_in_char. DO NOT SWAP THE FOLLOWING LINES! */
 	   end_pos_char=start_pos_char+matches->m.end_pos_in_char+1;
 	   start_pos_char=start_pos_char+matches->m.start_pos_in_char;
 	   end_from_eos=start_from_eos+matches->m.end_pos_in_char+1;
 	}
-	
+
 	/* Now we extract the 3 parts of the concordance */
 	extract_left_context(start_pos,matches->m.start_pos_in_char,left,tokens,options,token_length,buffer);
 	extract_match(start_pos,matches->m.start_pos_in_char,end_pos,matches->m.end_pos_in_char,matches->output,middle,tokens,buffer);

--- a/Concordance.cpp
+++ b/Concordance.cpp
@@ -42,7 +42,7 @@ int create_raw_text_concordance(U_FILE*,U_FILE*,ABSTRACTMAPFILE*,struct text_tok
 void compute_token_length(int*,struct text_tokens*);
 
 static void create_modified_text_file(const VersatileEncodingConfig*,U_FILE*,ABSTRACTMAPFILE*,struct text_tokens*,
-		char*,int,int,const int*, vector_uima_offset*,const char*, vector_offset* v_offsets);
+        char*,int,int,const int*, vector_uima_offset*,const char*, vector_offset* v_offsets);
 void write_HTML_header(U_FILE*,int,struct conc_opt*);
 void write_HTML_end(U_FILE*);
 void reverse_initial_vowels_thai(unichar*);
@@ -78,23 +78,23 @@ static void process_match_content_in_lemmatize_mode(unichar* s,vector_ptr* outpu
 int i;
 for (i=1;s[i]!='\0' && s[i]!='/';i++) {}
 if (s[i]=='\0') {
-	fatal_error("Internal error in process_match_content_in_lemmatize_mode\n");
+    fatal_error("Internal error in process_match_content_in_lemmatize_mode\n");
 }
 s[i]='\0';
 i+=1;
 for (;;) {
-	int start=i;
-	int j=i;
-	while (s[j]!='\0' && s[j]!=LEMMATIZE_DELIMITOR) {
-		j++;
-	}
-	int end=(s[j]=='\0');
-	s[j]='\0';
-	vector_ptr_add(outputs,u_strdup(s+start));
-	if (end) {
-		return;
-	}
-	i=j+1;
+    int start=i;
+    int j=i;
+    while (s[j]!='\0' && s[j]!=LEMMATIZE_DELIMITOR) {
+        j++;
+    }
+    int end=(s[j]=='\0');
+    s[j]='\0';
+    vector_ptr_add(outputs,u_strdup(s+start));
+    if (end) {
+        return;
+    }
+    i=j+1;
 }
 }
 
@@ -109,21 +109,21 @@ return c;
 static void print_PRGL_tag_for_csv(U_FILE* out,unichar* s) {
 if (s==NULL || s[0]=='\0') return;
 if (s[0]!='[') {
-	fatal_error("Invalid PRLG tag format in print_PRGL_tag_for_csv: <%S>\n",s);
+    fatal_error("Invalid PRLG tag format in print_PRGL_tag_for_csv: <%S>\n",s);
 }
 unichar* tmp=u_strchr(s,' ');
 if (tmp!=NULL) {
-	*tmp='\0';
+    *tmp='\0';
 }
 tmp=u_strchr(s,']');
 if (tmp!=NULL) {
-	*tmp='\0';
+    *tmp='\0';
 }
 s++;
 while (NULL!=(tmp=u_strchr(s,'-'))) {
-	*tmp='\0';
-	u_fprintf(out,"%S - ",s);
-	s=tmp+1;
+    *tmp='\0';
+    u_fprintf(out,"%S - ",s);
+    s=tmp+1;
 }
 u_fputs(s,out);
 }
@@ -132,25 +132,25 @@ u_fputs(s,out);
 static void print_dic_info_for_csv(U_FILE* out,unichar* s) {
 unichar* tmp=u_strchr(s+1,'/');
 if (tmp==NULL) {
-	u_fprintf(out,"%S\t\t",s);
-	return;
+    u_fprintf(out,"%S\t\t",s);
+    return;
 }
 *tmp='\0';
 if (s[0]=='{') {
-	struct dela_entry* e=tokenize_tag_token(s,0,NULL);
-	if (e==NULL) {
-		fatal_error("");
-	}
-	u_fputs(e->inflected,out);
-	free_dela_entry(e);
+    struct dela_entry* e=tokenize_tag_token(s,0,NULL);
+    if (e==NULL) {
+        fatal_error("");
+    }
+    u_fputs(e->inflected,out);
+    free_dela_entry(e);
 } else {
-	u_fputs(s,out);
+    u_fputs(s,out);
 }
 
 s=tmp+1;
 tmp=u_strchr(s,'.');
 if (tmp==NULL) {
-	fatal_error("Missing . in print_dic_info_for_csv: <%S>\n",s);
+    fatal_error("Missing . in print_dic_info_for_csv: <%S>\n",s);
 }
 *tmp='\t';
 u_fprintf(out,"\t%S",s);
@@ -222,74 +222,74 @@ if (token_length==NULL) {
 }
 compute_token_length(token_length,tokens);
 if (options->result_mode==MERGE_) {
-	/* If we have to produced a modified version of the original text, we
-	 * do it and return. */
+    /* If we have to produced a modified version of the original text, we
+     * do it and return. */
 
-	vector_offset* in_offsets = NULL;
-	vector_offset* out_offsets = NULL;
-	U_FILE* f_output_offsets = NULL;
-	if ((options->input_offsets[0] != '\0') && (options->output_offsets[0] != '\0')) {
+    vector_offset* in_offsets = NULL;
+    vector_offset* out_offsets = NULL;
+    U_FILE* f_output_offsets = NULL;
+    if ((options->input_offsets[0] != '\0') && (options->output_offsets[0] != '\0')) {
 
-		in_offsets = load_offsets(vec, options->input_offsets);
-		if (in_offsets == NULL) {
-			fatal_error("Cannot load offset file %s\n", options->input_offsets);
-		}
+        in_offsets = load_offsets(vec, options->input_offsets);
+        if (in_offsets == NULL) {
+            fatal_error("Cannot load offset file %s\n", options->input_offsets);
+        }
 
-		out_offsets = new_vector_offset();
+        out_offsets = new_vector_offset();
 
 
-		/* We deal with offsets only if we have to produce output offsets */
-		f_output_offsets = u_fopen(vec, options->output_offsets, U_WRITE);
-		if (f_output_offsets == NULL) {
-			error("Cannot create offset file %s\n", options->output_offsets);
-			return 1;
-		}
+        /* We deal with offsets only if we have to produce output offsets */
+        f_output_offsets = u_fopen(vec, options->output_offsets, U_WRITE);
+        if (f_output_offsets == NULL) {
+            error("Cannot create offset file %s\n", options->output_offsets);
+            return 1;
+        }
 
-	}
+    }
 
-	create_modified_text_file(vec,concordance,text,tokens,
-			options->output,options->convLFtoCRLF,n_enter_char,enter_pos,options->uima_offsets,
-			(out_offsets != NULL) ? NULL : options->output_offsets, out_offsets);
+    create_modified_text_file(vec,concordance,text,tokens,
+            options->output,options->convLFtoCRLF,n_enter_char,enter_pos,options->uima_offsets,
+            (out_offsets != NULL) ? NULL : options->output_offsets, out_offsets);
 
-	if (f_output_offsets != NULL) {
-		process_offsets(in_offsets, out_offsets, f_output_offsets);
-		u_fclose(f_output_offsets);
-	}
-	free(token_length);
-	free_vector_offset(in_offsets);
-	free_vector_offset(out_offsets);
-	return 0;
+    if (f_output_offsets != NULL) {
+        process_offsets(in_offsets, out_offsets, f_output_offsets);
+        u_fclose(f_output_offsets);
+    }
+    free(token_length);
+    free_vector_offset(in_offsets);
+    free_vector_offset(out_offsets);
+    return 0;
 }
 /* If the expected result is a concordance */
 if (options->result_mode==GLOSSANET_) {
-	/* The structure glossa_hash will be used to ignore duplicate lines
-	 * without sorting */
-	glossa_hash=new_string_hash();
-	/* Building GlossaNet concordances requires to locate square brackets in the
-	 * text. That's why we compute the token numbers associated to '[' and ']' */
-	unichar r[2];
-	r[0]='[';
-	r[1]='\0';
-	open_bracket=get_token_number(r,tokens);
-	r[0]=']';
-	close_bracket=get_token_number(r,tokens);
+    /* The structure glossa_hash will be used to ignore duplicate lines
+     * without sorting */
+    glossa_hash=new_string_hash();
+    /* Building GlossaNet concordances requires to locate square brackets in the
+     * text. That's why we compute the token numbers associated to '[' and ']' */
+    unichar r[2];
+    r[0]='[';
+    r[1]='\0';
+    open_bracket=get_token_number(r,tokens);
+    r[0]=']';
+    close_bracket=get_token_number(r,tokens);
 }
 /* We set temporary and final file names */
 strcpy(temp_file_name,options->working_directory);
 strcat(temp_file_name,"concord_.txt");
 if (options->output[0]=='\0') {
-	strcpy(options->output,options->working_directory);
-	if (options->result_mode==TEXT_ || options->result_mode==INDEX_
+    strcpy(options->output,options->working_directory);
+    if (options->result_mode==TEXT_ || options->result_mode==INDEX_
       || options->result_mode==UIMA_ || options->result_mode==AXIS_
       || options->result_mode==XALIGN_ || options->result_mode==DIFF_)
-		strcat(options->output,"concord.txt");
-	else if ((options->result_mode==XML_) || (options->result_mode==XML_WITH_HEADER_))
-		strcat(options->output,"concord.xml");
-	else if (options->result_mode==LEMMATIZE_)
-		strcat(options->output,"lemmatize.html");
-	else if (options->result_mode==CSV_)
-		strcat(options->output,"export.csv");
-	else strcat(options->output,"concord.html");
+        strcat(options->output,"concord.txt");
+    else if ((options->result_mode==XML_) || (options->result_mode==XML_WITH_HEADER_))
+        strcat(options->output,"concord.xml");
+    else if (options->result_mode==LEMMATIZE_)
+        strcat(options->output,"lemmatize.html");
+    else if (options->result_mode==CSV_)
+        strcat(options->output,"export.csv");
+    else strcat(options->output,"concord.html");
 }
 int N_MATCHES;
 
@@ -298,9 +298,9 @@ int N_MATCHES;
 if (options->result_mode==XALIGN_) f=u_fopen(UTF8,options->output,U_WRITE);
 else f=u_fopen(vec,temp_file_name,U_WRITE);
 if (f==NULL) {
-	error("Cannot write %s\n",temp_file_name);
-	free(token_length);
-	return 1;
+    error("Cannot write %s\n",temp_file_name);
+    free(token_length);
+    return 1;
 }
 /* First, we create a raw text concordance.
  * NOTE: columns may have been reordered according to the sort mode. See the
@@ -325,8 +325,8 @@ if (options->sort_mode!=TEXT_ORDER) {
 
 f=u_fopen(vec,temp_file_name,U_READ);
 if (f==NULL) {
-	error("Cannot read %s\n",temp_file_name);
-	return 1;
+    error("Cannot read %s\n",temp_file_name);
+    return 1;
 }
 if (options->result_mode==TEXT_ || options->result_mode==INDEX_
       || options->result_mode==XML_ || options->result_mode==XML_WITH_HEADER_
@@ -340,15 +340,15 @@ else {
    out=u_fopen(UTF8,options->output,U_WRITE);
 }
 if (out==NULL) {
-	error("Cannot write %s\n",options->output);
-	u_fclose(f);
-	return 1;
+    error("Cannot write %s\n",options->output);
+    u_fclose(f);
+    return 1;
 }
 /* If we have an HTML or a GlossaNet/script concordance, we must write an HTML
  * file header. */
 if (options->result_mode==HTML_ || options->result_mode==GLOSSANET_ || options->result_mode==SCRIPT_
-		|| options->result_mode==LEMMATIZE_) {
-	write_HTML_header(out,N_MATCHES,options);
+        || options->result_mode==LEMMATIZE_) {
+    write_HTML_header(out,N_MATCHES,options);
 }
 if (options->result_mode==XML_WITH_HEADER_) {
   if ((vec->encoding_output == UTF16_LE) || (vec->encoding_output == BIG_ENDIAN_UTF16)) {
@@ -366,7 +366,7 @@ if (options->result_mode==XML_) {
 }
 unichar* unichar_buffer=(unichar*)malloc(sizeof(unichar)*((3000*4) + 100));
 if (unichar_buffer==NULL) {
-	fatal_alloc_error("create_concordance");
+    fatal_alloc_error("create_concordance");
 }
 unichar* A = unichar_buffer + (3000 * 0);
 unichar* B = unichar_buffer + (3000 * 1);
@@ -382,167 +382,167 @@ int c;
 int csv_line=1;
 /* Now we process each line of the sorted raw text concordance */
 while ((c=u_fgetc(f))!=EOF) {
-	empty(PRLG_tag);
-	j=0;
-	/* We save the first column in A... */
-	while (c!=0x09) {
-		A[j++]=(unichar)c;
-		c=u_fgetc(f);
-	}
-	A[j]='\0';
-	c=u_fgetc(f);
-	j=0;
-	/* ...the second in B... */
-	while (c!=0x09) {
-		B[j++]=(unichar)c;
-		c=u_fgetc(f);
-	}
-	B[j]='\0';
-	c=u_fgetc(f);
-	j=0;
-	/* ...and the third in C */
-	while (c!='\n' && c!='\t') {
-		C[j++]=(unichar)c;
-		c=u_fgetc(f);
-	}
-	C[j]='\0';
-	indices[0]='\0';
-	/* If there are indices to be read like "15 17 1", we read them */
-	if (c=='\t') {
-		c=u_fgetc(f);
-		j=0;
-		while (c!='\t' && c!='\n' && c!=PRLG_DELIMITOR) {
-			indices[j++]=(unichar)c;
-			c=u_fgetc(f);
-		}
-		indices[j]='\0';
-		/*------------begin GlossaNet-------------------*/
-		/* If we are in GlossaNet mode, we extract the url at the end of the line */
-		if (options->result_mode==GLOSSANET_) {
-			if (c!='\t') {
-				error("ERROR in GlossaNet concordance: no URL found\n");
-				href[0]='\0';
-			} else {
-				j=0;
-				while ((c=u_fgetc(f))!='\n' && c!=PRLG_DELIMITOR) {
-					href[j++]=(unichar)c;
-				}
-				href[j]='\0';
-			}
-		}
-		/*------------end GlossaNet-------------------*/
-	}
-	if (c==PRLG_DELIMITOR) {
-		/* If there is a PRLG tag */
-		c=u_fgetc(f);
-		if (c!='[') {
-			fatal_error("Invalid PRLG tag in create_concordance");
-		}
-		while (c!='\n') {
-			u_strcat(PRLG_tag,(unichar)c);
-			c=u_fgetc(f);
-		}
-		u_strcat(PRLG_tag,"  ");
-	}
-	/* Now we will reorder the columns according to the sort mode */
-	switch(options->sort_mode) {
-		case TEXT_ORDER: left=A; middle=B; right=C; break;
-		case LEFT_CENTER: left=A; middle=B; right=C; break;
-		case LEFT_RIGHT: left=A; right=B; middle=C; break;
-		case CENTER_LEFT: middle=A; left=B; right=C; break;
-		case CENTER_RIGHT: middle=A; right=B; left=C; break;
-		case RIGHT_LEFT: right=A; left=B; middle=C; break;
-		case RIGHT_CENTER: right=A; middle=B; left=C; break;
-	}
-	/* We use 'can_print_line' to decide if the concordance line must be
-	 * printed, because in GlossaNet mode, duplicates must be removed. */
-	int can_print_line=1;
-	if (options->result_mode==GLOSSANET_) {
-		unichar line[4000];
+    empty(PRLG_tag);
+    j=0;
+    /* We save the first column in A... */
+    while (c!=0x09) {
+        A[j++]=(unichar)c;
+        c=u_fgetc(f);
+    }
+    A[j]='\0';
+    c=u_fgetc(f);
+    j=0;
+    /* ...the second in B... */
+    while (c!=0x09) {
+        B[j++]=(unichar)c;
+        c=u_fgetc(f);
+    }
+    B[j]='\0';
+    c=u_fgetc(f);
+    j=0;
+    /* ...and the third in C */
+    while (c!='\n' && c!='\t') {
+        C[j++]=(unichar)c;
+        c=u_fgetc(f);
+    }
+    C[j]='\0';
+    indices[0]='\0';
+    /* If there are indices to be read like "15 17 1", we read them */
+    if (c=='\t') {
+        c=u_fgetc(f);
+        j=0;
+        while (c!='\t' && c!='\n' && c!=PRLG_DELIMITOR) {
+            indices[j++]=(unichar)c;
+            c=u_fgetc(f);
+        }
+        indices[j]='\0';
+        /*------------begin GlossaNet-------------------*/
+        /* If we are in GlossaNet mode, we extract the url at the end of the line */
+        if (options->result_mode==GLOSSANET_) {
+            if (c!='\t') {
+                error("ERROR in GlossaNet concordance: no URL found\n");
+                href[0]='\0';
+            } else {
+                j=0;
+                while ((c=u_fgetc(f))!='\n' && c!=PRLG_DELIMITOR) {
+                    href[j++]=(unichar)c;
+                }
+                href[j]='\0';
+            }
+        }
+        /*------------end GlossaNet-------------------*/
+    }
+    if (c==PRLG_DELIMITOR) {
+        /* If there is a PRLG tag */
+        c=u_fgetc(f);
+        if (c!='[') {
+            fatal_error("Invalid PRLG tag in create_concordance");
+        }
+        while (c!='\n') {
+            u_strcat(PRLG_tag,(unichar)c);
+            c=u_fgetc(f);
+        }
+        u_strcat(PRLG_tag,"  ");
+    }
+    /* Now we will reorder the columns according to the sort mode */
+    switch(options->sort_mode) {
+        case TEXT_ORDER: left=A; middle=B; right=C; break;
+        case LEFT_CENTER: left=A; middle=B; right=C; break;
+        case LEFT_RIGHT: left=A; right=B; middle=C; break;
+        case CENTER_LEFT: middle=A; left=B; right=C; break;
+        case CENTER_RIGHT: middle=A; right=B; left=C; break;
+        case RIGHT_LEFT: right=A; left=B; middle=C; break;
+        case RIGHT_CENTER: right=A; middle=B; left=C; break;
+    }
+    /* We use 'can_print_line' to decide if the concordance line must be
+     * printed, because in GlossaNet mode, duplicates must be removed. */
+    int can_print_line=1;
+    if (options->result_mode==GLOSSANET_) {
+        unichar line[4000];
         u_sprintf(line,"%S%S\t%S\t%S",PRLG_tag->str,left,middle,right);
-		/* We test if the line was already seen */
-		if (NO_VALUE_INDEX==get_value_index(line,glossa_hash,DONT_INSERT)) {
-			can_print_line=1;
-			get_value_index(line,glossa_hash);
-		} else {
-			can_print_line=0;
-		}
-	}
-	/* If we can print the line */
-	if (can_print_line) {
-		if (options->sort_mode!=TEXT_ORDER) {
-			/* If the concordance was sorted, the left sequence was reversed, and
-			 * then, we have to reverse it again. However, the Thai sort algorithm
-			 * requires to modify some vowels. That's why we must apply a special
-			 * procedure if we have a Thai sorted concordance. */
-			if (options->thai_mode) reverse_initial_vowels_thai(left);
-			/* Now we revert and print the left context */
-			if (options->result_mode==HTML_ || options->result_mode==GLOSSANET_
-					|| options->result_mode==SCRIPT_ || options->result_mode==LEMMATIZE_) {
-				u_fprintf(out,"<tr><td nowrap>%S%HR",PRLG_tag->str,left);
-			} else {u_fprintf(out,"%R",left);}
-		} else {
-			/* If the concordance is not sorted, we do not need to revert the
-			 * left context. */
-			if (options->result_mode==HTML_ || options->result_mode==GLOSSANET_
-					|| options->result_mode==SCRIPT_ || options->result_mode==LEMMATIZE_) {
-				u_fprintf(out,"<tr><td nowrap>%S%HS",PRLG_tag->str,left);
-			} else if (options->result_mode!=CSV_) {
-				u_fprintf(out,"%S%S",PRLG_tag->str,left);
-			}
-		}
-		/* If we must produce an HTML concordance, then we surround the
-		 * located sequence by HTML tags in order to make it an hyperlink.
-		 * This hyperlink will contain a fake URL of the form "X Y Z", where
-		 * X and Y are the starting and ending position of the sequence (in
-		 * tokens) and Z is the number of the sentence that contains the
-		 * sequence. */
-		if (options->result_mode==HTML_) {
-			u_fprintf(out,"<a href=\"%S\">%HS</a>%HS&nbsp;</td></tr>\n",indices,middle,right);
-		} else if (options->result_mode==LEMMATIZE_) {
-			/* In lemmatize mode we must extract everything after the / */
-			vector_ptr* outputs=new_vector_ptr();
-			process_match_content_in_lemmatize_mode(middle,outputs);
-			u_fprintf(out,"<a href=\"%S\">%HS</a>",indices,middle);
-			u_fprintf(out,"<!--%d-->",outputs->nbelems);
-			for (int k=0;k<outputs->nbelems;k++) {
-				unichar* z=(unichar*)outputs->tab[k];
-				u_fprintf(out,"<!--%HS-->",z);
-			}
-			u_fprintf(out,"%HS&nbsp;</td></tr>\n",right);
-			free_vector_ptr(outputs,free);
-		} else if (options->result_mode==GLOSSANET_) {
-			/* If we must produce a GlossaNet concordance, we turn the sequence
-			 * into an URL, using the given GlossaNet script. */
-			u_fprintf(out,"<A HREF=\"%s?rec=%HS&adr=%HS",options->script,middle,href);
+        /* We test if the line was already seen */
+        if (NO_VALUE_INDEX==get_value_index(line,glossa_hash,DONT_INSERT)) {
+            can_print_line=1;
+            get_value_index(line,glossa_hash);
+        } else {
+            can_print_line=0;
+        }
+    }
+    /* If we can print the line */
+    if (can_print_line) {
+        if (options->sort_mode!=TEXT_ORDER) {
+            /* If the concordance was sorted, the left sequence was reversed, and
+             * then, we have to reverse it again. However, the Thai sort algorithm
+             * requires to modify some vowels. That's why we must apply a special
+             * procedure if we have a Thai sorted concordance. */
+            if (options->thai_mode) reverse_initial_vowels_thai(left);
+            /* Now we revert and print the left context */
+            if (options->result_mode==HTML_ || options->result_mode==GLOSSANET_
+                    || options->result_mode==SCRIPT_ || options->result_mode==LEMMATIZE_) {
+                u_fprintf(out,"<tr><td nowrap>%S%HR",PRLG_tag->str,left);
+            } else {u_fprintf(out,"%R",left);}
+        } else {
+            /* If the concordance is not sorted, we do not need to revert the
+             * left context. */
+            if (options->result_mode==HTML_ || options->result_mode==GLOSSANET_
+                    || options->result_mode==SCRIPT_ || options->result_mode==LEMMATIZE_) {
+                u_fprintf(out,"<tr><td nowrap>%S%HS",PRLG_tag->str,left);
+            } else if (options->result_mode!=CSV_) {
+                u_fprintf(out,"%S%S",PRLG_tag->str,left);
+            }
+        }
+        /* If we must produce an HTML concordance, then we surround the
+         * located sequence by HTML tags in order to make it an hyperlink.
+         * This hyperlink will contain a fake URL of the form "X Y Z", where
+         * X and Y are the starting and ending position of the sequence (in
+         * tokens) and Z is the number of the sentence that contains the
+         * sequence. */
+        if (options->result_mode==HTML_) {
+            u_fprintf(out,"<a href=\"%S\">%HS</a>%HS&nbsp;</td></tr>\n",indices,middle,right);
+        } else if (options->result_mode==LEMMATIZE_) {
+            /* In lemmatize mode we must extract everything after the / */
+            vector_ptr* outputs=new_vector_ptr();
+            process_match_content_in_lemmatize_mode(middle,outputs);
+            u_fprintf(out,"<a href=\"%S\">%HS</a>",indices,middle);
+            u_fprintf(out,"<!--%d-->",outputs->nbelems);
+            for (int k=0;k<outputs->nbelems;k++) {
+                unichar* z=(unichar*)outputs->tab[k];
+                u_fprintf(out,"<!--%HS-->",z);
+            }
+            u_fprintf(out,"%HS&nbsp;</td></tr>\n",right);
+            free_vector_ptr(outputs,free);
+        } else if (options->result_mode==GLOSSANET_) {
+            /* If we must produce a GlossaNet concordance, we turn the sequence
+             * into an URL, using the given GlossaNet script. */
+            u_fprintf(out,"<A HREF=\"%s?rec=%HS&adr=%HS",options->script,middle,href);
          u_fprintf(out,"\" style=\"color: rgb(0,0,128)\">%HS</A>%HS</td></tr>\n",middle,right);
-		}
-		/* If we must produce a script concordance */
-		else if (options->result_mode==SCRIPT_) {
-			u_fprintf(out,"<a href=\"%s%US",options->script,middle);
+        }
+        /* If we must produce a script concordance */
+        else if (options->result_mode==SCRIPT_) {
+            u_fprintf(out,"<a href=\"%s%US",options->script,middle);
             u_fprintf(out,"\">%HS</a>%HS</td></tr>\n",middle,right);
-		}
-		/* If we must produce a text concordance */
-		else if (options->result_mode==TEXT_) {
-			if (!options->only_matches) u_fputc('\t',out);
-			u_fputs(middle,out);
-			if (!options->only_matches) u_fputc('\t',out);
-			u_fprintf(out,"%S\n",right);
-		} else if (options->result_mode==CSV_) {
-			if (!u_strcmp(middle," ")) {
-				u_fprintf(out,"%d\t\t\t \t\t\n",csv_line++);
-			} else {
-				u_fprintf(out,"%d\t%d\t",csv_line++,get_sentence_number(indices));
-				print_PRGL_tag_for_csv(out,PRLG_tag->str);
-				u_fprintf(out,"\t");
-				print_dic_info_for_csv(out,middle);
-				u_fprintf(out,"\n");
-			}
-		}
-		/* If we must produce a concordance to be used by ConcorDiff*/
-		else if (options->result_mode==DIFF_) {
-			u_fprintf(out,"\t%S\t%S\t%S\n",middle,right,indices);
-		}
+        }
+        /* If we must produce a text concordance */
+        else if (options->result_mode==TEXT_) {
+            if (!options->only_matches) u_fputc('\t',out);
+            u_fputs(middle,out);
+            if (!options->only_matches) u_fputc('\t',out);
+            u_fprintf(out,"%S\n",right);
+        } else if (options->result_mode==CSV_) {
+            if (!u_strcmp(middle," ")) {
+                u_fprintf(out,"%d\t\t\t \t\t\n",csv_line++);
+            } else {
+                u_fprintf(out,"%d\t%d\t",csv_line++,get_sentence_number(indices));
+                print_PRGL_tag_for_csv(out,PRLG_tag->str);
+                u_fprintf(out,"\t");
+                print_dic_info_for_csv(out,middle);
+                u_fprintf(out,"\n");
+            }
+        }
+        /* If we must produce a concordance to be used by ConcorDiff*/
+        else if (options->result_mode==DIFF_) {
+            u_fprintf(out,"\t%S\t%S\t%S\n",middle,right,indices);
+        }
       /* If must must produce an index file */
       else if (options->result_mode==INDEX_) {
          unichar idx[128];
@@ -582,12 +582,12 @@ while ((c=u_fgetc(f))!=EOF) {
          med=((len+1)/2)+f1;
          u_fprintf(out,"%.1f\t%S\n",med,middle);
       }
-	}
+    }
 }
 /* If we have an HTML or a GlossaNet concordance, we must write some
  * HTML closing tags. */
 if ((options->result_mode==HTML_) || (options->result_mode==GLOSSANET_) ||
-		options->result_mode==LEMMATIZE_) write_HTML_end(out);
+        options->result_mode==LEMMATIZE_) write_HTML_end(out);
 if ((options->result_mode==XML_) || (options->result_mode==XML_WITH_HEADER_)){
   u_fprintf(out,"</concord>\n");
 }
@@ -597,7 +597,7 @@ u_fclose(out);
 free(unichar_buffer);
 free_Ustring(PRLG_tag);
 if (options->result_mode==GLOSSANET_) {
-	free_string_hash(glossa_hash);
+    free_string_hash(glossa_hash);
 }
 return 0;
 }
@@ -655,11 +655,11 @@ void extract_left_context(int pos,int pos_in_char,unichar* left,struct text_toke
 int i;
 /* If there is no left context at all, we fill 'left' with spaces. */
 if (pos==0 && pos_in_char==0) {
-	for (i=0;i<option->left_context;i++) {
-		left[i]=' ';
-	}
-	left[i]='\0';
-	return;
+    for (i=0;i<option->left_context;i++) {
+        left[i]=' ';
+    }
+    left[i]='\0';
+    return;
 }
 i=0;
 int count=0;
@@ -693,32 +693,32 @@ unichar* s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
 /* We look for every token, until we have the correct number of displayable
  * characters. */
 while (pos>=0 && count<option->left_context) {
-	left[i]=s[l--];
-	if (!option->thai_mode || !is_Thai_skipable(left[i])) {
-		/* We increase the character count only we don't have a diacritic mark */
-		count++;
-	}
-	i++;
-	if (l<0) {
-		/* If we must change of token */
-		if (option->left_context_until_eos
+    left[i]=s[l--];
+    if (!option->thai_mode || !is_Thai_skipable(left[i])) {
+        /* We increase the character count only we don't have a diacritic mark */
+        count++;
+    }
+    i++;
+    if (l<0) {
+        /* If we must change of token */
+        if (option->left_context_until_eos
                     && (buffer->int_buffer_[buffer->skip+pos] == tokens->SENTENCE_MARKER))
                   break; /* token was "{S}" */
-		pos--;
-		if (pos>=0) {
-			/* And if we can, i.e. we are not at the beginning of the text */
-			l=token_length[buffer->int_buffer_[buffer->skip+pos]]-1;
-			s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
-		}
-	}
+        pos--;
+        if (pos>=0) {
+            /* And if we can, i.e. we are not at the beginning of the text */
+            l=token_length[buffer->int_buffer_[buffer->skip+pos]]-1;
+            s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
+        }
+    }
 }
 /* If it was not possible to get to correct number of characters because
  * the sequence was too close to the beginning of the text, we fill
  * 'left' with spaces. */
 if (count!=option->left_context) {
-	while (count++!=option->left_context) {
-		left[i++]=' ';
-	}
+    while (count++!=option->left_context) {
+        left[i++]=' ';
+    }
 }
 left[i]='\0';
 /* Finally, we reverse the string because we want the left context and not its mirror.
@@ -738,7 +738,7 @@ mirror(left);
  * to work on.
  */
 void extract_match(int start_pos,int start_pos_char,int end_pos,int end_pos_char,unichar* output,unichar* middle,
-					struct text_tokens* tokens,struct buffer_mapped* buffer) {
+                    struct text_tokens* tokens,struct buffer_mapped* buffer) {
 if (output!=NULL) {
    /* If there is an output, then the match is the output */
    u_strcpy(middle,output);
@@ -762,10 +762,10 @@ if (start_pos_char!=0) {
 }
 for (int i=start_pos;i<end_pos;i++) {
    k=0;
-	s=tokens->token[buffer->int_buffer_[buffer->skip+i]];
-	while (s[k]!='\0') {
-		middle[j++]=s[k++];
-	}
+    s=tokens->token[buffer->int_buffer_[buffer->skip+i]];
+    while (s[k]!='\0') {
+        middle[j++]=s[k++];
+    }
 }
 /* We write the last token */
 s=tokens->token[buffer->int_buffer_[buffer->skip+end_pos]];
@@ -815,21 +815,21 @@ if (pos==buffer->size) {
 int l=0;
 unichar* s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
 while (pos<buffer->size && count<right_context_length) {
-	right[i]=s[l++];
-	if (!option->thai_mode || !is_Thai_skipable(right[i])) count++;
-	i++;
-	if (s[l]=='\0') {
-		/* If we must change of token */
-		if (option->right_context_until_eos
+    right[i]=s[l++];
+    if (!option->thai_mode || !is_Thai_skipable(right[i])) count++;
+    i++;
+    if (s[l]=='\0') {
+        /* If we must change of token */
+        if (option->right_context_until_eos
                     && (buffer->int_buffer_[buffer->skip+pos] == tokens->SENTENCE_MARKER))
                   break; /* token was "{S}" */
-		pos++;
-		if (pos<buffer->size) {
-			/* And if we can */
-			l=0;
-			s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
-		}
-	}
+        pos++;
+        if (pos<buffer->size) {
+            /* And if we can */
+            l=0;
+            s=tokens->token[buffer->int_buffer_[buffer->skip+pos]];
+        }
+    }
 }
 /* We don't fill 'right' with spaces if we have reached the end of the text, because
  * there is no alignment problem on the right side of concordance. */
@@ -857,40 +857,40 @@ right[i]='\0';
  * not work anymore if the buffer size is too small.
  */
 int extract_href(int end_pos,unichar* href,struct text_tokens* tokens,struct buffer_mapped* buffer,
-				int open_bracket,int close_bracket) {
+                int open_bracket,int close_bracket) {
 href[0]='\0';
 if (open_bracket==-1 || close_bracket==-1) {
-	/* If there are no both open and close square brackets, there
-	 * is no chance to find any URL. */
-	return 1;
+    /* If there are no both open and close square brackets, there
+     * is no chance to find any URL. */
+    return 1;
 }
 int i=end_pos+1;
 int op=0;
 int cl=0;
 /* First, we look for [[ or ]] */
 while (i<buffer->size && op!=2 && cl!=2) {
-	if (buffer->int_buffer_[buffer->skip+i]==open_bracket) {op++;cl=0;}
-	else if (buffer->int_buffer_[buffer->skip+i]==close_bracket) {cl++;op=0;}
-	else {op=0;cl=0;}
-	i++;
+    if (buffer->int_buffer_[buffer->skip+i]==open_bracket) {op++;cl=0;}
+    else if (buffer->int_buffer_[buffer->skip+i]==close_bracket) {cl++;op=0;}
+    else {op=0;cl=0;}
+    i++;
 }
 if (cl==2) {
-	/* If we have found ]], it means that the matched sequence is part of
-	 * an URL. */
-	return 0;
+    /* If we have found ]], it means that the matched sequence is part of
+     * an URL. */
+    return 0;
 }
 if (op!=2) {
-	/* If we have reached the end of the buffer without finding [[ */
-	return 1;
+    /* If we have reached the end of the buffer without finding [[ */
+    return 1;
 }
 /* We concatenate all the tokens we find before ]] */
 while (i+1<buffer->size && (buffer->int_buffer_[buffer->skip+i]!=close_bracket || buffer->int_buffer_[buffer->skip+i+1]!=close_bracket)) {
-	u_strcat(href,tokens->token[buffer->int_buffer_[buffer->skip+i]]);
-	i++;
+    u_strcat(href,tokens->token[buffer->int_buffer_[buffer->skip+i]]);
+    i++;
 }
 if (buffer->int_buffer_[buffer->skip+i]!=close_bracket || buffer->int_buffer_[buffer->skip+i+1]!=close_bracket) {
-	/* If we don't find ]], we empty href */
-	href[0]='\0';
+    /* If we don't find ]], we empty href */
+    href[0]='\0';
 }
 return 1;
 }
@@ -917,13 +917,13 @@ void reverse_initial_vowels_thai(unichar* s) {
 int i=0;
 unichar c;
 while (s[i]!='\0') {
-	if (is_Thai_initial_vowel(s[i]) && s[i+1]!='\0') {
-		c=s[i+1];
-		s[i+1]=s[i];
-		s[i]=c;
-		i++;
-	}
-	i++;
+    if (is_Thai_initial_vowel(s[i]) && s[i+1]!='\0') {
+        c=s[i+1];
+        s[i+1]=s[i];
+        s[i]=c;
+        i++;
+    }
+    i++;
 }
 }
 
@@ -952,31 +952,31 @@ while (s[i]!='\0') {
  */
 static void group_ambiguous_outputs(struct match_list* list) {
 while (list!=NULL && list->next!=NULL) {
-	if (are_ambiguous(list,list->next)) {
-		int i;
-		unichar* s=list->next->output;
-		for (i=1;s[i]!='\0' && s[i]!='/';i++) {
-			/* We must start at 1, because the input may be the "/" character */
-		}
-		if (s[i]=='\0') {
-			/* The output does not contain / */
-			fatal_error("Missing / in group_ambiguous_outputs\n");
-		}
-		s+=i+1;
-		/* +2: +1 for \0 and +1 for the delimitor */
-		int len=u_strlen(list->output);
-		list->output=(unichar*)realloc(list->output,sizeof(unichar)*(2+len+u_strlen(s)));
-		if (list->output==NULL) {
-			fatal_alloc_error("group_ambiguous_outputs");
-		}
-		list->output[len]=LEMMATIZE_DELIMITOR;
-		u_strcpy(list->output+len+1,s);
-		struct match_list* tmp=list->next;
-		list->next=list->next->next;
-		free_match_list_element(tmp);
-	} else {
-		list=list->next;
-	}
+    if (are_ambiguous(list,list->next)) {
+        int i;
+        unichar* s=list->next->output;
+        for (i=1;s[i]!='\0' && s[i]!='/';i++) {
+            /* We must start at 1, because the input may be the "/" character */
+        }
+        if (s[i]=='\0') {
+            /* The output does not contain / */
+            fatal_error("Missing / in group_ambiguous_outputs\n");
+        }
+        s+=i+1;
+        /* +2: +1 for \0 and +1 for the delimitor */
+        int len=u_strlen(list->output);
+        list->output=(unichar*)realloc(list->output,sizeof(unichar)*(2+len+u_strlen(s)));
+        if (list->output==NULL) {
+            fatal_alloc_error("group_ambiguous_outputs");
+        }
+        list->output[len]=LEMMATIZE_DELIMITOR;
+        u_strcpy(list->output+len+1,s);
+        struct match_list* tmp=list->next;
+        list->next=list->next->next;
+        free_match_list_element(tmp);
+    } else {
+        list=list->next;
+    }
 }
 }
 
@@ -984,14 +984,14 @@ while (list!=NULL && list->next!=NULL) {
 static void add_missing_spaces(struct match_list* *list) {
 unichar U_SPACE[2]={' ','\0'};
 while (*list!=NULL && (*list)->next!=NULL) {
-	if ((*list)->m.end_pos_in_token!=(*list)->next->m.start_pos_in_token-1) {
-		/* We insert a space here */
-		struct match_list* next=(*list)->next;
-		(*list)->next=new_match((*list)->m.end_pos_in_token+1,next->m.start_pos_in_token-1,U_SPACE,0,next,NULL);
-		list=&((*list)->next->next);
-	} else {
-		list=&((*list)->next);
-	}
+    if ((*list)->m.end_pos_in_token!=(*list)->next->m.start_pos_in_token-1) {
+        /* We insert a space here */
+        struct match_list* next=(*list)->next;
+        (*list)->next=new_match((*list)->m.end_pos_in_token+1,next->m.start_pos_in_token-1,U_SPACE,0,next,NULL);
+        list=&((*list)->next->next);
+    } else {
+        list=&((*list)->next);
+    }
 }
 }
 
@@ -1008,17 +1008,17 @@ while (*list!=NULL && (*list)->next!=NULL) {
  */
 static void eliminate_codes_for_ambiguous_matches(struct match_list* list) {
 while (list!=NULL) {
-	if (list->output==NULL) {
-		fatal_error("Unexpected NULL output in eliminate_codes_for_ambiguous_matches\n");
-	}
-	if (NULL!=u_strchr(list->output,LEMMATIZE_DELIMITOR)) {
-		unichar* pos=u_strchr(list->output+1,'/');
-		if (pos==NULL) {
-			fatal_error("Internal error in eliminate_codes_for_ambiguous_matches\n");
-		}
-		*pos='\0';
-	}
-	list=list->next;
+    if (list->output==NULL) {
+        fatal_error("Unexpected NULL output in eliminate_codes_for_ambiguous_matches\n");
+    }
+    if (NULL!=u_strchr(list->output,LEMMATIZE_DELIMITOR)) {
+        unichar* pos=u_strchr(list->output+1,'/');
+        if (pos==NULL) {
+            fatal_error("Internal error in eliminate_codes_for_ambiguous_matches\n");
+        }
+        *pos='\0';
+    }
+    list=list->next;
 }
 }
 
@@ -1069,7 +1069,7 @@ struct match_list* matches;
 struct match_list* matches_tmp;
 unichar* unichar_buffer=(unichar*)malloc(sizeof(unichar)*(MAX_CONTEXT_IN_UNITS+1)*4);
 if (unichar_buffer==NULL) {
-	fatal_alloc_error("create_raw_text_concordance");
+    fatal_alloc_error("create_raw_text_concordance");
 }
 unichar* left = unichar_buffer + ((MAX_CONTEXT_IN_UNITS+1) * 0);
 unichar* middle = unichar_buffer + ((MAX_CONTEXT_IN_UNITS+1) * 1);
@@ -1082,7 +1082,7 @@ int n_units_already_read=0;
 /* First, we allocate a buffer to read the "text.cod" file */
 struct buffer_mapped* buffer=(struct buffer_mapped*)malloc(sizeof(struct buffer_mapped));
 if (buffer==NULL) {
-	fatal_alloc_error("create_raw_text_concordance");
+    fatal_alloc_error("create_raw_text_concordance");
 }
 buffer->amf=(text);
 buffer->int_buffer_=(const int*)af_get_mapfile_pointer(buffer->amf);
@@ -1097,7 +1097,7 @@ u_printf("Loading concordance index...\n");
 OutputPolicy op;
 matches=load_match_list(concordance,&op,NULL);
 if (options->result_mode==LEMMATIZE_ && op!=MERGE_OUTPUTS) {
-	fatal_error("Invalid concordance in lemmatize mode: only MERGE concordances are allowed\n");
+    fatal_error("Invalid concordance in lemmatize mode: only MERGE concordances are allowed\n");
 }
 /* In an html concordance, we have to know the match number in the
  * concord.ind file, but we need a renumber system, since in
@@ -1106,19 +1106,19 @@ if (options->result_mode==LEMMATIZE_ && op!=MERGE_OUTPUTS) {
  */
 vector_int* renumber=NULL;
 if (options->only_ambiguous) {
-	renumber=new_vector_int();
-	filter_unambiguous_outputs(&matches,renumber);
+    renumber=new_vector_int();
+    filter_unambiguous_outputs(&matches,renumber);
 }
 if (options->result_mode==LEMMATIZE_ || options->result_mode==CSV_) {
-	/* Note that this operation makes the renumber array invalid, if any,
-	 * so we delete it to avoid any problems */
-	free_vector_int(renumber);
-	renumber=NULL;
-	group_ambiguous_outputs(matches);
-	if (options->result_mode==CSV_) {
-		eliminate_codes_for_ambiguous_matches(matches);
-		add_missing_spaces(&matches);
-	}
+    /* Note that this operation makes the renumber array invalid, if any,
+     * so we delete it to avoid any problems */
+    free_vector_int(renumber);
+    renumber=NULL;
+    group_ambiguous_outputs(matches);
+    if (options->result_mode==CSV_) {
+        eliminate_codes_for_ambiguous_matches(matches);
+        add_missing_spaces(&matches);
+    }
 }
 /* Then we fill the buffer with the beginning of the text */
 buffer->size=(int)buf_map_int_pseudo_read(buffer,buffer->nb_item);
@@ -1141,31 +1141,31 @@ int concord_ind_match_number;
  * position */
 u_printf("Constructing concordance...\n");
 while (matches!=NULL) {
-	match_number++;
-	if (renumber==NULL) {
-		if (options->result_mode==LEMMATIZE_) {
-			/* We don't use that information in lemmatize mode, so we use instead
-			 * the index of the first token (that should also be the only one if
-			 * there is no problem) */
-			concord_ind_match_number=matches->m.start_pos_in_token;
-		} else {
-			concord_ind_match_number=match_number;
-		}
-	} else {
-		concord_ind_match_number=renumber->tab[match_number];
-	}
-	/* Here, we are sure that the buffer contains all the tokens we need.
-	 * We adjust 'start_pos' and 'end_pos' so that the tokens that compose
-	 * the current match are between buffer[start_pos] and buffer[end_pos]. */
-	start_pos=matches->m.start_pos_in_token-n_units_already_read;
-	end_pos=matches->m.end_pos_in_token-n_units_already_read;
-	start_pos_char=position_in_chars;
-	/* We update the position in characters so that we know how
-	 * many characters there are before buffer[start_pos]. We update
-	 * the sentence number in the same way. */
-	if (position_in_tokens>start_pos) {
-	   /* If we have to go backward, in the case a Locate made in "All matches mode" */
-	   for (int z=position_in_tokens-1; z>=start_pos; z--) {
+    match_number++;
+    if (renumber==NULL) {
+        if (options->result_mode==LEMMATIZE_) {
+            /* We don't use that information in lemmatize mode, so we use instead
+             * the index of the first token (that should also be the only one if
+             * there is no problem) */
+            concord_ind_match_number=matches->m.start_pos_in_token;
+        } else {
+            concord_ind_match_number=match_number;
+        }
+    } else {
+        concord_ind_match_number=renumber->tab[match_number];
+    }
+    /* Here, we are sure that the buffer contains all the tokens we need.
+     * We adjust 'start_pos' and 'end_pos' so that the tokens that compose
+     * the current match are between buffer[start_pos] and buffer[end_pos]. */
+    start_pos=matches->m.start_pos_in_token-n_units_already_read;
+    end_pos=matches->m.end_pos_in_token-n_units_already_read;
+    start_pos_char=position_in_chars;
+    /* We update the position in characters so that we know how
+     * many characters there are before buffer[start_pos]. We update
+     * the sentence number in the same way. */
+    if (position_in_tokens>start_pos) {
+       /* If we have to go backward, in the case a Locate made in "All matches mode" */
+       for (int z=position_in_tokens-1; z>=start_pos; z--) {
          int token_size=0;
          if (options->original_file_offsets==0 || options->uima_offsets==NULL || buffer->int_buffer_[buffer->skip+z]!=tokens->SENTENCE_MARKER) {
             token_size=token_length[buffer->int_buffer_[buffer->skip+z]];
@@ -1180,10 +1180,10 @@ while (matches!=NULL) {
             start_from_eos = 0;
          }
       }
-	   position_in_tokens=start_pos;
-	}
-	else {
-	   /* If we have to go forward */
+       position_in_tokens=start_pos;
+    }
+    else {
+       /* If we have to go forward */
       for (int z=position_in_tokens; z<start_pos; z++) {
          int token_size=0;
          if (options->original_file_offsets==0 || options->uima_offsets==NULL || buffer->int_buffer_[buffer->skip+z]!=tokens->SENTENCE_MARKER) {
@@ -1198,137 +1198,137 @@ while (matches!=NULL) {
             start_from_eos = 0;
          }
       }
-	}
-	position_in_chars=start_pos_char;
-	position_in_tokens=start_pos;
+    }
+    position_in_chars=start_pos_char;
+    position_in_tokens=start_pos;
 
-	if (matches->m.start_pos_in_token<matches->m.end_pos_in_token) {
-	   /* If the match is made of several tokens, we must set end_pos_in_char
-	    * to the beginning of the next token */
-	   int start_of_first_token=start_pos_char;
-	   start_pos_char=start_of_first_token+matches->m.start_pos_in_char;
+    if (matches->m.start_pos_in_token<matches->m.end_pos_in_token) {
+       /* If the match is made of several tokens, we must set end_pos_in_char
+        * to the beginning of the next token */
+       int start_of_first_token=start_pos_char;
+       start_pos_char=start_of_first_token+matches->m.start_pos_in_char;
 
-	   end_pos_char=start_of_first_token;
-	   end_from_eos=start_from_eos;
+       end_pos_char=start_of_first_token;
+       end_from_eos=start_from_eos;
 
-	   /* We update 'end_pos_char' in the same way */
-	   for (int z=start_pos;z<end_pos;z++) {
-	      int token_size=0;
-	      if (options->original_file_offsets==0 || options->uima_offsets==NULL || buffer->int_buffer_[buffer->skip+z]!=tokens->SENTENCE_MARKER) {
-	         token_size=token_length[buffer->int_buffer_[buffer->skip+z]];
-	      }
-	      end_pos_char=end_pos_char+token_size;
-	      end_from_eos=end_from_eos+token_size;
-	   }
-	   end_pos_char=end_pos_char+matches->m.end_pos_in_char+1;
-	   end_from_eos=end_from_eos+matches->m.end_pos_in_char+1;
-	} else {
-	   /* If we work on just one token, we can set directly start_pos_in_char
-	    * and end_pos_in_char. DO NOT SWAP THE FOLLOWING LINES! */
-	   end_pos_char=start_pos_char+matches->m.end_pos_in_char+1;
-	   start_pos_char=start_pos_char+matches->m.start_pos_in_char;
-	   end_from_eos=start_from_eos+matches->m.end_pos_in_char+1;
-	}
+       /* We update 'end_pos_char' in the same way */
+       for (int z=start_pos;z<end_pos;z++) {
+          int token_size=0;
+          if (options->original_file_offsets==0 || options->uima_offsets==NULL || buffer->int_buffer_[buffer->skip+z]!=tokens->SENTENCE_MARKER) {
+             token_size=token_length[buffer->int_buffer_[buffer->skip+z]];
+          }
+          end_pos_char=end_pos_char+token_size;
+          end_from_eos=end_from_eos+token_size;
+       }
+       end_pos_char=end_pos_char+matches->m.end_pos_in_char+1;
+       end_from_eos=end_from_eos+matches->m.end_pos_in_char+1;
+    } else {
+       /* If we work on just one token, we can set directly start_pos_in_char
+        * and end_pos_in_char. DO NOT SWAP THE FOLLOWING LINES! */
+       end_pos_char=start_pos_char+matches->m.end_pos_in_char+1;
+       start_pos_char=start_pos_char+matches->m.start_pos_in_char;
+       end_from_eos=start_from_eos+matches->m.end_pos_in_char+1;
+    }
 
-	/* Now we extract the 3 parts of the concordance */
-	extract_left_context(start_pos,matches->m.start_pos_in_char,left,tokens,options,token_length,buffer);
-	extract_match(start_pos,matches->m.start_pos_in_char,end_pos,matches->m.end_pos_in_char,matches->output,middle,tokens,buffer);
-	/* To compute the 3rd part (right context), we need to know the length of
-	 * the matched sequence in displayable characters. */
-	int match_length_in_displayable_chars;
-	if (options->thai_mode) {match_length_in_displayable_chars=u_strlen_Thai(middle);}
-	else {
-		if (options->result_mode==LEMMATIZE_) {
-			/* In lemmatize mode, we hide the output */
-			int i;
-			for (i=1;middle[i]!='/' && middle[i]!='\0';i++) {}
-			match_length_in_displayable_chars=i;
-		} else {
-			match_length_in_displayable_chars=u_strlen(middle);
-		}
-	}
-	/* Then we can compute the right context */
-	extract_right_context(end_pos,matches->m.end_pos_in_char,right,tokens,match_length_in_displayable_chars,
+    /* Now we extract the 3 parts of the concordance */
+    extract_left_context(start_pos,matches->m.start_pos_in_char,left,tokens,options,token_length,buffer);
+    extract_match(start_pos,matches->m.start_pos_in_char,end_pos,matches->m.end_pos_in_char,matches->output,middle,tokens,buffer);
+    /* To compute the 3rd part (right context), we need to know the length of
+     * the matched sequence in displayable characters. */
+    int match_length_in_displayable_chars;
+    if (options->thai_mode) {match_length_in_displayable_chars=u_strlen_Thai(middle);}
+    else {
+        if (options->result_mode==LEMMATIZE_) {
+            /* In lemmatize mode, we hide the output */
+            int i;
+            for (i=1;middle[i]!='/' && middle[i]!='\0';i++) {}
+            match_length_in_displayable_chars=i;
+        } else {
+            match_length_in_displayable_chars=u_strlen(middle);
+        }
+    }
+    /* Then we can compute the right context */
+    extract_right_context(end_pos,matches->m.end_pos_in_char,right,tokens,match_length_in_displayable_chars,
                               options,buffer);
-	/* If we must produce a GlossaNet concordance, we look for a URL. After the
-	 * function call, 'is_a_good_match' can be set to 0 if the match
-	 * was a part of a URL instead of a valid match. */
-	if (expected_result==GLOSSANET_) {
-		is_a_good_match=extract_href(end_pos,href,tokens,buffer,open_bracket,close_bracket);
-	}
-	/* We compute the shift due to the new lines that count for 2 characters */
-	unichar positions[1024];
-	unichar positions_from_eos[100];
-	/* And we use it to compute the bounds of the matched sequence in characters
-	 * from the beginning of the text file. */
-	int shift=get_shift(n_enter_char,enter_pos,matches->m.start_pos_in_token,options->snt_offsets);
-	start_pos_char=start_pos_char+shift;
-	/* The shift value can be different at the end of the match since new lines
-	 * can occur inside a match. We add +1 because the last token of the match may
-	 * contain itself a shift, and get_shift returns the shift before the given
-	 * position */
-	shift=get_shift(n_enter_char,enter_pos,matches->m.end_pos_in_token+1,options->snt_offsets);
-	end_pos_char=end_pos_char+shift;
-	if ((options->only_matches || options->original_file_offsets) && options->uima_offsets!=NULL) {
-		/* In UIMA mode, we use the offset file to produce start and end positions
-		 * relative to the original input file, before any Unitex operation */
-		int first_token=matches->m.start_pos_in_token;
-		int last_token=matches->m.end_pos_in_token;
-		start_pos_char=uima_offset_token_start_pos(options->uima_offsets,first_token);
-		end_pos_char=uima_offset_token_end_pos(options->uima_offsets,last_token);
-	}
-	/* Finally, we copy the sequence bounds and t he sentence number into 'positions'. */
-	u_sprintf(positions,"\t%d %d %d %d",start_pos_char,end_pos_char,current_sentence,concord_ind_match_number);
-	const unichar* closest_tag=NULL;
-	if (options->PRLG_data!=NULL) {
-		int first_token=matches->m.start_pos_in_token;
-		int offset_in_original_file=uima_offset_token_start_pos(options->uima_offsets,first_token);
-		closest_tag=get_closest_PRLG_tag(options->PRLG_data,offset_in_original_file);
-	}
-	u_sprintf(positions_from_eos,"%d\t%d\t%d",current_sentence,start_from_eos,end_from_eos);
-	/* Now we save the concordance line to the output file, but only if
-	 * it's a valid match. */
-	if (is_a_good_match) {
-		if (options->sort_mode!=TEXT_ORDER) {
-			/* If we must reverse the left context in thai mode,
-			 * we must reverse initial vowels with their following consonants. */
-			if (options->thai_mode) {
-				reverse_initial_vowels_thai(left);
-			}
-		}
-		/* We save the 3 parts of the concordance line according to the sort mode */
-		switch(options->sort_mode) {
-			case TEXT_ORDER:
-			if(expected_result==XALIGN_) u_fprintf(output,"%S\t%S",positions_from_eos,middle);
-				else u_fprintf(output,"%S\t%S\t%S",left,middle,right);
-				break;
-			case LEFT_CENTER:  u_fprintf(output,"%R\t%S\t%S",left,middle,right); break;
-			case LEFT_RIGHT:   u_fprintf(output,"%R\t%S\t%S",left,right,middle); break;
-			case CENTER_LEFT:  u_fprintf(output,"%S\t%R\t%S",middle,left,right); break;
-			case CENTER_RIGHT: u_fprintf(output,"%S\t%S\t%R",middle,right,left);	break;
-			case RIGHT_LEFT:   u_fprintf(output,"%S\t%R\t%S",right,left,middle); break;
-			case RIGHT_CENTER: u_fprintf(output,"%S\t%S\t%R",right,middle,left);	break;
-		}
-		/* And we add the position information */
-		if(expected_result!=XALIGN_) u_fputs(positions,output);
-		/* And the GlossaNet URL if needed */
-		if (expected_result==GLOSSANET_) {
-			u_fprintf(output,"\t%S",href);
-		}
-		if (closest_tag!=NULL) {
-			u_fprintf(output,"%C[%S",PRLG_DELIMITOR,closest_tag);
-			int padding=options->PRLG_data->max_width-u_strlen(closest_tag);
-			for (int k=0;k<padding;k++) u_fprintf(output," ");
-			u_fprintf(output,"]");
-		}
-		u_fprintf(output,"\n");
-		/* We increase the number of matches actually written to the output */
-		number_of_matches++;
-	}
-	/* Finally, we go on the next match */
-	matches_tmp=matches;
-	matches=matches->next;
-	free_match_list_element(matches_tmp);
+    /* If we must produce a GlossaNet concordance, we look for a URL. After the
+     * function call, 'is_a_good_match' can be set to 0 if the match
+     * was a part of a URL instead of a valid match. */
+    if (expected_result==GLOSSANET_) {
+        is_a_good_match=extract_href(end_pos,href,tokens,buffer,open_bracket,close_bracket);
+    }
+    /* We compute the shift due to the new lines that count for 2 characters */
+    unichar positions[1024];
+    unichar positions_from_eos[100];
+    /* And we use it to compute the bounds of the matched sequence in characters
+     * from the beginning of the text file. */
+    int shift=get_shift(n_enter_char,enter_pos,matches->m.start_pos_in_token,options->snt_offsets);
+    start_pos_char=start_pos_char+shift;
+    /* The shift value can be different at the end of the match since new lines
+     * can occur inside a match. We add +1 because the last token of the match may
+     * contain itself a shift, and get_shift returns the shift before the given
+     * position */
+    shift=get_shift(n_enter_char,enter_pos,matches->m.end_pos_in_token+1,options->snt_offsets);
+    end_pos_char=end_pos_char+shift;
+    if ((options->only_matches || options->original_file_offsets) && options->uima_offsets!=NULL) {
+        /* In UIMA mode, we use the offset file to produce start and end positions
+         * relative to the original input file, before any Unitex operation */
+        int first_token=matches->m.start_pos_in_token;
+        int last_token=matches->m.end_pos_in_token;
+        start_pos_char=uima_offset_token_start_pos(options->uima_offsets,first_token);
+        end_pos_char=uima_offset_token_end_pos(options->uima_offsets,last_token);
+    }
+    /* Finally, we copy the sequence bounds and t he sentence number into 'positions'. */
+    u_sprintf(positions,"\t%d %d %d %d",start_pos_char,end_pos_char,current_sentence,concord_ind_match_number);
+    const unichar* closest_tag=NULL;
+    if (options->PRLG_data!=NULL) {
+        int first_token=matches->m.start_pos_in_token;
+        int offset_in_original_file=uima_offset_token_start_pos(options->uima_offsets,first_token);
+        closest_tag=get_closest_PRLG_tag(options->PRLG_data,offset_in_original_file);
+    }
+    u_sprintf(positions_from_eos,"%d\t%d\t%d",current_sentence,start_from_eos,end_from_eos);
+    /* Now we save the concordance line to the output file, but only if
+     * it's a valid match. */
+    if (is_a_good_match) {
+        if (options->sort_mode!=TEXT_ORDER) {
+            /* If we must reverse the left context in thai mode,
+             * we must reverse initial vowels with their following consonants. */
+            if (options->thai_mode) {
+                reverse_initial_vowels_thai(left);
+            }
+        }
+        /* We save the 3 parts of the concordance line according to the sort mode */
+        switch(options->sort_mode) {
+            case TEXT_ORDER:
+            if(expected_result==XALIGN_) u_fprintf(output,"%S\t%S",positions_from_eos,middle);
+                else u_fprintf(output,"%S\t%S\t%S",left,middle,right);
+                break;
+            case LEFT_CENTER:  u_fprintf(output,"%R\t%S\t%S",left,middle,right); break;
+            case LEFT_RIGHT:   u_fprintf(output,"%R\t%S\t%S",left,right,middle); break;
+            case CENTER_LEFT:  u_fprintf(output,"%S\t%R\t%S",middle,left,right); break;
+            case CENTER_RIGHT: u_fprintf(output,"%S\t%S\t%R",middle,right,left);    break;
+            case RIGHT_LEFT:   u_fprintf(output,"%S\t%R\t%S",right,left,middle); break;
+            case RIGHT_CENTER: u_fprintf(output,"%S\t%S\t%R",right,middle,left);    break;
+        }
+        /* And we add the position information */
+        if(expected_result!=XALIGN_) u_fputs(positions,output);
+        /* And the GlossaNet URL if needed */
+        if (expected_result==GLOSSANET_) {
+            u_fprintf(output,"\t%S",href);
+        }
+        if (closest_tag!=NULL) {
+            u_fprintf(output,"%C[%S",PRLG_DELIMITOR,closest_tag);
+            int padding=options->PRLG_data->max_width-u_strlen(closest_tag);
+            for (int k=0;k<padding;k++) u_fprintf(output," ");
+            u_fprintf(output,"]");
+        }
+        u_fprintf(output,"\n");
+        /* We increase the number of matches actually written to the output */
+        number_of_matches++;
+    }
+    /* Finally, we go on the next match */
+    matches_tmp=matches;
+    matches=matches->next;
+    free_match_list_element(matches_tmp);
 }
 af_release_mapfile_pointer(buffer->amf,buffer->int_buffer_);
 free_vector_int(renumber);
@@ -1347,39 +1347,39 @@ return number_of_matches;
  * returns the updated current position in the 'pos_in_enter_pos' array.
  */
 static int fprint_token(U_FILE* output,int convLFtoCRLF,struct text_tokens* tokens,long int offset_in_buffer,
-				int current_global_position,int n_enter_char,const int* enter_pos, int* len_written,
-				int pos_in_enter_pos,struct buffer_mapped* buffer) {
+                int current_global_position,int n_enter_char,const int* enter_pos, int* len_written,
+                int pos_in_enter_pos,struct buffer_mapped* buffer) {
 /* We look for the new line that is closer (but after) to the token to print */
 while (pos_in_enter_pos < n_enter_char) {
-	if ((current_global_position+offset_in_buffer) < enter_pos[pos_in_enter_pos]) {
-		/* We have found the new line that follows the token to print, so
-		 * we can stop. */
-		break;
-	}
-	else if ((current_global_position+offset_in_buffer) > enter_pos[pos_in_enter_pos]) {
-		/* The current new line is still before the token to print, so we go on */
-		pos_in_enter_pos++;
-		continue;
-	}
-	else if ((current_global_position+offset_in_buffer) == enter_pos[pos_in_enter_pos]) {
-		/* The token to print is a new line, so we print it and return */
-		pos_in_enter_pos++;
-		if (output != NULL) {
-			u_fputc_conv_lf_to_crlf_option((unichar)'\n', output, convLFtoCRLF);
-		}
-		if (len_written != NULL) {
-			(*len_written) += 1+convLFtoCRLF;
-		}
-		return pos_in_enter_pos;
-	}
+    if ((current_global_position+offset_in_buffer) < enter_pos[pos_in_enter_pos]) {
+        /* We have found the new line that follows the token to print, so
+         * we can stop. */
+        break;
+    }
+    else if ((current_global_position+offset_in_buffer) > enter_pos[pos_in_enter_pos]) {
+        /* The current new line is still before the token to print, so we go on */
+        pos_in_enter_pos++;
+        continue;
+    }
+    else if ((current_global_position+offset_in_buffer) == enter_pos[pos_in_enter_pos]) {
+        /* The token to print is a new line, so we print it and return */
+        pos_in_enter_pos++;
+        if (output != NULL) {
+            u_fputc_conv_lf_to_crlf_option((unichar)'\n', output, convLFtoCRLF);
+        }
+        if (len_written != NULL) {
+            (*len_written) += 1+convLFtoCRLF;
+        }
+        return pos_in_enter_pos;
+    }
 }
 /* The token to print is not a new line, so we print it and return */
 const unichar* token_to_write=tokens->token[buffer->int_buffer_[buffer->skip + offset_in_buffer]];
 if (output != NULL) {
-	u_fputs_conv_lf_to_crlf_option(token_to_write, output, convLFtoCRLF);
+    u_fputs_conv_lf_to_crlf_option(token_to_write, output, convLFtoCRLF);
 }
 if (len_written != NULL) {
-	(*len_written) += (int)u_strlen(token_to_write);
+    (*len_written) += (int)u_strlen(token_to_write);
 }
 return pos_in_enter_pos;
 }
@@ -1394,9 +1394,9 @@ return pos_in_enter_pos;
  * The function also makes sure that the last token #match_end has been loaded into the buffer.
  */
 static int move_in_text_with_writing(int match_start,int match_end,ABSTRACTMAPFILE* /*text*/,struct text_tokens* tokens,
-								int current_global_position,U_FILE* output,int convLFtoCRLF,int* len_written,int* len_skipped,
-								int n_enter_char,const int* enter_pos,int pos_in_enter_pos,
-								struct buffer_mapped* buffer,int *pos_int_char) {
+                                int current_global_position,U_FILE* output,int convLFtoCRLF,int* len_written,int* len_skipped,
+                                int n_enter_char,const int* enter_pos,int pos_in_enter_pos,
+                                struct buffer_mapped* buffer,int *pos_int_char) {
 buf_map_int_pseudo_seek(buffer,current_global_position);
 int last_pos_to_be_loaded=match_end+1;
 /* We read what we want to write in the output file + all the tokens of the match */
@@ -1407,18 +1407,18 @@ if (buffer->size>0) {
 }
 int last_pos_to_be_written=buffer->size-(match_end+1-match_start);
 for (int i=0;i<last_pos_to_be_written;i++) {
-	pos_in_enter_pos=fprint_token(output,convLFtoCRLF,tokens,i,current_global_position,
-									n_enter_char,enter_pos,len_written,pos_in_enter_pos,
-									buffer);
+    pos_in_enter_pos=fprint_token(output,convLFtoCRLF,tokens,i,current_global_position,
+                                    n_enter_char,enter_pos,len_written,pos_in_enter_pos,
+                                    buffer);
 }
 
 
 if (len_skipped != NULL) {
-	for (int i = last_pos_to_be_written;i+0<buffer->size;i++) {
-		pos_in_enter_pos=fprint_token(NULL, convLFtoCRLF,tokens, i, current_global_position,
-			n_enter_char, enter_pos, len_skipped, pos_in_enter_pos,
-			buffer);
-	}
+    for (int i = last_pos_to_be_written;i+0<buffer->size;i++) {
+        pos_in_enter_pos=fprint_token(NULL, convLFtoCRLF,tokens, i, current_global_position,
+            n_enter_char, enter_pos, len_skipped, pos_in_enter_pos,
+            buffer);
+    }
 }
 return pos_in_enter_pos;
 }
@@ -1429,18 +1429,18 @@ return pos_in_enter_pos;
  * the end.
  */
 static int move_to_end_of_text_with_writing(ABSTRACTMAPFILE* /*text*/,struct text_tokens* tokens,
-									int current_global_position,U_FILE* output,int convLFtoCRLF,int* len_written,
-									int n_enter_char,const int* enter_pos,int pos_in_enter_pos,
-									struct buffer_mapped* buffer) {
+                                    int current_global_position,U_FILE* output,int convLFtoCRLF,int* len_written,
+                                    int n_enter_char,const int* enter_pos,int pos_in_enter_pos,
+                                    struct buffer_mapped* buffer) {
 //long int address=current_global_position*sizeof(int);
 //fseek(text,address,SEEK_SET);
 buf_map_int_pseudo_seek(buffer,current_global_position);
 //while (0!=(buffer->size = (int)fread(buffer->int_buffer,sizeof(int),buffer->MAXIMUM_BUFFER_SIZE,text))) {
 while (0!=(buffer->size = (int)buf_map_int_pseudo_read(buffer,buffer->nb_item))) {
-	for (long address=0;address<buffer->size;address++) {
-		pos_in_enter_pos=fprint_token(output,convLFtoCRLF,tokens,address,current_global_position,
-										n_enter_char,enter_pos,len_written,pos_in_enter_pos,buffer);
-	}
+    for (long address=0;address<buffer->size;address++) {
+        pos_in_enter_pos=fprint_token(output,convLFtoCRLF,tokens,address,current_global_position,
+                                        n_enter_char,enter_pos,len_written,pos_in_enter_pos,buffer);
+    }
    current_global_position = current_global_position+(int)buffer->nb_item;
 }
 return pos_in_enter_pos;
@@ -1463,13 +1463,13 @@ static void create_modified_text_file(const VersatileEncodingConfig* vec,U_FILE*
                                       const char* offset_file_name, vector_offset* v_offsets) {
 U_FILE* output=u_fopen(vec,output_name,U_WRITE);
 if (output==NULL) {
-	u_fclose(concordance);
-	af_close_mapfile(text);
-	fatal_error("Cannot write file %s\n",output_name);
+    u_fclose(concordance);
+    af_close_mapfile(text);
+    fatal_error("Cannot write file %s\n",output_name);
 }
 U_FILE* f_offsets=NULL;
 if ((offset_file_name!=NULL) && ((*offset_file_name)!='\0')) {
-	f_offsets=u_fopen(vec, offset_file_name, U_WRITE);
+    f_offsets=u_fopen(vec, offset_file_name, U_WRITE);
 }
 int do_offset_compute = f_offsets || v_offsets;
 struct match_list* matches;
@@ -1493,117 +1493,117 @@ int pos_in_enter_pos=0;
 int pos_original_tokenized=0;
 u_printf("Merging outputs with text...\n");
 while (matches!=NULL) {
-	while (matches!=NULL &&
-	          (matches->m.start_pos_in_token<current_global_position_in_token
-	            || (matches->m.start_pos_in_token==current_global_position_in_token && matches->m.start_pos_in_char<current_global_position_in_char)
-	           )
-	       ) {
-		/* If we must ignore this match because it is overlapping a previous match */
-		matches_tmp=matches;
-		matches=matches->next;
-		free_match_list_element(matches_tmp);
-	}
-	if (matches!=NULL) {
-		/* There, we are sure that we have a valid match to process */
-		int pos_in_output_before=pos_in_output;
-		int size_skipped=0;
+    while (matches!=NULL &&
+              (matches->m.start_pos_in_token<current_global_position_in_token
+                || (matches->m.start_pos_in_token==current_global_position_in_token && matches->m.start_pos_in_char<current_global_position_in_char)
+               )
+           ) {
+        /* If we must ignore this match because it is overlapping a previous match */
+        matches_tmp=matches;
+        matches=matches->next;
+        free_match_list_element(matches_tmp);
+    }
+    if (matches!=NULL) {
+        /* There, we are sure that we have a valid match to process */
+        int pos_in_output_before=pos_in_output;
+        int size_skipped=0;
 
-		int copied_begin_first_token = 0;
+        int copied_begin_first_token = 0;
 
-		pos_in_enter_pos=move_in_text_with_writing(matches->m.start_pos_in_token,matches->m.end_pos_in_token,text,tokens,
-													current_global_position_in_token,output,convLFtoCRLF,
-													do_offset_compute ? (&pos_in_output) : NULL,
-													do_offset_compute ? (&size_skipped) : NULL,
-													n_enter_char,enter_pos,pos_in_enter_pos,
-													buffer,&current_global_position_in_char);
-		int size_copied=pos_in_output-pos_in_output_before;
-		pos_original_tokenized+=size_copied;
-		/* Now, we are sure that the buffer contains all we want */
-		/* If the match doesn't start at the beginning of the token, we add the prefix */
-		int zz=matches->m.start_pos_in_token-current_global_position_in_token;
-		size_t pos_token_original_before_match=buffer->skip+zz;
-		unichar* first_token=tokens->token[buffer->int_buffer_[pos_token_original_before_match]];
-		if ((uima_offsets != NULL) && (matches->m.start_pos_in_token < uima_offset_tokens_count(uima_offsets))) {
-			pos_in_original = uima_offset_token_start_pos(uima_offsets,matches->m.start_pos_in_token);
-		}
-		for (int i=current_global_position_in_char;i<matches->m.start_pos_in_char;i++) {
-		   u_fputc_conv_lf_to_crlf_option(first_token[i],output,convLFtoCRLF);
-		   pos_in_output++;
-		   pos_in_original++;
-		   pos_original_tokenized++;
-		   copied_begin_first_token++;
-		}
-		int pos_in_output_before_match=pos_in_output;
-		if (matches->output!=NULL) {
-			u_fputs_conv_lf_to_crlf_option(matches->output,output,convLFtoCRLF);
-			pos_in_output+=(int)u_strlen(matches->output);
-		}
-		zz=matches->m.end_pos_in_token-current_global_position_in_token;
-		size_t pos_token_original_after_match = buffer->skip + zz;
-		unichar* last_token=tokens->token[buffer->int_buffer_[pos_token_original_after_match]];
-		int pos_end_in_original=0;
-		if ((uima_offsets != NULL) && (matches->m.end_pos_in_token < uima_offset_tokens_count(uima_offsets))) {
-			pos_end_in_original = uima_offset_token_start_pos(uima_offsets,matches->m.end_pos_in_token);
-			pos_end_in_original += matches->m.end_pos_in_char;
-		}
-
-
-		if (last_token[matches->m.end_pos_in_char+1]=='\0') {
-		   /* If we have completely consumed the last token of the match */
-		   current_global_position_in_token=matches->m.end_pos_in_token+1;
-		   current_global_position_in_char=0;
-		} else {
-		   current_global_position_in_token=matches->m.end_pos_in_token;
-		   current_global_position_in_char=matches->m.end_pos_in_char+1;
-		}
-		/* If it was the last match or if the next match starts on another token,
-		 * we dump the end of the current token, if any */
-		int nb_char_from_last_token=0;
-		if (current_global_position_in_char!=0 &&
-		      (matches->next==NULL || matches->next->m.start_pos_in_token!=current_global_position_in_token)) {
-		   for (int i=current_global_position_in_char;last_token[i]!='\0';i++) {
-		      u_fputc_conv_lf_to_crlf_option(last_token[i],output,convLFtoCRLF);
-			  nb_char_from_last_token++;
-		   }
-		   /* We update the position in tokens so that 'move_to_end_of_text_with_writing'
-		    * will work fine */
-		   current_global_position_in_token++;
-		}
+        pos_in_enter_pos=move_in_text_with_writing(matches->m.start_pos_in_token,matches->m.end_pos_in_token,text,tokens,
+                                                    current_global_position_in_token,output,convLFtoCRLF,
+                                                    do_offset_compute ? (&pos_in_output) : NULL,
+                                                    do_offset_compute ? (&size_skipped) : NULL,
+                                                    n_enter_char,enter_pos,pos_in_enter_pos,
+                                                    buffer,&current_global_position_in_char);
+        int size_copied=pos_in_output-pos_in_output_before;
+        pos_original_tokenized+=size_copied;
+        /* Now, we are sure that the buffer contains all we want */
+        /* If the match doesn't start at the beginning of the token, we add the prefix */
+        int zz=matches->m.start_pos_in_token-current_global_position_in_token;
+        size_t pos_token_original_before_match=buffer->skip+zz;
+        unichar* first_token=tokens->token[buffer->int_buffer_[pos_token_original_before_match]];
+        if ((uima_offsets != NULL) && (matches->m.start_pos_in_token < uima_offset_tokens_count(uima_offsets))) {
+            pos_in_original = uima_offset_token_start_pos(uima_offsets,matches->m.start_pos_in_token);
+        }
+        for (int i=current_global_position_in_char;i<matches->m.start_pos_in_char;i++) {
+           u_fputc_conv_lf_to_crlf_option(first_token[i],output,convLFtoCRLF);
+           pos_in_output++;
+           pos_in_original++;
+           pos_original_tokenized++;
+           copied_begin_first_token++;
+        }
+        int pos_in_output_before_match=pos_in_output;
+        if (matches->output!=NULL) {
+            u_fputs_conv_lf_to_crlf_option(matches->output,output,convLFtoCRLF);
+            pos_in_output+=(int)u_strlen(matches->output);
+        }
+        zz=matches->m.end_pos_in_token-current_global_position_in_token;
+        size_t pos_token_original_after_match = buffer->skip + zz;
+        unichar* last_token=tokens->token[buffer->int_buffer_[pos_token_original_after_match]];
+        int pos_end_in_original=0;
+        if ((uima_offsets != NULL) && (matches->m.end_pos_in_token < uima_offset_tokens_count(uima_offsets))) {
+            pos_end_in_original = uima_offset_token_start_pos(uima_offsets,matches->m.end_pos_in_token);
+            pos_end_in_original += matches->m.end_pos_in_char;
+        }
 
 
-		if (f_offsets && uima_offsets) {
-			u_fprintf(f_offsets, "%d %d %d %d\n", pos_in_original, pos_end_in_original + 1, pos_in_output_before_match, pos_in_output);
-		}
+        if (last_token[matches->m.end_pos_in_char+1]=='\0') {
+           /* If we have completely consumed the last token of the match */
+           current_global_position_in_token=matches->m.end_pos_in_token+1;
+           current_global_position_in_char=0;
+        } else {
+           current_global_position_in_token=matches->m.end_pos_in_token;
+           current_global_position_in_char=matches->m.end_pos_in_char+1;
+        }
+        /* If it was the last match or if the next match starts on another token,
+         * we dump the end of the current token, if any */
+        int nb_char_from_last_token=0;
+        if (current_global_position_in_char!=0 &&
+              (matches->next==NULL || matches->next->m.start_pos_in_token!=current_global_position_in_token)) {
+           for (int i=current_global_position_in_char;last_token[i]!='\0';i++) {
+              u_fputc_conv_lf_to_crlf_option(last_token[i],output,convLFtoCRLF);
+              nb_char_from_last_token++;
+           }
+           /* We update the position in tokens so that 'move_to_end_of_text_with_writing'
+            * will work fine */
+           current_global_position_in_token++;
+        }
 
-		if (f_offsets && (!uima_offsets)) {
-			u_fprintf(f_offsets, "%d %d %d %d\n", pos_original_tokenized, pos_original_tokenized + ((size_skipped - copied_begin_first_token) - nb_char_from_last_token),
-				pos_in_output_before_match, pos_in_output);
-		}
 
-		if (v_offsets) {
-			vector_offset_add(v_offsets, pos_original_tokenized, pos_original_tokenized + ((size_skipped - copied_begin_first_token) - nb_char_from_last_token),
-				pos_in_output_before_match, pos_in_output);
-		}
+        if (f_offsets && uima_offsets) {
+            u_fprintf(f_offsets, "%d %d %d %d\n", pos_in_original, pos_end_in_original + 1, pos_in_output_before_match, pos_in_output);
+        }
 
-		pos_original_tokenized += ((size_skipped - copied_begin_first_token));
-		pos_in_output+=nb_char_from_last_token;
+        if (f_offsets && (!uima_offsets)) {
+            u_fprintf(f_offsets, "%d %d %d %d\n", pos_original_tokenized, pos_original_tokenized + ((size_skipped - copied_begin_first_token) - nb_char_from_last_token),
+                pos_in_output_before_match, pos_in_output);
+        }
 
-		/* We skip to the next match of the list */
-		matches_tmp=matches;
-		matches=matches->next;
-		free_match_list_element(matches_tmp);
-	}
+        if (v_offsets) {
+            vector_offset_add(v_offsets, pos_original_tokenized, pos_original_tokenized + ((size_skipped - copied_begin_first_token) - nb_char_from_last_token),
+                pos_in_output_before_match, pos_in_output);
+        }
+
+        pos_original_tokenized += ((size_skipped - copied_begin_first_token));
+        pos_in_output+=nb_char_from_last_token;
+
+        /* We skip to the next match of the list */
+        matches_tmp=matches;
+        matches=matches->next;
+        free_match_list_element(matches_tmp);
+    }
 }
 /* Finally, we don't forget to dump all the text that may remain after the
  * last match. */
 move_to_end_of_text_with_writing(text,tokens,current_global_position_in_token,output,convLFtoCRLF,
-								do_offset_compute ? (&pos_in_output) : NULL,
-								n_enter_char,enter_pos,pos_in_enter_pos,buffer);
+                                do_offset_compute ? (&pos_in_output) : NULL,
+                                n_enter_char,enter_pos,pos_in_enter_pos,buffer);
 af_release_mapfile_pointer(buffer->amf,buffer->int_buffer_);
 free(buffer);
 u_fclose(output);
 if (f_offsets) {
-	u_fclose(f_offsets);
+    u_fclose(f_offsets);
 }
 u_printf("Done.\n");
 }

--- a/Contexts.cpp
+++ b/Contexts.cpp
@@ -261,7 +261,7 @@ void set_list_context_output(struct list_context* l, const unichar* output)
 	if (l->output_allocated == NULL)
 	{
 		unsigned int len = u_strlen(output);
-		
+
 		if (len < (INTERNAL_OUTPUT_BUFFER_SIZE))
 		{
 			l->output = l->internal_output_buffer;

--- a/Contexts.cpp
+++ b/Contexts.cpp
@@ -246,7 +246,7 @@ return contexts;
 struct list_context* new_list_context(int n,struct list_context* next,Abstract_allocator prv_alloc) {
 struct list_context* l=(struct list_context*)malloc_cb(sizeof(struct list_context),prv_alloc);
 if (l==NULL) {
-	fatal_alloc_error("new_list_context");
+    fatal_alloc_error("new_list_context");
 }
 l->n=n;
 l->output=NULL;
@@ -258,27 +258,27 @@ return l;
 
 void set_list_context_output(struct list_context* l, const unichar* output)
 {
-	if (l->output_allocated == NULL)
-	{
-		unsigned int len = u_strlen(output);
+    if (l->output_allocated == NULL)
+    {
+        unsigned int len = u_strlen(output);
 
-		if (len < (INTERNAL_OUTPUT_BUFFER_SIZE))
-		{
-			l->output = l->internal_output_buffer;
-			memcpy(l->internal_output_buffer, output, sizeof(unichar) * (len+1));
-			return ;
-		}
-		else
-		{
-			l->output = l->output_allocated = (unichar*)malloc(sizeof(unichar) * (len+1));
-			memcpy(l->output, output, sizeof(unichar) * (len+1));
-			return;
-		}
-	}
+        if (len < (INTERNAL_OUTPUT_BUFFER_SIZE))
+        {
+            l->output = l->internal_output_buffer;
+            memcpy(l->internal_output_buffer, output, sizeof(unichar) * (len+1));
+            return ;
+        }
+        else
+        {
+            l->output = l->output_allocated = (unichar*)malloc(sizeof(unichar) * (len+1));
+            memcpy(l->output, output, sizeof(unichar) * (len+1));
+            return;
+        }
+    }
 
-	free(l->output_allocated);
-	l->output_allocated = NULL;
-	set_list_context_output(l, output);
+    free(l->output_allocated);
+    l->output_allocated = NULL;
+    set_list_context_output(l, output);
 }
 
 /**

--- a/Contexts.h
+++ b/Contexts.h
@@ -33,7 +33,7 @@
 namespace unitex {
 
 /**
- * This structure stores the information needed to deal with 
+ * This structure stores the information needed to deal with
  * the context marks $[ $![ and $]
  * If fst2 state has a transition with a positive context start mark $[, we compute
  * one time for all where the associated context end marks are. This is useful to
@@ -43,7 +43,7 @@ namespace unitex {
 struct opt_contexts {
    /* This is an array used to store both the positive context start marks and
     * their associated ending context marks.
-    * 
+    *
     * positive_mark[i] will contain the context transition and positive_mark[i+1] will
     * contain the context end transitions. */
    Transition** positive_mark;
@@ -64,12 +64,12 @@ struct opt_contexts {
 
 #define INTERNAL_OUTPUT_BUFFER_SIZE 0x20
 struct list_context {
-	int n;
-	unichar* output_allocated;
-	unichar* output;
-	struct list_context* next;
+    int n;
+    unichar* output_allocated;
+    unichar* output;
+    struct list_context* next;
 
-	unichar internal_output_buffer[INTERNAL_OUTPUT_BUFFER_SIZE];
+    unichar internal_output_buffer[INTERNAL_OUTPUT_BUFFER_SIZE];
 };
 
 void get_reachable_closing_context_marks(Fst2*,int,Transition**,Abstract_allocator prv_alloc=STANDARD_ALLOCATOR);

--- a/Convert.cpp
+++ b/Convert.cpp
@@ -150,7 +150,7 @@ bool only_verify_arguments = false;
 UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_Convert,lopts_Convert,&index))) {
    switch(val) {
-   case 'k': 
+   case 'k':
    case 's': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty source encoding\n");
                 free_encodings_context(encoding_ctx);
@@ -178,8 +178,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Convert,lopts_Convert,&i
    case 7: encode_control_characters=1; break;
 
 
-   case 'm': print_encoding_main_names(encoding_ctx); 
-             free_encodings_context(encoding_ctx); 
+   case 'm': print_encoding_main_names(encoding_ctx);
+             free_encodings_context(encoding_ctx);
              return SUCCESS_RETURN_CODE;
    case 'a': print_encoding_main_names(encoding_ctx);
              print_encoding_aliases(encoding_ctx);
@@ -194,14 +194,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Convert,lopts_Convert,&i
                 return USAGE_ERROR_CODE;
              }
              print_encoding_infos(encoding_ctx,options.vars()->optarg);
-             free_encodings_context(encoding_ctx); 
+             free_encodings_context(encoding_ctx);
              return SUCCESS_RETURN_CODE;
    case 'F': format=CONV_DELAF_FILE; break;
    case 'S': format=CONV_DELAS_FILE; break;
    case 'V': only_verify_arguments = true;
-             break;     
-   case 'h': usage(); 
-             free_encodings_context(encoding_ctx); 
+             break;
+   case 'h': usage();
+             free_encodings_context(encoding_ctx);
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Convert[index].name);
@@ -209,7 +209,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Convert,lopts_Convert,&i
              return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
-             free_encodings_context(encoding_ctx);                         
+             free_encodings_context(encoding_ctx);
              return USAGE_ERROR_CODE;
    }
    index=-1;
@@ -218,7 +218,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Convert,lopts_Convert,&i
 if (src[0]=='\0') {
   error("You must specify the source encoding\n");
   free_encodings_context(encoding_ctx);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 if (dest[0]=='\0') {
    strcpy(dest,"utf16-le");
@@ -226,30 +226,30 @@ if (dest[0]=='\0') {
 if (options.vars()->optind==argc) {
   error("Invalid arguments: rerun with --help\n");
   free_encodings_context(encoding_ctx);
-  return USAGE_ERROR_CODE;    
+  return USAGE_ERROR_CODE;
 }
 const struct encoding* src_encoding=get_encoding(encoding_ctx,src);
 if (src_encoding==NULL) {
   error("%s is not a valid encoding name\n",src);
   free_encodings_context(encoding_ctx);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 const struct encoding* dest_encoding=get_encoding(encoding_ctx,dest);
 if (dest_encoding==NULL) {
   error("%s is not a valid encoding name\n",dest);
   free_encodings_context(encoding_ctx);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 
 if ((output_mode == OUTPUT_EXPLICIT_FILENAME) && ((options.vars()->optind+1)!=argc)) {
   error("explicit output filename need exactly one input file\n");
   free_encodings_context(encoding_ctx);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
   // freeing all allocated memory
-  free_encodings_context(encoding_ctx);  
+  free_encodings_context(encoding_ctx);
   return SUCCESS_RETURN_CODE;
 }
 
@@ -259,26 +259,26 @@ if (only_verify_arguments) {
  */
 U_FILE* input=NULL;
 U_FILE* output=NULL;
-int error_code=CONVERSION_OK;  
+int error_code=CONVERSION_OK;
 for (int i=options.vars()->optind;i<argc;i++) {
   /*
    * We set input and output file names according to the output mode
    */
   switch (output_mode) {
-    case OUTPUT_EXPLICIT_FILENAME: 
-          strcpy(input_name,argv[i]); 
+    case OUTPUT_EXPLICIT_FILENAME:
+          strcpy(input_name,argv[i]);
           break;
     case REPLACE_FILE:
           strcpy(input_name,argv[i]);
           add_suffix_to_file_name(output_name,input_name,"_TEMP");
           break;
-    case PREFIX_SRC: 
+    case PREFIX_SRC:
           strcpy(output_name,argv[i]);
           add_prefix_to_file_name(input_name,output_name,FX);
           af_remove(input_name);
           af_rename(argv[i],input_name);
           break;
-    case SUFFIX_SRC: 
+    case SUFFIX_SRC:
           strcpy(output_name,argv[i]);
           add_suffix_to_file_name(input_name,output_name,FX);
           af_remove(input_name);
@@ -333,7 +333,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
     u_fclose(input);
     u_fclose(output);
     switch(error_code) {
-    case CONVERSION_OK: 
+    case CONVERSION_OK:
           u_printf("%s converted\n",argv[i]);
           if (output_mode==REPLACE_FILE) {
             /* If we must replace the input file */
@@ -350,7 +350,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
           }
           break;
     case INPUT_FILE_NOT_IN_UTF16_LE:
-          error("Error: %s is not a Unicode Little-Endian file\n",argv[i]); 
+          error("Error: %s is not a Unicode Little-Endian file\n",argv[i]);
           free_encodings_context(encoding_ctx);
           return DEFAULT_ERROR_CODE;
     case INPUT_FILE_NOT_IN_UTF16_BE:
@@ -361,7 +361,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
           error("Error: %s is not a UTF8 file\n",argv[i]);
           free_encodings_context(encoding_ctx);
           return DEFAULT_ERROR_CODE;
-    default: 
+    default:
           error("Internal error in Convert\n");
           free_encodings_context(encoding_ctx);
           return DEFAULT_ERROR_CODE;

--- a/Copyright.h
+++ b/Copyright.h
@@ -50,7 +50,7 @@
 #ifdef UNITEX_CORE_VERSION_GIT_COMMIT_HASH
 #define GIT_HEAD_STRING_AND_QUOTE(s) "\""#s"\""
 #define GIT_HEAD_REVISION GIT_HEAD_STRING_AND_QUOTE(UNITEX_CORE_VERSION_GIT_COMMIT_HASH)
-#endif	
+#endif
 #endif
 #endif
 
@@ -95,11 +95,11 @@ namespace unitex {
 /* ************************************************************************** */
 /**
  * @brief Defines a canonical copyright notice
- * 
- * This format is intend to be compliant with the Semantic Versioning scheme 
+ *
+ * This format is intend to be compliant with the Semantic Versioning scheme
  * VERSION = MAJOR.MINOR.PATCH('-'SUFFIX)? and with the information string
  * of the "Standards for Command Line Interfaces"
- * 
+ *
  * @see http://semver.org/spec/v2.0.0.html
  * @see https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html
  * @author Cristian Martinez

--- a/DELA.cpp
+++ b/DELA.cpp
@@ -132,18 +132,18 @@ static struct dela_entry* tokenize_DELAF_line(const unichar* line,int comments_a
 struct dela_entry* res;
 int i,val;
 if (line==NULL) {
-	if (!verbose) error("Internal NULL error in tokenize_DELAF_line\n");
+    if (!verbose) error("Internal NULL error in tokenize_DELAF_line\n");
    else (*verbose)=P_NULL_STRING;
-	return NULL;
+    return NULL;
 }
 unichar* temp=(unichar*)malloc_cb(sizeof(unichar)*(1+u_strlen(line)),prv_alloc);
 if (temp==NULL) {
-	fatal_alloc_error("tokenize_DELAF_line");
+    fatal_alloc_error("tokenize_DELAF_line");
 }
 /* Initialization of the result structure */
 res=(struct dela_entry*)malloc_cb(sizeof(struct dela_entry),prv_alloc);
 if (res==NULL) {
-	fatal_alloc_error("tokenize_DELAF_line");
+    fatal_alloc_error("tokenize_DELAF_line");
 }
 res->inflected=NULL;
 res->lemma=NULL;
@@ -210,13 +210,13 @@ if (line[i]=='\0') {
    goto error;
 }
 if (temp[0]=='\0') {
-	/* If the lemma is empty like in "eat,.V:W", it is supposed to be
-	 * the same as the inflected form. */
-	res->lemma=u_strdup(res->inflected,prv_alloc);
+    /* If the lemma is empty like in "eat,.V:W", it is supposed to be
+     * the same as the inflected form. */
+    res->lemma=u_strdup(res->inflected,prv_alloc);
 }
 else {
-	/* Otherwise, we copy it */
-	res->lemma=u_strdup(temp,prv_alloc);
+    /* Otherwise, we copy it */
+    res->lemma=u_strdup(temp,prv_alloc);
 }
 /*
  * We read the grammatical code
@@ -240,7 +240,7 @@ res->semantic_codes[0]=u_strdup(temp,prv_alloc);
  * Now we read the other gramatical and semantic codes if any
  */
 while (res->n_semantic_codes<MAX_SEMANTIC_CODES && line[i]=='+') {
-	i++;
+    i++;
    val=parse_string(line,&i,temp,P_PLUS_COLON_SLASH,P_EMPTY,P_EMPTY);
    if (val==P_BACKSLASH_AT_END) {
       if (!verbose) error("***Dictionary error: backslash at end of line\n_%S_\n",line);
@@ -255,13 +255,13 @@ while (res->n_semantic_codes<MAX_SEMANTIC_CODES && line[i]=='+') {
       goto error;
    }
    res->semantic_codes[res->n_semantic_codes]=u_strdup(temp,prv_alloc);
-	(res->n_semantic_codes)++;
+    (res->n_semantic_codes)++;
 }
 /*
  * Then we read the inflectional codes if any
  */
 while (res->n_inflectional_codes<MAX_INFLECTIONAL_CODES && line[i]==':') {
-	i++;
+    i++;
    val=parse_string(line,&i,temp,P_COLON_SLASH,P_EMPTY,P_EMPTY);
    if (val==P_BACKSLASH_AT_END) {
       if (!verbose) error("***Dictionary error: backslash at end of line\n_%S_\n",line);
@@ -276,7 +276,7 @@ while (res->n_inflectional_codes<MAX_INFLECTIONAL_CODES && line[i]==':') {
       goto error;
    }
    res->inflectional_codes[res->n_inflectional_codes]=u_strdup(temp,prv_alloc);
-	(res->n_inflectional_codes)++;
+    (res->n_inflectional_codes)++;
 }
 /* Finally we check if there is a comment */
 if (line[i]=='/' && !comments_allowed) {
@@ -371,16 +371,16 @@ struct dela_entry* tokenize_DELAF_line_opt(const unichar* line,Abstract_allocato
 struct dela_entry* res;
 unichar* temp=(unichar*)malloc_cb(sizeof(unichar)*(1+u_strlen(line)),prv_alloc);
 if (temp==NULL) {
-	fatal_alloc_error("tokenize_DELAF_line");
+    fatal_alloc_error("tokenize_DELAF_line");
 }
 int i,j;
 if (line==NULL) {
-	fatal_error("Internal NULL error in tokenize_DELAF_line\n");
+    fatal_error("Internal NULL error in tokenize_DELAF_line\n");
 }
 /* Initialization of the result structure */
 res=(struct dela_entry*)malloc_cb(sizeof(struct dela_entry),prv_alloc);
 if (res==NULL) {
-	fatal_error("Not enough memory in tokenize_DELA_line\n");
+    fatal_error("Not enough memory in tokenize_DELA_line\n");
 }
 res->inflected=NULL;
 res->lemma=NULL;
@@ -396,23 +396,23 @@ res->filter_codes[0]=NULL;
 i=0;
 j=0;
 while (line[i]!='\0' && line[i]!=',') {
-	/* If there is a backslash, we must unprotect a character */
-	if (line[i]=='\\') {
-		i++;
-		/* If the backslash is at the end of line, it's an error */
-		if (line[i]=='\0') {
-			fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
-		}
-		else if (line[i]=='=') {
-			temp[j++]='\\';
-		}
-	}
-	temp[j++]=line[i++];
+    /* If there is a backslash, we must unprotect a character */
+    if (line[i]=='\\') {
+        i++;
+        /* If the backslash is at the end of line, it's an error */
+        if (line[i]=='\0') {
+            fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+        }
+        else if (line[i]=='=') {
+            temp[j++]='\\';
+        }
+    }
+    temp[j++]=line[i++];
 }
 temp[j]='\0';
 /* If we are at the end of line, it's an error */
 if (line[i]=='\0') {
-	fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+    fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
 }
 res->inflected=u_strdup(temp,prv_alloc);
 /*
@@ -421,31 +421,31 @@ res->inflected=u_strdup(temp,prv_alloc);
 i++;
 j=0;
 while (line[i]!='\0' && line[i]!='.') {
-	/* If there is a backslash, we must unprotect a character */
-	if (line[i]=='\\') {
-		i++;
-		/* If the backslash is at the end of line, it's an error */
-		if (line[i]=='\0') {
-			fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
-		} else if (line[i]=='=') {
-			temp[j++]='\\';
-		}
-	}
-	temp[j++]=line[i++];
+    /* If there is a backslash, we must unprotect a character */
+    if (line[i]=='\\') {
+        i++;
+        /* If the backslash is at the end of line, it's an error */
+        if (line[i]=='\0') {
+            fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+        } else if (line[i]=='=') {
+            temp[j++]='\\';
+        }
+    }
+    temp[j++]=line[i++];
 }
 temp[j]='\0';
 /* If we are at the end of line, it's an error */
 if (line[i]=='\0') {
-	fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+    fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
 }
 if (j==0) {
-	/* If the lemma is empty like in "eat,.V:W", it is supposed to be
-	 * the same as the inflected form. */
-	res->lemma=u_strdup(res->inflected,prv_alloc);
+    /* If the lemma is empty like in "eat,.V:W", it is supposed to be
+     * the same as the inflected form. */
+    res->lemma=u_strdup(res->inflected,prv_alloc);
 }
 else {
-	/* Otherwise, we copy it */
-	res->lemma=u_strdup(temp,prv_alloc);
+    /* Otherwise, we copy it */
+    res->lemma=u_strdup(temp,prv_alloc);
 }
 /*
  * We read the grammatical code
@@ -453,15 +453,15 @@ else {
 i++;
 j=0;
 while (line[i]!='\0' && line[i]!='+' && line[i]!='/' && line[i]!=':') {
-	/* If there is a backslash, we must unprotect a character */
-	if (line[i]=='\\') {
-		i++;
-		/* If the backslash is at the end of line, it's an error */
-		if (line[i]=='\0') {
-			fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
-		}
-	}
-	temp[j++]=line[i++];
+    /* If there is a backslash, we must unprotect a character */
+    if (line[i]=='\\') {
+        i++;
+        /* If the backslash is at the end of line, it's an error */
+        if (line[i]=='\0') {
+            fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+        }
+    }
+    temp[j++]=line[i++];
 }
 temp[j]='\0';
 res->semantic_codes[0]=u_strdup(temp,prv_alloc);
@@ -469,43 +469,43 @@ res->semantic_codes[0]=u_strdup(temp,prv_alloc);
  * Now we read the other grammatical and semantic codes if any
  */
 while (res->n_semantic_codes<MAX_SEMANTIC_CODES && line[i]=='+') {
-	i++;
-	j=0;
-	while (line[i]!='\0' && line[i]!='+' && line[i]!=':' && line[i]!='/') {
-		/* If there is a backslash, we must unprotect a character */
-		if (line[i]=='\\') {
-			i++;
-			/* If the backslash is at the end of line, it's an error */
-			if (line[i]=='\0') {
-				fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
-			}
-		}
-		temp[j++]=line[i++];
-	}
-	temp[j]='\0';
-	res->semantic_codes[res->n_semantic_codes]=u_strdup(temp,prv_alloc);
-	(res->n_semantic_codes)++;
+    i++;
+    j=0;
+    while (line[i]!='\0' && line[i]!='+' && line[i]!=':' && line[i]!='/') {
+        /* If there is a backslash, we must unprotect a character */
+        if (line[i]=='\\') {
+            i++;
+            /* If the backslash is at the end of line, it's an error */
+            if (line[i]=='\0') {
+                fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+            }
+        }
+        temp[j++]=line[i++];
+    }
+    temp[j]='\0';
+    res->semantic_codes[res->n_semantic_codes]=u_strdup(temp,prv_alloc);
+    (res->n_semantic_codes)++;
 }
 /*
  * Then we read the inflectional codes if any
  */
 while (res->n_inflectional_codes<MAX_INFLECTIONAL_CODES && line[i]==':') {
-	i++;
-	j=0;
-	while (line[i]!='\0' && line[i]!=':' && line[i]!='/') {
-		/* If there is a backslash, we must unprotect a character */
-		if (line[i]=='\\') {
-			i++;
-			/* If the backslash is at the end of line, it's an error */
-			if (line[i]=='\0') {
-				fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
-			}
-		}
-		temp[j++]=line[i++];
-	}
-	temp[j]='\0';
-	res->inflectional_codes[res->n_inflectional_codes]=u_strdup(temp,prv_alloc);
-	(res->n_inflectional_codes)++;
+    i++;
+    j=0;
+    while (line[i]!='\0' && line[i]!=':' && line[i]!='/') {
+        /* If there is a backslash, we must unprotect a character */
+        if (line[i]=='\\') {
+            i++;
+            /* If the backslash is at the end of line, it's an error */
+            if (line[i]=='\0') {
+                fatal_error("***Dictionary error: incorrect line\n_%S_\n",line);
+            }
+        }
+        temp[j++]=line[i++];
+    }
+    temp[j]='\0';
+    res->inflectional_codes[res->n_inflectional_codes]=u_strdup(temp,prv_alloc);
+    (res->n_inflectional_codes)++;
 }
 free_cb(temp,prv_alloc);
 return res;
@@ -519,10 +519,10 @@ return res;
  * the tag.
  */
 struct dela_entry* tokenize_tag_token(const unichar* tag,
-					int emit_error,Abstract_allocator prv_alloc) {
+                    int emit_error,Abstract_allocator prv_alloc) {
 if (tag==NULL || tag[0]!='{') {
-	error("Internal error in tokenize_tag_token\n");
-	return NULL;
+    error("Internal error in tokenize_tag_token\n");
+    return NULL;
 }
 /* We copy the tag content without the round brackets in a string. We
  * must take care not to unprotect chars during this operation, since
@@ -534,7 +534,7 @@ if (tag==NULL || tag[0]!='{') {
 int i=1;
 unichar* temp=(unichar*)malloc_cb(sizeof(unichar)*(1+u_strlen(tag)),prv_alloc);
 if (temp==NULL) {
-	fatal_alloc_error("tokenize_DELAF_line");
+    fatal_alloc_error("tokenize_DELAF_line");
 }
 int val=parse_string(tag,&i,temp,P_CLOSING_ROUND_BRACKET,P_EMPTY,NULL);
 if (tag[i]!='}' || val!=P_OK) {
@@ -566,7 +566,7 @@ if (line==NULL) {
 }
 unichar* temp=(unichar*)malloc_cb(sizeof(unichar)*(1+u_strlen(line)),prv_alloc);
 if (temp==NULL) {
-	fatal_alloc_error("tokenize_DELAF_line");
+    fatal_alloc_error("tokenize_DELAF_line");
 }
 /* Initialization of the result structure */
 res=(struct dela_entry*)malloc_cb(sizeof(struct dela_entry),prv_alloc);
@@ -628,13 +628,13 @@ res->semantic_codes[0]=u_strdup(temp,prv_alloc);
  * Now we read the filters if any
  */
 if (line[i] == '!' && line[i+1] == '[') {//Negative filter
-	/* Initialization of the result structure */
-	res->filter_polarity = 0;
-	i=i+2; //we skip !
+    /* Initialization of the result structure */
+    res->filter_polarity = 0;
+    i=i+2; //we skip !
 }
 else if (line[i] == '[' ) {//Positive filter
-	res->filter_polarity = 1;
-	i++;
+    res->filter_polarity = 1;
+    i++;
 }
 /*
  * Now we read the list of filters
@@ -893,43 +893,43 @@ token[j]='\0';
  * consider letters before 'b'.
  */
 static void explore_semitic_tokens(const unichar* inflected,const unichar* lemma,unichar* result,
-		unichar* tmp_result,int *min_full_letters,int n_full_letters,
-		int pos_in_inflected,int pos_in_tmp_result) {
+        unichar* tmp_result,int *min_full_letters,int n_full_letters,
+        int pos_in_inflected,int pos_in_tmp_result) {
 if (*lemma=='\0') {
-	/* If we have finished to explore the lemma */
-	if ((*min_full_letters)==-1 || n_full_letters<*min_full_letters) {
-		/* If we have a best result than the current one, or if it's the first one */
-		tmp_result[pos_in_tmp_result]='\0';
-		u_strcpy(result,tmp_result);
-		*min_full_letters=n_full_letters;
-	}
-	return;
+    /* If we have finished to explore the lemma */
+    if ((*min_full_letters)==-1 || n_full_letters<*min_full_letters) {
+        /* If we have a best result than the current one, or if it's the first one */
+        tmp_result[pos_in_tmp_result]='\0';
+        u_strcpy(result,tmp_result);
+        *min_full_letters=n_full_letters;
+    }
+    return;
 }
 /* We will look for the first letter of lemma. We don't go over position 9,
  * because we only want to use 1 digit to represent position in consonant
  * skeleton, which is reasonable. */
 for (int i=pos_in_inflected;i<10 && inflected[i]!='\0';i++) {
-	if (*lemma==inflected[i]) {
-		tmp_result[pos_in_tmp_result]=(unichar)(i+'0');
-		explore_semitic_tokens(inflected,lemma+1,result,tmp_result,
-				min_full_letters,n_full_letters,i+1,pos_in_tmp_result+1);
-		if (*min_full_letters==0) {
-			/* If we have a perfect consonant skeleton, we can stop */
-			return;
-		}
-	}
+    if (*lemma==inflected[i]) {
+        tmp_result[pos_in_tmp_result]=(unichar)(i+'0');
+        explore_semitic_tokens(inflected,lemma+1,result,tmp_result,
+                min_full_letters,n_full_letters,i+1,pos_in_tmp_result+1);
+        if (*min_full_letters==0) {
+            /* If we have a perfect consonant skeleton, we can stop */
+            return;
+        }
+    }
 }
 /* And finally, we will act as the letter is absent, because the letter may be
  * there but at an irrelevant place like 'h' for lemma="hbc" and inflected="abcdefgh".
  * In such a case, "7bc" would be a worse solution than "h12".
  */
 if (n_full_letters==*min_full_letters) {
-	/* No need to produce a worse solution than the current one */
-	return;
+    /* No need to produce a worse solution than the current one */
+    return;
 }
 tmp_result[pos_in_tmp_result]=*lemma;
 explore_semitic_tokens(inflected,lemma+1,result,tmp_result,
-		min_full_letters,n_full_letters+1,pos_in_inflected,pos_in_tmp_result+1);
+        min_full_letters,n_full_letters+1,pos_in_inflected,pos_in_tmp_result+1);
 }
 
 /**
@@ -967,7 +967,7 @@ if (!u_strcmp(e->inflected,e->lemma)) {
 int n_inflected=get_number_of_tokens(e->inflected);
 int n_lemma=get_number_of_tokens(e->lemma);
 if (n_inflected!=n_lemma
-		|| is_str_mono_unichar_string(e->inflected,' ') ||  is_str_mono_unichar_string(e->inflected,'-')) {
+        || is_str_mono_unichar_string(e->inflected,' ') ||  is_str_mono_unichar_string(e->inflected,'-')) {
    /* If the 2 strings have not the same number of tokens,
     * we rawly consider them as two big tokens. However,
     * we put the prefix "_" in order to indicate that we have
@@ -987,17 +987,17 @@ unichar tmp_lemma[DIC_WORD_SIZE];
 unichar tmp_compressed[DIC_WORD_SIZE];
 result[0]='\0';
 if (semitic) {
-	/* We use "__" as a marker to indicate that semitic compression has been used */
-	u_strcpy(result,"__");
+    /* We use "__" as a marker to indicate that semitic compression has been used */
+    u_strcpy(result,"__");
 }
 for (int i=0;i<n_inflected;i++) {
    /* Tokens are compressed one by one */
    get_token(e->inflected,tmp_inflected,&pos_inflected);
    get_token(e->lemma,tmp_lemma,&pos_lemma);
    if (semitic) {
-	   semitic_token_compression(tmp_inflected,tmp_lemma,tmp_compressed);
+       semitic_token_compression(tmp_inflected,tmp_lemma,tmp_compressed);
    } else {
-	   get_compressed_token(tmp_inflected,tmp_lemma,tmp_compressed);
+       get_compressed_token(tmp_inflected,tmp_lemma,tmp_compressed);
    }
    u_strcat(result,tmp_compressed);
 }
@@ -1019,17 +1019,17 @@ u_strcpy(tmp,inflected);
 int size=u_strlen(tmp);
 int i=0;
 for (;compress_info[i]!='\0';i++) {
-	if (compress_info[i]>='0' && compress_info[i]<='9') {
-		/* If we have a consonant number */
-		int n=compress_info[i]-'0';
-		if (n>=size) {
-			error("compress info=<%S>\n",compress_info);
-			fatal_error("rebuild_token_semitic: consonant number #%d out of form <%S> of size %d\n",n,tmp,size);
-		}
-		inflected[i]=tmp[n];
-	} else {
-		inflected[i]=compress_info[i];
-	}
+    if (compress_info[i]>='0' && compress_info[i]<='9') {
+        /* If we have a consonant number */
+        int n=compress_info[i]-'0';
+        if (n>=size) {
+            error("compress info=<%S>\n",compress_info);
+            fatal_error("rebuild_token_semitic: consonant number #%d out of form <%S> of size %d\n",n,tmp,size);
+        }
+        inflected[i]=tmp[n];
+    } else {
+        inflected[i]=compress_info[i];
+    }
 }
 inflected[i]='\0';
 }
@@ -1044,7 +1044,7 @@ inflected[i]='\0';
  */
 void rebuild_token(unichar* inflected,unichar* compress_info) {
 if (inflected[0]=='\0') {
-	fatal_error("Unexpected empty inflected form in rebuild_token\n");
+    fatal_error("Unexpected empty inflected form in rebuild_token\n");
 }
 int n=0;
 int i,pos=0;
@@ -1074,7 +1074,7 @@ if (P_EOS==parse_string(compress_info,&pos,&(inflected[i]),P_EMPTY)) {
  */
 void uncompress_entry(const unichar* inflected,const unichar* INF_code,Ustring* result) {
 if (inflected[0]=='\0') {
-	fatal_error("Unexpected empty inflected form in uncompress_entry\n");
+    fatal_error("Unexpected empty inflected form in uncompress_entry\n");
 }
 unsigned int n;
 int pos;
@@ -1103,7 +1103,7 @@ if (INF_code[0]=='_' && !semitic) {
    u_strcat(result,inflected);
    /* But we start copying the code at position length-n */
    if (n>result->len) {
-	   fatal_error("Unexpected problem in uncompress_entry: inflected=<%S> inf=<%S>\n",inflected,INF_code);
+       fatal_error("Unexpected problem in uncompress_entry: inflected=<%S> inf=<%S>\n",inflected,INF_code);
    }
    truncate(result,result->len-n);
 
@@ -1143,9 +1143,9 @@ while (INF_code[pos]!='.') {
       }
       tmp_entry[j]='\0';
       if (semitic) {
-    	  rebuild_token_semitic(tmp_entry,tmp);
+          rebuild_token_semitic(tmp_entry,tmp);
       } else {
-    	  rebuild_token(tmp_entry,tmp);
+          rebuild_token(tmp_entry,tmp);
       }
       j=0;
       /* Once we have rebuilt the token, we protect in it the following chars: . + \ /
@@ -1168,9 +1168,9 @@ while (INF_code[pos]!='\0') {
 void uncompress_entry_and_print(unichar* content,struct list_ustring* tmp,U_FILE* output) {
 Ustring* s=new_Ustring(DIC_WORD_SIZE);
 while (tmp!=NULL) {
-	uncompress_entry(content,tmp->string,s);
-	u_fprintf(output,"%S\n",s->str);
-	tmp=tmp->next;
+    uncompress_entry(content,tmp->string,s);
+    u_fprintf(output,"%S\n",s->str);
+    tmp=tmp->next;
 }
 free_Ustring(s);
 }
@@ -1202,9 +1202,9 @@ if (final) {
 /* Nevermind the state finality, we explore all the reachable states */
 int adr;
 for (int i=0;i<n_transitions;i++) {
-	pos=read_dictionary_transition(d,pos,&(content[string_pos]),&adr,ustr);
-	explore_all_paths(adr,content,string_pos+1,d,output,ustr,base);
-	restore_output(z,ustr);
+    pos=read_dictionary_transition(d,pos,&(content[string_pos]),&adr,ustr);
+    explore_all_paths(adr,content,string_pos+1,d,output,ustr,base);
+    restore_output(z,ustr);
 }
 }
 
@@ -1459,15 +1459,15 @@ return 0;
  */
 int contains_unprotected_equal_sign(const unichar* s) {
 for (;;) {
-	if (*(s+0)==0) return 0;
-	if (*(s+0)==1) return 1;
-	if (*(s+1)==0) return 0;
-	if (*(s+1)==1) return 1;
-	if (*(s+2)==0) return 0;
-	if (*(s+2)==1) return 1;
-	if (*(s+3)==0) return 0;
-	if (*(s+3)==1) return 1;
-	s+=4;
+    if (*(s+0)==0) return 0;
+    if (*(s+0)==1) return 1;
+    if (*(s+1)==0) return 0;
+    if (*(s+1)==1) return 1;
+    if (*(s+2)==0) return 0;
+    if (*(s+2)==1) return 1;
+    if (*(s+3)==0) return 0;
+    if (*(s+3)==1) return 1;
+    s+=4;
 }
 }
 
@@ -1479,15 +1479,15 @@ for (;;) {
  */
 void replace_unprotected_equal_sign(unichar* s,unichar c) {
 for (;;) {
-	if (*(s+0)==0) return ;
-	if (*(s+0)==1) *(s+0) = c;
-	if (*(s+1)==0) return ;
-	if (*(s+1)==1) *(s+1) = c;
-	if (*(s+2)==0) return ;
-	if (*(s+2)==1) *(s+2) = c;
-	if (*(s+3)==0) return ;
-	if (*(s+3)==1) *(s+3) = c;
-	s+=4;
+    if (*(s+0)==0) return ;
+    if (*(s+0)==1) *(s+0) = c;
+    if (*(s+1)==0) return ;
+    if (*(s+1)==1) *(s+1) = c;
+    if (*(s+2)==0) return ;
+    if (*(s+2)==1) *(s+2) = c;
+    if (*(s+3)==0) return ;
+    if (*(s+3)==1) *(s+3) = c;
+    s+=4;
 }
 }
 
@@ -1780,7 +1780,7 @@ return -1;
  */
 int get_inf_code_exact_match(Dictionary* d,unichar* str) {
 if (d->type!=BIN_CLASSIC) {
-	fatal_error("get_inf_code_exact_match: unsupported dictionary type\n");
+    fatal_error("get_inf_code_exact_match: unsupported dictionary type\n");
 }
 return explore_for_exact_match(d->bin,d->initial_state_offset,str,0);
 }
@@ -1794,10 +1794,10 @@ return explore_for_exact_match(d->bin,d->initial_state_offset,str,0);
 void debug_print_entry(struct dela_entry* e) {
 error("%S,%S.%S",e->inflected,e->lemma,e->semantic_codes[0]);
 for (int i=1;i<e->n_semantic_codes;i++) {
-	error("+%S",e->semantic_codes[i]);
+    error("+%S",e->semantic_codes[i]);
 }
 for (int i=0;i<e->n_inflectional_codes;i++) {
-	error(":%S",e->inflectional_codes[i]);
+    error(":%S",e->inflectional_codes[i]);
 }
 }
 
@@ -1822,12 +1822,12 @@ escape(e->lemma,s,P_DOT);
 u_strcat(s,".");
 escape(e->semantic_codes[0],s,P_PLUS_COMMA_COLON_SLASH_BACKSLASH);
 for (int i=1;i<e->n_semantic_codes;i++) {
-	u_strcat(s,"+");
-	escape(e->semantic_codes[i],s,P_PLUS_COMMA_COLON_SLASH_BACKSLASH);
+    u_strcat(s,"+");
+    escape(e->semantic_codes[i],s,P_PLUS_COMMA_COLON_SLASH_BACKSLASH);
 }
 for (int i=0;i<e->n_inflectional_codes;i++) {
-	u_strcat(s,":");
-	escape(e->inflectional_codes[i],s,P_COLON_SLASH_BACKSLASH);
+    u_strcat(s,":");
+    escape(e->inflectional_codes[i],s,P_COLON_SLASH_BACKSLASH);
 }
 }
 
@@ -1843,16 +1843,16 @@ for (int i=0;i<e->n_inflectional_codes;i++) {
 int replace_special_equal_signs(unichar* s) {
 int i=0;
 while (s[i]!='\0') {
-	if (s[i]==PROTECTION_CHAR) {
-		if (s[i+1]=='\0') {
-			error("Unexpected \\ at end of string in replace_special_equal_signs\n");
-			return DEFAULT_ERROR_CODE;
-		}
-		i=i+2;
-	} else {
-		if (s[i]=='=') s[i]=1;
-		i++;
-	}
+    if (s[i]==PROTECTION_CHAR) {
+        if (s[i+1]=='\0') {
+            error("Unexpected \\ at end of string in replace_special_equal_signs\n");
+            return DEFAULT_ERROR_CODE;
+        }
+        i=i+2;
+    } else {
+        if (s[i]=='=') s[i]=1;
+        i++;
+    }
 }
 return SUCCESS_RETURN_CODE;
 }

--- a/DELA.cpp
+++ b/DELA.cpp
@@ -1233,12 +1233,12 @@ if (f==NULL) return;
 int i;
 struct dela_entry* entry;
 Ustring* line=new_Ustring(DIC_LINE_SIZE);
-    
+
 Abstract_allocator extract_semantic_codes_abstract_allocator=NULL;
 extract_semantic_codes_abstract_allocator=create_abstract_allocator("extract_semantic_codes",
                                                                   AllocatorFreeOnlyAtAllocatorDelete|AllocatorTipGrowingOftenRecycledObject,
                                                                   0);
-    
+
 while (EOF!=readline(line,f)) {
    /* NOTE: DLF and DLC files are not supposed to contain comment
     *       lines, but we test them, just in the case */
@@ -1293,7 +1293,7 @@ if (entry!=NULL) {
    for (i=0;i<entry->n_inflectional_codes;i++) {
       get_value_index(entry->inflectional_codes[i],inflectional_codes);
    }
-   
+
    int simple_entry;
    if (alph2!=NULL) {
       simple_entry=is_sequence_of_letters((is_a_DELAF)?entry->inflected:entry->lemma,alph2);
@@ -1846,7 +1846,7 @@ while (s[i]!='\0') {
 	if (s[i]==PROTECTION_CHAR) {
 		if (s[i+1]=='\0') {
 			error("Unexpected \\ at end of string in replace_special_equal_signs\n");
-			return DEFAULT_ERROR_CODE; 
+			return DEFAULT_ERROR_CODE;
 		}
 		i=i+2;
 	} else {

--- a/DELA.h
+++ b/DELA.h
@@ -83,25 +83,25 @@ namespace unitex {
  * semantic_codes[0] = "N"   semantic_codes[1] = "PR"
  * n_inflectional_codes: 1
  * inflectional_codes[0] = "ms"
- * n_filter_codes:	5
+ * n_filter_codes:  5
  * filter_codes[0] = "Kfs"
  */
 
 struct dela_entry {
-	unichar* inflected;
-	unichar* lemma;
-	/* Number of grammatical and semantic codes.
-	 * By convention, the first is supposed to be the
-	 * grammatical category of the entry. */
-	unsigned char n_semantic_codes;
-	unsigned char n_inflectional_codes;
-	unsigned char n_filter_codes;
-	unsigned char filter_polarity;
-	/* filter_polarity = 1 for positive filter
-	   filter_polarity = 0 for negative filter */
-	unichar* semantic_codes[MAX_SEMANTIC_CODES];
-	unichar* inflectional_codes[MAX_INFLECTIONAL_CODES];
-	unichar* filter_codes[MAX_FILTERS];
+    unichar* inflected;
+    unichar* lemma;
+    /* Number of grammatical and semantic codes.
+     * By convention, the first is supposed to be the
+     * grammatical category of the entry. */
+    unsigned char n_semantic_codes;
+    unsigned char n_inflectional_codes;
+    unsigned char n_filter_codes;
+    unsigned char filter_polarity;
+    /* filter_polarity = 1 for positive filter
+       filter_polarity = 0 for negative filter */
+    unichar* semantic_codes[MAX_SEMANTIC_CODES];
+    unichar* inflectional_codes[MAX_INFLECTIONAL_CODES];
+    unichar* filter_codes[MAX_FILTERS];
 };
 
 

--- a/DebugMode.cpp
+++ b/DebugMode.cpp
@@ -56,33 +56,33 @@ Ustring* output=new_Ustring();
 Ustring* tmp=new_Ustring();
 int n_contexts=0;
 while (*s!='\0') {
-	/* Skipping char #1 */
-	s++;
-	while (*s!=DEBUG_INFO_COORD_MARK) {
-		if (print_output && n_contexts==0) u_strcat(output,*s);
-		s++;
-	}
-	/* Skipping everything until char #3 */
-	while (*(s++)!=DEBUG_INFO_INPUT_MARK) {
-	}
-	empty(tmp);
-	/* Skipping everything until char #4 */
-	while (*s!=DEBUG_INFO_END_MARK) {
-		u_strcat(tmp,*s);
-		s++;
-	}
-	if (!u_strcmp(tmp->str,"$*")) {
-		empty(output);
-	} else if (!u_strcmp(tmp->str,"$[") || !u_strcmp(tmp->str,"$![")) {
-		n_contexts++;
-	} else if (!u_strcmp(tmp->str,"$]")) {
-		n_contexts--;
-	}
-	s++;
-	while (*s!='\0' && *s!=DEBUG_INFO_OUTPUT_MARK) {
-		if (print_input && n_contexts==0) u_strcat(output,*s);
-		s++;
-	}
+    /* Skipping char #1 */
+    s++;
+    while (*s!=DEBUG_INFO_COORD_MARK) {
+        if (print_output && n_contexts==0) u_strcat(output,*s);
+        s++;
+    }
+    /* Skipping everything until char #3 */
+    while (*(s++)!=DEBUG_INFO_INPUT_MARK) {
+    }
+    empty(tmp);
+    /* Skipping everything until char #4 */
+    while (*s!=DEBUG_INFO_END_MARK) {
+        u_strcat(tmp,*s);
+        s++;
+    }
+    if (!u_strcmp(tmp->str,"$*")) {
+        empty(output);
+    } else if (!u_strcmp(tmp->str,"$[") || !u_strcmp(tmp->str,"$![")) {
+        n_contexts++;
+    } else if (!u_strcmp(tmp->str,"$]")) {
+        n_contexts--;
+    }
+    s++;
+    while (*s!='\0' && *s!=DEBUG_INFO_OUTPUT_MARK) {
+        if (print_input && n_contexts==0) u_strcat(output,*s);
+        s++;
+    }
 }
 u_fputs(output->str,f);
 free_Ustring(tmp);
@@ -98,14 +98,14 @@ void create_graph_call_debug_tag(unichar* dst,unichar* src,int graph_number,int 
 u_sprintf(dst,"<E>/%C",DEBUG_INFO_OUTPUT_MARK);
 int i;
 for (i=0;src[i]!=DEBUG_INFO_COORD_MARK;i++) {
-	if (src[i]=='\0') {
-		fatal_error("Debug output error in create_graph_call_debug_tag\n");
-	}
+    if (src[i]=='\0') {
+        fatal_error("Debug output error in create_graph_call_debug_tag\n");
+    }
 }
 int n=5;
 i--;
 do {
-	dst[n++]=src[++i];
+    dst[n++]=src[++i];
 } while (src[i]!=DEBUG_INFO_INPUT_MARK);
 dst[n++]=DEBUG_INFO_GRAPHCALL_MARK;
 dst[n++]=before_call?'<':'>';

--- a/DicVariables.cpp
+++ b/DicVariables.cpp
@@ -39,9 +39,9 @@ if (tmp==NULL) {
 }
 tmp->name=u_strdup(name);
 if (must_clone) {
-	tmp->dic_entry=clone_dela_entry(dic_entry);
+    tmp->dic_entry=clone_dela_entry(dic_entry);
 } else {
-	tmp->dic_entry=dic_entry;
+    tmp->dic_entry=dic_entry;
 }
 tmp->next=next;
 return tmp;
@@ -85,9 +85,9 @@ while (*list!=NULL) {
       /* We have to free the previous value */
       free_dela_entry((*list)->dic_entry);
       if (must_clone) {
-    	  (*list)->dic_entry=clone_dela_entry(dic_entry);
+          (*list)->dic_entry=clone_dela_entry(dic_entry);
       } else {
-    	  (*list)->dic_entry=dic_entry;
+          (*list)->dic_entry=dic_entry;
       }
       return;
    }
@@ -129,10 +129,10 @@ return new_dic_variable(list->name,list->dic_entry,clone_dic_variable_list(list-
  */
 int same_dic_variables(struct dic_variable* backup,struct dic_variable* v) {
 while (backup!=NULL && v!=NULL) {
-	if (u_strcmp(backup->name,v->name)
-		|| !equal(backup->dic_entry,v->dic_entry)) return 0;
-	backup=backup->next;
-	v=v->next;
+    if (u_strcmp(backup->name,v->name)
+        || !equal(backup->dic_entry,v->dic_entry)) return 0;
+    backup=backup->next;
+    v=v->next;
 }
 
 return (backup==NULL && v==NULL);

--- a/DicVariables.cpp
+++ b/DicVariables.cpp
@@ -99,7 +99,7 @@ while (*list!=NULL) {
 
 
 /**
- * Returns the struct dela_entry* associated to the given dic variable name, 
+ * Returns the struct dela_entry* associated to the given dic variable name,
  * or NULL if not found.
  */
 struct dela_entry* get_dic_variable(const unichar* name,struct dic_variable* list) {

--- a/Dico.cpp
+++ b/Dico.cpp
@@ -264,12 +264,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 free(buffer_filename);
                 return USAGE_ERROR_CODE;
              }
-             if ((strcmp(options.vars()->optarg,"minus")!=0) && (strcmp(options.vars()->optarg,"-")!=0) && 
+             if ((strcmp(options.vars()->optarg,"minus")!=0) && (strcmp(options.vars()->optarg,"-")!=0) &&
                  (strcmp(options.vars()->optarg,"tilde")!=0) && (strcmp(options.vars()->optarg,"~")!=0)) {
                  error("You must specify a valid argument for negation operator\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;               
+                return USAGE_ERROR_CODE;
              }
              strcpy(negation_operator,options.vars()->optarg);
              break;
@@ -277,7 +277,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("You must specify a non empty text file name\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(text,options.vars()->optarg);
              break;
@@ -285,7 +285,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("You must specify a non empty alphabet name\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(alph,options.vars()->optarg);
              break;
@@ -296,7 +296,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                     alloc_error("main_Dico");
                     free(morpho_dic);
                     free(buffer_filename);
-                    return ALLOC_ERROR_CODE;                     
+                    return ALLOC_ERROR_CODE;
                   }
                 }
                 else
@@ -306,7 +306,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                      alloc_error("main_Dico");
                      free(morpho_dic);
                      free(buffer_filename);
-                     return ALLOC_ERROR_CODE; 
+                     return ALLOC_ERROR_CODE;
                     }
                     strcat(morpho_dic,";");
                     strcat(morpho_dic,options.vars()->optarg);
@@ -316,7 +316,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
    case 'K': is_korean=1;
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': usage();
              free(morpho_dic);
              free(buffer_filename);
@@ -325,7 +325,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("You must specify a non empty arabic rule configuration file name\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(arabic_rules,options.vars()->optarg);
              break;
@@ -340,7 +340,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("You must specify a non empty output file name\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(raw_output,options.vars()->optarg);
              break;
@@ -348,7 +348,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                          error("Missing argument for option --%s\n",lopts_Dico[index].name);
              free(morpho_dic);
              free(buffer_filename);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              free(morpho_dic);
@@ -358,7 +358,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("Empty input_encoding argument\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
@@ -366,7 +366,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Dico,lopts_Dico,&index))
                 error("Empty output_encoding argument\n");
                 free(morpho_dic);
                 free(buffer_filename);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -384,13 +384,13 @@ if (options.vars()->optind==argc) {
    error("Invalid arguments: rerun with --help\n");
    free(morpho_dic);
    free(buffer_filename);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
   // freeing all allocated memory
   free(morpho_dic);
-  free(buffer_filename);  
+  free(buffer_filename);
   return SUCCESS_RETURN_CODE;
 }
 
@@ -413,12 +413,12 @@ if (raw_output[0]!='\0') {
     free_alphabet(alphabet);
     free(morpho_dic);
     free(buffer_filename);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 if (f_raw_output!=NULL) {
   U_FILE* f_text=u_fopen(&vec,text,U_READ);
-  
+
   if ((*text)=='\0') {
     error("Cannot open text file %s\n",text);
     if (f_raw_output!=U_STDOUT) {
@@ -427,11 +427,11 @@ if (f_raw_output!=NULL) {
     free_alphabet(alphabet);
     free(morpho_dic);
     free(buffer_filename);
-    return DEFAULT_ERROR_CODE;     
+    return DEFAULT_ERROR_CODE;
   }
-  
+
   int ret_applic=raw_dic_application(&vec,f_text,f_raw_output,alphabet,options.vars()->optind,argv);
-  
+
   u_fclose(f_text);
   if (f_raw_output!=U_STDOUT) {
     u_fclose(f_raw_output);
@@ -473,7 +473,7 @@ if(snt_files_creation_error) {
   free_alphabet(alphabet);
   free(morpho_dic);
   free(buffer_filename);
-  return DEFAULT_ERROR_CODE;   
+  return DEFAULT_ERROR_CODE;
 }
 
 /* We remove the text morphological dictionary files, if any */
@@ -485,7 +485,7 @@ af_remove(snt_files->morpho_inf);
 struct text_tokens* tokens=load_text_tokens(&vec,snt_files->tokens_txt);
 if (tokens==NULL) {
    error("Cannot open token file %s\n",snt_files->tokens_txt);
-   free_snt_files(snt_files);  
+   free_snt_files(snt_files);
    free_alphabet(alphabet);
    free(morpho_dic);
    free(buffer_filename);
@@ -531,8 +531,8 @@ for (int priority=1;priority<4;priority++) {
             /* We open output files: dictionaries in APPEND mode since we
              * can only add entries to them, and 'err' in WRITE mode because
              * each dictionary application may reduce this file */
- 
-            /* 
+
+            /*
              * We are using encoding preference
              */
             info->dlf=u_fopen(&vec,snt_files->dlf,U_APPEND);
@@ -541,7 +541,7 @@ for (int priority=1;priority<4;priority++) {
             /* Working... */
             if (dico_application(&vec,argv[i],info,priority) != 0) {
                 ret = 1;
-            }    
+            }
             /* Dumping and closing output files */
             save_unknown_words(info);
             u_fclose(info->dlf);
@@ -601,12 +601,12 @@ for (int priority=1;priority<4;priority++) {
             /* And we merge the Locate results with current dictionaries */
             merge_dic_locate_results(info,snt_files->concord_ind,priority,export_in_morpho_dic);
             if (export_in_morpho_dic==PRODUCE_MORPHO_DIC_NOW) {
-               // only if the local morphological dictionary isn't empty 
+               // only if the local morphological dictionary isn't empty
                if(get_file_size(info->morpho) > 0l) {
                   /* If we have to compress right now the local morphological dictionary,
                    * we must close it, sort it, call Compress and reopen it in append mode */
                   u_fclose(info->morpho);
-                  
+
                   pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,
                                       snt_files->morpho_dic,1);
                   /* Then we compress it */
@@ -626,7 +626,7 @@ for (int priority=1;priority<4;priority++) {
                  free_alphabet(alphabet);
                  free(morpho_dic);
                  free(buffer_filename);
-                 return DEFAULT_ERROR_CODE;                  
+                 return DEFAULT_ERROR_CODE;
                }
             }
             /* We dump and close output files */
@@ -666,11 +666,11 @@ u_fclose(info->err);
 u_fclose(info->tags_err);
 
 if (info->morpho!=NULL) {
-   // only if morpho.dic isn't empty 
+   // only if morpho.dic isn't empty
    if(get_file_size(info->morpho) > 0l) {
       /* If we have produced a morpho.dic file, it's time to work with it */
       u_fclose(info->morpho);
-      
+
       /* We sort it to remove duplicates */
       pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,
                           snt_files->morpho_dic,1);

--- a/DictionaryTree.cpp
+++ b/DictionaryTree.cpp
@@ -35,7 +35,7 @@ namespace unitex {
 struct dictionary_node* new_dictionary_node(Abstract_allocator prv_alloc) {
 struct dictionary_node* a=(struct dictionary_node*)malloc_cb(sizeof(struct dictionary_node),prv_alloc);
 if (a==NULL) {
-	fatal_alloc_error("new_dictionary_node");
+    fatal_alloc_error("new_dictionary_node");
 }
 a->single_INF_code_list=NULL;
 a->offset=-1;
@@ -53,7 +53,7 @@ return a;
 static inline struct dictionary_node_transition* new_dictionary_node_transition(Abstract_allocator prv_alloc) {
 struct dictionary_node_transition* t=(struct dictionary_node_transition*)malloc_cb(sizeof(struct dictionary_node_transition),prv_alloc);
 if (t==NULL) {
-	fatal_alloc_error("new_dictionary_node_transition");
+    fatal_alloc_error("new_dictionary_node_transition");
 }
 t->letter='\0';
 t->output=NULL;
@@ -72,10 +72,10 @@ if (a==NULL) return;
 if (get_allocator_cb_flag(prv_alloc) & AllocatorGetFlagAutoFreePresent) return;
 
 if (a->incoming>1) {
-	/* We don't free a state that is still pointed by someone else
-	 * in order to avoid double freeing problems. */
+    /* We don't free a state that is still pointed by someone else
+     * in order to avoid double freeing problems. */
    (a->incoming)--;
-	return;
+    return;
 }
 free_list_int(a->single_INF_code_list,prv_alloc);
 free_dictionary_node_transition(a->trans,prv_alloc);
@@ -146,8 +146,8 @@ return tmp->next;
  * 'add_entry_to_dictionary_tree'.
  */
 struct info {
-	unichar* INF_code;
-	struct string_hash* INF_code_list;
+    unichar* INF_code;
+    struct string_hash* INF_code_list;
 };
 
 
@@ -164,10 +164,10 @@ static int get_value_index_for_string_colon_string(const unichar* str1,const uni
    unichar*tmp=tmp_default;
    int nb_unichar_buffer=u_strlen(str1)+u_strlen(str2)+2;
    if (nb_unichar_buffer>DEFAULT_TMP_GET_VALUE_INDEX_BUFFER_SIZE) {
-	   tmp=allocated_buffer=(unichar*)malloc(sizeof(unichar*)*nb_unichar_buffer);
-	   if (allocated_buffer==NULL) {
+       tmp=allocated_buffer=(unichar*)malloc(sizeof(unichar*)*nb_unichar_buffer);
+       if (allocated_buffer==NULL) {
           fatal_alloc_error("get_value_index_for_string_colon_string");
-	   }
+       }
    }
    u_sprintf(tmp,"%S,%S",str1,str2);
    value=get_value_index(tmp,hash);
@@ -205,7 +205,7 @@ if (inflected[pos]=='\0') {
    }
    /* Otherwise, we add it to the INF code list */
    node->single_INF_code_list=head_insert(N,node->single_INF_code_list,prv_alloc);
-	/* And we update the global INF line for this node */
+    /* And we update the global INF line for this node */
    node->INF_code=get_value_index_for_string_colon_string(infos->INF_code_list->value[node->INF_code],infos->INF_code,infos->INF_code_list);
    return;
 }
@@ -305,17 +305,17 @@ unsigned int H=sort_by_height(root,transitions_by_height,used_inf_values,prv_all
 
 unsigned int nb=0;
 for (unsigned int k1=0;k1<=H;k1++) {
-	unsigned int nbcur = convert_list_to_array_size(k1,transitions_by_height);
-	if (nbcur>nb) {
-		nb = nbcur;
-	}
+    unsigned int nbcur = convert_list_to_array_size(k1,transitions_by_height);
+    if (nbcur>nb) {
+        nb = nbcur;
+    }
 }
 init_minimize_arrays_dictionary_node_transition(&transitions,nb);
 float z;
 for (unsigned int k=0;k<=H;k++) {
    int size=convert_list_to_array(k,transitions_by_height,transitions,nb,prv_alloc);
    for (int l=0;l<size;l++) {
-	   check_nodes(transitions[l]);
+       check_nodes(transitions[l]);
    }
    quicksort(0,size-1,transitions);
    merge(size,transitions,prv_alloc);
@@ -435,13 +435,13 @@ free(transitions);
  * The function returns the height of the given node.
  */
 static int sort_by_height(struct dictionary_node* n,struct transition_list** transitions_by_height,
-					struct bit_array* used_inf_values,Abstract_allocator prv_alloc) {
+                    struct bit_array* used_inf_values,Abstract_allocator prv_alloc) {
 if (n==NULL) {
    fatal_error("NULL error in sort_by_height\n");
 }
 /* We mark used INF codes */
 if (n->single_INF_code_list!=NULL) {
-	set_value(used_inf_values,n->INF_code,1);
+    set_value(used_inf_values,n->INF_code,1);
 }
 if (n->trans==NULL) {
    /* If the node is a leaf, we have nothing to do */
@@ -593,12 +593,12 @@ while (i<size) {
  */
 static void get_longest_common_prefix(Ustring* pfx,unichar* s) {
 if (s==NULL) {
-	empty(pfx);
-	return;
+    empty(pfx);
+    return;
 }
 int i=0;
 while (pfx->str[i]==s[i] && s[i]!='\0') {
-	i++;
+    i++;
 }
 pfx->len=i;
 pfx->str[i]='\0';
@@ -613,7 +613,7 @@ pfx->str[i]='\0';
 static void remove_prefix(int n,unichar* s) {
 if (n==0) return;
 for (int i=n;s[i-1]!='\0';i++) {
-	s[i-n]=s[i];
+    s[i-n]=s[i];
 }
 }
 
@@ -622,55 +622,55 @@ for (int i=n;s[i-1]!='\0';i++) {
  * This function moves outputs from final nodes to transitions leading to final nodes.
  */
 static void subsequential_to_normal_transducer(struct dictionary_node* root,
-		struct dictionary_node* node,
-		struct string_hash* inf_codes,
-		int pos,unichar* z,
-		Ustring* normalizedOutput) {
+        struct dictionary_node* node,
+        struct string_hash* inf_codes,
+        int pos,unichar* z,
+        Ustring* normalizedOutput) {
 struct dictionary_node_transition* tmp=node->trans;
 int prefix_set=0;
 Ustring* prefix=new_Ustring();
 while (tmp!=NULL) {
-	z[pos]=tmp->letter;
-	z[pos+1]='\0';
-	subsequential_to_normal_transducer(root,tmp->node,inf_codes,pos+1,z,normalizedOutput);
-	/* First, if the destination state is final, we place its output on the output
-	 * of the current transition */
+    z[pos]=tmp->letter;
+    z[pos+1]='\0';
+    subsequential_to_normal_transducer(root,tmp->node,inf_codes,pos+1,z,normalizedOutput);
+    /* First, if the destination state is final, we place its output on the output
+     * of the current transition */
 
-	if (tmp->node->single_INF_code_list!=NULL) {
-		//error("<%S>: output=<%S>\n",z,normalizedOutput->str);
-		tmp->output=u_strdup(inf_codes->value[tmp->node->INF_code]);
-	}
-	if (normalizedOutput->len!=0) {
-		/* Then, we add the normalized output obtained recursively, if any */
-		//error("<%S>: moving normalized output <%S>\n",z,normalizedOutput->str);
-		if (tmp->output==NULL) {
-			tmp->output=u_strdup(normalizedOutput->str);
-		} else {
-			tmp->output=(unichar*)realloc(tmp->output,sizeof(unichar)*(1+normalizedOutput->len+u_strlen(tmp->output)));
-		}
-	}
-	if (!prefix_set) {
-		prefix_set=1;
-		u_strcpy(prefix,tmp->output);
-	} else {
-		get_longest_common_prefix(prefix,tmp->output);
-	}
-	tmp=tmp->next;
+    if (tmp->node->single_INF_code_list!=NULL) {
+        //error("<%S>: output=<%S>\n",z,normalizedOutput->str);
+        tmp->output=u_strdup(inf_codes->value[tmp->node->INF_code]);
+    }
+    if (normalizedOutput->len!=0) {
+        /* Then, we add the normalized output obtained recursively, if any */
+        //error("<%S>: moving normalized output <%S>\n",z,normalizedOutput->str);
+        if (tmp->output==NULL) {
+            tmp->output=u_strdup(normalizedOutput->str);
+        } else {
+            tmp->output=(unichar*)realloc(tmp->output,sizeof(unichar)*(1+normalizedOutput->len+u_strlen(tmp->output)));
+        }
+    }
+    if (!prefix_set) {
+        prefix_set=1;
+        u_strcpy(prefix,tmp->output);
+    } else {
+        get_longest_common_prefix(prefix,tmp->output);
+    }
+    tmp=tmp->next;
 }
 if (node==root || node->single_INF_code_list!=NULL) {
-	/* If we are in the initial state or a final one, we let the transitions as they are, since
-	 * their outputs can not move more to the left */
-	z[pos]='\0';
-	free_Ustring(prefix);
-	empty(normalizedOutput);
-	return;
+    /* If we are in the initial state or a final one, we let the transitions as they are, since
+     * their outputs can not move more to the left */
+    z[pos]='\0';
+    free_Ustring(prefix);
+    empty(normalizedOutput);
+    return;
 }
 tmp=node->trans;
 while (tmp!=NULL) {
-	//error("prefix removal: <%S> => ",tmp->output);
-	remove_prefix(prefix->len,tmp->output);
-	//error("<%S>\n",tmp->output);
-	tmp=tmp->next;
+    //error("prefix removal: <%S> => ",tmp->output);
+    remove_prefix(prefix->len,tmp->output);
+    //error("<%S>\n",tmp->output);
+    tmp=tmp->next;
 }
 z[pos]='\0';
 u_strcpy(normalizedOutput,prefix);

--- a/DictionaryTree.cpp
+++ b/DictionaryTree.cpp
@@ -168,7 +168,7 @@ static int get_value_index_for_string_colon_string(const unichar* str1,const uni
 	   if (allocated_buffer==NULL) {
           fatal_alloc_error("get_value_index_for_string_colon_string");
 	   }
-   }   
+   }
    u_sprintf(tmp,"%S,%S",str1,str2);
    value=get_value_index(tmp,hash);
    if (allocated_buffer != NULL) {
@@ -342,10 +342,10 @@ if (a==NULL || a->node==NULL) {
  */
 static inline int compare_nodes(const struct dictionary_node_transition* a,const struct dictionary_node_transition* b) {
 /* If the nodes have not the same INF codes, they are different */
-    
+
     struct dictionary_node* a_node = a->node;
     struct dictionary_node* b_node = b->node;
-    
+
     if (a_node->single_INF_code_list!=b_node->single_INF_code_list) {
         if (a_node->single_INF_code_list!=NULL && b_node->single_INF_code_list==NULL) return -1;
         if (a_node->single_INF_code_list==NULL && b_node->single_INF_code_list!=NULL) return 1;
@@ -353,7 +353,7 @@ static inline int compare_nodes(const struct dictionary_node_transition* a,const
     if (a_node->single_INF_code_list!=NULL && b_node->single_INF_code_list!=NULL &&
             a_node->INF_code!=b_node->INF_code)
             return (a_node->INF_code - b_node->INF_code);
-     
+
 /* Then, we compare all the outgoing transitions, two by two */
 a=a_node->trans;
 b=b_node->trans;
@@ -368,7 +368,7 @@ while(a!=NULL && b!=NULL) {
    a=a->next;
    b=b->next;
 }
-if (a==b) { 
+if (a==b) {
    /* If a==b==NULL, the transition lists are equal, the nodes are equivalent */
    return 0;
 }
@@ -510,7 +510,7 @@ static int convert_list_to_array_size(unsigned int height,struct transition_list
 unsigned int size=0;
 struct transition_list* l=transitions_by_height[height];
 
-while (l!=NULL) {   
+while (l!=NULL) {
    size++;
    l=l->next;
 }

--- a/DictionaryTree.h
+++ b/DictionaryTree.h
@@ -41,40 +41,40 @@ namespace unitex {
  * Dominique Revuz's algorithm.
  */
 struct dictionary_node {
-	/*
-	 * 'trans' is the list of the transitions outgoing from this node.
-	 */
-	struct dictionary_node_transition* trans;
-	/*
-	 * 'n_trans' stands for the number of transitions outgoing from this node. It is
-	 * equivalent the size of the list 'trans', but it is cached for efficiency
-	 * reasons.
-	 */
-	int n_trans;
-	/*
-	 * 'single_INF_code_list' is a list that contains the numbers of all the single
-	 * INF codes that are associated with this node.
-	 */
-	struct list_int* single_INF_code_list;
-	/*
-	 * 'INF_code' is a value representing the final INF line number associated
-	 * with this dictionary node. This INF code correspond to the union of all
-	 * the single INF codes of this node, separated with commas:
-	 * 
-	 * .DET:ms,.A:ms
-	 *
-	 * WARNING: this field has sense only if 'single_INF_code_list' is not NULL
-	 */
-	int INF_code;
-	/*
-	 * 'offset' is used to give to this node an address in the .BIN file
-	 */
-	int offset;
-	/*
-	 * Number of incoming transitions. It is used to know when a state can actually
-	 * be freed.
-	 */
-	int incoming;
+    /*
+     * 'trans' is the list of the transitions outgoing from this node.
+     */
+    struct dictionary_node_transition* trans;
+    /*
+     * 'n_trans' stands for the number of transitions outgoing from this node. It is
+     * equivalent the size of the list 'trans', but it is cached for efficiency
+     * reasons.
+     */
+    int n_trans;
+    /*
+     * 'single_INF_code_list' is a list that contains the numbers of all the single
+     * INF codes that are associated with this node.
+     */
+    struct list_int* single_INF_code_list;
+    /*
+     * 'INF_code' is a value representing the final INF line number associated
+     * with this dictionary node. This INF code correspond to the union of all
+     * the single INF codes of this node, separated with commas:
+     *
+     * .DET:ms,.A:ms
+     *
+     * WARNING: this field has sense only if 'single_INF_code_list' is not NULL
+     */
+    int INF_code;
+    /*
+     * 'offset' is used to give to this node an address in the .BIN file
+     */
+    int offset;
+    /*
+     * Number of incoming transitions. It is used to know when a state can actually
+     * be freed.
+     */
+    int incoming;
 };
 
 
@@ -96,7 +96,7 @@ struct dictionary_node_transition {
 void free_dictionary_node(struct dictionary_node*,Abstract_allocator);
 void free_dictionary_node_transition(struct dictionary_node_transition*,Abstract_allocator);
 void add_entry_to_dictionary_tree(unichar*,unichar*,struct dictionary_node*,struct string_hash*,
-		int,Abstract_allocator);
+        int,Abstract_allocator);
 struct dictionary_node* new_dictionary_node(Abstract_allocator);
 
 void minimize_tree(struct dictionary_node*,struct bit_array*,Abstract_allocator);

--- a/Diff.cpp
+++ b/Diff.cpp
@@ -92,7 +92,7 @@ u_fprintf(f,"</table>\n</body>\n</html>\n");
  * those two concordances.
  */
 int diff(const VersatileEncodingConfig* vec,const char* in1,const char* in2,const char* out,
-		const char* font,int size,int diff_only) {
+        const char* font,int size,int diff_only) {
 char concor1[FILENAME_MAX];
 char concor2[FILENAME_MAX];
 get_path(in1,concor1);
@@ -147,17 +147,17 @@ return 1;
  * NOTE: the return value is different from look_for_same_outputs!
  */
 static int look_for_same_outputs_(struct match_list* m,
-							struct match_list* list) {
+                            struct match_list* list) {
 struct match_list* head=list;
 while (list!=NULL && compare_matches(&(m->m),&(list->m))==A_EQUALS_B) {
-	if (!u_strcmp(m->output,list->output)) {
-		/* We have an identical match */
-		unichar* tmp=head->output;
-		head->output=list->output;
-		list->output=tmp;
-		return 1;
-	}
-	list=list->next;
+    if (!u_strcmp(m->output,list->output)) {
+        /* We have an identical match */
+        unichar* tmp=head->output;
+        head->output=list->output;
+        list->output=tmp;
+        return 1;
+    }
+    list=list->next;
 }
 return 0;
 }
@@ -182,7 +182,7 @@ return 0;
  * lists unmodified.
  */
 int look_for_same_outputs(struct match_list* list1,
-							struct match_list* list2) {
+                            struct match_list* list2) {
 if (look_for_same_outputs_(list1,list2)) return 0;
 if (look_for_same_outputs_(list2,list1)) return 0;
 return 1;
@@ -257,7 +257,7 @@ while (!(list1==NULL && list2==NULL)) {
       case B_INCLUDES_A: {
          /* list1 is included in list2:
           * abcd,abcdef */
-    	 print_diff_matches(output,f1,f2,RED,list1->output,list2->output);
+         print_diff_matches(output,f1,f2,RED,list1->output,list2->output);
          list1=list1->next;
          list2=list2->next;
          break;
@@ -274,20 +274,20 @@ while (!(list1==NULL && list2==NULL)) {
       case A_EQUALS_B: {
          /* list1 == list2:
           * abcd,abcd */
-    	 int different_outputs=u_strcmp(list1->output,list2->output);
-    	 if (different_outputs) {
-    		 /* If there are matches with ambiguous outputs, we may find
-    		  * an exact match pair forward in the lists
-    		  */
-    		 different_outputs=look_for_same_outputs(list1,list2);
-    	 }
-    	 if (!diff_only || different_outputs) {
+         int different_outputs=u_strcmp(list1->output,list2->output);
+         if (different_outputs) {
+             /* If there are matches with ambiguous outputs, we may find
+              * an exact match pair forward in the lists
+              */
+             different_outputs=look_for_same_outputs(list1,list2);
+         }
+         if (!diff_only || different_outputs) {
             print_diff_matches(output,f1,f2,different_outputs?VIOLET:BLUE,list1->output,list2->output);
-    	 } else {
-    		 /* We have to skip the unused lines */
-    		 u_fskip_line(f1);
-    		 u_fskip_line(f2);
-    	 }
+         } else {
+             /* We have to skip the unused lines */
+             u_fskip_line(f1);
+             u_fskip_line(f2);
+         }
          list1=list1->next;
          list2=list2->next;
          break;
@@ -307,7 +307,7 @@ while (!(list1==NULL && list2==NULL)) {
  *            This is why there is the (++total>=60) hack.
  */
 void read_concordance_line(U_FILE* f,unichar* left,unichar* middle,unichar* right,unichar* indices,int
-		expected_match_length) {
+        expected_match_length) {
 int i,c;
 i=0;
 while ((c=u_fgetc(f))!='\t') {
@@ -322,9 +322,9 @@ while ((c=u_fgetc(f))!='\t') {
 middle[i]='\0';
 i=0;
 while ((c=u_fgetc(f))!='\t') {
-	if (++total>=60) {
-		c='\0';
-	}
+    if (++total>=60) {
+        c='\0';
+    }
    right[i++]=(unichar)c;
 }
 right[i]='\0';
@@ -343,7 +343,7 @@ static void adjust(unichar* src,unichar* dst,unichar* middle,int n) {
 u_strcpy(dst,src);
 int pos=u_strlen(dst);
 for (int i=0;i<n;i++) {
-	dst[pos++]=middle[i];
+    dst[pos++]=middle[i];
 }
 dst[pos]='\0';
 }
@@ -353,7 +353,7 @@ dst[pos]='\0';
  * 'output' in the given color.
  */
 void print_diff_matches(U_FILE* output,U_FILE* f1,U_FILE* f2,const char* color,
-		unichar* match1,unichar* match2) {
+        unichar* match1,unichar* match2) {
 unichar left1[MAX_CONTEXT_IN_UNITS];
 unichar middle1[MAX_CONTEXT_IN_UNITS];
 unichar right1[MAX_CONTEXT_IN_UNITS];
@@ -371,23 +371,23 @@ if (f2!=NULL) {
 if (match1!=NULL) u_strcpy(middle1,match1);
 if (match2!=NULL) u_strcpy(middle2,match2);
 if (!strcmp(color,RED)) {
-	/* If we have one match included in the another, we want to align
-	 * them. We do that by adjusting their left contexts */
-	int pos1,pos2;
-	u_sscanf(indices1,"%d",&pos1);
-	u_sscanf(indices2,"%d",&pos2);
-	if (pos1<pos2) {
-		adjust(left1,left2,middle1,pos2-pos1);
-	} else if (pos1>pos2) {
-		adjust(left2,left1,middle2,pos1-pos2);
-	} /*  Nothing to adjust if pos1==pos2 */
+    /* If we have one match included in the another, we want to align
+     * them. We do that by adjusting their left contexts */
+    int pos1,pos2;
+    u_sscanf(indices1,"%d",&pos1);
+    u_sscanf(indices2,"%d",&pos2);
+    if (pos1<pos2) {
+        adjust(left1,left2,middle1,pos2-pos1);
+    } else if (pos1>pos2) {
+        adjust(left2,left1,middle2,pos1-pos2);
+    } /*  Nothing to adjust if pos1==pos2 */
 }
 /* We print the line from the first file, if needed */
 u_fprintf(output,"<tr><td nowrap bgcolor=\"#FFE4C4\"><font color=\"%s\">",color);
 if (f1!=NULL) {
    u_fprintf(output,"%HS<a href=\"%S\" style=\"color:%s\">%HS</a>%HS",left1,indices1,color,middle1,right1);
 } else {
-	u_fprintf(output,"&nbsp;");
+    u_fprintf(output,"&nbsp;");
 }
 u_fprintf(output,"</font></td></tr>\n");
 u_fprintf(output,"<tr><td nowrap bgcolor=\"#90EE90\"><font color=\"%s\">",color);
@@ -395,7 +395,7 @@ u_fprintf(output,"<tr><td nowrap bgcolor=\"#90EE90\"><font color=\"%s\">",color)
 if (f2!=NULL) {
    u_fprintf(output,"%HS<a href=\"%S\" style=\"color:%s\">%HS</a>%HS",left2,indices2,color,middle2,right2);
 } else {
-	u_fprintf(output,"&nbsp;");
+    u_fprintf(output,"&nbsp;");
 }
 u_fprintf(output,"</font></td></tr>\n");
 }

--- a/Diff.cpp
+++ b/Diff.cpp
@@ -268,7 +268,7 @@ while (!(list1==NULL && list2==NULL)) {
           * We consider that they are two distinct lines, and we
           * print the first */
          print_diff_matches(output,NULL,f2,GREEN,list1->output,list2->output);
-         list2=list2->next;         
+         list2=list2->next;
          break;
       }
       case A_EQUALS_B: {

--- a/Diff.h
+++ b/Diff.h
@@ -32,7 +32,7 @@ namespace unitex {
 
 int diff(const VersatileEncodingConfig*,const char*,const char*,const char*,const char*,int,int);
 void compute_concordance_differences(struct match_list*,struct match_list*,U_FILE*,
-		U_FILE*,U_FILE*,int);
+        U_FILE*,U_FILE*,int);
 void print_diff_matches(U_FILE*,U_FILE*,U_FILE*,const char*,unichar*,unichar*);
 
 } // namespace unitex

--- a/DirHelper.h
+++ b/DirHelper.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/DirHelperPosix.cpp
+++ b/DirHelperPosix.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/DirHelperPosix.cpp
+++ b/DirHelperPosix.cpp
@@ -79,41 +79,41 @@ int rmDirPortable(const char* dirname)
 
 char** buildListFileInDiskDir(const char*dirname)
 {
-	DIR *dir;
-	struct dirent *ent;
-	dir = opendir(dirname);
+    DIR *dir;
+    struct dirent *ent;
+    dir = opendir(dirname);
 
 
-	if (dir == NULL)
-		return NULL;
+    if (dir == NULL)
+        return NULL;
 
-	int count = 0;
-	char**ret = (char**)malloc(sizeof(char*));
-	if (ret == NULL)
-	{
-		closedir(dir);
-		return NULL;
-	}
-	*ret = NULL;
+    int count = 0;
+    char**ret = (char**)malloc(sizeof(char*));
+    if (ret == NULL)
+    {
+        closedir(dir);
+        return NULL;
+    }
+    *ret = NULL;
 
-	while ((ent = readdir(dir)) != NULL)
-	{
-		if (ent->d_type == DT_DIR)
-			continue;
-		char** newret = (char**)realloc(ret, sizeof(char*)*(count + 2));
-		if (newret == NULL)
-		{
-			break;
-		}
-		ret = newret;
-		*(newret + count) = (char*)malloc(strlen(ent->d_name) + 1);
-		if ((*(newret + count)) == NULL)
-			break;
-		strcpy(*(newret + count), ent->d_name);
-		count++;
-		*(newret + count) = NULL;
-	}
+    while ((ent = readdir(dir)) != NULL)
+    {
+        if (ent->d_type == DT_DIR)
+            continue;
+        char** newret = (char**)realloc(ret, sizeof(char*)*(count + 2));
+        if (newret == NULL)
+        {
+            break;
+        }
+        ret = newret;
+        *(newret + count) = (char*)malloc(strlen(ent->d_name) + 1);
+        if ((*(newret + count)) == NULL)
+            break;
+        strcpy(*(newret + count), ent->d_name);
+        count++;
+        *(newret + count) = NULL;
+    }
 
-	closedir(dir);
-	return ret;
+    closedir(dir);
+    return ret;
 }

--- a/DirHelperWin.cpp
+++ b/DirHelperWin.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/DirHelperWin.cpp
+++ b/DirHelperWin.cpp
@@ -81,54 +81,54 @@ int rmDirPortable(const char* dirname)
 
 char** buildListFileInDiskDir(const char*dirname)
 {
-	HANDLE hFind;
-	WIN32_FIND_DATAA FindFileData;
+    HANDLE hFind;
+    WIN32_FIND_DATAA FindFileData;
 
-	char* dirnameWithSuffix = (char*)malloc(strlen(dirname) + 4);
-	if (dirnameWithSuffix == NULL)
-		return NULL;
-	strcpy(dirnameWithSuffix, dirname);
-	strcat(dirnameWithSuffix, "\\");
-	strcat(dirnameWithSuffix, "*");
+    char* dirnameWithSuffix = (char*)malloc(strlen(dirname) + 4);
+    if (dirnameWithSuffix == NULL)
+        return NULL;
+    strcpy(dirnameWithSuffix, dirname);
+    strcat(dirnameWithSuffix, "\\");
+    strcat(dirnameWithSuffix, "*");
 #ifdef UNITEX_USING_WINRT_API
-	hFind = FindFirstFileExA(dirnameWithSuffix, FindExInfoStandard, &FindFileData,
-		FindExSearchNameMatch, NULL, 0);
+    hFind = FindFirstFileExA(dirnameWithSuffix, FindExInfoStandard, &FindFileData,
+        FindExSearchNameMatch, NULL, 0);
 #else
-	hFind = FindFirstFileA(dirnameWithSuffix, &FindFileData);
+    hFind = FindFirstFileA(dirnameWithSuffix, &FindFileData);
 #endif
-	free(dirnameWithSuffix);
-	if ((hFind == NULL) || (hFind == INVALID_HANDLE_VALUE))
-		return NULL;
+    free(dirnameWithSuffix);
+    if ((hFind == NULL) || (hFind == INVALID_HANDLE_VALUE))
+        return NULL;
 
-	int count = 0;
-	char**ret = (char**)malloc(sizeof(char*));
-	if (ret == NULL)
-	{
-		FindClose(hFind);
-		return NULL;
-	}
-	*ret = NULL;
+    int count = 0;
+    char**ret = (char**)malloc(sizeof(char*));
+    if (ret == NULL)
+    {
+        FindClose(hFind);
+        return NULL;
+    }
+    *ret = NULL;
 
-	do
-	{
-		if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-			continue;
-		char** newret = (char**)realloc(ret,sizeof(char*)*(count+2));
-		if (newret == NULL)
-		{
-			break;
-		}
-		ret = newret;
-		*(newret + count) = (char*)malloc(strlen(FindFileData.cFileName) + 1);
-		if ((*(newret + count)) == NULL)
-			break;
-		strcpy(*(newret + count), FindFileData.cFileName);
-		count++;
-		*(newret + count) = NULL;
-	}
-	while (FindNextFileA(hFind, &FindFileData) != 0);
+    do
+    {
+        if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            continue;
+        char** newret = (char**)realloc(ret,sizeof(char*)*(count+2));
+        if (newret == NULL)
+        {
+            break;
+        }
+        ret = newret;
+        *(newret + count) = (char*)malloc(strlen(FindFileData.cFileName) + 1);
+        if ((*(newret + count)) == NULL)
+            break;
+        strcpy(*(newret + count), FindFileData.cFileName);
+        count++;
+        *(newret + count) = NULL;
+    }
+    while (FindNextFileA(hFind, &FindFileData) != 0);
 
 
-	FindClose(hFind);
-	return ret;
+    FindClose(hFind);
+    return ret;
 }

--- a/DumpOffsets.cpp
+++ b/DumpOffsets.cpp
@@ -181,7 +181,7 @@ static unichar* read_text_file(U_FILE* f, int* filesize){
         alloc_error("read_text_file");
         return NULL;
     }
-    
+
     int size_read;
     int pos_in_text = 0;
     do {
@@ -201,7 +201,7 @@ static unichar* read_text_file(U_FILE* f, int* filesize){
         pos_in_text += size_read;
         *(text + pos_in_text) = '\0';
     } while (size_read != 0);
-    
+
     *filesize = pos_in_text;
     return text;
 }
@@ -492,7 +492,7 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                             while(old_c != new_c) {
                                 u_fputc_raw(old_c, f);
                                 i++;
-                                if (i >= old_end) { 
+                                if (i >= old_end) {
                                     error("End of old text reached in denormalize!!\n");
                                     break;
                                 }
@@ -516,7 +516,7 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                             new_c = *(new_text + j);
                         }
                     }
-#ifdef NEW_DENORMALIZE_FIX_EXPERIMENT					
+#ifdef NEW_DENORMALIZE_FIX_EXPERIMENT
                     else if(old_c ==' ' || old_c =='\t' || old_c =='\n' || old_c =='\r') { //add the missing white spaces back
                         while(old_c ==' ' || old_c =='\t' || old_c =='\n' || old_c =='\r') {
                             u_fputc_raw(old_c, f);
@@ -544,7 +544,7 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                 }
             }
 #ifdef NEW_DENORMALIZE_FIX_EXPERIMENT
-            else if(new_c !='<' && i < old_end) { 
+            else if(new_c !='<' && i < old_end) {
                 if(new_c=='{') {
                     /* check if it is annotation in raw format
                      If yes then preference is given to the new text*/
@@ -559,7 +559,7 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                         }
                         look_ahead++;
                     }
-                 
+
 
                     if(look_ahead == new_end && *(new_text+look_ahead-1) == '}') {
                         look_ahead += 1;
@@ -579,9 +579,9 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                         old_c = *(old_text + i);
                     }
                 }
-                /*we know that characters don't match and the new text 
+                /*we know that characters don't match and the new text
                  * is not the start of a tag so we give preference to the
-                 * old text 
+                 * old text
                  */
                 while(i < old_end && old_c != new_c) {
                     u_fputc_raw(old_c, f);
@@ -599,8 +599,8 @@ static int DenormalizeSequence_new(U_FILE* f,const unichar* old_text, int old_te
                 }
                 look_ahead++;
                 new_c = *(new_text + look_ahead);
-                if(new_c != old_c) { 
-                //if the text after the tag is not same then print old text first    
+                if(new_c != old_c) {
+                //if the text after the tag is not same then print old text first
                     while(old_c != new_c && i < old_end) {
                         u_fputc_raw(old_c, f);
                         i++;
@@ -1107,7 +1107,7 @@ int copy_chars_between_unicharfiles(U_FILE* input, U_FILE* output, int* pos_in, 
 		if (result_read >= (int)size_buffer)
 			result_read = (int)(size_buffer - 1);
 		*(buffer + result_read) = 0;
-		
+
 		if ((result_read>0) && (output != NULL)) {
 			u_fputs_raw(buffer, output);
 		}
@@ -1197,13 +1197,13 @@ int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfi
 	int delta_output_against_processed = 0;
 	int size_skip_original_for_ignored_offset = 0;
 
-	for (;;) 
+	for (;;)
 	{
 		// we search position in next change in processed_offset
 		int next_stop_processed = (pos_in_processed_offset >= v_processed_offset->nbelems) ?
 			-1 : v_processed_offset->tab[pos_in_processed_offset].old_start;
 
-		
+
 		// now, between pos_in_preprocessed_file and next_stop_preprocessed, we can integrate revert modification made by pre-processing
 
 		int next_stop_preprocessed = (pos_in_preprocessed_offset >= v_preprocessed_offset->nbelems) ?
@@ -1216,7 +1216,7 @@ int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfi
 			preprocess_next_action_apply_process,
 			preprocess_next_action_break,
 		} preprocess_next_action ;
-		
+
 		// if there is no more preprocess offset, just apply next process offset
 		if ((next_stop_processed == -1) && (next_stop_preprocessed == -1))
 		{
@@ -1263,7 +1263,7 @@ int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfi
 			// copy next text from processed file
 			copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, size_new_in_process_modification, buffer_for_copy, buffer_for_copy_size);
 			pos_in_preprocessed_file += size_old_in_process_modification;
-			
+
 			size_skip_original_for_ignored_offset += size_old_in_process_modification;
 
 			pos_in_processed_offset++;
@@ -1289,7 +1289,7 @@ int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfi
 			int size_new_in_preprocess_keep = v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
 
 			// copy text from first, original text to replace texte modified by preprocessing and still in processed file
-			if (v_modification_offset != NULL) vector_offset_add(v_modification_offset, 
+			if (v_modification_offset != NULL) vector_offset_add(v_modification_offset,
 				pos_in_processed_file, pos_in_processed_file + size_new_in_preprocess_keep,
 				pos_in_processed_file + delta_output_against_processed, pos_in_processed_file + delta_output_against_processed + size_old_in_preprocess_keep);
 			delta_output_against_processed += (size_old_in_preprocess_keep - size_new_in_preprocess_keep);
@@ -1322,7 +1322,7 @@ int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfi
 		}
 		U_FILE* f_output_offsets = u_fopen(vec, params->output_offsets, U_WRITE);
 		if (f_output_offsets == NULL) {
-			error("Cannot create offset file %s\n", params->output_offsets);				
+			error("Cannot create offset file %s\n", params->output_offsets);
 		}
 		else {
 			process_offsets(v_input_offsets, v_modification_offset, f_output_offsets);
@@ -1439,7 +1439,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_UnPreprocess,lopts_UnPre
              }
              strcpy(params.input_offsets,options.vars()->optarg);
              break;
-			 
+
    case '@': if (options.vars()->optarg[0]=='\0') {
               error("You must specify a non empty output offset file name\n");
               return USAGE_ERROR_CODE;
@@ -1460,7 +1460,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_UnPreprocess,lopts_UnPre
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': display_usage_UnPreprocess();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
@@ -1469,7 +1469,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_UnPreprocess,lopts_UnPre
              break;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
-             return USAGE_ERROR_CODE;  
+             return USAGE_ERROR_CODE;
              break;
    }
    index = -1;
@@ -1483,7 +1483,7 @@ if (options.vars()->optind != argc - 1) {
 }
 
 if (only_verify_arguments) {
-	// freeing all allocated memory 
+	// freeing all allocated memory
 	return SUCCESS_RETURN_CODE;
 }
 

--- a/DumpOffsets.cpp
+++ b/DumpOffsets.cpp
@@ -1082,13 +1082,13 @@ else {
 
 typedef struct
 {
-	char original_file[FILENAME_MAX];
-	char processed_file[FILENAME_MAX];
-	char output_file[FILENAME_MAX];
-	char preprocessed_offset[FILENAME_MAX];
-	char processed_offset[FILENAME_MAX];
-	char input_offsets[FILENAME_MAX];
-	char output_offsets[FILENAME_MAX];
+    char original_file[FILENAME_MAX];
+    char processed_file[FILENAME_MAX];
+    char output_file[FILENAME_MAX];
+    char preprocessed_offset[FILENAME_MAX];
+    char processed_offset[FILENAME_MAX];
+    char input_offsets[FILENAME_MAX];
+    char output_offsets[FILENAME_MAX];
 } UnPreprocessParam;
 
 
@@ -1096,39 +1096,39 @@ typedef struct
 
 int copy_chars_between_unicharfiles(U_FILE* input, U_FILE* output, int* pos_in, int* pos_out, int nb_needed, unichar* buffer, size_t size_buffer)
 {
-	int result = 0;
-	while (nb_needed > 0) {
-		int nb_this = (nb_needed < (int)(size_buffer-1)) ? nb_needed : (int)(size_buffer-1);
-		//int result_read = u_fread_raw(buffer, nb_this, input);
-		int result_read = u_fget_unichars_raw(buffer, nb_this, input);
-		if (result_read < 0) {
-			result_read = 0;
-		}
-		if (result_read >= (int)size_buffer)
-			result_read = (int)(size_buffer - 1);
-		*(buffer + result_read) = 0;
+    int result = 0;
+    while (nb_needed > 0) {
+        int nb_this = (nb_needed < (int)(size_buffer-1)) ? nb_needed : (int)(size_buffer-1);
+        //int result_read = u_fread_raw(buffer, nb_this, input);
+        int result_read = u_fget_unichars_raw(buffer, nb_this, input);
+        if (result_read < 0) {
+            result_read = 0;
+        }
+        if (result_read >= (int)size_buffer)
+            result_read = (int)(size_buffer - 1);
+        *(buffer + result_read) = 0;
 
-		if ((result_read>0) && (output != NULL)) {
-			u_fputs_raw(buffer, output);
-		}
-		result += result_read;
-		nb_needed -= result_read;
-		if ((result_read == 0) || (nb_needed == 0))
-			break;
-	}
-	if (pos_in != NULL) {
-		(*pos_in) += result;
-	}
-	if (pos_out != NULL) {
-		(*pos_out) += result;
-	}
-	return result;
+        if ((result_read>0) && (output != NULL)) {
+            u_fputs_raw(buffer, output);
+        }
+        result += result_read;
+        nb_needed -= result_read;
+        if ((result_read == 0) || (nb_needed == 0))
+            break;
+    }
+    if (pos_in != NULL) {
+        (*pos_in) += result;
+    }
+    if (pos_out != NULL) {
+        (*pos_out) += result;
+    }
+    return result;
 }
 
 
 int skip_chars_in_unicharfiles(U_FILE* input, int* pos_in, int nb_needed, unichar* buffer, size_t size_buffer)
 {
-	return copy_chars_between_unicharfiles(input, NULL, pos_in, NULL, nb_needed, buffer, size_buffer);
+    return copy_chars_between_unicharfiles(input, NULL, pos_in, NULL, nb_needed, buffer, size_buffer);
 }
 
 
@@ -1136,234 +1136,234 @@ int skip_chars_in_unicharfiles(U_FILE* input, int* pos_in, int nb_needed, unicha
 // if (*accumulated_skip) < 0, we do nothing
 int skip_chars_in_unicharfiles_as_possible(U_FILE* input, int* pos_in, int* accumulated_skip, unichar* buffer, size_t size_buffer)
 {
-	if ((*accumulated_skip) < 0)
-		return 0;
-	int result = copy_chars_between_unicharfiles(input, NULL, pos_in, NULL, *accumulated_skip, buffer, size_buffer);
-	(*accumulated_skip) -= result;
-	return result;
+    if ((*accumulated_skip) < 0)
+        return 0;
+    int result = copy_chars_between_unicharfiles(input, NULL, pos_in, NULL, *accumulated_skip, buffer, size_buffer);
+    (*accumulated_skip) -= result;
+    return result;
 }
 
 #define uprep_min(a,b) (((a)<(b)) ? (a) : (b))
 
 int runUnPreprocess(const UnPreprocessParam*params, const VersatileEncodingConfig *vec)
 {
-	vector_offset* v_preprocessed_offset = NULL;
-	vector_offset* v_processed_offset = NULL;
-	vector_offset* v_modification_offset = NULL;
-	unichar buffer_for_copy[COPY_BUFFER_SIZE];
-	size_t buffer_for_copy_size = COPY_BUFFER_SIZE;
+    vector_offset* v_preprocessed_offset = NULL;
+    vector_offset* v_processed_offset = NULL;
+    vector_offset* v_modification_offset = NULL;
+    unichar buffer_for_copy[COPY_BUFFER_SIZE];
+    size_t buffer_for_copy_size = COPY_BUFFER_SIZE;
 
-	if (params->preprocessed_offset[0] != '\0') {
-		v_preprocessed_offset = load_offsets(vec, params->preprocessed_offset);
-		}
-
-
-	if (params->processed_offset[0] != '\0') {
-		v_processed_offset = load_offsets(vec, params->processed_offset);
-	}
-
-	U_FILE* f_input_original_file = u_fopen(vec, params->original_file, U_READ);
-	U_FILE* f_input_processed = u_fopen(vec, params->processed_file, U_READ);
-	U_FILE* f_output = NULL;
-
-	if ((v_preprocessed_offset == NULL) || (v_processed_offset == NULL) || (f_input_original_file == NULL) || (f_input_processed == NULL)) {
-		error("Cannot open source files\n");
-	}
-	else
-	{
-		if ((f_output = u_fopen(vec, params->output_file, U_WRITE)) == NULL) {
-			error("Cannot open output file files %s\n", params->output_file);
-		}
-	}
-
-	if (f_output == NULL) {
-		free_vector_offset(v_preprocessed_offset);
-		free_vector_offset(v_processed_offset);
-		u_fclose(f_input_original_file);
-		u_fclose(f_input_processed);
-		return DEFAULT_ERROR_CODE;
-	}
-
-	if (params->output_offsets[0] != '\0') {
-		v_modification_offset = new_vector_offset();
-	}
-
-	int pos_in_processed_offset = 0;
-	int pos_in_preprocessed_offset = 0;
-	int pos_in_original_file = 0;
-	int pos_in_preprocessed_file = 0;
-	int pos_in_processed_file = 0;
-	int pos_in_output = 0;
-	int delta_output_against_processed = 0;
-	int size_skip_original_for_ignored_offset = 0;
-
-	for (;;)
-	{
-		// we search position in next change in processed_offset
-		int next_stop_processed = (pos_in_processed_offset >= v_processed_offset->nbelems) ?
-			-1 : v_processed_offset->tab[pos_in_processed_offset].old_start;
+    if (params->preprocessed_offset[0] != '\0') {
+        v_preprocessed_offset = load_offsets(vec, params->preprocessed_offset);
+        }
 
 
-		// now, between pos_in_preprocessed_file and next_stop_preprocessed, we can integrate revert modification made by pre-processing
+    if (params->processed_offset[0] != '\0') {
+        v_processed_offset = load_offsets(vec, params->processed_offset);
+    }
 
-		int next_stop_preprocessed = (pos_in_preprocessed_offset >= v_preprocessed_offset->nbelems) ?
-				-1 : v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
+    U_FILE* f_input_original_file = u_fopen(vec, params->original_file, U_READ);
+    U_FILE* f_input_processed = u_fopen(vec, params->processed_file, U_READ);
+    U_FILE* f_output = NULL;
 
+    if ((v_preprocessed_offset == NULL) || (v_processed_offset == NULL) || (f_input_original_file == NULL) || (f_input_processed == NULL)) {
+        error("Cannot open source files\n");
+    }
+    else
+    {
+        if ((f_output = u_fopen(vec, params->output_file, U_WRITE)) == NULL) {
+            error("Cannot open output file files %s\n", params->output_file);
+        }
+    }
 
-		enum {
-			preprocess_next_action_skip_preprocess,
-			preprocess_next_action_apply_preprocess,
-			preprocess_next_action_apply_process,
-			preprocess_next_action_break,
-		} preprocess_next_action ;
+    if (f_output == NULL) {
+        free_vector_offset(v_preprocessed_offset);
+        free_vector_offset(v_processed_offset);
+        u_fclose(f_input_original_file);
+        u_fclose(f_input_processed);
+        return DEFAULT_ERROR_CODE;
+    }
 
-		// if there is no more preprocess offset, just apply next process offset
-		if ((next_stop_processed == -1) && (next_stop_preprocessed == -1))
-		{
-			preprocess_next_action = preprocess_next_action_break;
-		}
-		else
-		if (next_stop_preprocessed == -1) {
-			preprocess_next_action = preprocess_next_action_apply_process;
-		}
-		else // if process offset is before next preprocess offset and doesn't overlap
-		if (v_processed_offset->tab[pos_in_processed_offset].old_end <= v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start) {
-			preprocess_next_action = preprocess_next_action_apply_process;
-		}
-		else // if process offset is after next preprocess offset and doesn't overlap
-		if (v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end <= v_processed_offset->tab[pos_in_processed_offset].old_start) {
-			preprocess_next_action = preprocess_next_action_apply_preprocess;
-		}
-		else {
-			preprocess_next_action = preprocess_next_action_skip_preprocess;
-		}
+    if (params->output_offsets[0] != '\0') {
+        v_modification_offset = new_vector_offset();
+    }
 
+    int pos_in_processed_offset = 0;
+    int pos_in_preprocessed_offset = 0;
+    int pos_in_original_file = 0;
+    int pos_in_preprocessed_file = 0;
+    int pos_in_processed_file = 0;
+    int pos_in_output = 0;
+    int delta_output_against_processed = 0;
+    int size_skip_original_for_ignored_offset = 0;
 
-		if (preprocess_next_action == preprocess_next_action_break)
-			break;
-
-		int first_stop;
-		if ((next_stop_processed != -1) && (next_stop_preprocessed != -1))
-			first_stop = (next_stop_processed < next_stop_preprocessed) ? next_stop_processed : next_stop_preprocessed;
-		else first_stop = (next_stop_preprocessed == -1) ? next_stop_processed : next_stop_preprocessed;
-
-		int until_first_stop = first_stop - pos_in_preprocessed_file;
-		// copy unmodified text before first stop from processed file
-		copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, until_first_stop, buffer_for_copy, buffer_for_copy_size);
-		pos_in_preprocessed_file += until_first_stop;
-
-		size_skip_original_for_ignored_offset += until_first_stop;
-
-		// test if there the next modification is a processed modification to keep
-		if (preprocess_next_action == preprocess_next_action_apply_process)
-		{
-			int size_old_in_process_modification = v_processed_offset->tab[pos_in_processed_offset].old_end - v_processed_offset->tab[pos_in_processed_offset].old_start;
-			int size_new_in_process_modification = v_processed_offset->tab[pos_in_processed_offset].new_end - v_processed_offset->tab[pos_in_processed_offset].new_start;
-
-			// copy next text from processed file
-			copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, size_new_in_process_modification, buffer_for_copy, buffer_for_copy_size);
-			pos_in_preprocessed_file += size_old_in_process_modification;
-
-			size_skip_original_for_ignored_offset += size_old_in_process_modification;
-
-			pos_in_processed_offset++;
-		}
-		else
-		// test if there the next modification if a preprocessed modification which overlap and will be ignored
-		// if this test is true, we knwown that next_stop_processed > next_stop_preprocessed)
-
-		// we test if there is overlap. If there is overlap, we ignore preprocessed modification
-		if (preprocess_next_action == preprocess_next_action_skip_preprocess)
-		{
-			int size_old_in_preprocess_skip = v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_start;
-			int size_new_in_preprocess_skip = v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
-			size_skip_original_for_ignored_offset += size_old_in_preprocess_skip - size_new_in_preprocess_skip;
-
-			pos_in_preprocessed_offset++;
-		}
-		else // here if (preprocess_next_action == preprocess_next_action_apply_process)
-		{
-		// the modification is a preprocessed modification to keep
-
-			int size_old_in_preprocess_keep = v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_start;
-			int size_new_in_preprocess_keep = v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
-
-			// copy text from first, original text to replace texte modified by preprocessing and still in processed file
-			if (v_modification_offset != NULL) vector_offset_add(v_modification_offset,
-				pos_in_processed_file, pos_in_processed_file + size_new_in_preprocess_keep,
-				pos_in_processed_file + delta_output_against_processed, pos_in_processed_file + delta_output_against_processed + size_old_in_preprocess_keep);
-			delta_output_against_processed += (size_old_in_preprocess_keep - size_new_in_preprocess_keep);
-
-			skip_chars_in_unicharfiles_as_possible(f_input_original_file, &pos_in_original_file, &size_skip_original_for_ignored_offset, buffer_for_copy, buffer_for_copy_size);
-			copy_chars_between_unicharfiles(f_input_original_file, f_output, &pos_in_original_file, &pos_in_output, size_old_in_preprocess_keep, buffer_for_copy, buffer_for_copy_size);
-
-			pos_in_preprocessed_file+=size_new_in_preprocess_keep;
-			skip_chars_in_unicharfiles(f_input_processed, &pos_in_processed_file, size_new_in_preprocess_keep, buffer_for_copy, buffer_for_copy_size);
-
-			pos_in_preprocessed_offset++;
-		}
-	}
-
-	// copy unmodified text after all offsets
-	for (;;)
-	{
-		int nb_copy_this = copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, (int)buffer_for_copy_size, buffer_for_copy, buffer_for_copy_size);
-		if (nb_copy_this == 0)
-			break;
-	}
-
-	if (v_modification_offset != NULL) {
-		vector_offset* v_input_offsets = NULL;
+    for (;;)
+    {
+        // we search position in next change in processed_offset
+        int next_stop_processed = (pos_in_processed_offset >= v_processed_offset->nbelems) ?
+            -1 : v_processed_offset->tab[pos_in_processed_offset].old_start;
 
 
-		/* We deal with offsets only if we have to produce output offsets */
-		if (params->input_offsets[0] != '\0') {
-			v_input_offsets = load_offsets(vec, params->input_offsets);
-		}
-		U_FILE* f_output_offsets = u_fopen(vec, params->output_offsets, U_WRITE);
-		if (f_output_offsets == NULL) {
-			error("Cannot create offset file %s\n", params->output_offsets);
-		}
-		else {
-			process_offsets(v_input_offsets, v_modification_offset, f_output_offsets);
-			u_fclose(f_output_offsets);
-		}
-		free_vector_offset(v_input_offsets);
-		free_vector_offset(v_modification_offset);
-	}
+        // now, between pos_in_preprocessed_file and next_stop_preprocessed, we can integrate revert modification made by pre-processing
+
+        int next_stop_preprocessed = (pos_in_preprocessed_offset >= v_preprocessed_offset->nbelems) ?
+                -1 : v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
 
 
-	u_fclose(f_output);
-	free_vector_offset(v_preprocessed_offset);
-	free_vector_offset(v_processed_offset);
-	u_fclose(f_input_original_file);
-	u_fclose(f_input_processed);
+        enum {
+            preprocess_next_action_skip_preprocess,
+            preprocess_next_action_apply_preprocess,
+            preprocess_next_action_apply_process,
+            preprocess_next_action_break,
+        } preprocess_next_action ;
 
-	return SUCCESS_RETURN_CODE;
+        // if there is no more preprocess offset, just apply next process offset
+        if ((next_stop_processed == -1) && (next_stop_preprocessed == -1))
+        {
+            preprocess_next_action = preprocess_next_action_break;
+        }
+        else
+        if (next_stop_preprocessed == -1) {
+            preprocess_next_action = preprocess_next_action_apply_process;
+        }
+        else // if process offset is before next preprocess offset and doesn't overlap
+        if (v_processed_offset->tab[pos_in_processed_offset].old_end <= v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start) {
+            preprocess_next_action = preprocess_next_action_apply_process;
+        }
+        else // if process offset is after next preprocess offset and doesn't overlap
+        if (v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end <= v_processed_offset->tab[pos_in_processed_offset].old_start) {
+            preprocess_next_action = preprocess_next_action_apply_preprocess;
+        }
+        else {
+            preprocess_next_action = preprocess_next_action_skip_preprocess;
+        }
+
+
+        if (preprocess_next_action == preprocess_next_action_break)
+            break;
+
+        int first_stop;
+        if ((next_stop_processed != -1) && (next_stop_preprocessed != -1))
+            first_stop = (next_stop_processed < next_stop_preprocessed) ? next_stop_processed : next_stop_preprocessed;
+        else first_stop = (next_stop_preprocessed == -1) ? next_stop_processed : next_stop_preprocessed;
+
+        int until_first_stop = first_stop - pos_in_preprocessed_file;
+        // copy unmodified text before first stop from processed file
+        copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, until_first_stop, buffer_for_copy, buffer_for_copy_size);
+        pos_in_preprocessed_file += until_first_stop;
+
+        size_skip_original_for_ignored_offset += until_first_stop;
+
+        // test if there the next modification is a processed modification to keep
+        if (preprocess_next_action == preprocess_next_action_apply_process)
+        {
+            int size_old_in_process_modification = v_processed_offset->tab[pos_in_processed_offset].old_end - v_processed_offset->tab[pos_in_processed_offset].old_start;
+            int size_new_in_process_modification = v_processed_offset->tab[pos_in_processed_offset].new_end - v_processed_offset->tab[pos_in_processed_offset].new_start;
+
+            // copy next text from processed file
+            copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, size_new_in_process_modification, buffer_for_copy, buffer_for_copy_size);
+            pos_in_preprocessed_file += size_old_in_process_modification;
+
+            size_skip_original_for_ignored_offset += size_old_in_process_modification;
+
+            pos_in_processed_offset++;
+        }
+        else
+        // test if there the next modification if a preprocessed modification which overlap and will be ignored
+        // if this test is true, we knwown that next_stop_processed > next_stop_preprocessed)
+
+        // we test if there is overlap. If there is overlap, we ignore preprocessed modification
+        if (preprocess_next_action == preprocess_next_action_skip_preprocess)
+        {
+            int size_old_in_preprocess_skip = v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_start;
+            int size_new_in_preprocess_skip = v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
+            size_skip_original_for_ignored_offset += size_old_in_preprocess_skip - size_new_in_preprocess_skip;
+
+            pos_in_preprocessed_offset++;
+        }
+        else // here if (preprocess_next_action == preprocess_next_action_apply_process)
+        {
+        // the modification is a preprocessed modification to keep
+
+            int size_old_in_preprocess_keep = v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].old_start;
+            int size_new_in_preprocess_keep = v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_end - v_preprocessed_offset->tab[pos_in_preprocessed_offset].new_start;
+
+            // copy text from first, original text to replace texte modified by preprocessing and still in processed file
+            if (v_modification_offset != NULL) vector_offset_add(v_modification_offset,
+                pos_in_processed_file, pos_in_processed_file + size_new_in_preprocess_keep,
+                pos_in_processed_file + delta_output_against_processed, pos_in_processed_file + delta_output_against_processed + size_old_in_preprocess_keep);
+            delta_output_against_processed += (size_old_in_preprocess_keep - size_new_in_preprocess_keep);
+
+            skip_chars_in_unicharfiles_as_possible(f_input_original_file, &pos_in_original_file, &size_skip_original_for_ignored_offset, buffer_for_copy, buffer_for_copy_size);
+            copy_chars_between_unicharfiles(f_input_original_file, f_output, &pos_in_original_file, &pos_in_output, size_old_in_preprocess_keep, buffer_for_copy, buffer_for_copy_size);
+
+            pos_in_preprocessed_file+=size_new_in_preprocess_keep;
+            skip_chars_in_unicharfiles(f_input_processed, &pos_in_processed_file, size_new_in_preprocess_keep, buffer_for_copy, buffer_for_copy_size);
+
+            pos_in_preprocessed_offset++;
+        }
+    }
+
+    // copy unmodified text after all offsets
+    for (;;)
+    {
+        int nb_copy_this = copy_chars_between_unicharfiles(f_input_processed, f_output, &pos_in_processed_file, &pos_in_output, (int)buffer_for_copy_size, buffer_for_copy, buffer_for_copy_size);
+        if (nb_copy_this == 0)
+            break;
+    }
+
+    if (v_modification_offset != NULL) {
+        vector_offset* v_input_offsets = NULL;
+
+
+        /* We deal with offsets only if we have to produce output offsets */
+        if (params->input_offsets[0] != '\0') {
+            v_input_offsets = load_offsets(vec, params->input_offsets);
+        }
+        U_FILE* f_output_offsets = u_fopen(vec, params->output_offsets, U_WRITE);
+        if (f_output_offsets == NULL) {
+            error("Cannot create offset file %s\n", params->output_offsets);
+        }
+        else {
+            process_offsets(v_input_offsets, v_modification_offset, f_output_offsets);
+            u_fclose(f_output_offsets);
+        }
+        free_vector_offset(v_input_offsets);
+        free_vector_offset(v_modification_offset);
+    }
+
+
+    u_fclose(f_output);
+    free_vector_offset(v_preprocessed_offset);
+    free_vector_offset(v_processed_offset);
+    u_fclose(f_input_original_file);
+    u_fclose(f_input_processed);
+
+    return SUCCESS_RETURN_CODE;
 }
 
 
 const char* usage_UnPreprocess =
-	"Usage: usage_UnPreprocess [OPTIONS] <txt>\n" \
-	"\n" \
-	"  -r X/--original_file=X: name of corpus file before preprocessing\n" \
-	"  -p X/--preprocessed_file=X: name of corpus file after preprocessing\n" \
-	"  -d X/--processed_file=X: name of corpus file after complete processing\n" \
-	"  -f X/--preprocessed_offset=X: name of offset file about preprocessing step\n" \
-	"  -s X/--processed_offset=X: name of file file about processing step\n" \
-	"  --output_offsets = XXX: offset file to be produced between processed file and result.\n" \
-	"  <txt>: a modified version of processed file to be produced, where modification\n" \
-	"              made durring preprocessing step are reverted if possible.\n" \
-	"\n" \
-	"OPTIONS:\n" \
-	"\n" \
-	"\n" \
-	"" \
-	;
+    "Usage: usage_UnPreprocess [OPTIONS] <txt>\n" \
+    "\n" \
+    "  -r X/--original_file=X: name of corpus file before preprocessing\n" \
+    "  -p X/--preprocessed_file=X: name of corpus file after preprocessing\n" \
+    "  -d X/--processed_file=X: name of corpus file after complete processing\n" \
+    "  -f X/--preprocessed_offset=X: name of offset file about preprocessing step\n" \
+    "  -s X/--processed_offset=X: name of file file about processing step\n" \
+    "  --output_offsets = XXX: offset file to be produced between processed file and result.\n" \
+    "  <txt>: a modified version of processed file to be produced, where modification\n" \
+    "              made durring preprocessing step are reverted if possible.\n" \
+    "\n" \
+    "OPTIONS:\n" \
+    "\n" \
+    "\n" \
+    "" \
+    ;
 
 static void display_usage_UnPreprocess() {
-	display_copyright_notice();
-	u_printf(usage_UnPreprocess);
+    display_copyright_notice();
+    u_printf(usage_UnPreprocess);
 }
 
 const char* optstring_UnPreprocess = "h$:@:r:d:f:s:Vq:r:";
@@ -1478,20 +1478,20 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_UnPreprocess,lopts_UnPre
 
 
 if (options.vars()->optind != argc - 1) {
-	error("Invalid arguments: rerun with --help\n");
-	return USAGE_ERROR_CODE;
+    error("Invalid arguments: rerun with --help\n");
+    return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
-	// freeing all allocated memory
-	return SUCCESS_RETURN_CODE;
+    // freeing all allocated memory
+    return SUCCESS_RETURN_CODE;
 }
 
 strcpy(params.output_file, argv[options.vars()->optind]);
 
 int result = runUnPreprocess(&params, &vec);
 if (SUCCESS_RETURN_CODE == result) {
-	u_printf("UnPreprocess done.\n");
+    u_printf("UnPreprocess done.\n");
 }
 return result;
 }

--- a/DumpOffsets.h
+++ b/DumpOffsets.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/DuplicateFile.cpp
+++ b/DuplicateFile.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -133,18 +133,18 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_DuplicateFile,lopts_Dupl
                 error("Empty input argument\n");
                 return USAGE_ERROR_CODE;
              }
-             input_file = options.vars()->optarg; 
+             input_file = options.vars()->optarg;
              break;
    case 'm': if (options.vars()->optarg[0]=='\0') {
                 error("Empty move argument\n");
                 return USAGE_ERROR_CODE;
              }
-             input_file = options.vars()->optarg; 
-             do_move=1; 
+             input_file = options.vars()->optarg;
+             do_move=1;
              break;
    case 'V': only_verify_arguments = true;
-             break;   
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt):
                          error("Missing argument for option --%s\n",lopts_DuplicateFile[index].name);

--- a/DuplicateFile.cpp
+++ b/DuplicateFile.cpp
@@ -82,27 +82,27 @@ const struct option_TS lopts_DuplicateFile[]= {
 
 static int mkDirRecursiveIfNeeded(const char* dir_name)
 {
-	int res_mk = mkDirPortable(dir_name);
-	if (res_mk == 0)
-		return 0;
+    int res_mk = mkDirPortable(dir_name);
+    if (res_mk == 0)
+        return 0;
 
-	int len_dir = (int)strlen(dir_name);
-	int last_separator = -1;
-	for (int i = 0;i < len_dir;i++) {
-		if ((*(dir_name + i) == '\\') || (*(dir_name + i) == '/'))
-			last_separator = i;
-	}
+    int len_dir = (int)strlen(dir_name);
+    int last_separator = -1;
+    for (int i = 0;i < len_dir;i++) {
+        if ((*(dir_name + i) == '\\') || (*(dir_name + i) == '/'))
+            last_separator = i;
+    }
 
-	if (last_separator == -1)
-		return res_mk;
+    if (last_separator == -1)
+        return res_mk;
 
-	char* up_dir_name = (char*)malloc(last_separator + 1);
-	memcpy(up_dir_name, dir_name, last_separator);
-	*(up_dir_name + last_separator) = '\0';
-	mkDirRecursiveIfNeeded(up_dir_name);
-	free(up_dir_name);
+    char* up_dir_name = (char*)malloc(last_separator + 1);
+    memcpy(up_dir_name, dir_name, last_separator);
+    *(up_dir_name + last_separator) = '\0';
+    mkDirRecursiveIfNeeded(up_dir_name);
+    free(up_dir_name);
 
-	return mkDirPortable(dir_name);
+    return mkDirPortable(dir_name);
 }
 
 
@@ -199,8 +199,8 @@ if (input_file != NULL) {
     u_printf("make dir %s\n", output_file);
     result = mkDirPortable(output_file);
 } else if (do_make_dir_parent != 0) {
-	u_printf("make dir %s with parent\n", output_file);
-	result = mkDirRecursiveIfNeeded(output_file);
+    u_printf("make dir %s with parent\n", output_file);
+    result = mkDirRecursiveIfNeeded(output_file);
 } else {
     if (do_recursive_delete == 0) {
         u_printf("remove file %s\n",output_file);

--- a/DuplicateFile.h
+++ b/DuplicateFile.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/DutchCompounds.cpp
+++ b/DutchCompounds.cpp
@@ -65,763 +65,763 @@ namespace unitex {
 #define INVALID_LEFT_COMPONENT 4
 
 
-	/**
-	* This structure is used to englobe settings for the analysis of
-	* Dutch unknown words.
-	*/
-	struct dutch_infos {
-		/* The Dutch alphabet */
-		const Alphabet* alphabet;
-		Dictionary* d;
-		/* The file where to read the words to analyze from */
-		U_FILE* unknown_word_list;
-		/* The file where new dictionary lines will be written */
-		U_FILE* output;
-		/* The file where to print information about the analysis */
-		U_FILE* info_output;
-		/* The file where to write words that cannot be analyzed as
-		* compound words */
-		U_FILE* new_unknown_word_list;
-		/* The words that cannot appear in a decomposition, like single letters */
-		struct string_hash* forbidden_words;
-		/* These arrays indicates for each INF code if it can be
-		* viewed as a valid code for a left/right component of a
-		* compound word. */
-		char* valid_left_component;
-		char* valid_right_component;
-	};
-
-
-	struct word_decomposition {
-		int n_parts;
-		const unichar* decomposition;
-		const unichar* dela_line;
-	};
-
-
-	struct word_decomposition_list {
-		struct word_decomposition* element;
-		struct word_decomposition_list* next;
-	};
-
-	// must be at last 4096
-	#define PERMANENT_STRING_BUFFER_SIZE            8192
-	#define PERMANENT_DEC_STRING_BUFFER_SIZE        PERMANENT_STRING_BUFFER_SIZE
-	#define PERMANENT_STRING_TOKENIZE_BUFFER_SIZE   PERMANENT_STRING_BUFFER_SIZE
-
-	struct original_tokenize_DELAF_line_buffer {
-		unichar buffer[PERMANENT_STRING_TOKENIZE_BUFFER_SIZE];
-	};
-
-	struct analyse_dutch_permanent {
-		unichar original_dec_buffer[PERMANENT_DEC_STRING_BUFFER_SIZE];
-		unichar original_siacode_buffer[PERMANENT_STRING_BUFFER_SIZE];
-		unichar original_new_dela_line_buffer[PERMANENT_STRING_BUFFER_SIZE];
-		struct original_tokenize_DELAF_line_buffer tok_buffer;
-
-		unichar decomposition[PERMANENT_STRING_BUFFER_SIZE];
-		unichar dela_line[PERMANENT_STRING_BUFFER_SIZE];
-		unichar correct_word[PERMANENT_STRING_BUFFER_SIZE];
-		long nb_word_decomposition_list_possible;
-	};
-
-
-	static void analyse_dutch_unknown_words(struct dutch_infos*);
-	static int analyse_dutch_word(const unichar* word, struct dutch_infos*);
-	static void explore_state_dutch(int offset, unichar* current_component, int pos_in_current_component,
-		const unichar* word_to_analyze, int pos_in_word_to_analyze, const unichar* analysis,
-		const unichar* output_dela_line, struct word_decomposition_list** L, struct analyse_dutch_permanent * adp,
-		int number_of_components, const struct dutch_infos* infos, Ustring*, int base);
-	static void check_valid_right_component_dutch(char*, const struct INF_codes*, struct original_tokenize_DELAF_line_buffer*);
-	static char check_valid_right_component_for_an_INF_line_dutch(const struct list_ustring*, struct original_tokenize_DELAF_line_buffer*);
-	static char check_valid_right_component_for_one_INF_code_dutch(const unichar*, struct original_tokenize_DELAF_line_buffer*);
-	static void check_valid_left_component_dutch(char*, const struct INF_codes*, struct original_tokenize_DELAF_line_buffer*);
-	static char check_valid_left_component_for_an_INF_line_dutch(const struct list_ustring*, struct original_tokenize_DELAF_line_buffer*);
-	static char check_valid_left_component_for_one_INF_code_dutch(const unichar*, struct original_tokenize_DELAF_line_buffer*);
-
-	static struct word_decomposition* new_word_decomposition_dutch(int n_parts, const unichar* decomposition, const unichar* dela_line);
-	static void free_word_decomposition_dutch(struct word_decomposition*);
-	static struct word_decomposition_list* new_word_decomposition_list_dutch();
-	static void free_word_decomposition_list_dutch(struct word_decomposition_list*);
-
-
-	/**
-	* This function analyzes a list of unknown Dutch words.
-	*/
-	void analyse_dutch_unknown_words(const Alphabet* alphabet, Dictionary* d,
-		U_FILE* unknown_word_list, U_FILE* output, U_FILE* info_output,
-		U_FILE* new_unknown_word_list, struct string_hash* forbidden_words) {
-		/* We create a structure that will contain all settings */
-		struct dutch_infos infos;
-		infos.alphabet = alphabet;
-		infos.d = d;
-		infos.unknown_word_list = unknown_word_list;
-		infos.forbidden_words = forbidden_words;
-		infos.output = output;
-		infos.info_output = info_output;
-		infos.new_unknown_word_list = new_unknown_word_list;
-		infos.valid_left_component = (char*)malloc(sizeof(char)*(d->inf->N));
-		if (infos.valid_left_component == NULL) {
-			fatal_alloc_error("analyse_dutch_unknown_words");
-		}
-		infos.valid_right_component = (char*)malloc(sizeof(char)*(d->inf->N));
-		if (infos.valid_right_component == NULL) {
-			fatal_alloc_error("analyse_dutch_unknown_words");
-		}
-		/* We look for all INF codes if they correspond to valid left/right
-		* components of compounds words. */
-
-		struct original_tokenize_DELAF_line_buffer* tokenize_buffer = (struct original_tokenize_DELAF_line_buffer*)malloc(sizeof(struct original_tokenize_DELAF_line_buffer));
-		check_valid_left_component_dutch(infos.valid_left_component, d->inf, tokenize_buffer);
-		check_valid_right_component_dutch(infos.valid_right_component, d->inf, tokenize_buffer);
-		free(tokenize_buffer);
-		/* Now we are ready to analyse the given word list */
-		analyse_dutch_unknown_words(&infos);
-		free(infos.valid_left_component);
-		free(infos.valid_right_component);
-	}
-
-
-	/**
-	* This function checks all the INF codes of 'inf' and sets 'valid_left_component[i]'
-	* to 1 if the i-th INF line contains at least one INF code that contains
-	* the "N" grammatical code.
-	*/
-	void check_valid_right_component_dutch(char* valid_left_component, const struct INF_codes* inf, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		u_printf("Check valid right components...\n");
-		for (int i = 0; i<inf->N; i++) {
-			valid_left_component[i] = check_valid_right_component_for_an_INF_line_dutch(inf->codes[i], tokenize_buffer);
-		}
-	}
-
-
-	/**
-	* Returns 1 if at least one of the INF codes of 'INF_codes' is a valid
-	* right component, 0 otherwise.
-	*/
-	char check_valid_right_component_for_an_INF_line_dutch(const struct list_ustring* INF_codes, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		while (INF_codes != NULL) {
-			if (check_valid_right_component_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer)) {
-				return 1;
-			}
-			INF_codes = INF_codes->next;
-		}
-		return 0;
-	}
-
-
-	/**
-	* Returns 1 if the given dictionary entry is a "N" one.
-	*/
-	char check_N_dutch(struct dela_entry* d) {
-		unichar t1[2];
-		u_strcpy(t1, "N");
-		return (char)dic_entry_contain_gram_code(d, t1);
-	}
-
-
-
-	/**
-	* Returns 1 if the given dictionary entry is a "A" one.
-	*/
-	char check_A_dutch(struct dela_entry* d) {
-		unichar t1[2];
-		u_strcpy(t1, "A");
-		return (char)dic_entry_contain_gram_code(d, t1);
-	}
-
-
-	/**
-	* Returns 1 if the given dictionary entry is a "V:P1s" one.
-	*/
-	char check_VP1s_dutch(struct dela_entry* d) {
-		unichar t1[2];
-		u_strcpy(t1, "V");
-		unichar t2[4];
-		u_strcpy(t2, "P1s");
-		return dic_entry_contain_gram_code(d, t1) && dic_entry_contain_inflectional_code(d, t2);
-	}
-
-
-	/**
-	* Returns 1 if the given dictionary entry is a "ADV" one.
-	*/
-	char check_ADV_dutch(struct dela_entry* d) {
-		unichar t1[4];
-		u_strcpy(t1, "ADV");
-		return (char)dic_entry_contain_gram_code(d, t1);
-	}
-
-
-
-	/**
-	* This function checks all the INF codes of 'inf' and sets 'valid_right_component[i]'
-	* to 1 if the i-th INF line contains at least one INF code that
-	* one of the following codes: "N:sia", "A:sio", "V:W" or "ADV".
-	*/
-	void check_valid_left_component_dutch(char* valid_right_component, const struct INF_codes* inf, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		u_printf("Check valid left components...\n");
-		for (int i = 0; i<inf->N; i++) {
-			valid_right_component[i] = check_valid_left_component_for_an_INF_line_dutch(inf->codes[i], tokenize_buffer);
-		}
-	}
-
-
-	/**
-	* Returns 1 if at least one of the INF codes of 'INF_codes' is a valid
-	* left component, 0 otherwise.
-	*/
-	char check_valid_left_component_for_an_INF_line_dutch(const struct list_ustring* INF_codes, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		while (INF_codes != NULL) {
-			if (check_valid_left_component_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer)) {
-				return 1;
-			}
-			INF_codes = INF_codes->next;
-		}
-		return 0;
-	}
-
-
-	/**
-	* This function analyzes an INF code and returns a value that indicates
-	* if it is a valid left component or not.
-	*/
-	int get_valid_left_component_type_for_one_INF_code_dutch(unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		/* We produce an artifical dictionary entry with the given INF code,
-		* and then, we tokenize it in order to get grammatical and inflectional
-		* codes in a structured way. */
-		u_strcpy(tokenize_buffer->buffer, "x,");
-		u_strcat(tokenize_buffer->buffer, INF_code);
-		struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
-		int res;
-		/* Now we can test if the INF code corresponds to a valid left component */
-		if (check_N_dutch(d)) res = is_N;
-		else if (check_A_dutch(d)) res = is_A;
-		else if (check_VP1s_dutch(d)) res = is_VP1s;
-		else if (check_ADV_dutch(d)) res = is_ADV;
-		else res = INVALID_LEFT_COMPONENT;
-		/* Finally we free the artifical dictionary entry */
-		free_dela_entry(d);
-		return res;
-	}
-
-
-	/**
-	* This function looks in the INF line number 'n' for the first INF code that
-	* contains a valid left component.
-	* 'code' is a string that will contains the selected code.
-	**/
-	void get_first_valid_left_component_dutch(struct list_ustring* INF_codes, unichar* code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		int tmp;
-		code[0] = '\0';
-		while (INF_codes != NULL) {
-			tmp = get_valid_left_component_type_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer);
-			if (tmp != INVALID_LEFT_COMPONENT) {
-				/* If we find a valid left component, then we return it */
-				u_strcpy(code, INF_codes->string);
-				return;
-			}
-			INF_codes = INF_codes->next;
-		}
-	}
-
-
-	/**
-	* This function looks in the INF line number 'n' for the first INF code that
-	* contains a valid left component.
-	* 'code' is a string that will contains the selected code.
-	**/
-	unichar* get_first_valid_left_component_dutch(struct list_ustring* INF_codes, unichar * original_buffer_code, size_t original_buffer_code_size,
-		unichar**allocated_buffer_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		int tmp;
-		while (INF_codes != NULL) {
-			tmp = get_valid_left_component_type_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer);
-			if (tmp != INVALID_LEFT_COMPONENT) {
-				/* If we find a valid left component, then we return it */
-				return u_strcpy_optional_buffer(original_buffer_code, original_buffer_code_size,allocated_buffer_code, INF_codes->string);
-
-			}
-			INF_codes = INF_codes->next;
-		}
-		return u_strcpy_optional_buffer(original_buffer_code, original_buffer_code_size, allocated_buffer_code, "");
-	}
-
-
-
-	/**
-	* Returns 1 if the INF code refers to a valid left component, 0 otherwise.
-	*/
-	char check_valid_left_component_for_one_INF_code_dutch(const unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		/* We produce an artifical dictionary entry with the given INF code,
-		* and then, we tokenize it in order to get grammatical and inflectional
-		* codes in a structured way. */
-		u_strcpy(tokenize_buffer->buffer, "x,");
-		u_strcat(tokenize_buffer->buffer, INF_code);
-		struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
-		/* Now, we can use this structured representation to check if the INF code
-		* corresponds to a valid left component. */
-		char res = check_N_dutch(d) || check_A_dutch(d) || check_VP1s_dutch(d) || check_ADV_dutch(d);
-		/* Finally, we free the artificial dictionary entry */
-		free_dela_entry(d);
-		return res;
-	}
-
-
-
-	/**
-	* Returns 1 if the given INF code is a "N" one.
-	*/
-	char check_N_dutch(unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		/* We produce an artifical dictionary entry with the given INF code,
-		* and then, we tokenize it in order to get grammatical and inflectional
-		* codes in a structured way. */
-		u_strcpy(tokenize_buffer->buffer, "x,");
-		u_strcat(tokenize_buffer->buffer, INF_code);
-		struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
-		char res = check_N_dutch(d);
-		/* We free the artifical dictionary entry */
-		free_dela_entry(d);
-		return res;
-	}
-
-
-
-
-	/**
-	* Returns 1 if the INF code refers to a valid left component, 0 otherwise.
-	*/
-	char check_valid_right_component_for_one_INF_code_dutch(const unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
-		/* We produce an artifical dictionary entry with the given INF code,
-		* and then, we tokenize it in order to get grammatical and inflectional
-		* codes in a structured way. */
-		u_strcpy(tokenize_buffer->buffer, "x,");
-		u_strcat(tokenize_buffer->buffer, INF_code);
-		struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
-		char res = check_N_dutch(d);
-		/* We free the artifical dictionary entry */
-		free_dela_entry(d);
-		return res;
-	}
-
-
-
-
-	/**
-	* This function reads words from the unknown word file and tries to
-	* analyse them. The unknown word file is supposed to contain one word
-	* per line. If a word cannot be analyzed, we print it to the new
-	* unknown word list file.
-	*/
-	void analyse_dutch_unknown_words(struct dutch_infos* infos) {
-		u_printf("Analysing Dutch unknown words...\n");
-		int n = 0;
-		/* We read each line of the unknown word list and we try to analyze it */
-		Ustring* line = new_Ustring(1024);
-		while (EOF != readline(line, infos->unknown_word_list)) {
-			if (!analyse_dutch_word(line->str, infos)) {
-				/* If the analysis has failed, we store the word in the
-				* new unknown word file */
-				u_fprintf(infos->new_unknown_word_list, "%S\n", line->str);
-			} else {
-				/* Otherwise, we increase the number of analyzed words */
-				n++;
-			}
-		}
-		free_Ustring(line);
-		u_printf("%d words decomposed as compound word%s\n", n, (n>1) ? "s" : "");
-	}
-
-
-	/**
-	* This function tries to analyse an unknown Dutch word. If OK,
-	* it returns 1 and print the dictionary entry to the output (and
-	* information if an information file has been specified in 'infos');
-	* returns 0 otherwise.
-	*/
-	int analyse_dutch_word(const unichar* word, struct dutch_infos* infos) {
-		/*
-		unichar decomposition[4096];
-		unichar dela_line[4096];
-		unichar correct_word[4096];*/
-		struct word_decomposition_list* l = NULL;
-		/* We look if there are decompositions for this word */
-		struct analyse_dutch_permanent * adp = (struct analyse_dutch_permanent *)malloc(sizeof(struct analyse_dutch_permanent));
-		if (adp == NULL) {
-			fatal_alloc_error("analyse_dutch_word");
-		}
-		adp->decomposition[0] = '\0';
-		adp->dela_line[0] = '\0';
-		adp->correct_word[0] = '\0';
-
-		Ustring* ustr = new_Ustring();
-		adp->nb_word_decomposition_list_possible = MAX_NB_WORD_DECOMPOSITION_LIST_POSSIBLE;
-		explore_state_dutch(infos->d->initial_state_offset, adp->correct_word, 0, word, 0, adp->decomposition, adp->dela_line, &l, adp, 1, infos, ustr, 0);
-		free_Ustring(ustr);
-		if (l == NULL) {
-			/* If there is no decomposition, we return */
-			free(adp);
-			return 0;
-		}
-		/* Otherwise, we will choose the one to keep */
-		struct word_decomposition_list* tmp = l;
-		int n = 1000;
-		/* First, we count the minimal number of components, because
-		* we want to give priority to analysis with smallest number
-		* of components. By the way, we note if there is a minimal
-		* analysis ending by a noun or an adjective. */
-		while (tmp != NULL) {
-			if (tmp->element->n_parts <= n) {
-				n = tmp->element->n_parts;
-			}
-			tmp = tmp->next;
-		}
-		tmp = l;
-		while (tmp != NULL) {
-			if (n == tmp->element->n_parts) {
-				/* We only consider the words that have shortest decompositions.
-				* The test (tmp->element->n_parts==1) is used to
-				* match simple words that would have been wrongly considered
-				* as unknown words. */
-				if (infos->info_output != NULL) {
-					u_fprintf(infos->info_output, "%S = %S\n", word, tmp->element->decomposition);
-				}
-				u_fprintf(infos->output, "%S\n", tmp->element->dela_line);
-			}
-			tmp = tmp->next;
-		}
-		free_word_decomposition_list_dutch(l);
-		free(adp);
-		return 1;
-	}
-
-
-	/**
-	* Allocates, initializes and returns a word decomposition structure.
-	*/
-	static struct word_decomposition* new_word_decomposition_dutch(int n_parts, const unichar* decomposition, const unichar* dela_line) {
-
-		#define AroundSizeBorder(x) (((x + 0xf) / 0x10) * 0x10)
-
-		unsigned int len_decomposition_string_in_bytes = (u_strlen(decomposition) + 1) * sizeof(unichar);
-		unsigned int len_dela_line_in_bytes = (u_strlen(dela_line) + 1) * sizeof(unichar);
-		size_t pos_decomposition = sizeof(struct word_decomposition);
-		size_t pos_dela_line = sizeof(struct word_decomposition) + AroundSizeBorder(len_decomposition_string_in_bytes);
-		size_t size_allocation = pos_dela_line + AroundSizeBorder(len_dela_line_in_bytes);
-		struct word_decomposition* tmp;
-		tmp = (struct word_decomposition*)malloc(size_allocation);
-		if (tmp == NULL) {
-			fatal_alloc_error("new_word_decomposition_dutch");
-		}
-
-		unichar* buffer_decomposition = (unichar*)(((unsigned char*)tmp) + pos_decomposition);
-		unichar* buffer_dela_line = (unichar*)(((unsigned char*)tmp) + pos_dela_line);
-		u_strcpy(buffer_decomposition, decomposition);
-		u_strcpy(buffer_dela_line, dela_line);
-
-		tmp->n_parts = n_parts;
-		tmp->decomposition = buffer_decomposition;
-		tmp->dela_line = buffer_dela_line;
-
-		return tmp;
-	}
-
-
-	/**
-	* Frees a word decomposition structure.
-	*/
-	static void free_word_decomposition_dutch(struct word_decomposition* t) {
-		if (t == NULL) return;
-		free(t);
-	}
-
-
-	/**
-	* Allocates, initializes and returns a word decomposition list structure.
-	*/
-	static struct word_decomposition_list* new_word_decomposition_list_dutch() {
-		struct word_decomposition_list* tmp;
-		tmp = (struct word_decomposition_list*)malloc(sizeof(struct word_decomposition_list));
-		if (tmp == NULL) {
-			fatal_alloc_error("new_word_decomposition_list_dutch");
-		}
-		tmp->element = NULL;
-		tmp->next = NULL;
-		return tmp;
-	}
-
-
-	/**
-	* Frees a word decomposition list.
-	*/
-	static void free_word_decomposition_list_dutch(struct word_decomposition_list* l) {
-		struct word_decomposition_list* tmp;
-		while (l != NULL) {
-			free_word_decomposition_dutch(l->element);
-			tmp = l->next;
-			free(l);
-			l = tmp;
-		}
-	}
-
-
-	/**
-	* This explores the dictionary in order decompose the given word into a valid sequence
-	* of simple words. For instance, if we have the word "Sommervarmt", we will first
-	* explore the dictionary and find that "sommer" is a valid left component that
-	* corresponds to the dictionary entry "sommer,.N:msia". Then we will
-	* look if the following word "varmt" is in the dictionary. It is
-	* the case, with the entry "varmt,varm.A:nsio". As we are at the end of the word to
-	* analyze and as "varmt" is a valid rightmost component, we will generate an entry
-	* according to the following things:
-	*
-	* 'output_dela_line'="sommervarmt,sommervarm.A:nsio"
-	* 'analysis'="sommer,.N:msia +++ varmt,varm.A:nsio"
-	* 'number_of_components'=2
-	*
-	* Note that the initial "S" was put in lowercase, because the dictionary
-	* contains "sommer" and not "Sommer". The lemma is obtained with
-	* the lemma of the rightmost component (here "varm"), and the word inherits
-	* from the grammatical information of its rightmost component.
-	*
-	* 'offset': offset of the current node in the binary array 'infos->bin'
-	* 'current_component': string that represents the current simple word
-	* 'pos_in_current_component': position in the string 'current_component'
-	* 'word_to_analyze': the word to analyze
-	* 'pos_in_word_to_analyze': position in the string 'word_to_analyze'
-	* 'analysis': string that represents the analysis as a concatenation like
-	*             "sommer,.N:msia +++ varmt,varm.A:nsio"
-	* 'output_dela_line': string that contains the final DELA line. The lemma is
-	*                     obtained by replacing the rightmost term of
-	*                     the word to analyze by its lemma.
-	* 'L': list of all analysis for the given word
-	* 'number_of_components': number of components that compose the word.
-	* 'infos': global settings.
-	*/
-	static void explore_state_dutch(int offset, unichar* current_component, int pos_in_current_component,
-		const unichar* word_to_analyze, int pos_in_word_to_analyze, const unichar* analysis,
-		const unichar* output_dela_line, struct word_decomposition_list** L, struct analyse_dutch_permanent * adp,
-		int number_of_components, const struct dutch_infos* infos, Ustring* ustr, int base) {
-
-		/* abort if excess list size */
-		if ((adp->nb_word_decomposition_list_possible) <= 0)
-			return;
-
-		int final, n_transitions, inf_number;
-		int z = save_output(ustr);
-		offset = read_dictionary_state(infos->d, offset, &final, &n_transitions, &inf_number);
-		if (final) {
-			/* If we are in a final state, we can set the end of our current component */
-			current_component[pos_in_current_component] = '\0';
-			/* We do not consider forbidden words */
-			if (infos->forbidden_words == NULL || NO_VALUE_INDEX == get_value_index(current_component, infos->forbidden_words, DONT_INSERT)) {
-				/* We don't consider components with a length of 1 */
-				if (word_to_analyze[pos_in_word_to_analyze] == '\0') {
-					/* If we have explored the entire original word */
-					/* And if we do not have forbidden word in last position */
-					struct list_ustring* l = infos->d->inf->codes[inf_number];
-					/* We will look at all the INF codes of the last component in order
-					* to produce analysis */
-					while (l != NULL) {
-						unichar* allocated_dec = NULL; const unichar* dec;
-						dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
-						//u_strcpy(dec,analysis);
-						if (dec[0] != '\0') {
-							/* If we have already something in the analysis (i.e. if
-							* we have not a simple word), we insert the concatenation
-							* mark before the entry to come */
-							dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++ ");
-						}
-						Ustring* entry = new_Ustring(4096);
-						/* We get the dictionary line that corresponds to the current INF code */
-						uncompress_entry(current_component, l->string, entry);
-						/* And we add it to the analysis */
-						dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
-						unichar* allocated_new_dela_line = NULL; const unichar* new_dela_line;
-						/* We copy the current output DELA line that contains
-						* the concatenation of the previous components */
-						new_dela_line = u_strcpy_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, output_dela_line);
-						/* Then we tokenize the DELA line that corresponds the current INF
-						* code in order to obtain its lemma and grammatical/inflectional
-						* information */
-						struct dela_entry* tmp_entry = tokenize_DELAF_line(entry->str, 1);
-						free_Ustring(entry);
-						/* We concatenate the inflected form of the last component to
-						* the output DELA line */
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->inflected);
-						/* We put the comma that separates the inflected form and the lemma */
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ",");
-						/* And we build the lemma in the same way than the inflected form */
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, output_dela_line);
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->lemma);
-						/* We put the dot that separates the the lemma and the grammatical/inflectional
-						* information */
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ".");
-						/* And finally we put the grammatical/inflectional information */
-						new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->semantic_codes[0]);
-						int k;
-						for (k = 1; k<tmp_entry->n_semantic_codes; k++) {
-							new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, "+");
-							new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->semantic_codes[k]);
-						}
-						for (k = 0; k<tmp_entry->n_inflectional_codes; k++) {
-							new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ":");
-							new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->inflectional_codes[k]);
-						}
-						/*
-						* Now we can build an analysis in the form of a word decomposition
-						* structure, but only if the last component is a valid
-						* right one or if it is a verb long enough, or if we find out
-						* that the word to analyze was in fact a simple word
-						* in the dictionary */
-						if (check_valid_right_component_for_one_INF_code_dutch(l->string, &(adp->tok_buffer))
-							|| number_of_components == 1) {
-							/*
-							* We set the number of components, the analysis, the actual
-							* DELA line and information about
-							*/
-							struct word_decomposition* wd = new_word_decomposition_dutch(number_of_components, dec, new_dela_line);
-							/* Then we add the decomposition word structure to the list that
-							* contains all the analysis for the word to analyze */
-							struct word_decomposition_list* wdl = new_word_decomposition_list_dutch();
-							wdl->element = wd;
-							wdl->next = (*L);
-							(*L) = wdl;
-							(adp->nb_word_decomposition_list_possible)--;
-
-							struct word_decomposition_list* wdlbrowse = wdl;
-							while (wdlbrowse != NULL)
-							{
-								wdlbrowse = wdlbrowse->next;
-							}
-						}
-						free_dela_entry(tmp_entry);
-						free_string_optional_buffer(&allocated_dec);
-						free_string_optional_buffer(&allocated_new_dela_line);
-						/* We go on with the next INF code of the last component */
-						l = l->next;
-					}
-					/* If are at the end of the word to analyze, we have nothing more to do */
-					return;
-				}
-				else {
-					/* If we are not at the end of the word to analyze, we must
-					* 1) look if the current component is a valid left one
-					* 2) explore the rest of the original word
-					*/
-					if (infos->valid_left_component[inf_number]) {
-						/* If we have a valid component, we look first if we are
-						* in the case of a word followed by a "s" */
-						if (word_to_analyze[pos_in_word_to_analyze] == 's') {
-							/* If we have such a word, we add it to the current analysis,
-							* putting "+++ s +++*/
-
-							unichar* allocated_dec = NULL; const unichar* dec;
-							dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
-							if (dec[0] != '\0') {
-								u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++");
-							}
-							/* In order to print the component in the analysis, we arbitrary
-							* take a valid left component among all those that are available
-							* for the current component */
-							unichar* allocated_sia_code = NULL; const unichar* sia_code;
-							unichar original_line[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_line = NULL; unichar* line;
-
-							Ustring* entry = new_Ustring(4096);
-							sia_code = get_first_valid_left_component_dutch(infos->d->inf->codes[inf_number], adp->original_siacode_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_sia_code, &(adp->tok_buffer));
-							uncompress_entry(current_component, sia_code, entry);
-							dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
-							free_Ustring(entry);
-							line = u_strcpy_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, output_dela_line);
-							line = u_strcat_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, current_component);
-							/* As we have a double letter at the end of the word,
-							* we must remove a character */
-							line[u_strlen(line) - 1] = '\0';
-
-							unichar *temp = (unichar*)malloc(4096 * sizeof(unichar));
-							if (temp == NULL){
-								fatal_alloc_error("explore_state_dutch");
-							}
-							unichar original_dec_temp[DEC_TEMP_STRING_BUFFER_SIZE]; unichar* allocated_dec_temp = NULL; const unichar* dec_temp;
-
-							dec_temp = u_strcpy_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, dec);
-							dec_temp = u_strcat_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, " +++ s");
-
-							free_string_optional_buffer(&allocated_dec);
-							free_string_optional_buffer(&allocated_sia_code);
-
-							/* Then, we explore the dictionary in order to analyze the
-							* next component. We start at the root of the dictionary
-							* and we go back one position in the word to analyze */
-							Ustring* foo = new_Ustring();
-							explore_state_dutch (infos->d->initial_state_offset, temp, 0, word_to_analyze, pos_in_word_to_analyze + 1,
-								dec_temp, line, L, adp, number_of_components + 1, infos, foo, 0);
-							free_Ustring(foo);
-
-							free(temp);
-							free_string_optional_buffer(&allocated_dec_temp);
-							free_string_optional_buffer(&allocated_line);
-
-						}
-						/* Now, we try to analyze the component normally */
-						unichar* allocated_dec = NULL; const unichar* dec;
-						unichar original_line[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_line = NULL; const unichar* line;
-						dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
-						if (dec[0] != '\0') {
-							/* We add the "+++" mark if the current component is not the first one */
-							dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++ ");
-						}
-						unichar original_sia_code[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_sia_code = NULL; const unichar* sia_code;
-						Ustring* entry = new_Ustring(4096);
-						/* In order to print the component in the analysis, we arbitrary
-						* take a valid left component among all those that are available
-						* for the current component */
-						sia_code = get_first_valid_left_component_dutch(infos->d->inf->codes[inf_number], original_sia_code, STANDARD_STRING_BUFFER_SIZE, &allocated_sia_code, &(adp->tok_buffer));
-						uncompress_entry(current_component, sia_code, entry);
-						free_string_optional_buffer(&allocated_sia_code);
-						dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
-						free_Ustring(entry);
-						line = u_strcpy_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, output_dela_line);
-						line = u_strcat_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, current_component);
-
-						unichar *temp = (unichar*)malloc(4096*sizeof(unichar));
-						if (temp == NULL){
-							fatal_alloc_error("explore_state_dutch");
-						}
-						unichar original_dec_temp[DEC_TEMP_STRING_BUFFER_SIZE]; unichar* allocated_dec_temp = NULL; const unichar* dec_temp;
-						dec_temp = u_strcpy_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, dec);
-						free_string_optional_buffer(&allocated_dec);
-						/* Then, we explore the dictionary in order to analyze the
-						* next component. We start at the root of the dictionary */
-						Ustring* foo = new_Ustring();
-						explore_state_dutch (infos->d->initial_state_offset, temp, 0, word_to_analyze, pos_in_word_to_analyze,
-							dec_temp, line, L, adp, number_of_components + 1, infos, foo, 0);
-						free_string_optional_buffer(&allocated_dec_temp);
-
-						free_string_optional_buffer(&allocated_line);
-
-						free(temp);
-						free_Ustring(foo);
-					}
-				}
-			}
-			/* Once we have finished to deal with the current final dictionary node,
-			* we go on because we may match a longer word */
-			base = ustr->len;
-		}
-		/* We examine each transition that goes out from the node */
-		unichar c;
-		int adr;
-		for (int i = 0; i<n_transitions; i++) {
-			offset = read_dictionary_transition(infos->d, offset, &c, &adr, ustr);
-			if (is_equal_or_uppercase(c, word_to_analyze[pos_in_word_to_analyze], infos->alphabet)) {
-				/* If the transition's letter is case compatible with the current letter of the
-				* word to analyze, we follow it */
-				current_component[pos_in_current_component] = c;
-				explore_state_dutch (adr, current_component, pos_in_current_component + 1, word_to_analyze, pos_in_word_to_analyze + 1,
-					analysis, output_dela_line, L, adp, number_of_components, infos, ustr, base);
-			}
-			restore_output(z, ustr);
-		}
-	}
+    /**
+    * This structure is used to englobe settings for the analysis of
+    * Dutch unknown words.
+    */
+    struct dutch_infos {
+        /* The Dutch alphabet */
+        const Alphabet* alphabet;
+        Dictionary* d;
+        /* The file where to read the words to analyze from */
+        U_FILE* unknown_word_list;
+        /* The file where new dictionary lines will be written */
+        U_FILE* output;
+        /* The file where to print information about the analysis */
+        U_FILE* info_output;
+        /* The file where to write words that cannot be analyzed as
+        * compound words */
+        U_FILE* new_unknown_word_list;
+        /* The words that cannot appear in a decomposition, like single letters */
+        struct string_hash* forbidden_words;
+        /* These arrays indicates for each INF code if it can be
+        * viewed as a valid code for a left/right component of a
+        * compound word. */
+        char* valid_left_component;
+        char* valid_right_component;
+    };
+
+
+    struct word_decomposition {
+        int n_parts;
+        const unichar* decomposition;
+        const unichar* dela_line;
+    };
+
+
+    struct word_decomposition_list {
+        struct word_decomposition* element;
+        struct word_decomposition_list* next;
+    };
+
+    // must be at last 4096
+    #define PERMANENT_STRING_BUFFER_SIZE            8192
+    #define PERMANENT_DEC_STRING_BUFFER_SIZE        PERMANENT_STRING_BUFFER_SIZE
+    #define PERMANENT_STRING_TOKENIZE_BUFFER_SIZE   PERMANENT_STRING_BUFFER_SIZE
+
+    struct original_tokenize_DELAF_line_buffer {
+        unichar buffer[PERMANENT_STRING_TOKENIZE_BUFFER_SIZE];
+    };
+
+    struct analyse_dutch_permanent {
+        unichar original_dec_buffer[PERMANENT_DEC_STRING_BUFFER_SIZE];
+        unichar original_siacode_buffer[PERMANENT_STRING_BUFFER_SIZE];
+        unichar original_new_dela_line_buffer[PERMANENT_STRING_BUFFER_SIZE];
+        struct original_tokenize_DELAF_line_buffer tok_buffer;
+
+        unichar decomposition[PERMANENT_STRING_BUFFER_SIZE];
+        unichar dela_line[PERMANENT_STRING_BUFFER_SIZE];
+        unichar correct_word[PERMANENT_STRING_BUFFER_SIZE];
+        long nb_word_decomposition_list_possible;
+    };
+
+
+    static void analyse_dutch_unknown_words(struct dutch_infos*);
+    static int analyse_dutch_word(const unichar* word, struct dutch_infos*);
+    static void explore_state_dutch(int offset, unichar* current_component, int pos_in_current_component,
+        const unichar* word_to_analyze, int pos_in_word_to_analyze, const unichar* analysis,
+        const unichar* output_dela_line, struct word_decomposition_list** L, struct analyse_dutch_permanent * adp,
+        int number_of_components, const struct dutch_infos* infos, Ustring*, int base);
+    static void check_valid_right_component_dutch(char*, const struct INF_codes*, struct original_tokenize_DELAF_line_buffer*);
+    static char check_valid_right_component_for_an_INF_line_dutch(const struct list_ustring*, struct original_tokenize_DELAF_line_buffer*);
+    static char check_valid_right_component_for_one_INF_code_dutch(const unichar*, struct original_tokenize_DELAF_line_buffer*);
+    static void check_valid_left_component_dutch(char*, const struct INF_codes*, struct original_tokenize_DELAF_line_buffer*);
+    static char check_valid_left_component_for_an_INF_line_dutch(const struct list_ustring*, struct original_tokenize_DELAF_line_buffer*);
+    static char check_valid_left_component_for_one_INF_code_dutch(const unichar*, struct original_tokenize_DELAF_line_buffer*);
+
+    static struct word_decomposition* new_word_decomposition_dutch(int n_parts, const unichar* decomposition, const unichar* dela_line);
+    static void free_word_decomposition_dutch(struct word_decomposition*);
+    static struct word_decomposition_list* new_word_decomposition_list_dutch();
+    static void free_word_decomposition_list_dutch(struct word_decomposition_list*);
+
+
+    /**
+    * This function analyzes a list of unknown Dutch words.
+    */
+    void analyse_dutch_unknown_words(const Alphabet* alphabet, Dictionary* d,
+        U_FILE* unknown_word_list, U_FILE* output, U_FILE* info_output,
+        U_FILE* new_unknown_word_list, struct string_hash* forbidden_words) {
+        /* We create a structure that will contain all settings */
+        struct dutch_infos infos;
+        infos.alphabet = alphabet;
+        infos.d = d;
+        infos.unknown_word_list = unknown_word_list;
+        infos.forbidden_words = forbidden_words;
+        infos.output = output;
+        infos.info_output = info_output;
+        infos.new_unknown_word_list = new_unknown_word_list;
+        infos.valid_left_component = (char*)malloc(sizeof(char)*(d->inf->N));
+        if (infos.valid_left_component == NULL) {
+            fatal_alloc_error("analyse_dutch_unknown_words");
+        }
+        infos.valid_right_component = (char*)malloc(sizeof(char)*(d->inf->N));
+        if (infos.valid_right_component == NULL) {
+            fatal_alloc_error("analyse_dutch_unknown_words");
+        }
+        /* We look for all INF codes if they correspond to valid left/right
+        * components of compounds words. */
+
+        struct original_tokenize_DELAF_line_buffer* tokenize_buffer = (struct original_tokenize_DELAF_line_buffer*)malloc(sizeof(struct original_tokenize_DELAF_line_buffer));
+        check_valid_left_component_dutch(infos.valid_left_component, d->inf, tokenize_buffer);
+        check_valid_right_component_dutch(infos.valid_right_component, d->inf, tokenize_buffer);
+        free(tokenize_buffer);
+        /* Now we are ready to analyse the given word list */
+        analyse_dutch_unknown_words(&infos);
+        free(infos.valid_left_component);
+        free(infos.valid_right_component);
+    }
+
+
+    /**
+    * This function checks all the INF codes of 'inf' and sets 'valid_left_component[i]'
+    * to 1 if the i-th INF line contains at least one INF code that contains
+    * the "N" grammatical code.
+    */
+    void check_valid_right_component_dutch(char* valid_left_component, const struct INF_codes* inf, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        u_printf("Check valid right components...\n");
+        for (int i = 0; i<inf->N; i++) {
+            valid_left_component[i] = check_valid_right_component_for_an_INF_line_dutch(inf->codes[i], tokenize_buffer);
+        }
+    }
+
+
+    /**
+    * Returns 1 if at least one of the INF codes of 'INF_codes' is a valid
+    * right component, 0 otherwise.
+    */
+    char check_valid_right_component_for_an_INF_line_dutch(const struct list_ustring* INF_codes, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        while (INF_codes != NULL) {
+            if (check_valid_right_component_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer)) {
+                return 1;
+            }
+            INF_codes = INF_codes->next;
+        }
+        return 0;
+    }
+
+
+    /**
+    * Returns 1 if the given dictionary entry is a "N" one.
+    */
+    char check_N_dutch(struct dela_entry* d) {
+        unichar t1[2];
+        u_strcpy(t1, "N");
+        return (char)dic_entry_contain_gram_code(d, t1);
+    }
+
+
+
+    /**
+    * Returns 1 if the given dictionary entry is a "A" one.
+    */
+    char check_A_dutch(struct dela_entry* d) {
+        unichar t1[2];
+        u_strcpy(t1, "A");
+        return (char)dic_entry_contain_gram_code(d, t1);
+    }
+
+
+    /**
+    * Returns 1 if the given dictionary entry is a "V:P1s" one.
+    */
+    char check_VP1s_dutch(struct dela_entry* d) {
+        unichar t1[2];
+        u_strcpy(t1, "V");
+        unichar t2[4];
+        u_strcpy(t2, "P1s");
+        return dic_entry_contain_gram_code(d, t1) && dic_entry_contain_inflectional_code(d, t2);
+    }
+
+
+    /**
+    * Returns 1 if the given dictionary entry is a "ADV" one.
+    */
+    char check_ADV_dutch(struct dela_entry* d) {
+        unichar t1[4];
+        u_strcpy(t1, "ADV");
+        return (char)dic_entry_contain_gram_code(d, t1);
+    }
+
+
+
+    /**
+    * This function checks all the INF codes of 'inf' and sets 'valid_right_component[i]'
+    * to 1 if the i-th INF line contains at least one INF code that
+    * one of the following codes: "N:sia", "A:sio", "V:W" or "ADV".
+    */
+    void check_valid_left_component_dutch(char* valid_right_component, const struct INF_codes* inf, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        u_printf("Check valid left components...\n");
+        for (int i = 0; i<inf->N; i++) {
+            valid_right_component[i] = check_valid_left_component_for_an_INF_line_dutch(inf->codes[i], tokenize_buffer);
+        }
+    }
+
+
+    /**
+    * Returns 1 if at least one of the INF codes of 'INF_codes' is a valid
+    * left component, 0 otherwise.
+    */
+    char check_valid_left_component_for_an_INF_line_dutch(const struct list_ustring* INF_codes, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        while (INF_codes != NULL) {
+            if (check_valid_left_component_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer)) {
+                return 1;
+            }
+            INF_codes = INF_codes->next;
+        }
+        return 0;
+    }
+
+
+    /**
+    * This function analyzes an INF code and returns a value that indicates
+    * if it is a valid left component or not.
+    */
+    int get_valid_left_component_type_for_one_INF_code_dutch(unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        /* We produce an artifical dictionary entry with the given INF code,
+        * and then, we tokenize it in order to get grammatical and inflectional
+        * codes in a structured way. */
+        u_strcpy(tokenize_buffer->buffer, "x,");
+        u_strcat(tokenize_buffer->buffer, INF_code);
+        struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
+        int res;
+        /* Now we can test if the INF code corresponds to a valid left component */
+        if (check_N_dutch(d)) res = is_N;
+        else if (check_A_dutch(d)) res = is_A;
+        else if (check_VP1s_dutch(d)) res = is_VP1s;
+        else if (check_ADV_dutch(d)) res = is_ADV;
+        else res = INVALID_LEFT_COMPONENT;
+        /* Finally we free the artifical dictionary entry */
+        free_dela_entry(d);
+        return res;
+    }
+
+
+    /**
+    * This function looks in the INF line number 'n' for the first INF code that
+    * contains a valid left component.
+    * 'code' is a string that will contains the selected code.
+    **/
+    void get_first_valid_left_component_dutch(struct list_ustring* INF_codes, unichar* code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        int tmp;
+        code[0] = '\0';
+        while (INF_codes != NULL) {
+            tmp = get_valid_left_component_type_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer);
+            if (tmp != INVALID_LEFT_COMPONENT) {
+                /* If we find a valid left component, then we return it */
+                u_strcpy(code, INF_codes->string);
+                return;
+            }
+            INF_codes = INF_codes->next;
+        }
+    }
+
+
+    /**
+    * This function looks in the INF line number 'n' for the first INF code that
+    * contains a valid left component.
+    * 'code' is a string that will contains the selected code.
+    **/
+    unichar* get_first_valid_left_component_dutch(struct list_ustring* INF_codes, unichar * original_buffer_code, size_t original_buffer_code_size,
+        unichar**allocated_buffer_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        int tmp;
+        while (INF_codes != NULL) {
+            tmp = get_valid_left_component_type_for_one_INF_code_dutch(INF_codes->string, tokenize_buffer);
+            if (tmp != INVALID_LEFT_COMPONENT) {
+                /* If we find a valid left component, then we return it */
+                return u_strcpy_optional_buffer(original_buffer_code, original_buffer_code_size,allocated_buffer_code, INF_codes->string);
+
+            }
+            INF_codes = INF_codes->next;
+        }
+        return u_strcpy_optional_buffer(original_buffer_code, original_buffer_code_size, allocated_buffer_code, "");
+    }
+
+
+
+    /**
+    * Returns 1 if the INF code refers to a valid left component, 0 otherwise.
+    */
+    char check_valid_left_component_for_one_INF_code_dutch(const unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        /* We produce an artifical dictionary entry with the given INF code,
+        * and then, we tokenize it in order to get grammatical and inflectional
+        * codes in a structured way. */
+        u_strcpy(tokenize_buffer->buffer, "x,");
+        u_strcat(tokenize_buffer->buffer, INF_code);
+        struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
+        /* Now, we can use this structured representation to check if the INF code
+        * corresponds to a valid left component. */
+        char res = check_N_dutch(d) || check_A_dutch(d) || check_VP1s_dutch(d) || check_ADV_dutch(d);
+        /* Finally, we free the artificial dictionary entry */
+        free_dela_entry(d);
+        return res;
+    }
+
+
+
+    /**
+    * Returns 1 if the given INF code is a "N" one.
+    */
+    char check_N_dutch(unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        /* We produce an artifical dictionary entry with the given INF code,
+        * and then, we tokenize it in order to get grammatical and inflectional
+        * codes in a structured way. */
+        u_strcpy(tokenize_buffer->buffer, "x,");
+        u_strcat(tokenize_buffer->buffer, INF_code);
+        struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
+        char res = check_N_dutch(d);
+        /* We free the artifical dictionary entry */
+        free_dela_entry(d);
+        return res;
+    }
+
+
+
+
+    /**
+    * Returns 1 if the INF code refers to a valid left component, 0 otherwise.
+    */
+    char check_valid_right_component_for_one_INF_code_dutch(const unichar* INF_code, struct original_tokenize_DELAF_line_buffer* tokenize_buffer) {
+        /* We produce an artifical dictionary entry with the given INF code,
+        * and then, we tokenize it in order to get grammatical and inflectional
+        * codes in a structured way. */
+        u_strcpy(tokenize_buffer->buffer, "x,");
+        u_strcat(tokenize_buffer->buffer, INF_code);
+        struct dela_entry* d = tokenize_DELAF_line(tokenize_buffer->buffer, 0);
+        char res = check_N_dutch(d);
+        /* We free the artifical dictionary entry */
+        free_dela_entry(d);
+        return res;
+    }
+
+
+
+
+    /**
+    * This function reads words from the unknown word file and tries to
+    * analyse them. The unknown word file is supposed to contain one word
+    * per line. If a word cannot be analyzed, we print it to the new
+    * unknown word list file.
+    */
+    void analyse_dutch_unknown_words(struct dutch_infos* infos) {
+        u_printf("Analysing Dutch unknown words...\n");
+        int n = 0;
+        /* We read each line of the unknown word list and we try to analyze it */
+        Ustring* line = new_Ustring(1024);
+        while (EOF != readline(line, infos->unknown_word_list)) {
+            if (!analyse_dutch_word(line->str, infos)) {
+                /* If the analysis has failed, we store the word in the
+                * new unknown word file */
+                u_fprintf(infos->new_unknown_word_list, "%S\n", line->str);
+            } else {
+                /* Otherwise, we increase the number of analyzed words */
+                n++;
+            }
+        }
+        free_Ustring(line);
+        u_printf("%d words decomposed as compound word%s\n", n, (n>1) ? "s" : "");
+    }
+
+
+    /**
+    * This function tries to analyse an unknown Dutch word. If OK,
+    * it returns 1 and print the dictionary entry to the output (and
+    * information if an information file has been specified in 'infos');
+    * returns 0 otherwise.
+    */
+    int analyse_dutch_word(const unichar* word, struct dutch_infos* infos) {
+        /*
+        unichar decomposition[4096];
+        unichar dela_line[4096];
+        unichar correct_word[4096];*/
+        struct word_decomposition_list* l = NULL;
+        /* We look if there are decompositions for this word */
+        struct analyse_dutch_permanent * adp = (struct analyse_dutch_permanent *)malloc(sizeof(struct analyse_dutch_permanent));
+        if (adp == NULL) {
+            fatal_alloc_error("analyse_dutch_word");
+        }
+        adp->decomposition[0] = '\0';
+        adp->dela_line[0] = '\0';
+        adp->correct_word[0] = '\0';
+
+        Ustring* ustr = new_Ustring();
+        adp->nb_word_decomposition_list_possible = MAX_NB_WORD_DECOMPOSITION_LIST_POSSIBLE;
+        explore_state_dutch(infos->d->initial_state_offset, adp->correct_word, 0, word, 0, adp->decomposition, adp->dela_line, &l, adp, 1, infos, ustr, 0);
+        free_Ustring(ustr);
+        if (l == NULL) {
+            /* If there is no decomposition, we return */
+            free(adp);
+            return 0;
+        }
+        /* Otherwise, we will choose the one to keep */
+        struct word_decomposition_list* tmp = l;
+        int n = 1000;
+        /* First, we count the minimal number of components, because
+        * we want to give priority to analysis with smallest number
+        * of components. By the way, we note if there is a minimal
+        * analysis ending by a noun or an adjective. */
+        while (tmp != NULL) {
+            if (tmp->element->n_parts <= n) {
+                n = tmp->element->n_parts;
+            }
+            tmp = tmp->next;
+        }
+        tmp = l;
+        while (tmp != NULL) {
+            if (n == tmp->element->n_parts) {
+                /* We only consider the words that have shortest decompositions.
+                * The test (tmp->element->n_parts==1) is used to
+                * match simple words that would have been wrongly considered
+                * as unknown words. */
+                if (infos->info_output != NULL) {
+                    u_fprintf(infos->info_output, "%S = %S\n", word, tmp->element->decomposition);
+                }
+                u_fprintf(infos->output, "%S\n", tmp->element->dela_line);
+            }
+            tmp = tmp->next;
+        }
+        free_word_decomposition_list_dutch(l);
+        free(adp);
+        return 1;
+    }
+
+
+    /**
+    * Allocates, initializes and returns a word decomposition structure.
+    */
+    static struct word_decomposition* new_word_decomposition_dutch(int n_parts, const unichar* decomposition, const unichar* dela_line) {
+
+        #define AroundSizeBorder(x) (((x + 0xf) / 0x10) * 0x10)
+
+        unsigned int len_decomposition_string_in_bytes = (u_strlen(decomposition) + 1) * sizeof(unichar);
+        unsigned int len_dela_line_in_bytes = (u_strlen(dela_line) + 1) * sizeof(unichar);
+        size_t pos_decomposition = sizeof(struct word_decomposition);
+        size_t pos_dela_line = sizeof(struct word_decomposition) + AroundSizeBorder(len_decomposition_string_in_bytes);
+        size_t size_allocation = pos_dela_line + AroundSizeBorder(len_dela_line_in_bytes);
+        struct word_decomposition* tmp;
+        tmp = (struct word_decomposition*)malloc(size_allocation);
+        if (tmp == NULL) {
+            fatal_alloc_error("new_word_decomposition_dutch");
+        }
+
+        unichar* buffer_decomposition = (unichar*)(((unsigned char*)tmp) + pos_decomposition);
+        unichar* buffer_dela_line = (unichar*)(((unsigned char*)tmp) + pos_dela_line);
+        u_strcpy(buffer_decomposition, decomposition);
+        u_strcpy(buffer_dela_line, dela_line);
+
+        tmp->n_parts = n_parts;
+        tmp->decomposition = buffer_decomposition;
+        tmp->dela_line = buffer_dela_line;
+
+        return tmp;
+    }
+
+
+    /**
+    * Frees a word decomposition structure.
+    */
+    static void free_word_decomposition_dutch(struct word_decomposition* t) {
+        if (t == NULL) return;
+        free(t);
+    }
+
+
+    /**
+    * Allocates, initializes and returns a word decomposition list structure.
+    */
+    static struct word_decomposition_list* new_word_decomposition_list_dutch() {
+        struct word_decomposition_list* tmp;
+        tmp = (struct word_decomposition_list*)malloc(sizeof(struct word_decomposition_list));
+        if (tmp == NULL) {
+            fatal_alloc_error("new_word_decomposition_list_dutch");
+        }
+        tmp->element = NULL;
+        tmp->next = NULL;
+        return tmp;
+    }
+
+
+    /**
+    * Frees a word decomposition list.
+    */
+    static void free_word_decomposition_list_dutch(struct word_decomposition_list* l) {
+        struct word_decomposition_list* tmp;
+        while (l != NULL) {
+            free_word_decomposition_dutch(l->element);
+            tmp = l->next;
+            free(l);
+            l = tmp;
+        }
+    }
+
+
+    /**
+    * This explores the dictionary in order decompose the given word into a valid sequence
+    * of simple words. For instance, if we have the word "Sommervarmt", we will first
+    * explore the dictionary and find that "sommer" is a valid left component that
+    * corresponds to the dictionary entry "sommer,.N:msia". Then we will
+    * look if the following word "varmt" is in the dictionary. It is
+    * the case, with the entry "varmt,varm.A:nsio". As we are at the end of the word to
+    * analyze and as "varmt" is a valid rightmost component, we will generate an entry
+    * according to the following things:
+    *
+    * 'output_dela_line'="sommervarmt,sommervarm.A:nsio"
+    * 'analysis'="sommer,.N:msia +++ varmt,varm.A:nsio"
+    * 'number_of_components'=2
+    *
+    * Note that the initial "S" was put in lowercase, because the dictionary
+    * contains "sommer" and not "Sommer". The lemma is obtained with
+    * the lemma of the rightmost component (here "varm"), and the word inherits
+    * from the grammatical information of its rightmost component.
+    *
+    * 'offset': offset of the current node in the binary array 'infos->bin'
+    * 'current_component': string that represents the current simple word
+    * 'pos_in_current_component': position in the string 'current_component'
+    * 'word_to_analyze': the word to analyze
+    * 'pos_in_word_to_analyze': position in the string 'word_to_analyze'
+    * 'analysis': string that represents the analysis as a concatenation like
+    *             "sommer,.N:msia +++ varmt,varm.A:nsio"
+    * 'output_dela_line': string that contains the final DELA line. The lemma is
+    *                     obtained by replacing the rightmost term of
+    *                     the word to analyze by its lemma.
+    * 'L': list of all analysis for the given word
+    * 'number_of_components': number of components that compose the word.
+    * 'infos': global settings.
+    */
+    static void explore_state_dutch(int offset, unichar* current_component, int pos_in_current_component,
+        const unichar* word_to_analyze, int pos_in_word_to_analyze, const unichar* analysis,
+        const unichar* output_dela_line, struct word_decomposition_list** L, struct analyse_dutch_permanent * adp,
+        int number_of_components, const struct dutch_infos* infos, Ustring* ustr, int base) {
+
+        /* abort if excess list size */
+        if ((adp->nb_word_decomposition_list_possible) <= 0)
+            return;
+
+        int final, n_transitions, inf_number;
+        int z = save_output(ustr);
+        offset = read_dictionary_state(infos->d, offset, &final, &n_transitions, &inf_number);
+        if (final) {
+            /* If we are in a final state, we can set the end of our current component */
+            current_component[pos_in_current_component] = '\0';
+            /* We do not consider forbidden words */
+            if (infos->forbidden_words == NULL || NO_VALUE_INDEX == get_value_index(current_component, infos->forbidden_words, DONT_INSERT)) {
+                /* We don't consider components with a length of 1 */
+                if (word_to_analyze[pos_in_word_to_analyze] == '\0') {
+                    /* If we have explored the entire original word */
+                    /* And if we do not have forbidden word in last position */
+                    struct list_ustring* l = infos->d->inf->codes[inf_number];
+                    /* We will look at all the INF codes of the last component in order
+                    * to produce analysis */
+                    while (l != NULL) {
+                        unichar* allocated_dec = NULL; const unichar* dec;
+                        dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
+                        //u_strcpy(dec,analysis);
+                        if (dec[0] != '\0') {
+                            /* If we have already something in the analysis (i.e. if
+                            * we have not a simple word), we insert the concatenation
+                            * mark before the entry to come */
+                            dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++ ");
+                        }
+                        Ustring* entry = new_Ustring(4096);
+                        /* We get the dictionary line that corresponds to the current INF code */
+                        uncompress_entry(current_component, l->string, entry);
+                        /* And we add it to the analysis */
+                        dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
+                        unichar* allocated_new_dela_line = NULL; const unichar* new_dela_line;
+                        /* We copy the current output DELA line that contains
+                        * the concatenation of the previous components */
+                        new_dela_line = u_strcpy_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, output_dela_line);
+                        /* Then we tokenize the DELA line that corresponds the current INF
+                        * code in order to obtain its lemma and grammatical/inflectional
+                        * information */
+                        struct dela_entry* tmp_entry = tokenize_DELAF_line(entry->str, 1);
+                        free_Ustring(entry);
+                        /* We concatenate the inflected form of the last component to
+                        * the output DELA line */
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->inflected);
+                        /* We put the comma that separates the inflected form and the lemma */
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ",");
+                        /* And we build the lemma in the same way than the inflected form */
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, output_dela_line);
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->lemma);
+                        /* We put the dot that separates the the lemma and the grammatical/inflectional
+                        * information */
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ".");
+                        /* And finally we put the grammatical/inflectional information */
+                        new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->semantic_codes[0]);
+                        int k;
+                        for (k = 1; k<tmp_entry->n_semantic_codes; k++) {
+                            new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, "+");
+                            new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->semantic_codes[k]);
+                        }
+                        for (k = 0; k<tmp_entry->n_inflectional_codes; k++) {
+                            new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, ":");
+                            new_dela_line = u_strcat_optional_buffer(adp->original_new_dela_line_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_new_dela_line, tmp_entry->inflectional_codes[k]);
+                        }
+                        /*
+                        * Now we can build an analysis in the form of a word decomposition
+                        * structure, but only if the last component is a valid
+                        * right one or if it is a verb long enough, or if we find out
+                        * that the word to analyze was in fact a simple word
+                        * in the dictionary */
+                        if (check_valid_right_component_for_one_INF_code_dutch(l->string, &(adp->tok_buffer))
+                            || number_of_components == 1) {
+                            /*
+                            * We set the number of components, the analysis, the actual
+                            * DELA line and information about
+                            */
+                            struct word_decomposition* wd = new_word_decomposition_dutch(number_of_components, dec, new_dela_line);
+                            /* Then we add the decomposition word structure to the list that
+                            * contains all the analysis for the word to analyze */
+                            struct word_decomposition_list* wdl = new_word_decomposition_list_dutch();
+                            wdl->element = wd;
+                            wdl->next = (*L);
+                            (*L) = wdl;
+                            (adp->nb_word_decomposition_list_possible)--;
+
+                            struct word_decomposition_list* wdlbrowse = wdl;
+                            while (wdlbrowse != NULL)
+                            {
+                                wdlbrowse = wdlbrowse->next;
+                            }
+                        }
+                        free_dela_entry(tmp_entry);
+                        free_string_optional_buffer(&allocated_dec);
+                        free_string_optional_buffer(&allocated_new_dela_line);
+                        /* We go on with the next INF code of the last component */
+                        l = l->next;
+                    }
+                    /* If are at the end of the word to analyze, we have nothing more to do */
+                    return;
+                }
+                else {
+                    /* If we are not at the end of the word to analyze, we must
+                    * 1) look if the current component is a valid left one
+                    * 2) explore the rest of the original word
+                    */
+                    if (infos->valid_left_component[inf_number]) {
+                        /* If we have a valid component, we look first if we are
+                        * in the case of a word followed by a "s" */
+                        if (word_to_analyze[pos_in_word_to_analyze] == 's') {
+                            /* If we have such a word, we add it to the current analysis,
+                            * putting "+++ s +++*/
+
+                            unichar* allocated_dec = NULL; const unichar* dec;
+                            dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
+                            if (dec[0] != '\0') {
+                                u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++");
+                            }
+                            /* In order to print the component in the analysis, we arbitrary
+                            * take a valid left component among all those that are available
+                            * for the current component */
+                            unichar* allocated_sia_code = NULL; const unichar* sia_code;
+                            unichar original_line[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_line = NULL; unichar* line;
+
+                            Ustring* entry = new_Ustring(4096);
+                            sia_code = get_first_valid_left_component_dutch(infos->d->inf->codes[inf_number], adp->original_siacode_buffer, PERMANENT_STRING_BUFFER_SIZE, &allocated_sia_code, &(adp->tok_buffer));
+                            uncompress_entry(current_component, sia_code, entry);
+                            dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
+                            free_Ustring(entry);
+                            line = u_strcpy_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, output_dela_line);
+                            line = u_strcat_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, current_component);
+                            /* As we have a double letter at the end of the word,
+                            * we must remove a character */
+                            line[u_strlen(line) - 1] = '\0';
+
+                            unichar *temp = (unichar*)malloc(4096 * sizeof(unichar));
+                            if (temp == NULL){
+                                fatal_alloc_error("explore_state_dutch");
+                            }
+                            unichar original_dec_temp[DEC_TEMP_STRING_BUFFER_SIZE]; unichar* allocated_dec_temp = NULL; const unichar* dec_temp;
+
+                            dec_temp = u_strcpy_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, dec);
+                            dec_temp = u_strcat_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, " +++ s");
+
+                            free_string_optional_buffer(&allocated_dec);
+                            free_string_optional_buffer(&allocated_sia_code);
+
+                            /* Then, we explore the dictionary in order to analyze the
+                            * next component. We start at the root of the dictionary
+                            * and we go back one position in the word to analyze */
+                            Ustring* foo = new_Ustring();
+                            explore_state_dutch (infos->d->initial_state_offset, temp, 0, word_to_analyze, pos_in_word_to_analyze + 1,
+                                dec_temp, line, L, adp, number_of_components + 1, infos, foo, 0);
+                            free_Ustring(foo);
+
+                            free(temp);
+                            free_string_optional_buffer(&allocated_dec_temp);
+                            free_string_optional_buffer(&allocated_line);
+
+                        }
+                        /* Now, we try to analyze the component normally */
+                        unichar* allocated_dec = NULL; const unichar* dec;
+                        unichar original_line[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_line = NULL; const unichar* line;
+                        dec = u_strcpy_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, analysis);
+                        if (dec[0] != '\0') {
+                            /* We add the "+++" mark if the current component is not the first one */
+                            dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, " +++ ");
+                        }
+                        unichar original_sia_code[STANDARD_STRING_BUFFER_SIZE]; unichar* allocated_sia_code = NULL; const unichar* sia_code;
+                        Ustring* entry = new_Ustring(4096);
+                        /* In order to print the component in the analysis, we arbitrary
+                        * take a valid left component among all those that are available
+                        * for the current component */
+                        sia_code = get_first_valid_left_component_dutch(infos->d->inf->codes[inf_number], original_sia_code, STANDARD_STRING_BUFFER_SIZE, &allocated_sia_code, &(adp->tok_buffer));
+                        uncompress_entry(current_component, sia_code, entry);
+                        free_string_optional_buffer(&allocated_sia_code);
+                        dec = u_strcat_optional_buffer(adp->original_dec_buffer, PERMANENT_DEC_STRING_BUFFER_SIZE, &allocated_dec, entry->str);
+                        free_Ustring(entry);
+                        line = u_strcpy_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, output_dela_line);
+                        line = u_strcat_optional_buffer(original_line, STANDARD_STRING_BUFFER_SIZE, &allocated_line, current_component);
+
+                        unichar *temp = (unichar*)malloc(4096*sizeof(unichar));
+                        if (temp == NULL){
+                            fatal_alloc_error("explore_state_dutch");
+                        }
+                        unichar original_dec_temp[DEC_TEMP_STRING_BUFFER_SIZE]; unichar* allocated_dec_temp = NULL; const unichar* dec_temp;
+                        dec_temp = u_strcpy_optional_buffer(original_dec_temp, DEC_TEMP_STRING_BUFFER_SIZE, &allocated_dec_temp, dec);
+                        free_string_optional_buffer(&allocated_dec);
+                        /* Then, we explore the dictionary in order to analyze the
+                        * next component. We start at the root of the dictionary */
+                        Ustring* foo = new_Ustring();
+                        explore_state_dutch (infos->d->initial_state_offset, temp, 0, word_to_analyze, pos_in_word_to_analyze,
+                            dec_temp, line, L, adp, number_of_components + 1, infos, foo, 0);
+                        free_string_optional_buffer(&allocated_dec_temp);
+
+                        free_string_optional_buffer(&allocated_line);
+
+                        free(temp);
+                        free_Ustring(foo);
+                    }
+                }
+            }
+            /* Once we have finished to deal with the current final dictionary node,
+            * we go on because we may match a longer word */
+            base = ustr->len;
+        }
+        /* We examine each transition that goes out from the node */
+        unichar c;
+        int adr;
+        for (int i = 0; i<n_transitions; i++) {
+            offset = read_dictionary_transition(infos->d, offset, &c, &adr, ustr);
+            if (is_equal_or_uppercase(c, word_to_analyze[pos_in_word_to_analyze], infos->alphabet)) {
+                /* If the transition's letter is case compatible with the current letter of the
+                * word to analyze, we follow it */
+                current_component[pos_in_current_component] = c;
+                explore_state_dutch (adr, current_component, pos_in_current_component + 1, word_to_analyze, pos_in_word_to_analyze + 1,
+                    analysis, output_dela_line, L, adp, number_of_components, infos, ustr, base);
+            }
+            restore_output(z, ustr);
+        }
+    }
 
 } // namespace unitex

--- a/DutchCompounds.cpp
+++ b/DutchCompounds.cpp
@@ -32,7 +32,7 @@ namespace unitex {
 
 
 /* this define the maximum nomber of item in word_decomposition_list before abort an exploration */
-#ifndef MAX_NB_WORD_DECOMPOSITION_LIST_POSSIBLE 
+#ifndef MAX_NB_WORD_DECOMPOSITION_LIST_POSSIBLE
 #define MAX_NB_WORD_DECOMPOSITION_LIST_POSSIBLE (10000)
 #endif
 
@@ -439,7 +439,7 @@ namespace unitex {
 	* returns 0 otherwise.
 	*/
 	int analyse_dutch_word(const unichar* word, struct dutch_infos* infos) {
-		/* 
+		/*
 		unichar decomposition[4096];
 		unichar dela_line[4096];
 		unichar correct_word[4096];*/
@@ -760,7 +760,7 @@ namespace unitex {
 							free(temp);
 							free_string_optional_buffer(&allocated_dec_temp);
 							free_string_optional_buffer(&allocated_line);
-							
+
 						}
 						/* Now, we try to analyze the component normally */
 						unichar* allocated_dec = NULL; const unichar* dec;
@@ -796,9 +796,9 @@ namespace unitex {
 						explore_state_dutch (infos->d->initial_state_offset, temp, 0, word_to_analyze, pos_in_word_to_analyze,
 							dec_temp, line, L, adp, number_of_components + 1, infos, foo, 0);
 						free_string_optional_buffer(&allocated_dec_temp);
-						
+
 						free_string_optional_buffer(&allocated_line);
-						
+
 						free(temp);
 						free_Ustring(foo);
 					}

--- a/DutchCompounds.h
+++ b/DutchCompounds.h
@@ -35,7 +35,7 @@
 namespace unitex {
 
 void analyse_dutch_unknown_words(const Alphabet*,Dictionary*,U_FILE*,
-									U_FILE*,U_FILE*,U_FILE*,struct string_hash*);
+                                    U_FILE*,U_FILE*,U_FILE*,struct string_hash*);
 
 } // namespace unitex
 

--- a/ElagComp.cpp
+++ b/ElagComp.cpp
@@ -141,12 +141,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_ElagComp,lopts_ElagComp,
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_ElagComp[index].name);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;

--- a/ElagFstFilesIO.cpp
+++ b/ElagFstFilesIO.cpp
@@ -529,20 +529,20 @@ for (int i=0;i<input->tfst->automaton->number_of_states;i++) {
    SingleGraphState state=input->tfst->automaton->states[i];
    Transition* t=state->outgoing_transitions;
    while (t!=NULL) {
-	   /* We constructs the symbol list corresponding to the transition tag number */
-	  TfstTag* tag=(TfstTag*)input->tfst->tags->tab[t->tag_number];
-	  symbol_t* symbols=load_text_symbol(input->language,tag->content,t->tag_number);
-	  t->label=symbols;
-	  /* And we replace a single transition with a symbol list by several transitions
-	   * with one symbol each */
-	  if (t->label!=NULL) {
-		  while (t->label->next!=NULL) {
-			  Transition* foo=new_Transition_no_dup(t->label->next,t->state_number,t->next);
-			  t->label->next=NULL;
-			  t->next=foo;
-			  t=t->next;
-		  }
-	  }
+       /* We constructs the symbol list corresponding to the transition tag number */
+      TfstTag* tag=(TfstTag*)input->tfst->tags->tab[t->tag_number];
+      symbol_t* symbols=load_text_symbol(input->language,tag->content,t->tag_number);
+      t->label=symbols;
+      /* And we replace a single transition with a symbol list by several transitions
+       * with one symbol each */
+      if (t->label!=NULL) {
+          while (t->label->next!=NULL) {
+              Transition* foo=new_Transition_no_dup(t->label->next,t->state_number,t->next);
+              t->label->next=NULL;
+              t->next=foo;
+              t=t->next;
+          }
+      }
       t=t->next;
    }
    state->outgoing_transitions=filter_NULL_symbols(state->outgoing_transitions);

--- a/ElagRulesCompilation.cpp
+++ b/ElagRulesCompilation.cpp
@@ -509,11 +509,11 @@ for (e=1;e<automaton->number_of_states;e++) {
             }
          }
          if (c==nbConstraints) {
-	         if (++nbConstraints>=ELAG_MAX_CONSTRAINTS) {
+             if (++nbConstraints>=ELAG_MAX_CONSTRAINTS) {
                fatal_error("Too many constraints with same condition\n");
             }
-	         constraints[c]=t->state_number;
-	      }
+             constraints[c]=t->state_number;
+          }
       }
    }
 }

--- a/Error.h
+++ b/Error.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-/* ************************************************************************** */ 
+/* ************************************************************************** */
 #ifndef ErrorH
 #define ErrorH
 /* ************************************************************************** */
@@ -31,11 +31,11 @@
 namespace unitex {
 
 /**
- * Like EXIT_SUCCESS: expands to a system-dependent integral expression that, 
- * when used as the argument for function return, signifies that the 
+ * Like EXIT_SUCCESS: expands to a system-dependent integral expression that,
+ * when used as the argument for function return, signifies that the
  * function was successful
  */
-#define SUCCESS_RETURN_CODE EXIT_SUCCESS  
+#define SUCCESS_RETURN_CODE EXIT_SUCCESS
 
 /**
  * Like EXIT_FAILURE: expands to a system-dependent integral expression that,
@@ -82,5 +82,5 @@ void fatal_assert(int condition, const char*, ...);
 
 
 } // namespace unitex
-/* ************************************************************************** */ 
+/* ************************************************************************** */
 #endif  // ErrorH

--- a/Evamb.cpp
+++ b/Evamb.cpp
@@ -116,12 +116,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Evamb,lopts_Evamb,&index
                decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
                break;
      case 'V': only_verify_arguments = true;
-               break;                
-     case 'h': usage(); 
+               break;
+     case 'h': usage();
                return SUCCESS_RETURN_CODE;
      case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                            error("Missing argument for option --%s\n",lopts_Evamb[index].name);
-               return USAGE_ERROR_CODE;                         
+               return USAGE_ERROR_CODE;
      case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                            error("Invalid option --%s\n",options.vars()->optarg);
                return USAGE_ERROR_CODE;

--- a/Extract.cpp
+++ b/Extract.cpp
@@ -50,7 +50,7 @@ const char* usage_Extract =
          "  -i X/--index=X: the .ind file that describes the concordance. By default,\n"
          "                  X is the concord.ind file located in the text directory.\n"
          "  -o OUT/--output=OUT: the text file where the units will be stored\n"
-         "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"         
+         "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"
          "  -h/--help: this help\n"
          "\n"
          "\nExtract all the units that contain (or not) any part of a utterance. The\n"
@@ -108,8 +108,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Extract,lopts_Extract,&i
              strcpy(concord_ind,options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Extract[index].name);
@@ -171,7 +171,7 @@ if (concord_ind[0]=='\0') {
       free_text_tokens(tok);
       af_close_mapfile(text);
       free_snt_files(snt_files);
-      return DEFAULT_ERROR_CODE;   
+      return DEFAULT_ERROR_CODE;
    }
    remove_extension(text_name,concord_ind);
    strcat(concord_ind,"_snt");

--- a/Extract.cpp
+++ b/Extract.cpp
@@ -192,19 +192,19 @@ struct match_list* l=load_match_list(concord,NULL,NULL);
 u_fclose(concord);
 
 if (tok->SENTENCE_MARKER==-1) {
-	/* We have a special case when the text has not been
-	 * split into sentences: the result will be either an empty
-	 * file or the text itself
-	 */
-	if ((extract_matching_units && l==NULL) ||
+    /* We have a special case when the text has not been
+     * split into sentences: the result will be either an empty
+     * file or the text itself
+     */
+    if ((extract_matching_units && l==NULL) ||
        (!extract_matching_units && l!=NULL)) {
-		/* result = empty file */
-		u_fempty(&vec,output);
-		return SUCCESS_RETURN_CODE;
-	}
-	free_match_list(l);
-	af_copy(text_name,output);
-	return SUCCESS_RETURN_CODE;
+        /* result = empty file */
+        u_fempty(&vec,output);
+        return SUCCESS_RETURN_CODE;
+    }
+    free_match_list(l);
+    af_copy(text_name,output);
+    return SUCCESS_RETURN_CODE;
 }
 
 U_FILE* result=u_fopen(&vec,output,U_WRITE);

--- a/ExtractUnits.cpp
+++ b/ExtractUnits.cpp
@@ -59,7 +59,7 @@ current_end=-1;
 
 struct extract_buf_mapped* buffer=(struct extract_buf_mapped*)malloc(sizeof(struct extract_buf_mapped));
 if (buffer==NULL) {
-	fatal_alloc_error("new_buffer");
+    fatal_alloc_error("new_buffer");
 }
 buffer->amf=(snt);
 buffer->int_buffer_=(const int*)af_get_mapfile_pointer(buffer->amf);
@@ -76,7 +76,7 @@ while (buffer->pos < buffer->nb_item) {
    if ((RESULT && extract_matching_units) || (!RESULT && !extract_matching_units)) {
       /* if we must print this sentence, we print it */
       for (size_t i=0;i<buffer->size_current_item;i++) {
-		  u_fputs(tokens->token[buffer->int_buffer_[buffer->pos+i]],result);
+          u_fputs(tokens->token[buffer->int_buffer_[buffer->pos+i]],result);
       }
       u_fprintf(result,"\n");
    }

--- a/ExtractUnits.cpp
+++ b/ExtractUnits.cpp
@@ -120,7 +120,7 @@ for (;;)
 if (i>=MAX_TOKENS_BY_SENTENCE) {
    error("Sentence too long to be entirely displayed\n");
    /* We show the error and we read the sentence till its end in order
-    * to keep a valid sentence numerotation */  
+    * to keep a valid sentence numerotation */
    buffer->size_current_item=MAX_TOKENS_BY_SENTENCE;
    (*N_TOKENS_READ)=i;
    return;

--- a/FIFO.cpp
+++ b/FIFO.cpp
@@ -74,7 +74,7 @@ while (list!=NULL) {
 
 /**
  * Frees a FIFO. If it still contains elements, its linked list is freed.
- * 
+ *
  * WARNING: if the remaining elements have pointer values, these pointers
  * are not freed, so that it is the responsibility of the user to free this
  * memory.
@@ -114,7 +114,7 @@ f->input=f->input->next;
 }
 
 
-/** 
+/**
  * Takes a generic value from the given FIFO, or raises a fatal error
  * if the FIFO is empty.
  */
@@ -147,7 +147,7 @@ put_any(f,tmp);
 }
 
 
-/** 
+/**
  * Takes a pointer value from the given FIFO, or raises a fatal error
  * if the FIFO is empty.
  */
@@ -167,7 +167,7 @@ put_any(f,tmp);
 }
 
 
-/** 
+/**
  * Takes an integer value from the given FIFO, or raises a fatal error
  * if the FIFO is empty.
  */

--- a/FIFO.h
+++ b/FIFO.h
@@ -42,9 +42,9 @@ struct fifo_list {
 /**
  * This structure is used to handle generic FIFO. We represent it with a
  * linked list as follows:
- * 
+ *
  * output -->  ......... --> input --> NULL
- * 
+ *
  */
 struct fifo {
    struct fifo_list* input;

--- a/File.cpp
+++ b/File.cpp
@@ -107,10 +107,10 @@ char* to_unix_path_separators(char* file_path) {
 
   // pointer to the first occurrence of '\'
   char* it_current = strchr(file_path, '\\');
-  
+
   // return when there are nothing to do
   if (it_current == NULL) return file_path;
-  
+
   // pointer to the next character after the first '\'
   char* it_next    = it_current + 1;
 
@@ -122,14 +122,14 @@ char* to_unix_path_separators(char* file_path) {
     }
     ++it_current;
   }
-  
+
   // conserve UNC paths
-  if(file_path[0] && file_path[0] == '/' && 
+  if(file_path[0] && file_path[0] == '/' &&
      file_path[1] && file_path[1] == '/') {
      file_path[0] = '\\';
      file_path[1] = '\\';
   }
-  
+
   // remove trailing slashes
   if (file_path[1] && *(it_current-1) == '/') {
     while (*(it_current-1) == '/') {
@@ -138,12 +138,12 @@ char* to_unix_path_separators(char* file_path) {
     }
     // put back a single slash if file_path is now empty
     if(file_path[0] == '\0') {
-       file_path[0]  = '/'; 
+       file_path[0]  = '/';
     }
   }
 
   // put a trailing slash to DRIVE:/, e.g. 'c:/'
-  if (file_path[1] == ':' && 
+  if (file_path[1] == ':' &&
       file_path[2] == '\0') {
       file_path[2]  = '/';
       file_path[3]  = '\0';
@@ -164,10 +164,10 @@ char* to_windows_path_separators(char* file_path) {
 
   // pointer to the first occurrence of '\'
   char* it_current = strchr(file_path, '/');
-  
+
   // return when there are nothing to do
   if (it_current == NULL) return file_path;
-  
+
   // convert '/' to '\'
   while (*it_current != '\0') {
     if (*it_current  == '/') {
@@ -186,14 +186,14 @@ char* to_windows_path_separators(char* file_path) {
  *
  * @param[in,out] filename null-terminated string, with a filename to convert
  * @return returns a pointer to the \file_path C string
- * @author Cristian Martinez 
+ * @author Cristian Martinez
  */
 char* to_native_path_separators(char* file_path) {
 #ifdef _NOT_UNDER_WINDOWS
   return to_unix_path_separators(file_path);
 #else   // under Windows
   return to_windows_path_separators(file_path);
-#endif  // #ifdef _NOT_UNDER_WINDOWS  
+#endif  // #ifdef _NOT_UNDER_WINDOWS
 }
 
 /**
@@ -210,30 +210,30 @@ UnitexFileType get_file_type(const char* filename) {
   if (is_filename_in_abstract_file_space(filename)) {
     return FILE_ABST;
   }
-  
-  // by default the file type is unknown 
+
+  // by default the file type is unknown
   UnitexFileType file_type = FILE_UNK;
-  
+
 #ifndef _MSC_VER
   struct stat info;
-  
+
   // return information about filename
   int status = stat(filename,&info);
-  
+
   // on error, stat returns a non zero value
   if (status < 0) {
     // no such file or directory
-    if      (errno == ENOENT || 
+    if      (errno == ENOENT ||
              errno == ENOTDIR)      return FILE_NOT_FOUND;
     // permission denied
     else if (errno == EACCES)       return FUNC_EACCES;
     // other stat() error
     else                            return FUNC_ERROR;
   }  // if (status < 0)
-  
+
   if       (S_ISDIR (info.st_mode)) file_type = FILE_DIR;
   else if  (S_ISREG (info.st_mode)) file_type = FILE_REG;
-# ifdef _NOT_UNDER_WINDOWS  
+# ifdef _NOT_UNDER_WINDOWS
   else if  (S_ISCHR (info.st_mode)) file_type = FILE_CHR;
   else if  (S_ISBLK (info.st_mode)) file_type = FILE_BLK;
   else if  (S_ISLNK (info.st_mode)) file_type = FILE_LNK;
@@ -242,7 +242,7 @@ UnitexFileType get_file_type(const char* filename) {
 # endif  // _NOT_UNDER_WINDOWS
 #else  // under a non-POSIX system
   wchar_t w_filename[FILENAME_MAX + 1] = {0};
-  
+
   // get the required size, in characters, for the wide string buffer output
   int length = MultiByteToWideChar(CP_ACP,    // Windows ANSI code page
                                    0,         // no flags for conversion type
@@ -253,33 +253,33 @@ UnitexFileType get_file_type(const char* filename) {
 
   // maps filename string to w_filename wide character string
   MultiByteToWideChar(CP_ACP,                 // Windows ANSI code page
-                      0,                      // no flags for conversion type 
+                      0,                      // no flags for conversion type
                       filename,               // string to convert
-                      -1,                     // filename is null-terminated 
+                      -1,                     // filename is null-terminated
                       w_filename,             // wide string buffer output
                       length);                // size of the buffer output
 
-  // retrieves file system attributes for a specified file or directory 
+  // retrieves file system attributes for a specified file or directory
   DWORD dwAttribute =  GetFileAttributesW(w_filename);
-  
+
   // on error, dwAttribute is 0xFFFFFFFF
   if (dwAttribute == INVALID_FILE_ATTRIBUTES) {
     DWORD lastError = GetLastError();
-    
+
     // no such file or directory
-    if      (lastError == ERROR_FILE_NOT_FOUND || 
+    if      (lastError == ERROR_FILE_NOT_FOUND ||
              lastError == ERROR_PATH_NOT_FOUND)   return FILE_NOT_FOUND;
     // permission denied
-    else if (lastError == ERROR_ACCESS_DENIED)       
+    else if (lastError == ERROR_ACCESS_DENIED)
                                                   return FUNC_EACCES;
     // other stat() error
     else                                          return FUNC_ERROR;
   }  // if (status < 0)
-  
+
        if ((dwAttribute &  FILE_ATTRIBUTE_DIRECTORY) != 0) file_type = FILE_DIR;
   else if ((dwAttribute &  FILE_ATTRIBUTE_ARCHIVE)   != 0) file_type = FILE_REG;
 #endif  // _MSC_VER
-  
+
   // return main file type
   return file_type;
 }
@@ -314,7 +314,7 @@ int is_regular_file(const char* filename) {
  * @author Cristian Martinez
  */
 int is_abstract_file(const char* filename) {
-  return (get_file_type(filename)  == FILE_ABST);  
+  return (get_file_type(filename)  == FILE_ABST);
 }
 
 /**
@@ -325,13 +325,13 @@ int is_abstract_file(const char* filename) {
  * @author Cristian Martinez
  */
 int is_unknown_file(const char* filename) {
-  return (get_file_type(filename)  == FILE_UNK);  
+  return (get_file_type(filename)  == FILE_UNK);
 }
 
 /**
  * @brief Unitex implementation of realpath()
  *
- * Derives from the pathname pointed to by filename, an absolute pathname that 
+ * Derives from the pathname pointed to by filename, an absolute pathname that
  * names the same file, whose resolution does not involve ".", "..", or symbolic
  * links
  *
@@ -350,22 +350,22 @@ int get_real_path(const char* filename, char* resolved_name) {
  if (filename[0]=='\0') {
   return DEFAULT_ERROR_CODE;
  }
- 
+
  // get the file type
  UnitexFileType file_type = get_file_type(filename);
- 
- // if get_file_type() fails or the file doesn't exist 
+
+ // if get_file_type() fails or the file doesn't exist
  if(file_type <= FILE_NOT_FOUND) {
    return DEFAULT_ERROR_CODE;
  }
- 
+
  // if the file is under the abstract file layer, the name
  // is already resolved
  if(file_type == FILE_ABST) {
   strncpy(resolved_name, filename, FILENAME_MAX);
   return SUCCESS_RETURN_CODE;
  }
- 
+
  // default value to be returned by this function
  int return_code = DEFAULT_ERROR_CODE;
 
@@ -380,7 +380,7 @@ int get_real_path(const char* filename, char* resolved_name) {
 #else   // under Windows
  wchar_t w_filename[FILENAME_MAX + 1] = {0};  // wide string filename
  wchar_t w_buffer[FILENAME_MAX + 1]   = {0};  // wide string resolved filename
- 
+
  // get the required size, in characters, for the wide string buffer output
  int length = MultiByteToWideChar(CP_ACP,     // Windows ANSI code page
                                   0,          // no flags for conversion type
@@ -391,7 +391,7 @@ int get_real_path(const char* filename, char* resolved_name) {
 
  // maps filename C string to w_filename wide character string
  MultiByteToWideChar(CP_ACP,                  // Windows ANSI code page
-                     0,                       // no flags for conversion type 
+                     0,                       // no flags for conversion type
                      filename,                // string to convert
                      -1,                      // filename is null-terminated
                      w_filename,              // wide string buffer output
@@ -400,11 +400,11 @@ int get_real_path(const char* filename, char* resolved_name) {
  // try to get the resolved filename
  if (_wfullpath(w_buffer, w_filename, FILENAME_MAX)) {
   WideCharToMultiByte(CP_ACP,                 // Windows ANSI code page
-                      0,                      // no flags for conversion type 
+                      0,                      // no flags for conversion type
                       w_buffer,               // string to convert
                       -1,                     // w_buffer is null-terminated
                       buffer,                 // C string buffer output
-                      FILENAME_MAX,           // size of the buffer output  
+                      FILENAME_MAX,           // size of the buffer output
                       NULL,                   // use the system default character
                       NULL);                  // parameter can be set to NULL
   return_code = SUCCESS_RETURN_CODE;
@@ -416,7 +416,7 @@ int get_real_path(const char* filename, char* resolved_name) {
  if(return_code == SUCCESS_RETURN_CODE) {
    strncpy(resolved_name, buffer, FILENAME_MAX);
  }
- 
+
  return return_code;
 }
 
@@ -593,13 +593,13 @@ return 1;
  * @brief Checks whether a file or directory exists
  * @param filename null-terminated string, with a filename to check
  * @return 1 if the given file or directory exists; 0 otherwise
- * @see http://stackoverflow.com/a/12774387/2042871 
+ * @see http://stackoverflow.com/a/12774387/2042871
  * @see get_file_type
  * @author Cristian Martinez
  */
 int file_exists(const char* filename) {
   // This is different than the af_fopen() approach implemented in
-  // fexists(). Under POSIX systems, get_file_type() uses stat() to 
+  // fexists(). Under POSIX systems, get_file_type() uses stat() to
   // check if the file exists, in Windows, it uses GetFileAttributes().
   // Hence, this function could return 1 (file exists) even if the file
   // isn't readable. Besides that, this is reported to be faster than

--- a/File.cpp
+++ b/File.cpp
@@ -693,7 +693,7 @@ return ((path[0]>='a' && path[0]<='z') || (path[0]>='A' && path[0]<='Z'))
 #ifdef PREVENT_USING_METRO_INCOMPATIBLE_FUNCTION
 #include "DirHelper.h"
 static int create_path(const char* path) {
-	return mkDirPortable(path);
+    return mkDirPortable(path);
 }
 #else
 static int create_path(const char* path) {

--- a/File.h
+++ b/File.h
@@ -47,7 +47,7 @@
 #endif
 
 #ifdef _NOT_UNDER_WINDOWS
-  #include <unistd.h>  // access() 
+  #include <unistd.h>  // access()
 #else
 // Exclude some of the less frequently used APIs in Windows.h
 # ifndef WIN32_LEAN_AND_MEAN
@@ -65,7 +65,7 @@ namespace unitex {
 
 /**
  * Unitex FileTypes returned by get_file_type() function
- * FUNC_ERROR and FUNC_EACCES are used as function status values. 
+ * FUNC_ERROR and FUNC_EACCES are used as function status values.
  * FILE_NOT_FOUND, FILE_ABST, FILE_DIR, FILE_REG and FILE_UNK are
  * available on all the supported operating systems. The remaining
  * types are only available on POSIX-compliant systems

--- a/FileEncoding.h
+++ b/FileEncoding.h
@@ -69,13 +69,13 @@ typedef enum {
 #define VEC_DEFAULT {DEFAULT_MASK_ENCODING_COMPATIBILITY_INPUT,DEFAULT_ENCODING_OUTPUT,DEFAULT_BOM_OUTPUT}
 
 typedef struct {
-	/* Describes the encodings that are supported in input files */
-	int mask_encoding_compatibility_input;
-	/* Encoding output for file creation */
-	Encoding encoding_output;
-	/* Do we need to write BOM when creating a file ?
-	 * 0=no 1=yes 2=yes for UTF16LE and UTF16BE */
-	int bom_output;
+    /* Describes the encodings that are supported in input files */
+    int mask_encoding_compatibility_input;
+    /* Encoding output for file creation */
+    Encoding encoding_output;
+    /* Do we need to write BOM when creating a file ?
+     * 0=no 1=yes 2=yes for UTF16LE and UTF16BE */
+    int bom_output;
 } VersatileEncodingConfig;
 
 } // namespace unitex

--- a/Flatten.cpp
+++ b/Flatten.cpp
@@ -157,7 +157,7 @@ switch (flatten_fst2(origin,depth,temp,&vec,RTN)) {
    case EQUIVALENT_RTN:
       u_printf("The resulting grammar is an equivalent FST2 (RTN).\n");
       break;
-   default: 
+   default:
       error("Internal state error in Flatten's main\n");
       free_abstract_Fst2(origin,&fst2_free);
       return DEFAULT_ERROR_CODE;

--- a/Fst2.cpp
+++ b/Fst2.cpp
@@ -861,7 +861,7 @@ u_fclose(f);
  * don't have this content, graph negation operator is tilde
  *
  * LOAD_UNITEX_GRAPH_COMPATIBILITY_MODE is optional for performance issues on opening file
- * 
+ *
  */
 int get_graph_compatibility_mode_by_file(const VersatileEncodingConfig* vec,int *p_tilde_negation_operator) {
 #ifdef LOAD_UNITEX_GRAPH_COMPATIBILITY_MODE
@@ -894,7 +894,7 @@ int get_graph_compatibility_mode_by_file(const VersatileEncodingConfig* vec,int 
 
 
 /*******************************************************************/
-/* cloning 
+/* cloning
 */
 
 
@@ -925,14 +925,14 @@ Fst2Tag new_Fst2Tag_clone(Fst2Tag Fst2TagSrc,Abstract_allocator prv_alloc)
     Fst2TagDest->input = u_strdup(Fst2TagSrc->input,prv_alloc);
     Fst2TagDest->morphological_filter = u_strdup(Fst2TagSrc->morphological_filter,prv_alloc);
     Fst2TagDest->output = u_strdup(Fst2TagSrc->output,prv_alloc);
-    Fst2TagDest->variable = u_strdup(Fst2TagSrc->variable,prv_alloc);	 
+    Fst2TagDest->variable = u_strdup(Fst2TagSrc->variable,prv_alloc);
     Fst2TagDest->matching_tokens = clone(Fst2TagSrc->matching_tokens,prv_alloc);
 
 	Fst2TagDest->filter_number = Fst2TagSrc->filter_number;
 	Fst2TagDest->meta = Fst2TagSrc->meta;
 	Fst2TagDest->pattern = clone(Fst2TagSrc->pattern,prv_alloc);
 	Fst2TagDest->pattern_number = Fst2TagSrc->pattern_number;
-	
+
 	Fst2TagDest->compound_pattern = Fst2TagSrc->compound_pattern;
 
 	return Fst2TagDest;
@@ -973,7 +973,7 @@ Fst2* fst2ret;
             fst2ret->tags[i] = new_Fst2Tag_clone(fst2org->tags[i],prv_alloc);
         }
 
-   
+
         fst2ret->initial_states=(int*)malloc_cb((fst2ret->number_of_graphs+1)*sizeof(int),prv_alloc);
         if (fst2ret->initial_states==NULL) {fatal_error("Not enough memory in new_Fst2_clone\n");}
 

--- a/Fst2.cpp
+++ b/Fst2.cpp
@@ -170,17 +170,17 @@ int respect_case=(line[0]=='@');
  */
 all_input[k++]=line[i++];
 while(line[i]!='\0' && !(line[i]=='/' && i>0 && line[i-1]!='\\')) {
-	all_input[k++]=line[i++];
+    all_input[k++]=line[i++];
 }
 all_input[k]='\0';
 /*
  * If we find an output, we copy it
  */
 if(line[i]=='/') {
-	i++;
-	while(line[i]!='\0') {
-		output[j++]=line[i++];
-	}
+    i++;
+    while(line[i]!='\0') {
+        output[j++]=line[i++];
+    }
 }
 /* Then, if there is an output, we have it, and if not, 'output'
  * contains an empty string */
@@ -198,28 +198,28 @@ filter[0] = '\0';
 i = 0; j = 0;
 /* We copy the real input into 'input' */
 while (all_input[i]!='\0' && (all_input[i]!='<' || all_input[i+1]!='<')) {
-	input[j++]=all_input[i++];
+    input[j++]=all_input[i++];
 }
 input[j]='\0';
 /* If something remains, we have a morphological filter */
 if (all_input[i]!='\0') {
-	j = 0;
-	/* We copy the "<<...>>"  sequence */
-	while (all_input[i]!='\0' && (all_input[i]!='>' || all_input[i+1]!='>')) {
-		filter[j++]=all_input[i++];
-	}
+    j = 0;
+    /* We copy the "<<...>>"  sequence */
+    while (all_input[i]!='\0' && (all_input[i]!='>' || all_input[i+1]!='>')) {
+        filter[j++]=all_input[i++];
+    }
     filter[j++]='>';filter[j++]='>';
     /* If something remains, then we have an optional part like "_f_",
      * and we add it to 'filter' */
     if (all_input[i]!='\0') {
-		i=i+2;
-		if (all_input[i]=='_') {
-			do {
-				filter[j++]=all_input[i++];
-			} while (all_input[i]!='\0' && all_input[i]!= '_');
-			filter[j++] = '_';
-		}
-	}
+        i=i+2;
+        if (all_input[i]=='_') {
+            do {
+                filter[j++]=all_input[i++];
+            } while (all_input[i]!='\0' && all_input[i]!= '_');
+            filter[j++] = '_';
+        }
+    }
     filter[j] = '\0';
 }
 /* If there is a morphological filter but no input ("%<<^in>>/PFX"), then
@@ -279,24 +279,24 @@ if (!u_strcmp(input,"{$}")) {
 int length=u_strlen(input);
 if (input[0]=='$' &&
     (input[length-1]=='(' || input[length-1]==')')) {
-	int output_var=(input[1]=='|');
+    int output_var=(input[1]=='|');
    tag->variable=u_strdup(&(input[1+output_var]),length-2-output_var,prv_alloc);
    if (!output_var) {
-	   fst2->input_variables=sorted_insert(tag->variable,fst2->input_variables,prv_alloc);
-	   if (input[length-1]=='(') {
-		   tag->type=BEGIN_VAR_TAG;
-	   }
-	   else {
-		   tag->type=END_VAR_TAG;
-	   }
+       fst2->input_variables=sorted_insert(tag->variable,fst2->input_variables,prv_alloc);
+       if (input[length-1]=='(') {
+           tag->type=BEGIN_VAR_TAG;
+       }
+       else {
+           tag->type=END_VAR_TAG;
+       }
    } else {
-	   fst2->output_variables=sorted_insert(tag->variable,fst2->output_variables,prv_alloc);
-	   if (input[length-1]=='(') {
-		   tag->type=BEGIN_OUTPUT_VAR_TAG;
-	   }
-	   else {
-		   tag->type=END_OUTPUT_VAR_TAG;
-	   }
+       fst2->output_variables=sorted_insert(tag->variable,fst2->output_variables,prv_alloc);
+       if (input[length-1]=='(') {
+           tag->type=BEGIN_OUTPUT_VAR_TAG;
+       }
+       else {
+           tag->type=END_OUTPUT_VAR_TAG;
+       }
    }
 }
 return tag;
@@ -319,7 +319,7 @@ u_fputs(tag->input,f);
 /* If any, we add the morphological filter: <A><<^pre>> */
 if (tag->morphological_filter!=NULL &&
    tag->morphological_filter[0]!='\0') {
-	u_fputs(tag->morphological_filter,f);
+    u_fputs(tag->morphological_filter,f);
 }
 /* If any, we add the output */
 if (tag->output!=NULL) {
@@ -358,26 +358,26 @@ if (fst2->tags==NULL) {
 }
 /* If the position in the file is not correct we exit */
 if (((c=(unichar)u_fgetc(f))!='%')&&(c!='@')) {
-	fatal_error("Unexpected character in .fst2 file: %c (read tag)\n",c);
+    fatal_error("Unexpected character in .fst2 file: %c (read tag)\n",c);
 }
 /* There cannot have no tag line, because by convention, every .fst2 file
  * must have "%<E>" as first tag. */
 while (c!='f' && (limit==NO_TAG_LIMIT || current_tag<=limit)) {
-	/* We read the line and copy it without the ending '\n' */
-	i=0;
-	do {
-		line[i++]=c;
-	} while ((c=(unichar)u_fgetc(f))!='\n');
-	/* And we read the first character of the next line */
-  	if (((c=(unichar)u_fgetc(f))!='f')&&(c!='%')&&(c!='@')) {
-  		/* If the character is not an expected one we exit */
-  		fatal_error("Unexpected character in .fst2 file: %c (read tag)\n",c);
-  	}
-	line[i]='\0';
-	/* We create the tag and add it to the fst2 */
-	fst2->tags[current_tag]=create_tag(fst2,line,prv_alloc);
-	/* We do not forget to increase the tag counter */
-	current_tag++;
+    /* We read the line and copy it without the ending '\n' */
+    i=0;
+    do {
+        line[i++]=c;
+    } while ((c=(unichar)u_fgetc(f))!='\n');
+    /* And we read the first character of the next line */
+    if (((c=(unichar)u_fgetc(f))!='f')&&(c!='%')&&(c!='@')) {
+        /* If the character is not an expected one we exit */
+        fatal_error("Unexpected character in .fst2 file: %c (read tag)\n",c);
+    }
+    line[i]='\0';
+    /* We create the tag and add it to the fst2 */
+    fst2->tags[current_tag]=create_tag(fst2,line,prv_alloc);
+    /* We do not forget to increase the tag counter */
+    current_tag++;
    if (current_tag==SIZE) {
       /* If necessary, we double the size of the array */
       SIZE=SIZE*2;
@@ -458,11 +458,11 @@ register int value;
 int negative_number;
 /* We ignore spaces */
 do {
-	c=(unichar)u_fgetc(f);
+    c=(unichar)u_fgetc(f);
 } while (c==' ');
 /* If 'c' is neither a digit nor a minus sign nor an end of line, we exit */
 if (((c<'0')||(c>'9'))&&(c!='-')&&(c!='\n')) {
-	fatal_error("Unexpected character in fst2: %c (read int 1)\n",c);
+    fatal_error("Unexpected character in fst2: %c (read int 1)\n",c);
 }
 if (c=='\n') {
   /* If we have an end of line */
@@ -480,7 +480,7 @@ if (c=='-') {
 /* We compute the value of the integer */
 value=c-'0';
 while(((c=(unichar)u_fgetc(f))>='0')&&(c<='9')) {
-	value=value*10+(c-'0');
+    value=value*10+(c-'0');
 }
 if (negative_number) value=-value;
 return value;
@@ -527,74 +527,74 @@ if (fst2->states==NULL) {
 }
 /* We read all the graphs that make the fst2 */
 for (i=0;i<fst2->number_of_graphs;i++) {
-	/* We read the graph number and the space after it */
+    /* We read the graph number and the space after it */
    u_fscanf(f,"%d ",&current_graph);
    /* And we make it positive */
    current_graph=current_graph*(-1);
-	/* We set the initial state of the graph */
-	fst2->initial_states[current_graph]=current_state;
-	int relative_state=0;
-	/*
-	 * We read the graph name
-	 */
-	unichar* graph_name=readline_safe(f);
-	if (graph_number==NO_GRAPH_NUMBER_SPECIFIED || graph_number==current_graph) {
-		/* If we must read the graph either because it is the one we look for
-		 * or because we must read them all, then we initialize 'max_tag_number' */
-    	(*max_tag_number)=0;
-		/*
-		 * We save the graph name if needed
-		 */
-		if (read_names) {
-			fst2->graph_names[current_graph]=graph_name;
-		} else {
-			free(graph_name);
-		}
-		/*
-		 * We read the next char that must be 't' or ':' but not 'f', because
-		 * empty graphs are not allowed
-		 */
-		c=(unichar)u_fgetc(f);
-		if ((c!='t')&&(c!=':')) {fatal_error("Unexpected character in fst2: %c (read state)\n",c);}
-		/*
-		 * Then, we read the states of the graph, until we find a line beginning by 'f'.
-		 */
-		fst2->number_of_states_per_graphs[current_graph]=0;
-		while (c!='f') {
-			fst2->states[current_state]=new_Fst2State(prv_alloc);
-			fst2->number_of_states_per_graphs[current_graph]++;
-			/*
-			 * We set the finality and initiality bits of the state
-			 */
-			set_final_state(fst2->states[current_state],(c=='t'));
-			set_initial_state(fst2->states[current_state],(relative_state==0));
-			/*
-			 * We read the tag number
-			 */
-			tag_number=read_int(f,&end_of_line);
-			/*
-			 * We read transitions made of couple of integers (tag number/state number)
-			 * until we find an end of line
-			 */
-			while (!end_of_line) {
-				if (tag_number>(*max_tag_number)) {
-					/* We update the highest tag number */
-					(*max_tag_number)=tag_number;
-				}
-				/* We read the destination state number */
-				destination_state_number=read_int(f,&end_of_line);
-				if (end_of_line) {fatal_error("Missing state number in transition (graph %d, state %d)\n",current_graph,relative_state);}
-				/* We adjust the destination state number in order to make it global */
-				destination_state_number=destination_state_number+fst2->initial_states[current_graph];
-				/* We add the transition to the current state */
-				add_transition_to_state(fst2->states[current_state],tag_number,destination_state_number,prv_alloc);
-				/* And we do not forget to read the next integer */
-				tag_number=read_int(f,&end_of_line);
-			}
-			if (((c=(unichar)u_fgetc(f))!=':')&&(c!='t')&&(c!='f')) {
+    /* We set the initial state of the graph */
+    fst2->initial_states[current_graph]=current_state;
+    int relative_state=0;
+    /*
+     * We read the graph name
+     */
+    unichar* graph_name=readline_safe(f);
+    if (graph_number==NO_GRAPH_NUMBER_SPECIFIED || graph_number==current_graph) {
+        /* If we must read the graph either because it is the one we look for
+         * or because we must read them all, then we initialize 'max_tag_number' */
+        (*max_tag_number)=0;
+        /*
+         * We save the graph name if needed
+         */
+        if (read_names) {
+            fst2->graph_names[current_graph]=graph_name;
+        } else {
+            free(graph_name);
+        }
+        /*
+         * We read the next char that must be 't' or ':' but not 'f', because
+         * empty graphs are not allowed
+         */
+        c=(unichar)u_fgetc(f);
+        if ((c!='t')&&(c!=':')) {fatal_error("Unexpected character in fst2: %c (read state)\n",c);}
+        /*
+         * Then, we read the states of the graph, until we find a line beginning by 'f'.
+         */
+        fst2->number_of_states_per_graphs[current_graph]=0;
+        while (c!='f') {
+            fst2->states[current_state]=new_Fst2State(prv_alloc);
+            fst2->number_of_states_per_graphs[current_graph]++;
+            /*
+             * We set the finality and initiality bits of the state
+             */
+            set_final_state(fst2->states[current_state],(c=='t'));
+            set_initial_state(fst2->states[current_state],(relative_state==0));
+            /*
+             * We read the tag number
+             */
+            tag_number=read_int(f,&end_of_line);
+            /*
+             * We read transitions made of couple of integers (tag number/state number)
+             * until we find an end of line
+             */
+            while (!end_of_line) {
+                if (tag_number>(*max_tag_number)) {
+                    /* We update the highest tag number */
+                    (*max_tag_number)=tag_number;
+                }
+                /* We read the destination state number */
+                destination_state_number=read_int(f,&end_of_line);
+                if (end_of_line) {fatal_error("Missing state number in transition (graph %d, state %d)\n",current_graph,relative_state);}
+                /* We adjust the destination state number in order to make it global */
+                destination_state_number=destination_state_number+fst2->initial_states[current_graph];
+                /* We add the transition to the current state */
+                add_transition_to_state(fst2->states[current_state],tag_number,destination_state_number,prv_alloc);
+                /* And we do not forget to read the next integer */
+                tag_number=read_int(f,&end_of_line);
+            }
+            if (((c=(unichar)u_fgetc(f))!=':')&&(c!='t')&&(c!='f')) {
             fatal_error("Unexpected character in fst2: %c\n",c);
-			}
-			current_state++;
+            }
+            current_state++;
          if (current_state==SIZE) {
             /* If necessary, we double the size of the state array */
             SIZE=SIZE*2;
@@ -603,22 +603,22 @@ for (i=0;i<fst2->number_of_graphs;i++) {
                fatal_alloc_error("read_fst2_states");
             }
          }
-			relative_state++;
-		}
-	}
-	else {
-		/*
-		 * If we do not need to read this graph, then we just go to the 'f' that
-		 * indicates the end of the graph. However, if the 'graph_names' array
-		 * exists, we set the name of the current graph to NULL, in order to
-		 * avoid memory error during the freeing of the fst2.
-		 */
-		if (read_names) {
-			fst2->graph_names[current_graph]=NULL;
-		}
-		while(((c=(unichar)u_fgetc(f))!='f')) {}
-	}
-	/* We read the space and the '\n' that follows the final 'f' */
+            relative_state++;
+        }
+    }
+    else {
+        /*
+         * If we do not need to read this graph, then we just go to the 'f' that
+         * indicates the end of the graph. However, if the 'graph_names' array
+         * exists, we set the name of the current graph to NULL, in order to
+         * avoid memory error during the freeing of the fst2.
+         */
+        if (read_names) {
+            fst2->graph_names[current_graph]=NULL;
+        }
+        while(((c=(unichar)u_fgetc(f))!='f')) {}
+    }
+    /* We read the space and the '\n' that follows the final 'f' */
    u_fgetc(f);
    u_fgetc(f);
 }
@@ -656,20 +656,20 @@ read_fst2_states(f,fst2,read_names,NO_GRAPH_NUMBER_SPECIFIED,NULL,prv_alloc);
 Fst2* load_fst2(const VersatileEncodingConfig* vec,const char* filename,int read_names,int graph_number,Abstract_allocator prv_alloc) {
 void* ptr=get_persistent_structure(filename);
 if (ptr!=NULL) {
-	return new_Fst2_clone((Fst2*)ptr);
+    return new_Fst2_clone((Fst2*)ptr);
 }
 U_FILE* f;
 f=u_fopen(vec,filename,U_READ);
 Fst2* fst2;
 if (f==NULL) {
-	error("Cannot open the file %s\n",filename);
-	return NULL;
+    error("Cannot open the file %s\n",filename);
+    return NULL;
 }
 int ret=load_fst2_from_file(f,read_names, &fst2, graph_number, prv_alloc);
 switch (ret) {
 case GRAPH_IS_EMPTY:
-	error("Graph %s is empty\n",filename);
-	return NULL;
+    error("Graph %s is empty\n",filename);
+    return NULL;
 }
 
 return fst2;
@@ -685,7 +685,7 @@ unichar debug;
 /* We read the number of graphs contained in the fst2 */
 u_fscanf(f,"%C%d\n",&debug,&(fst2->number_of_graphs));
 if (fst2->number_of_graphs==0) {
-	return GRAPH_IS_EMPTY;
+    return GRAPH_IS_EMPTY;
 }
 fst2->debug=(debug=='d');
 /*
@@ -698,14 +698,14 @@ if (fst2->initial_states==NULL) {
    fatal_alloc_error("load_fst2_from_file");
 }
 for (int i=0;i<fst2->number_of_graphs+1;i++) {
-	fst2->initial_states[i]=0;
+    fst2->initial_states[i]=0;
 }
 fst2->number_of_states_per_graphs=(int*)malloc_cb((fst2->number_of_graphs+1)*sizeof(int),prv_alloc);
 if (fst2->number_of_states_per_graphs==NULL) {
    fatal_alloc_error("load_fst2_from_file");
 }
 for (int i=0;i<fst2->number_of_graphs+1;i++) {
-	fst2->number_of_states_per_graphs[i]=0;
+    fst2->number_of_states_per_graphs[i]=0;
 }
 
 /*
@@ -713,10 +713,10 @@ for (int i=0;i<fst2->number_of_graphs+1;i++) {
  * than above.
  */
 if (read_names) {
-	fst2->graph_names=(unichar**)malloc_cb((fst2->number_of_graphs+1)*sizeof(unichar*),prv_alloc);
-	if (fst2->graph_names==NULL) {
-	   fatal_alloc_error("load_fst2_from_file");
-	}
+    fst2->graph_names=(unichar**)malloc_cb((fst2->number_of_graphs+1)*sizeof(unichar*),prv_alloc);
+    if (fst2->graph_names==NULL) {
+       fatal_alloc_error("load_fst2_from_file");
+    }
 }
 /*
  * Then we read the states of the fst2
@@ -727,9 +727,9 @@ read_fst2_states(f,fst2,read_names,graph_number,&max_tag_number,prv_alloc);
  * And we read the tags
  */
 if (graph_number==NO_GRAPH_NUMBER_SPECIFIED) {
-	read_fst2_tags(f,fst2,prv_alloc);
+    read_fst2_tags(f,fst2,prv_alloc);
 } else {
-	read_fst2_tags(f,fst2,max_tag_number,prv_alloc);
+    read_fst2_tags(f,fst2,max_tag_number,prv_alloc);
 }
 u_fclose(f);
 *retval=fst2;
@@ -745,7 +745,7 @@ return load_fst2(vec,filename,read_names,NO_GRAPH_NUMBER_SPECIFIED,prv_alloc);
 }
 
 int load_fst2_from_file(U_FILE* f,int read_names,Fst2* *fst2,Abstract_allocator prv_alloc) {
-	return load_fst2_from_file(f,read_names,fst2,NO_GRAPH_NUMBER_SPECIFIED,prv_alloc);
+    return load_fst2_from_file(f,read_names,fst2,NO_GRAPH_NUMBER_SPECIFIED,prv_alloc);
 
 }
 
@@ -773,7 +773,7 @@ if (e==NULL) {
 e->control=e->control & (0xFF-FST2_INITIAL_STATE_BIT_MASK);
 /* And we add it if necessary*/
 if (finality) {
-	e->control=e->control | FST2_INITIAL_STATE_BIT_MASK;
+    e->control=e->control | FST2_INITIAL_STATE_BIT_MASK;
 }
 }
 
@@ -804,7 +804,7 @@ if (e==NULL) {
 e->control=e->control & (0xFF-FST2_FINAL_STATE_BIT_MASK);
 /* And we add it if necessary*/
 if (finality) {
-	e->control=e->control | FST2_FINAL_STATE_BIT_MASK;
+    e->control=e->control | FST2_FINAL_STATE_BIT_MASK;
 }
 }
 
@@ -900,27 +900,27 @@ int get_graph_compatibility_mode_by_file(const VersatileEncodingConfig* vec,int 
 
 Fst2State new_Fst2State_clone(Fst2State Fst2StateSrc,Abstract_allocator prv_alloc)
 {
-	if (Fst2StateSrc == NULL)
-		return NULL;
+    if (Fst2StateSrc == NULL)
+        return NULL;
 
-	Fst2State Fst2dest=(fst2State*)malloc_cb(sizeof(fst2State),prv_alloc);
-	if (Fst2dest==NULL) {
-	   fatal_error("Not enough memory in new_Fst2State_clone\n");
-	}
-	Fst2dest->control = Fst2StateSrc->control;
-	Fst2dest->transitions = clone_transition_list(Fst2StateSrc->transitions,NULL,NULL,prv_alloc);
-	return Fst2dest;
+    Fst2State Fst2dest=(fst2State*)malloc_cb(sizeof(fst2State),prv_alloc);
+    if (Fst2dest==NULL) {
+       fatal_error("Not enough memory in new_Fst2State_clone\n");
+    }
+    Fst2dest->control = Fst2StateSrc->control;
+    Fst2dest->transitions = clone_transition_list(Fst2StateSrc->transitions,NULL,NULL,prv_alloc);
+    return Fst2dest;
 }
 
 Fst2Tag new_Fst2Tag_clone(Fst2Tag Fst2TagSrc,Abstract_allocator prv_alloc)
 {
-	if  (Fst2TagSrc==NULL)
-		return NULL;
+    if  (Fst2TagSrc==NULL)
+        return NULL;
 
 
-	Fst2Tag Fst2TagDest=(fst2Tag*)malloc_cb(sizeof(fst2Tag),prv_alloc);
-	Fst2TagDest->type = Fst2TagSrc->type;
-	Fst2TagDest->control = Fst2TagSrc->control;
+    Fst2Tag Fst2TagDest=(fst2Tag*)malloc_cb(sizeof(fst2Tag),prv_alloc);
+    Fst2TagDest->type = Fst2TagSrc->type;
+    Fst2TagDest->control = Fst2TagSrc->control;
 
     Fst2TagDest->input = u_strdup(Fst2TagSrc->input,prv_alloc);
     Fst2TagDest->morphological_filter = u_strdup(Fst2TagSrc->morphological_filter,prv_alloc);
@@ -928,14 +928,14 @@ Fst2Tag new_Fst2Tag_clone(Fst2Tag Fst2TagSrc,Abstract_allocator prv_alloc)
     Fst2TagDest->variable = u_strdup(Fst2TagSrc->variable,prv_alloc);
     Fst2TagDest->matching_tokens = clone(Fst2TagSrc->matching_tokens,prv_alloc);
 
-	Fst2TagDest->filter_number = Fst2TagSrc->filter_number;
-	Fst2TagDest->meta = Fst2TagSrc->meta;
-	Fst2TagDest->pattern = clone(Fst2TagSrc->pattern,prv_alloc);
-	Fst2TagDest->pattern_number = Fst2TagSrc->pattern_number;
+    Fst2TagDest->filter_number = Fst2TagSrc->filter_number;
+    Fst2TagDest->meta = Fst2TagSrc->meta;
+    Fst2TagDest->pattern = clone(Fst2TagSrc->pattern,prv_alloc);
+    Fst2TagDest->pattern_number = Fst2TagSrc->pattern_number;
 
-	Fst2TagDest->compound_pattern = Fst2TagSrc->compound_pattern;
+    Fst2TagDest->compound_pattern = Fst2TagSrc->compound_pattern;
 
-	return Fst2TagDest;
+    return Fst2TagDest;
 }
 
 
@@ -967,7 +967,7 @@ Fst2* fst2ret;
             fst2ret->states[i] = new_Fst2State_clone(fst2org->states[i],prv_alloc);
         }
 
-		fst2ret->tags = (Fst2Tag*)malloc_cb(sizeof(Fst2Tag)*fst2ret->number_of_tags,prv_alloc);
+        fst2ret->tags = (Fst2Tag*)malloc_cb(sizeof(Fst2Tag)*fst2ret->number_of_tags,prv_alloc);
         for (i=0;i<fst2org->number_of_tags;i++)
         {
             fst2ret->tags[i] = new_Fst2Tag_clone(fst2org->tags[i],prv_alloc);
@@ -1008,17 +1008,17 @@ Fst2* fst2ret;
           }
         }
 
-	    if (fst2org->input_variables!=NULL) {
-		    fst2ret->input_variables = clone(fst2org->input_variables,prv_alloc);
-		    if (fst2ret->input_variables == NULL) {fatal_error("Not enough memory in new_Fst2_clone\n");}
-	    }
-	    if (fst2org->output_variables!=NULL) {
-		    fst2ret->output_variables = clone(fst2org->output_variables,prv_alloc);
-		    if (fst2ret->output_variables == NULL) {fatal_error("Not enough memory in new_Fst2_clone\n");}
-	    }
+        if (fst2org->input_variables!=NULL) {
+            fst2ret->input_variables = clone(fst2org->input_variables,prv_alloc);
+            if (fst2ret->input_variables == NULL) {fatal_error("Not enough memory in new_Fst2_clone\n");}
+        }
+        if (fst2org->output_variables!=NULL) {
+            fst2ret->output_variables = clone(fst2org->output_variables,prv_alloc);
+            if (fst2ret->output_variables == NULL) {fatal_error("Not enough memory in new_Fst2_clone\n");}
+        }
 
     }
-	return fst2ret;
+    return fst2ret;
 }
 
 
@@ -1046,13 +1046,13 @@ free_Fst2(f);
  */
 int get_graph_index(Fst2* fst2,int n_state) {
 if (n_state<0 || n_state>=fst2->number_of_states) {
-	fatal_error("Internal error in get_graph_index\n");
+    fatal_error("Internal error in get_graph_index\n");
 }
 for (int i=1;i<=fst2->number_of_graphs;i++) {
-	if (n_state>=fst2->initial_states[i]
-	    && n_state<(fst2->initial_states[i]+fst2->number_of_states_per_graphs[i])) {
-		return i;
-	}
+    if (n_state>=fst2->initial_states[i]
+        && n_state<(fst2->initial_states[i]+fst2->number_of_states_per_graphs[i])) {
+        return i;
+    }
 }
 /* Should not happen */
 return -1;

--- a/Fst2.h
+++ b/Fst2.h
@@ -88,26 +88,26 @@ enum tag_type {
  * This structure represents a tag of a .fst2 file.
  */
 struct fst2Tag {
-	/* Field used to indicate the nature of the tag */
+    /* Field used to indicate the nature of the tag */
    enum tag_type type;
 
-	/* This control byte is used to set information about the tag with
-	 * bit masks. The meaning of these tags can be found in LocateConstants.h
-	 *
-	 * This field is also used in the Grf2Fst2 program in order to mark the
-	 * tags that can match the empty word <E>.
-	 */
-	unsigned char control;
+    /* This control byte is used to set information about the tag with
+     * bit masks. The meaning of these tags can be found in LocateConstants.h
+     *
+     * This field is also used in the Grf2Fst2 program in order to mark the
+     * tags that can match the empty word <E>.
+     */
+    unsigned char control;
 
-	/*
-	 * 'input' represents the input part of a tag, that is to say without
-	 * its morphological filter and output if any.
-	 * Example: "<V:P><<^in>>/[V]" => input="<V:P>"
-	 *
-	 * NOTE: if the input only contains a morphological filter like "<<^in>>",
-	 *       the default sequence "<TOKEN>" will be copied in the 'input' field.
-	 */
-	unichar* input;
+    /*
+     * 'input' represents the input part of a tag, that is to say without
+     * its morphological filter and output if any.
+     * Example: "<V:P><<^in>>/[V]" => input="<V:P>"
+     *
+     * NOTE: if the input only contains a morphological filter like "<<^in>>",
+     *       the default sequence "<TOKEN>" will be copied in the 'input' field.
+     */
+    unichar* input;
 
    /*
     * If a tag contains a morphological filter, it is copied into this field
@@ -144,19 +144,19 @@ struct fst2Tag {
     unichar* variable;
 
    /*
-	 * This field represents the list of the numbers of the tokens that this tag
-	 * can match.
-	 */
-	struct list_int* matching_tokens;
+     * This field represents the list of the numbers of the tokens that this tag
+     * can match.
+     */
+    struct list_int* matching_tokens;
 
-	/*
-	 * If the tag can match one or several compound words, a compound pattern is
-	 * created, and this field is used to store the number of this compound
-	 * pattern. Note that if a tag ("<Einstein>") can match both simple ("Einstein")
-	 * and compound ("Albert Einstein") words, simple words will be handled as
-	 * tokens, and compound words will be handled via a compound pattern.
-	 */
-	int compound_pattern;
+    /*
+     * If the tag can match one or several compound words, a compound pattern is
+     * created, and this field is used to store the number of this compound
+     * pattern. Note that if a tag ("<Einstein>") can match both simple ("Einstein")
+     * and compound ("Albert Einstein") words, simple words will be handled as
+     * tokens, and compound words will be handled via a compound pattern.
+     */
+    int compound_pattern;
 };
 typedef struct fst2Tag* Fst2Tag;
 
@@ -165,15 +165,15 @@ typedef struct fst2Tag* Fst2Tag;
  * This structure represents a state of a .fst2 file.
  */
 struct fst2State {
-	/* This control byte is used to set information about the state with
-	 * bit masks. The two lowest bits are reserved to mark initial and final
-	 * states. This field can also be used to mark states when exploring a fst2. For
-	 * instance, it is used for cycle detection in the Grf2Fst2 program.
-	 */
-	unsigned char control;
+    /* This control byte is used to set information about the state with
+     * bit masks. The two lowest bits are reserved to mark initial and final
+     * states. This field can also be used to mark states when exploring a fst2. For
+     * instance, it is used for cycle detection in the Grf2Fst2 program.
+     */
+    unsigned char control;
 
-	/* Transitions outgoing from this state */
-	Transition* transitions;
+    /* Transitions outgoing from this state */
+    Transition* transitions;
 };
 typedef struct fst2State* Fst2State;
 
@@ -182,7 +182,7 @@ typedef struct fst2State* Fst2State;
  * This structure represent a fst2.
  */
 struct fst2 {
-	/* Array that contains all the states of the fst2 */
+    /* Array that contains all the states of the fst2 */
     Fst2State* states;
 
     /* Array that contains all the tags of the fst2 */

--- a/Fst2Check.cpp
+++ b/Fst2Check.cpp
@@ -72,7 +72,7 @@ Fst2* fst2=load_abstract_fst2(vec,name,1,&fst2_free);
 char name_without_path[FILENAME_MAX];
 remove_path(name,name_without_path);
 if (fst2==NULL) {
-	error("Cannot load graph %s\n",name);
+    error("Cannot load graph %s\n",name);
     if (ferr != NULL)
         u_fprintf(ferr,"Cannot load graph %s\n",name);
     return 0;

--- a/Fst2Check.cpp
+++ b/Fst2Check.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -212,8 +212,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Fst2Check,lopts_Fst2Chec
              break;
    case 'e': no_empty_graph_warning=1; break;
    case 'V': only_verify_arguments = true;
-             break;   
-   case 'h': usage();  
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Fst2Check[index].name);
@@ -264,7 +264,7 @@ if (output[0]!=0) {
   }
   else {
       ferr=u_fopen(&vec,output,U_APPEND);
-  }  
+  }
 }
 
 if (display_statistics) {

--- a/Fst2Check.h
+++ b/Fst2Check.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Fst2Check_lib.cpp
+++ b/Fst2Check_lib.cpp
@@ -33,7 +33,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1
@@ -856,13 +856,13 @@ return 1;
 /**
  * Returns 1 if the given .fst2 corresponds to a valid sentence automaton; 0
  * otherwise. Following conditions must be true:
- * 
+ *
  * 1) there must be only one graph
  * 2) it must be acyclic
  * 3) there must not be any <E> transition with an ouput
  * 4) <E> must the only tag without output
  * 5) all other tags must have an ouput of the form w x y z f g, with
- *    w and y being integers >=0, and x, z, f and g being integers >=-1 
+ *    w and y being integers >=0, and x, z, f and g being integers >=-1
  */
 int valid_sentence_automaton_write_error(const VersatileEncodingConfig* vec,const char* name,U_FILE*) {
 struct FST2_free_info fst2_free;

--- a/Fst2Check_lib.cpp
+++ b/Fst2Check_lib.cpp
@@ -43,9 +43,9 @@ namespace unitex {
 typedef enum {CHK_MATCHES_E,CHK_DOES_NOT_MATCH_E,CHK_DONT_KNOW} E_MATCHING_STATUS;
 
 typedef struct {
-	Fst2* fst2;
-	E_MATCHING_STATUS* graphs_matching_E;
-	SingleGraph* condition_graphs;
+    Fst2* fst2;
+    E_MATCHING_STATUS* graphs_matching_E;
+    SingleGraph* condition_graphs;
 } GrfCheckInfo;
 
 
@@ -71,46 +71,46 @@ static int get_end_of_context(Fst2* fst2,int state);
 static int get_end_of_context__(Fst2* fst2,int state,struct list_int* *visited_states) {
 int res;
 if (is_in_list(state,*visited_states)) {
-	/* No need to visit twice a state */
-	return -1;
+    /* No need to visit twice a state */
+    return -1;
 }
 (*visited_states)=new_list_int(state,*visited_states);
 for (Transition* t=fst2->states[state]->transitions;t!=NULL;t=t->next) {
-	if (t->tag_number<=0) {
-		/* If we have a graph call or a E transition, we look after it */
-		res=get_end_of_context__(fst2,t->state_number,visited_states);
-		if (res!=-1) {
-			return res;
-		}
-		continue;
-	}
-	Fst2Tag tag=fst2->tags[t->tag_number];
-	if (tag->type==END_CONTEXT_TAG) {
-		/* We found it! */
-		return t->state_number;
-	}
-	if (tag->type==BEGIN_POSITIVE_CONTEXT_TAG || tag->type==BEGIN_NEGATIVE_CONTEXT_TAG) {
-		/* If we have a nested context, we deal with it */
-		int end=get_end_of_context(fst2,t->state_number);
-		if (end==-1) {
-			/* No end for this nested context ? There is nothing more to be done
-			 * with this transition */
-			continue;
-		} else {
-			/* Now, we can continue to explore from the end of the nested context */
-			res=get_end_of_context__(fst2,end,visited_states);
-			if (res!=-1) {
-				return res;
-			}
-			continue;
-		}
-	}
-	/* If we have a normal transition, we explore it */
-	res=get_end_of_context__(fst2,t->state_number,visited_states);
-	if (res!=-1) {
-		return res;
-	}
-	continue;
+    if (t->tag_number<=0) {
+        /* If we have a graph call or a E transition, we look after it */
+        res=get_end_of_context__(fst2,t->state_number,visited_states);
+        if (res!=-1) {
+            return res;
+        }
+        continue;
+    }
+    Fst2Tag tag=fst2->tags[t->tag_number];
+    if (tag->type==END_CONTEXT_TAG) {
+        /* We found it! */
+        return t->state_number;
+    }
+    if (tag->type==BEGIN_POSITIVE_CONTEXT_TAG || tag->type==BEGIN_NEGATIVE_CONTEXT_TAG) {
+        /* If we have a nested context, we deal with it */
+        int end=get_end_of_context(fst2,t->state_number);
+        if (end==-1) {
+            /* No end for this nested context ? There is nothing more to be done
+             * with this transition */
+            continue;
+        } else {
+            /* Now, we can continue to explore from the end of the nested context */
+            res=get_end_of_context__(fst2,end,visited_states);
+            if (res!=-1) {
+                return res;
+            }
+            continue;
+        }
+    }
+    /* If we have a normal transition, we explore it */
+    res=get_end_of_context__(fst2,t->state_number,visited_states);
+    if (res!=-1) {
+        return res;
+    }
+    continue;
 }
 return -1;
 }
@@ -135,10 +135,10 @@ return res;
  */
 static int matches_E(Fst2* fst2,int tag_number) {
 if (tag_number<0) {
-	return 0;
+    return 0;
 }
 if (tag_number==0) {
-	return 1;
+    return 1;
 }
 Fst2Tag tag=fst2->tags[tag_number];
 switch (tag->type) {
@@ -168,7 +168,7 @@ case TEXT_END_TAG: return 1;   // {$}
 }
 /* Finally, we test if we have a <E> transition with an output */
 if (!u_strcmp(tag->input,"<E>")) {
-	return 1;
+    return 1;
 }
 return 0;
 }
@@ -178,17 +178,17 @@ static void clean_condition_graph(SingleGraph g) {
 remove_epsilon_transitions(g,0);
 trim(g,NULL);
 if (g->number_of_states!=0) {
-	determinize(g);
+    determinize(g);
 }
 /* And we print the resulting graph */
 /*save_fst2_subgraph(U_STDERR,g,graph,NULL);
 if (graph==1) {
-	for (int i=0;i<fst2->number_of_tags;i++) {
-		error("%d: %S",i,fst2->tags[i]->input);
-		if (fst2->tags[i]->output!=NULL && fst2->tags[i]->output[0]!='\0') {
-			error("/%S",fst2->tags[i]->output);
-		}
-		error("\n");
+    for (int i=0;i<fst2->number_of_tags;i++) {
+        error("%d: %S",i,fst2->tags[i]->input);
+        if (fst2->tags[i]->output!=NULL && fst2->tags[i]->output[0]!='\0') {
+            error("/%S",fst2->tags[i]->output);
+        }
+        error("\n");
 }
 }*/
 }
@@ -200,31 +200,31 @@ if (graph==1) {
  */
 static void deal_with_transition_v1(Fst2* fst2,Transition* t,SingleGraphState dst,int initial_state) {
 if (t->tag_number<=0) {
-	/* For graphs and <E> we keep the transition as is, except for
-	 * the state number that we have to adjust */
-	add_outgoing_transition(dst,t->tag_number,t->state_number-initial_state);
+    /* For graphs and <E> we keep the transition as is, except for
+     * the state number that we have to adjust */
+    add_outgoing_transition(dst,t->tag_number,t->state_number-initial_state);
 } else if (is_right_context_beginning(fst2,t->tag_number)) {
-	/* Right contexts are a special case: we skip the whole context by
-	 * using an E transition that points to the end of the context
-	 */
-	int dst_state=get_end_of_context(fst2,t->state_number);
-	if (dst_state!=-1) {
-		add_outgoing_transition(dst,0,dst_state-initial_state);
-	} else {
-		/* If we cannot reach the end of the context, then this transition cannot
-		 * match anything anyway, so we can just ignore it */
-	}
+    /* Right contexts are a special case: we skip the whole context by
+     * using an E transition that points to the end of the context
+     */
+    int dst_state=get_end_of_context(fst2,t->state_number);
+    if (dst_state!=-1) {
+        add_outgoing_transition(dst,0,dst_state-initial_state);
+    } else {
+        /* If we cannot reach the end of the context, then this transition cannot
+         * match anything anyway, so we can just ignore it */
+    }
 } else if (matches_E(fst2,t->tag_number)) {
-	/* Tags like $*, variable tags, etc. can be considered
-	 * like E transitions, but they must be kept, because they
-	 * could be involved into an infinite E loop. However, we also have to
-	 * add a real E transition, so that the final state can be reached by the
-	 * regular E removal algorithm. */
-	add_outgoing_transition(dst,0,t->state_number-initial_state);
-	add_outgoing_transition(dst,t->tag_number,t->state_number-initial_state);
+    /* Tags like $*, variable tags, etc. can be considered
+     * like E transitions, but they must be kept, because they
+     * could be involved into an infinite E loop. However, we also have to
+     * add a real E transition, so that the final state can be reached by the
+     * regular E removal algorithm. */
+    add_outgoing_transition(dst,0,t->state_number-initial_state);
+    add_outgoing_transition(dst,t->tag_number,t->state_number-initial_state);
 } else {
-	/* If we have a transition does actually match something in the text, we just
-	 * ignore it */
+    /* If we have a transition does actually match something in the text, we just
+     * ignore it */
 }
 }
 
@@ -237,16 +237,16 @@ static void deal_with_transition_v2(Fst2* fst2,Transition* t,SingleGraphState ds
 /* We always add the original transition */
 add_outgoing_transition(dst,t->tag_number,t->state_number-initial_state);
 if (t->tag_number>0 && is_right_context_beginning(fst2,t->tag_number)) {
-	/* Right contexts are a special case: we allow to skip the whole context by
-	 * adding an E transition that points to the end of the context
-	 */
-	int dst_state=get_end_of_context(fst2,t->state_number);
-	if (dst_state!=-1) {
-		add_outgoing_transition(dst,0,dst_state-initial_state);
-	} else {
-		/* If we cannot reach the end of the context, then this transition cannot
-		 * match anything anyway, so we can just ignore it */
-	}
+    /* Right contexts are a special case: we allow to skip the whole context by
+     * adding an E transition that points to the end of the context
+     */
+    int dst_state=get_end_of_context(fst2,t->state_number);
+    if (dst_state!=-1) {
+        add_outgoing_transition(dst,0,dst_state-initial_state);
+    } else {
+        /* If we cannot reach the end of the context, then this transition cannot
+         * match anything anyway, so we can just ignore it */
+    }
 }
 }
 
@@ -276,23 +276,23 @@ SingleGraph g=new_SingleGraph(INT_TAGS);
 int initial_state=fst2->initial_states[graph];
 int n_states=fst2->number_of_states_per_graphs[graph];
 for (int i=initial_state;i<initial_state+n_states;i++) {
-	SingleGraphState dst=add_state(g);
-	Fst2State src=fst2->states[i];
-	if (is_initial_state(src)) {
-		set_initial_state(dst);
-	}
-	if (is_final_state(src)) {
-		set_final_state(dst);
-	}
-	Transition* t=src->transitions;
-	while (t!=NULL) {
-		if (full_simplification) {
-			deal_with_transition_v1(fst2,t,dst,initial_state);
-		} else {
-			deal_with_transition_v2(fst2,t,dst,initial_state);
-		}
-		t=t->next;
-	}
+    SingleGraphState dst=add_state(g);
+    Fst2State src=fst2->states[i];
+    if (is_initial_state(src)) {
+        set_initial_state(dst);
+    }
+    if (is_final_state(src)) {
+        set_final_state(dst);
+    }
+    Transition* t=src->transitions;
+    while (t!=NULL) {
+        if (full_simplification) {
+            deal_with_transition_v1(fst2,t,dst,initial_state);
+        } else {
+            deal_with_transition_v2(fst2,t,dst,initial_state);
+        }
+        t=t->next;
+    }
 }
 clean_condition_graph(g);
 return g;
@@ -301,17 +301,17 @@ return g;
 
 static E_MATCHING_STATUS get_status(SingleGraph g) {
 if (g->number_of_states==0) {
-	return CHK_DOES_NOT_MATCH_E;
+    return CHK_DOES_NOT_MATCH_E;
 }
 int i=get_initial_state(g);
 if (i<0) {
-	fatal_error("Internal error in get_status: invalid negative initial state %d\n",i);
+    fatal_error("Internal error in get_status: invalid negative initial state %d\n",i);
 }
 SingleGraphState s=g->states[i];
 if (is_final_state(s)) {
-	/* If the initial state is final, it means that we can reach it without matching
-	 * anything in the text */
-	return CHK_MATCHES_E;
+    /* If the initial state is final, it means that we can reach it without matching
+     * anything in the text */
+    return CHK_MATCHES_E;
 }
 return CHK_DONT_KNOW;
 }
@@ -324,21 +324,21 @@ return CHK_DONT_KNOW;
 static GrfCheckInfo* new_GrfCheckInfo(Fst2* fst2) {
 GrfCheckInfo* res=(GrfCheckInfo*)malloc(sizeof(GrfCheckInfo));
 if (res==NULL) {
-	fatal_alloc_error("new_GrfCheckInfo");
+    fatal_alloc_error("new_GrfCheckInfo");
 }
 res->fst2=fst2;
 res->graphs_matching_E=(E_MATCHING_STATUS*)malloc(sizeof(E_MATCHING_STATUS)*(fst2->number_of_graphs+1));
 if (res->graphs_matching_E==NULL) {
-	fatal_alloc_error("new_GrfCheckInfo");
+    fatal_alloc_error("new_GrfCheckInfo");
 }
 res->condition_graphs=(SingleGraph*)calloc(fst2->number_of_graphs+1,sizeof(SingleGraph));
 if (res->condition_graphs==NULL) {
-	fatal_alloc_error("new_GrfCheckInfo");
+    fatal_alloc_error("new_GrfCheckInfo");
 }
 for (int i=1;i<fst2->number_of_graphs+1;i++) {
-	SingleGraph g=create_condition_graph(fst2,i,1);
-	res->condition_graphs[i]=g;
-	res->graphs_matching_E[i]=get_status(g);
+    SingleGraph g=create_condition_graph(fst2,i,1);
+    res->condition_graphs[i]=g;
+    res->graphs_matching_E[i]=get_status(g);
 }
 return res;
 }
@@ -349,14 +349,14 @@ return res;
  */
 static void free_GrfCheckInfo(GrfCheckInfo* info) {
 if (info==NULL) {
-	return;
+    return;
 }
 free(info->graphs_matching_E);
 if (info->condition_graphs!=NULL) {
-	for (int i=1;i<info->fst2->number_of_graphs+1;i++) {
-		free_SingleGraph(info->condition_graphs[i],NULL);
-	}
-	free(info->condition_graphs);
+    for (int i=1;i<info->fst2->number_of_graphs+1;i++) {
+        free_SingleGraph(info->condition_graphs[i],NULL);
+    }
+    free(info->condition_graphs);
 }
 free(info);
 }
@@ -370,36 +370,36 @@ free(info);
 static void resolve_conditions(GrfCheckInfo* chk,int graph,struct list_int* updated_graphs) {
 SingleGraph g=chk->condition_graphs[graph];
 for (int i=0;i<g->number_of_states;i++) {
-	SingleGraphState state=g->states[i];
-	Transition** t=&(state->outgoing_transitions);
-	while ((*t)!=NULL) {
-		if ((*t)->tag_number<0) {
-			if (is_in_list(-(*t)->tag_number,updated_graphs)) {
-				/* We only look at graphs that have been updated */
-				E_MATCHING_STATUS status=chk->graphs_matching_E[-(*t)->tag_number];
-				switch(status) {
-					case CHK_DONT_KNOW: fatal_error("Unexpected CHK_DONT_KNOW value in resolve_conditions\n"); break;
-					case CHK_MATCHES_E: {
-						/* The graph matches E, we can add an E transition */
-						Transition* new_E_transition=new_Transition(0,(*t)->state_number,(*t)->next);
-						(*t)->next=new_E_transition;
-						t=&(new_E_transition->next);
-						break;
-					}
-					case CHK_DOES_NOT_MATCH_E: {
-						/* We have to remove this transition */
-						Transition* next=(*t)->next;
-						free_Transition(*t);
-						(*t)=next;
-						break;
-					}
-				}
-				continue;
-			}
-		}
-		/* Not a transition we are concerned about */
-		t=&((*t)->next);
-	}
+    SingleGraphState state=g->states[i];
+    Transition** t=&(state->outgoing_transitions);
+    while ((*t)!=NULL) {
+        if ((*t)->tag_number<0) {
+            if (is_in_list(-(*t)->tag_number,updated_graphs)) {
+                /* We only look at graphs that have been updated */
+                E_MATCHING_STATUS status=chk->graphs_matching_E[-(*t)->tag_number];
+                switch(status) {
+                    case CHK_DONT_KNOW: fatal_error("Unexpected CHK_DONT_KNOW value in resolve_conditions\n"); break;
+                    case CHK_MATCHES_E: {
+                        /* The graph matches E, we can add an E transition */
+                        Transition* new_E_transition=new_Transition(0,(*t)->state_number,(*t)->next);
+                        (*t)->next=new_E_transition;
+                        t=&(new_E_transition->next);
+                        break;
+                    }
+                    case CHK_DOES_NOT_MATCH_E: {
+                        /* We have to remove this transition */
+                        Transition* next=(*t)->next;
+                        free_Transition(*t);
+                        (*t)=next;
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+        /* Not a transition we are concerned about */
+        t=&((*t)->next);
+    }
 }
 clean_condition_graph(g);
 }
@@ -414,26 +414,26 @@ static int resolve_all_conditions(GrfCheckInfo* chk,struct list_int* *list,int *
 *unknown=0;
 struct list_int* new_list=NULL;
 for (int i=1;i<chk->fst2->number_of_graphs+1;i++) {
-	if (chk->graphs_matching_E[i]==CHK_DONT_KNOW) {
-		/* We only need to look at the graphs we are not sure about yet */
-		resolve_conditions(chk,i,*list);
-		chk->graphs_matching_E[i]=get_status(chk->condition_graphs[i]);
-		if (chk->graphs_matching_E[i]!=CHK_DONT_KNOW) {
-			/* If we have found an answer, we note that graph #i must be
-			 * looked at on the next loop */
-			new_list=new_list_int(i,new_list);
-		} else {
-			/* The graph is still unknown */
-			(*unknown)++;
-		}
-	}
+    if (chk->graphs_matching_E[i]==CHK_DONT_KNOW) {
+        /* We only need to look at the graphs we are not sure about yet */
+        resolve_conditions(chk,i,*list);
+        chk->graphs_matching_E[i]=get_status(chk->condition_graphs[i]);
+        if (chk->graphs_matching_E[i]!=CHK_DONT_KNOW) {
+            /* If we have found an answer, we note that graph #i must be
+             * looked at on the next loop */
+            new_list=new_list_int(i,new_list);
+        } else {
+            /* The graph is still unknown */
+            (*unknown)++;
+        }
+    }
 }
 /* Now we can use the new list */
 free_list_int(*list);
 *list=new_list;
 if (chk->graphs_matching_E[1]==CHK_MATCHES_E) {
-	error("Main graph matches epsilon!\n");
-	return 0;
+    error("Main graph matches epsilon!\n");
+    return 0;
 }
 return ((*list)!=NULL && (*unknown)!=0);
 }
@@ -442,18 +442,18 @@ return ((*list)!=NULL && (*unknown)!=0);
 
 static void rebuild_condition_graphs(GrfCheckInfo* chk) {
 for (int i=1;i<chk->fst2->number_of_graphs+1;i++) {
-	free_SingleGraph(chk->condition_graphs[i],NULL);
-	chk->condition_graphs[i]=create_condition_graph(chk->fst2,i,0);
+    free_SingleGraph(chk->condition_graphs[i],NULL);
+    chk->condition_graphs[i]=create_condition_graph(chk->fst2,i,0);
 }
 }
 
 
 static int transition_can_match_E(int tag_number,GrfCheckInfo* chk) {
 if (tag_number==0) {
-	return 1;
+    return 1;
 }
 if (tag_number<0) {
-	return chk->graphs_matching_E[-tag_number]==CHK_MATCHES_E;
+    return chk->graphs_matching_E[-tag_number]==CHK_MATCHES_E;
 }
 return matches_E(chk->fst2,tag_number);
 }
@@ -465,22 +465,22 @@ return matches_E(chk->fst2,tag_number);
  */
 static void print_reversed_list(struct list_pointer* list,Fst2* fst2,int stop,int depth) {
 if (list==NULL) {
-	return;
+    return;
 }
 Transition* t=(Transition*)list->pointer;
 if (depth!=0) {
-	if ((stop>=0 && t->state_number==stop) || (stop<0 && t->tag_number==stop)) {
-		return;
-	}
+    if ((stop>=0 && t->state_number==stop) || (stop<0 && t->tag_number==stop)) {
+        return;
+    }
 }
 print_reversed_list(list->next,fst2,stop,depth+1);
 if (t->tag_number<0) {
-	error("   :%S",fst2->graph_names[-t->tag_number]);
+    error("   :%S",fst2->graph_names[-t->tag_number]);
 } else {
-	error("   %S",fst2->tags[t->tag_number]->input);
-	if (fst2->tags[t->tag_number]->output!=NULL && fst2->tags[t->tag_number]->output[0]!='\0') {
-		error("/%S",fst2->tags[t->tag_number]->output);
-	}
+    error("   %S",fst2->tags[t->tag_number]->input);
+    if (fst2->tags[t->tag_number]->output!=NULL && fst2->tags[t->tag_number]->output[0]!='\0') {
+        error("/%S",fst2->tags[t->tag_number]->output);
+    }
 }
 error("\n");
 }
@@ -493,32 +493,32 @@ error("\n");
  * 1 if a loop is found; 0 otherwise.
  */
 static int find_an_E_loop(int* mark,int current_state,int graph,GrfCheckInfo* chk,
-		struct list_pointer* transitions) {
+        struct list_pointer* transitions) {
 if (mark[current_state]==1) {
-	/* The state has been visited, nothing to do */
-	return 0;
+    /* The state has been visited, nothing to do */
+    return 0;
 }
 if (mark[current_state]==2) {
-	/* The state is being visited, we have a loop */
-	error("E loop in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
-	print_reversed_list(transitions,chk->fst2,current_state,0);
-	return 1;
+    /* The state is being visited, we have a loop */
+    error("E loop in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
+    print_reversed_list(transitions,chk->fst2,current_state,0);
+    return 1;
 }
 /* We start visiting the state */
 mark[current_state]=2;
 SingleGraphState s=chk->condition_graphs[graph]->states[current_state];
 Transition* t=s->outgoing_transitions;
 while (t!=NULL) {
-	if (transition_can_match_E(t->tag_number,chk)) {
-		struct list_pointer* new_head=new_list_pointer(t,transitions);
-		int res=find_an_E_loop(mark,t->state_number,graph,chk,new_head);
-		new_head->next=NULL;
-		free_list_pointer(new_head);
-		if (res==1) {
-			return 1;
-		}
-	}
-	t=t->next;
+    if (transition_can_match_E(t->tag_number,chk)) {
+        struct list_pointer* new_head=new_list_pointer(t,transitions);
+        int res=find_an_E_loop(mark,t->state_number,graph,chk,new_head);
+        new_head->next=NULL;
+        free_list_pointer(new_head);
+        if (res==1) {
+            return 1;
+        }
+    }
+    t=t->next;
 }
 /* The state has been fully visited */
 mark[current_state]=1;
@@ -540,14 +540,14 @@ SingleGraph g=chk->condition_graphs[graph];
 int* mark=(int*)calloc(g->number_of_states,sizeof(int));
 int loop=0;
 for (int i=0;loop==0 && i<g->number_of_states;i++) {
-	if (mark[i]==1) {
-		/* No need to examine twice a state */
-		continue;
-	}
-	if (find_an_E_loop(mark,i,graph,chk,NULL)) {
-		loop=1;
-	}
-	mark[i]=1;
+    if (mark[i]==1) {
+        /* No need to examine twice a state */
+        continue;
+    }
+    if (find_an_E_loop(mark,i,graph,chk,NULL)) {
+        loop=1;
+    }
+    mark[i]=1;
 }
 free(mark);
 return loop;
@@ -563,9 +563,9 @@ return loop;
 static int is_any_E_loop(GrfCheckInfo* chk) {
 int loop=0;
 for (int i=1;i<chk->fst2->number_of_graphs+1;i++) {
-	if (is_E_loop(chk,i)) {
-		loop=1;
-	}
+    if (is_E_loop(chk,i)) {
+        loop=1;
+    }
 }
 return loop;
 }
@@ -575,44 +575,44 @@ return loop;
 static int is_left_recursion(GrfCheckInfo* chk,int graph,int* mark_graph,struct list_pointer* transitions);
 
 static int find_a_left_recursion(int* mark_graph,int* mark_state,int current_state,int graph,
-									GrfCheckInfo* chk,struct list_pointer* transitions) {
+                                    GrfCheckInfo* chk,struct list_pointer* transitions) {
 if (mark_state[current_state]==1) {
-	/* The state has been visited, nothing to do */
-	return 0;
+    /* The state has been visited, nothing to do */
+    return 0;
 }
 if (mark_state[current_state]==2) {
-	/* The state is being visited, we have a loop, but it should have been detected before */
-	error("E loop in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
-	print_reversed_list(transitions,chk->fst2,current_state,0);
-	return 1;
+    /* The state is being visited, we have a loop, but it should have been detected before */
+    error("E loop in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
+    print_reversed_list(transitions,chk->fst2,current_state,0);
+    return 1;
 }
 /* We start visiting the state */
 mark_state[current_state]=2;
 SingleGraphState s=chk->condition_graphs[graph]->states[current_state];
 Transition* t=s->outgoing_transitions;
 while (t!=NULL) {
-	if (t->tag_number<0) {
-		/* As we look for left recursions, we always test recursively
-		 * graph calls, regardless the fact that they may match E
-		 */
-		struct list_pointer* new_head=new_list_pointer(t,transitions);
-		int res=is_left_recursion(chk,-(t->tag_number),mark_graph,new_head);
-		new_head->next=NULL;
-		free_list_pointer(new_head);
-		if (res==1) {
-			return 1;
-		}
-	}
-	if (transition_can_match_E(t->tag_number,chk)) {
-		struct list_pointer* new_head=new_list_pointer(t,transitions);
-		int res=find_a_left_recursion(mark_graph,mark_state,t->state_number,graph,chk,new_head);
-		new_head->next=NULL;
-		free_list_pointer(new_head);
-		if (res==1) {
-			return 1;
-		}
-	}
-	t=t->next;
+    if (t->tag_number<0) {
+        /* As we look for left recursions, we always test recursively
+         * graph calls, regardless the fact that they may match E
+         */
+        struct list_pointer* new_head=new_list_pointer(t,transitions);
+        int res=is_left_recursion(chk,-(t->tag_number),mark_graph,new_head);
+        new_head->next=NULL;
+        free_list_pointer(new_head);
+        if (res==1) {
+            return 1;
+        }
+    }
+    if (transition_can_match_E(t->tag_number,chk)) {
+        struct list_pointer* new_head=new_list_pointer(t,transitions);
+        int res=find_a_left_recursion(mark_graph,mark_state,t->state_number,graph,chk,new_head);
+        new_head->next=NULL;
+        free_list_pointer(new_head);
+        if (res==1) {
+            return 1;
+        }
+    }
+    t=t->next;
 }
 /* The state has been fully visited */
 mark_state[current_state]=1;
@@ -626,14 +626,14 @@ return 0;
  */
 static int is_left_recursion(GrfCheckInfo* chk,int graph,int* mark_graph,struct list_pointer* transitions) {
 if (mark_graph[graph]==1) {
-	/* The graph has already been tested for left recursions */
-	return 0;
+    /* The graph has already been tested for left recursions */
+    return 0;
 }
 if (mark_graph[graph]==2) {
-	/* We found a left recursion */
-	error("Left recursion found in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
-	print_reversed_list(transitions,chk->fst2,-graph,0);
-	return 1;
+    /* We found a left recursion */
+    error("Left recursion found in graph %S, made of the following tags:\n",chk->fst2->graph_names[graph]);
+    print_reversed_list(transitions,chk->fst2,-graph,0);
+    return 1;
 }
 
 mark_graph[graph]=2;
@@ -647,16 +647,16 @@ int* mark_state=(int*)calloc(g->number_of_states,sizeof(int));
 int recursion=0;
 int initial_state=get_initial_state(g);
 if (initial_state==-2) {
-	fatal_error("Internal error: several initial states in graph %S\n",chk->fst2->graph_names[graph]);
+    fatal_error("Internal error: several initial states in graph %S\n",chk->fst2->graph_names[graph]);
 }
 if (initial_state==-1) {
-	/* If the graph could not be loaded, we just ignore */
-	mark_graph[graph]=1;
-	free(mark_state);
-	return 0;
+    /* If the graph could not be loaded, we just ignore */
+    mark_graph[graph]=1;
+    free(mark_state);
+    return 0;
 }
 if (find_a_left_recursion(mark_graph,mark_state,initial_state,graph,chk,transitions)) {
-	recursion=1;
+    recursion=1;
 }
 free(mark_state);
 mark_graph[graph]=1;
@@ -675,12 +675,12 @@ int recursion=0;
 int* mark_graph=(int*)calloc(chk->fst2->number_of_graphs+1,sizeof(int));
 
 for (int i=1;recursion==0 && i<chk->fst2->number_of_graphs+1;i++) {
-	if (mark_graph[i]==0) {
-		/* No need to look a graph twice */
-		if (is_left_recursion(chk,i,mark_graph,NULL)) {
-			recursion=1;
-		}
-	}
+    if (mark_graph[i]==0) {
+        /* No need to look a graph twice */
+        if (is_left_recursion(chk,i,mark_graph,NULL)) {
+            recursion=1;
+        }
+    }
 }
 free(mark_graph);
 return recursion;
@@ -700,7 +700,7 @@ int RESULT=1;
 struct FST2_free_info fst2_free;
 Fst2* fst2=load_abstract_fst2(vec,name,1,&fst2_free);
 if (fst2==NULL) {
-	fatal_error("Cannot load graph %s\n",name);
+    fatal_error("Cannot load graph %s\n",name);
 }
 u_printf("Creating condition sets...\n");
 GrfCheckInfo* chk=new_GrfCheckInfo(fst2);
@@ -709,33 +709,33 @@ struct list_int* list=NULL;
 /* To do that, we start by creating a list of all the graphs we are sure about */
 int unknown=0;
 for (int i=1;i<fst2->number_of_graphs+1;i++) {
-	if (chk->graphs_matching_E[i]!=CHK_DONT_KNOW) {
-		list=new_list_int(i,list);
-	} else {
-		unknown++;
-	}
+    if (chk->graphs_matching_E[i]!=CHK_DONT_KNOW) {
+        list=new_list_int(i,list);
+    } else {
+        unknown++;
+    }
 }
 /* While there is something to do for E matching */
 u_printf("Checking empty word matching...\n");
 while (resolve_all_conditions(chk,&list,&unknown)) {}
 if (chk->graphs_matching_E[1]==CHK_MATCHES_E) {
-	if (!no_empty_graph_warning) {
+    if (!no_empty_graph_warning) {
        error("ERROR: the main graph %S recognizes <E>\n",fst2->graph_names[1]);
        if (ferr!=NULL) {
-    	   u_fprintf(ferr,"ERROR: the main graph %S recognizes <E>\n",fst2->graph_names[1]);
-	   }
-	}
-	goto evil_goto;
+           u_fprintf(ferr,"ERROR: the main graph %S recognizes <E>\n",fst2->graph_names[1]);
+       }
+    }
+    goto evil_goto;
 }
 if (!no_empty_graph_warning) {
-	for (int i=2;i<fst2->number_of_graphs+1;i++) {
-		if (chk->graphs_matching_E[i]==CHK_MATCHES_E) {
-			error("WARNING: the graph %S recognizes <E>\n",fst2->graph_names[i]);
-			if (ferr!=NULL) {
-				u_fprintf(ferr,"WARNING: the graph %S recognizes <E>\n",fst2->graph_names[i]);
-			}
-		}
-	}
+    for (int i=2;i<fst2->number_of_graphs+1;i++) {
+        if (chk->graphs_matching_E[i]==CHK_MATCHES_E) {
+            error("WARNING: the graph %S recognizes <E>\n",fst2->graph_names[i]);
+            if (ferr!=NULL) {
+                u_fprintf(ferr,"WARNING: the graph %S recognizes <E>\n",fst2->graph_names[i]);
+            }
+        }
+    }
 }
 /* Now, we look for E loops and left recursions. And to do that, we need a new version
  * of the condition graphs, because a graph that does not match E would have been emptied.
@@ -743,13 +743,13 @@ if (!no_empty_graph_warning) {
 rebuild_condition_graphs(chk);
 u_printf("Checking E loops...\n");
 if (is_any_E_loop(chk)) {
-	/* Error messages have already been printed */
-	goto evil_goto;
+    /* Error messages have already been printed */
+    goto evil_goto;
 }
 u_printf("Checking left recursions...\n");
 if (is_any_left_recursion(chk)) {
-	/* Error messages have already been printed */
-	goto evil_goto;
+    /* Error messages have already been printed */
+    goto evil_goto;
 }
 evil_goto:
 /* There may be something unused in the list that we need to free */
@@ -897,68 +897,68 @@ if (fst2==NULL) return 0;
 int ret=1;
 int mark,a,b,c;
 for (int i=1;i<=fst2->number_of_graphs;i++) {
-	mark=a=b=c=0;
-	for (int j=0;j<fst2->number_of_states_per_graphs[i];j++) {
-		Transition* t=fst2->states[fst2->initial_states[i]+j]->transitions;
-		while (t!=NULL) {
-			if (t->tag_number<0) {
-				t=t->next;
-				continue;
-			}
-			Fst2Tag tag=fst2->tags[t->tag_number];
-			switch (tag->type) {
-				case BEGIN_POSITIVE_CONTEXT_TAG:
-				case BEGIN_NEGATIVE_CONTEXT_TAG:
-				case END_CONTEXT_TAG:
-				case LEFT_CONTEXT_TAG: {
-					if (!mark) {
-						/* Don't modify this line!! This exact wording is expected
-						 * by the Gramlab console in order to display a clickable
-						 * link that the user can use to open the faulty graph
-						 */
-						error("Error in graph %S:\n",fst2->graph_names[i]);
-						mark=1;
-					}
-					if (!a) error("- unsupported context\n");
-					ret=0;
-					a=1;
-					break;
-				}
-				case BEGIN_MORPHO_TAG:
-				case END_MORPHO_TAG: {
-					if (!mark) {
-						/* Don't modify this line!! This exact wording is expected
-						 * by the Gramlab console in order to display a clickable
-						 * link that the user can use to open the faulty graph
-						 */
-						error("Error in graph %S:\n",fst2->graph_names[i]);
-						mark=1;
-					}
-					if (!b) error("- unsupported morphological mode\n");
-					ret=0;
-					b=1;
-					break;
-				}
-				default: {
-					if (tag->morphological_filter!=NULL && tag->morphological_filter[0]!='\0') {
-						if (!mark) {
-							/* Don't modify this line!! This exact wording is expected
-							 * by the Gramlab console in order to display a clickable
-							 * link that the user can use to open the faulty graph
-							 */
-							error("Error in graph %S:\n",fst2->graph_names[i]);
-							mark=1;
-						}
-						if (!c) error("- unsupported morphological filter\n");
-						ret=0;
-						c=1;
-						break;
-					}
-				}
-			}
-			t=t->next;
-		}
-	}
+    mark=a=b=c=0;
+    for (int j=0;j<fst2->number_of_states_per_graphs[i];j++) {
+        Transition* t=fst2->states[fst2->initial_states[i]+j]->transitions;
+        while (t!=NULL) {
+            if (t->tag_number<0) {
+                t=t->next;
+                continue;
+            }
+            Fst2Tag tag=fst2->tags[t->tag_number];
+            switch (tag->type) {
+                case BEGIN_POSITIVE_CONTEXT_TAG:
+                case BEGIN_NEGATIVE_CONTEXT_TAG:
+                case END_CONTEXT_TAG:
+                case LEFT_CONTEXT_TAG: {
+                    if (!mark) {
+                        /* Don't modify this line!! This exact wording is expected
+                         * by the Gramlab console in order to display a clickable
+                         * link that the user can use to open the faulty graph
+                         */
+                        error("Error in graph %S:\n",fst2->graph_names[i]);
+                        mark=1;
+                    }
+                    if (!a) error("- unsupported context\n");
+                    ret=0;
+                    a=1;
+                    break;
+                }
+                case BEGIN_MORPHO_TAG:
+                case END_MORPHO_TAG: {
+                    if (!mark) {
+                        /* Don't modify this line!! This exact wording is expected
+                         * by the Gramlab console in order to display a clickable
+                         * link that the user can use to open the faulty graph
+                         */
+                        error("Error in graph %S:\n",fst2->graph_names[i]);
+                        mark=1;
+                    }
+                    if (!b) error("- unsupported morphological mode\n");
+                    ret=0;
+                    b=1;
+                    break;
+                }
+                default: {
+                    if (tag->morphological_filter!=NULL && tag->morphological_filter[0]!='\0') {
+                        if (!mark) {
+                            /* Don't modify this line!! This exact wording is expected
+                             * by the Gramlab console in order to display a clickable
+                             * link that the user can use to open the faulty graph
+                             */
+                            error("Error in graph %S:\n",fst2->graph_names[i]);
+                            mark=1;
+                        }
+                        if (!c) error("- unsupported morphological filter\n");
+                        ret=0;
+                        c=1;
+                        break;
+                    }
+                }
+            }
+            t=t->next;
+        }
+    }
 }
 return ret;
 }

--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2144,7 +2144,7 @@ int main_Fst2List(int argc, char* const argv[]) {
           case '\\':
             wp++;
             if (*wp == '\0') {
-            	// TODO(jhondoe) Put an error message here
+                // TODO(jhondoe) Put an error message here
               error("");
               return DEFAULT_ERROR_CODE;
             }
@@ -2181,7 +2181,7 @@ int main_Fst2List(int argc, char* const argv[]) {
           if (*wp == '\\') {
             wp++;
             if (*wp == '\0') {
-            	// TODO(jhondoe) Put an error message here
+                // TODO(jhondoe) Put an error message here
               error("");
               return DEFAULT_ERROR_CODE;
             }

--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2218,8 +2218,8 @@ int main_Fst2List(int argc, char* const argv[]) {
       break;
     case 'V': only_verify_arguments = true;
               break;
-    case 'h': usage(); 
-              return SUCCESS_RETURN_CODE;      
+    case 'h': usage();
+              return SUCCESS_RETURN_CODE;
     case 'q': {
       char* arg;
       if (argv[iargIndex][2] == '\0') {

--- a/Fst2Txt.cpp
+++ b/Fst2Txt.cpp
@@ -57,7 +57,7 @@ const char* usage_Fst2Txt =
          "  --output_offsets=XXX: offset file to be produced\n"
          "\n"
          "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"
-         "  -h/--help: this help\n"         
+         "  -h/--help: this help\n"
          "\n"
          "Applies a grammar to a text. The text file is modified.\n";
 
@@ -133,13 +133,13 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Fst2Txt,lopts_Fst2Txt,&i
    case 'a': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty alphabet file name\n");
                 free_fst2txt_parameters(p);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              p->alphabet_file=strdup(options.vars()->optarg);
              if (p->alphabet_file==NULL) {
                alloc_error("main_Fst2Txt");
                free_fst2txt_parameters(p);
-               return ALLOC_ERROR_CODE;               
+               return ALLOC_ERROR_CODE;
              }
              break;
    case 'M': p->output_policy=MERGE_OUTPUTS; break;
@@ -156,32 +156,32 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Fst2Txt,lopts_Fst2Txt,&i
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Fst2Txt[index].name);
              free_fst2txt_parameters(p);
-             return USAGE_ERROR_CODE; 
+             return USAGE_ERROR_CODE;
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
                 free_fst2txt_parameters(p);
-                return USAGE_ERROR_CODE;                 
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(p->vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
    case 'q': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_encoding argument\n");
                 free_fst2txt_parameters(p);
-                return USAGE_ERROR_CODE; 
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(p->vec.encoding_output),&(p->vec.bom_output),options.vars()->optarg);
              break;
    case '$': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_offsets argument\n");
                 free_fst2txt_parameters(p);
-                return USAGE_ERROR_CODE; 
+                return USAGE_ERROR_CODE;
              }
              strcpy(in_offsets,options.vars()->optarg);
              break;
    case '@': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_offsets argument\n");
                 free_fst2txt_parameters(p);
-                return USAGE_ERROR_CODE; 
+                return USAGE_ERROR_CODE;
              }
              strcpy(out_offsets,options.vars()->optarg);
              break;
@@ -204,7 +204,7 @@ if (options.vars()->optind!=argc-1) {
 if (p->input_text_file==NULL) {
    error("You must specify the text file\n");
    free_fst2txt_parameters(p);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
@@ -220,7 +220,7 @@ if (out_offsets[0]!='\0') {
 		if (p->v_in_offsets==NULL) {
 			error("Cannot load offset file %s\n",in_offsets);
       free_fst2txt_parameters(p);
-      return DEFAULT_ERROR_CODE;      
+      return DEFAULT_ERROR_CODE;
 		}
 	} else {
 		/* If there is no input offset file, we create an empty offset vector
@@ -231,7 +231,7 @@ if (out_offsets[0]!='\0') {
 	if (p->f_out_offsets==NULL) {
 		error("Cannot create file %s\n",out_offsets);
     free_fst2txt_parameters(p);
-    return DEFAULT_ERROR_CODE;     
+    return DEFAULT_ERROR_CODE;
 	}
 }
 
@@ -251,7 +251,7 @@ p->fst_file=strdup(argv[options.vars()->optind]);
 if (p->fst_file==NULL) {
    alloc_error("main_Fst2Txt");
    free_fst2txt_parameters(p);
-   return ALLOC_ERROR_CODE;   
+   return ALLOC_ERROR_CODE;
 }
 
 int result=main_fst2txt(p);

--- a/Fst2Txt.cpp
+++ b/Fst2Txt.cpp
@@ -123,7 +123,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Fst2Txt,lopts_Fst2Txt,&i
                 return USAGE_ERROR_CODE;
              }
              p->output_text_file=strdup(options.vars()->optarg);
-			 p->output_text_file_is_temp=0;
+             p->output_text_file_is_temp=0;
              if (p->output_text_file==NULL) {
                 alloc_error("main_Fst2Txt");
                 free_fst2txt_parameters(p);
@@ -214,38 +214,38 @@ if (only_verify_arguments) {
 }
 
 if (out_offsets[0]!='\0') {
-	/* We deal with offsets only if the program is expected to produce some */
-	if (in_offsets[0]!='\0') {
-		p->v_in_offsets=load_offsets(&(p->vec),in_offsets);
-		if (p->v_in_offsets==NULL) {
-			error("Cannot load offset file %s\n",in_offsets);
+    /* We deal with offsets only if the program is expected to produce some */
+    if (in_offsets[0]!='\0') {
+        p->v_in_offsets=load_offsets(&(p->vec),in_offsets);
+        if (p->v_in_offsets==NULL) {
+            error("Cannot load offset file %s\n",in_offsets);
       free_fst2txt_parameters(p);
       return DEFAULT_ERROR_CODE;
-		}
-	} else {
-		/* If there is no input offset file, we create an empty offset vector
-		 * in order to avoid testing whether the vector is NULL or not */
-		p->v_in_offsets=new_vector_offset(1);
-	}
-	p->f_out_offsets=u_fopen(&(p->vec),out_offsets,U_WRITE);
-	if (p->f_out_offsets==NULL) {
-		error("Cannot create file %s\n",out_offsets);
+        }
+    } else {
+        /* If there is no input offset file, we create an empty offset vector
+         * in order to avoid testing whether the vector is NULL or not */
+        p->v_in_offsets=new_vector_offset(1);
+    }
+    p->f_out_offsets=u_fopen(&(p->vec),out_offsets,U_WRITE);
+    if (p->f_out_offsets==NULL) {
+        error("Cannot create file %s\n",out_offsets);
     free_fst2txt_parameters(p);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 if (p->output_text_file == NULL) {
-	char tmp[FILENAME_MAX];
-	remove_extension(p->input_text_file, tmp);
-	strcat(tmp, ".tmp");
-	p->output_text_file_is_temp=1;
-	p->output_text_file = strdup(tmp);
-	if (p->output_text_file == NULL) {
-		alloc_error("main_Fst2Txt");
-		free_fst2txt_parameters(p);
-		return ALLOC_ERROR_CODE;
-	}
+    char tmp[FILENAME_MAX];
+    remove_extension(p->input_text_file, tmp);
+    strcat(tmp, ".tmp");
+    p->output_text_file_is_temp=1;
+    p->output_text_file = strdup(tmp);
+    if (p->output_text_file == NULL) {
+        alloc_error("main_Fst2Txt");
+        free_fst2txt_parameters(p);
+        return ALLOC_ERROR_CODE;
+    }
 }
 p->fst_file=strdup(argv[options.vars()->optind]);
 if (p->fst_file==NULL) {

--- a/Fst2TxtAsRoutine.cpp
+++ b/Fst2TxtAsRoutine.cpp
@@ -835,7 +835,7 @@ static void scan_graph(
 				}
 			} else if ((contenu_len_possible_match == 5 // <MOT> <WORD>
 						&& !u_trymatch_superfast5(contenu, ETIQ_MOT_LN5))
-					|| (contenu_len_possible_match == 6 // 
+					|| (contenu_len_possible_match == 6 //
 						&& !u_trymatch_superfast6(contenu, ETIQ_WORD_LN6))) {
 				// case of transition by any sequence of letters
 				if (!end_of_text) {

--- a/Fst2TxtAsRoutine.cpp
+++ b/Fst2TxtAsRoutine.cpp
@@ -42,175 +42,175 @@ static void build_state_token_trees(struct fst2txt_parameters*);
 static void parse_text(struct fst2txt_parameters*);
 
 int main_fst2txt(struct fst2txt_parameters* p) {
-	p->f_input = u_fopen(&(p->vec), p->input_text_file, U_READ);
-	if (p->f_input == NULL) {
-		error("Cannot open file %s\n", p->input_text_file);
-		return 1;
-	}
+    p->f_input = u_fopen(&(p->vec), p->input_text_file, U_READ);
+    if (p->f_input == NULL) {
+        error("Cannot open file %s\n", p->input_text_file);
+        return 1;
+    }
 
-	p->text_buffer = new_buffer_for_file(UNICHAR_BUFFER, p->f_input,
-			CAPACITY_LIMIT);
-	p->buffer = p->text_buffer->unichar_buffer;
+    p->text_buffer = new_buffer_for_file(UNICHAR_BUFFER, p->f_input,
+            CAPACITY_LIMIT);
+    p->buffer = p->text_buffer->unichar_buffer;
 
-	p->f_output = u_fopen(&(p->vec), p->output_text_file, U_WRITE);
-	if (p->f_output == NULL) {
-		error("Cannot open output file %s\n", p->output_text_file);
-		u_fclose(p->f_input);
-		return 1;
-	}
+    p->f_output = u_fopen(&(p->vec), p->output_text_file, U_WRITE);
+    if (p->f_output == NULL) {
+        error("Cannot open output file %s\n", p->output_text_file);
+        u_fclose(p->f_input);
+        return 1;
+    }
 
-	struct FST2_free_info fst2load_free;
-	Fst2* fst2load = load_abstract_fst2(&(p->vec), p->fst_file, 1, &fst2load_free);
-	if (fst2load == NULL) {
-		error("Cannot load grammar %s\n", p->fst_file);
-		u_fclose(p->f_input);
-		u_fclose(p->f_output);
-		return 1;
-	}
-	if (fst2load->debug) {
-		error("Cannot use debug fst2 %s\n", p->fst_file);
-		u_fclose(p->f_input);
-		u_fclose(p->f_output);
-		free_abstract_Fst2(fst2load,&fst2load_free);
-		return 1;
-	}
-
-
-	p->fst2txt_abstract_allocator = create_abstract_allocator("fst2txt_fst2",AllocatorCreationFlagAutoFreePrefered);
-
-	p->pa.prv_alloc_vector_int_inside_token = create_abstract_allocator("fst2_txt_inside_token", AllocatorCreationFlagAutoFreePrefered);
-	p->pa.prv_alloc_recycle = create_abstract_allocator("fst2_txt_recycle",
-		AllocatorFreeOnlyAtAllocatorDelete | AllocatorTipGrowingOftenRecycledObject,
-		0);
-	p->pa.prv_alloc_backup_growing_recycle = create_abstract_allocator("fst2_txt_pattern_growing_recycle",
-		AllocatorFreeOnlyAtAllocatorDelete | AllocatorTipGrowingOftenRecycledObject,
-		0);
-
-	p->fst2=new_Fst2_clone(fst2load,p->fst2txt_abstract_allocator);
-	free_abstract_Fst2(fst2load,&fst2load_free);
+    struct FST2_free_info fst2load_free;
+    Fst2* fst2load = load_abstract_fst2(&(p->vec), p->fst_file, 1, &fst2load_free);
+    if (fst2load == NULL) {
+        error("Cannot load grammar %s\n", p->fst_file);
+        u_fclose(p->f_input);
+        u_fclose(p->f_output);
+        return 1;
+    }
+    if (fst2load->debug) {
+        error("Cannot use debug fst2 %s\n", p->fst_file);
+        u_fclose(p->f_input);
+        u_fclose(p->f_output);
+        free_abstract_Fst2(fst2load,&fst2load_free);
+        return 1;
+    }
 
 
-	OK_for_Fst2Txt(p->fst2);
+    p->fst2txt_abstract_allocator = create_abstract_allocator("fst2txt_fst2",AllocatorCreationFlagAutoFreePrefered);
 
-	if (p->alphabet_file != NULL && p->alphabet_file[0] != '\0') {
-		p->alphabet = load_alphabet(&(p->vec), p->alphabet_file);
-		if (p->alphabet == NULL) {
-			error("Cannot load alphabet file %s\n", p->alphabet_file);
-			u_fclose(p->f_input);
-			u_fclose(p->f_output);
-			free_abstract_Fst2(p->fst2, NULL);
-			return 1;
-		}
-	}
+    p->pa.prv_alloc_vector_int_inside_token = create_abstract_allocator("fst2_txt_inside_token", AllocatorCreationFlagAutoFreePrefered);
+    p->pa.prv_alloc_recycle = create_abstract_allocator("fst2_txt_recycle",
+        AllocatorFreeOnlyAtAllocatorDelete | AllocatorTipGrowingOftenRecycledObject,
+        0);
+    p->pa.prv_alloc_backup_growing_recycle = create_abstract_allocator("fst2_txt_pattern_growing_recycle",
+        AllocatorFreeOnlyAtAllocatorDelete | AllocatorTipGrowingOftenRecycledObject,
+        0);
 
-	u_printf("Applying %s in %s mode...\n", p->fst_file, (p->output_policy
-			== MERGE_OUTPUTS) ? "merge" : "replace");
-	build_state_token_trees(p);
-	parse_text(p);
-	u_fclose(p->f_input);
-	u_fclose(p->f_output);
-	if (p->output_text_file_is_temp) {
-		af_remove(p->input_text_file);
-		af_rename(p->output_text_file, p->input_text_file);
-	}
-	/* And finally, we compute offsets */
-	process_offsets(p->v_in_offsets, p->v_out_offsets, p->f_out_offsets);
-	u_printf("Done.\n");
-	return 0;
+    p->fst2=new_Fst2_clone(fst2load,p->fst2txt_abstract_allocator);
+    free_abstract_Fst2(fst2load,&fst2load_free);
+
+
+    OK_for_Fst2Txt(p->fst2);
+
+    if (p->alphabet_file != NULL && p->alphabet_file[0] != '\0') {
+        p->alphabet = load_alphabet(&(p->vec), p->alphabet_file);
+        if (p->alphabet == NULL) {
+            error("Cannot load alphabet file %s\n", p->alphabet_file);
+            u_fclose(p->f_input);
+            u_fclose(p->f_output);
+            free_abstract_Fst2(p->fst2, NULL);
+            return 1;
+        }
+    }
+
+    u_printf("Applying %s in %s mode...\n", p->fst_file, (p->output_policy
+            == MERGE_OUTPUTS) ? "merge" : "replace");
+    build_state_token_trees(p);
+    parse_text(p);
+    u_fclose(p->f_input);
+    u_fclose(p->f_output);
+    if (p->output_text_file_is_temp) {
+        af_remove(p->input_text_file);
+        af_rename(p->output_text_file, p->input_text_file);
+    }
+    /* And finally, we compute offsets */
+    process_offsets(p->v_in_offsets, p->v_out_offsets, p->f_out_offsets);
+    u_printf("Done.\n");
+    return 0;
 }
 
 /**
  * Allocates, initializes and returns a new fst2txt_parameters structure.
  */
 struct fst2txt_parameters* new_fst2txt_parameters() {
-	struct fst2txt_parameters* p = (struct fst2txt_parameters*) malloc(
-			sizeof(struct fst2txt_parameters));
-	if (p == NULL) {
-		fatal_alloc_error("new_fst2txt_parameters");
-	}
-	p->input_text_file = NULL;
-	p->output_text_file = NULL;
-	p->output_text_file_is_temp = 1;
-	p->fst_file = NULL;
-	p->alphabet_file = NULL;
-	p->f_input = NULL;
-	p->f_output = NULL;
-	p->fst2 = NULL;
-	p->fst2txt_abstract_allocator = NULL;
-	p->pa.prv_alloc_backup_growing_recycle = NULL;
-	p->pa.prv_alloc_recycle = NULL;
-	p->pa.prv_alloc_vector_int_inside_token = NULL;
-	p->alphabet = NULL;
-	p->fst_file = NULL;
-	p->alphabet_file = NULL;
-	p->token_tree = NULL;
-	p->n_token_trees = 0;
-	p->variables = NULL;
-	p->output_policy = MERGE_OUTPUTS;
-	p->tokenization_policy = WORD_BY_WORD_TOKENIZATION;
-	p->space_policy = DONT_START_WITH_SPACE;
-	p->text_buffer = NULL;
-	p->buffer = NULL;
-	p->current_origin = 0;
-	p->absolute_offset = 0;
-	p->stack = new_stack_unichar(MAX_OUTPUT_LENGTH);
-	p->input_length = 0;
-	p->vec.mask_encoding_compatibility_input
-				= DEFAULT_MASK_ENCODING_COMPATIBILITY_INPUT;
-	p->vec.encoding_output = DEFAULT_ENCODING_OUTPUT;
-	p->vec.bom_output = DEFAULT_BOM_OUTPUT;
-	p->v_in_offsets = NULL;
-	p->v_out_offsets = NULL;
-	p->f_out_offsets = NULL;
-	p->insertions = NULL;
-	p->current_insertions = NULL;
-	p->CR_shift = 0;
-	p->new_absolute_origin = 0;
-	p->convLFtoCRLF = 1;
-	p->keepCR = 0;
-	return p;
+    struct fst2txt_parameters* p = (struct fst2txt_parameters*) malloc(
+            sizeof(struct fst2txt_parameters));
+    if (p == NULL) {
+        fatal_alloc_error("new_fst2txt_parameters");
+    }
+    p->input_text_file = NULL;
+    p->output_text_file = NULL;
+    p->output_text_file_is_temp = 1;
+    p->fst_file = NULL;
+    p->alphabet_file = NULL;
+    p->f_input = NULL;
+    p->f_output = NULL;
+    p->fst2 = NULL;
+    p->fst2txt_abstract_allocator = NULL;
+    p->pa.prv_alloc_backup_growing_recycle = NULL;
+    p->pa.prv_alloc_recycle = NULL;
+    p->pa.prv_alloc_vector_int_inside_token = NULL;
+    p->alphabet = NULL;
+    p->fst_file = NULL;
+    p->alphabet_file = NULL;
+    p->token_tree = NULL;
+    p->n_token_trees = 0;
+    p->variables = NULL;
+    p->output_policy = MERGE_OUTPUTS;
+    p->tokenization_policy = WORD_BY_WORD_TOKENIZATION;
+    p->space_policy = DONT_START_WITH_SPACE;
+    p->text_buffer = NULL;
+    p->buffer = NULL;
+    p->current_origin = 0;
+    p->absolute_offset = 0;
+    p->stack = new_stack_unichar(MAX_OUTPUT_LENGTH);
+    p->input_length = 0;
+    p->vec.mask_encoding_compatibility_input
+                = DEFAULT_MASK_ENCODING_COMPATIBILITY_INPUT;
+    p->vec.encoding_output = DEFAULT_ENCODING_OUTPUT;
+    p->vec.bom_output = DEFAULT_BOM_OUTPUT;
+    p->v_in_offsets = NULL;
+    p->v_out_offsets = NULL;
+    p->f_out_offsets = NULL;
+    p->insertions = NULL;
+    p->current_insertions = NULL;
+    p->CR_shift = 0;
+    p->new_absolute_origin = 0;
+    p->convLFtoCRLF = 1;
+    p->keepCR = 0;
+    return p;
 }
 
 /**
  * Frees the given structure
  */
 void free_fst2txt_parameters(struct fst2txt_parameters* p) {
-	if (p == NULL)
-		return;
-	free(p->input_text_file);
-	free(p->output_text_file);
-	free(p->fst_file);
-	free(p->alphabet_file);
-	for (int i = 0; i < p->n_token_trees; i++) {
-		free_fst2txt_token_tree(p->token_tree[i],p->fst2txt_abstract_allocator);
-	}
+    if (p == NULL)
+        return;
+    free(p->input_text_file);
+    free(p->output_text_file);
+    free(p->fst_file);
+    free(p->alphabet_file);
+    for (int i = 0; i < p->n_token_trees; i++) {
+        free_fst2txt_token_tree(p->token_tree[i],p->fst2txt_abstract_allocator);
+    }
 
-	int free_abstract_allocator_item = (get_allocator_cb_flag(p->fst2txt_abstract_allocator) & AllocatorGetFlagAutoFreePresent) ? 0 : 1;
+    int free_abstract_allocator_item = (get_allocator_cb_flag(p->fst2txt_abstract_allocator) & AllocatorGetFlagAutoFreePresent) ? 0 : 1;
 
-	if (p->token_tree != NULL) {
-		free_cb(p->token_tree, p->fst2txt_abstract_allocator);
-	}
+    if (p->token_tree != NULL) {
+        free_cb(p->token_tree, p->fst2txt_abstract_allocator);
+    }
 
-	free_Variables(p->variables);
-	free_buffer(p->text_buffer);
+    free_Variables(p->variables);
+    free_buffer(p->text_buffer);
 
-	free_alphabet(p->alphabet);
-	free_stack_unichar(p->stack);
-	free_vector_offset(p->v_in_offsets);
-	free_vector_offset(p->v_out_offsets);
-	if (free_abstract_allocator_item) {
-		free_Fst2(p->fst2, p->fst2txt_abstract_allocator);
-		free_vector_int(p->insertions, p->fst2txt_abstract_allocator);
-		free_vector_int(p->current_insertions, p->fst2txt_abstract_allocator);
-	}
-	u_fclose(p->f_out_offsets);
+    free_alphabet(p->alphabet);
+    free_stack_unichar(p->stack);
+    free_vector_offset(p->v_in_offsets);
+    free_vector_offset(p->v_out_offsets);
+    if (free_abstract_allocator_item) {
+        free_Fst2(p->fst2, p->fst2txt_abstract_allocator);
+        free_vector_int(p->insertions, p->fst2txt_abstract_allocator);
+        free_vector_int(p->current_insertions, p->fst2txt_abstract_allocator);
+    }
+    u_fclose(p->f_out_offsets);
 
-	close_abstract_allocator(p->fst2txt_abstract_allocator);
-	close_abstract_allocator(p->pa.prv_alloc_vector_int_inside_token);
-	close_abstract_allocator(p->pa.prv_alloc_recycle);
-	close_abstract_allocator(p->pa.prv_alloc_backup_growing_recycle);
+    close_abstract_allocator(p->fst2txt_abstract_allocator);
+    close_abstract_allocator(p->pa.prv_alloc_vector_int_inside_token);
+    close_abstract_allocator(p->pa.prv_alloc_recycle);
+    close_abstract_allocator(p->pa.prv_alloc_backup_growing_recycle);
 
-	free(p);
+    free(p);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -219,231 +219,231 @@ void free_fst2txt_parameters(struct fst2txt_parameters* p) {
 
 
 static void scan_graph(int, int, int, int, struct parsing_info**, unichar*,
-				struct fst2txt_parameters*);
+                struct fst2txt_parameters*);
 
 int write_transduction();
 
 static void push_output_string(struct fst2txt_parameters* p, unichar s[]) {
-	int i = 0;
-	while (s[i] != '\0') {
-		if (s[i] == '$') {
-			// case of a variable name
-			unichar name[100];
-			int L = 0;
-			i++;
-			while (is_variable_char(s[i])) {
-				name[L++] = s[i++];
-			}
-			name[L] = '\0';
-			if (s[i] != '$') {
-				error("Error: missing closing $ after $%S\n", name);
-			} else {
-				i++;
-				if (L == 0) {
-					// case of $$ in order to print a $
-					push(p->stack, '$');
-				} else {
-					struct transduction_variable* v =
-							get_transduction_variable(p->variables, name);
-					if (v == NULL) {
-						error("Error: undefined variable $%S\n", name);
-					} else if (v->start_in_tokens == -1) {
-						error(
-								"Error: starting position of variable $%S undefined\n",
-								name);
-					} else if (v->end_in_tokens == -1) {
-						error(
-								"Error: end position of variable $%S undefined\n",
-								name);
-					} else if (v->start_in_tokens > v->end_in_tokens) {
-						error(
-								"Error: end position before starting position for variable $%S\n",
-								name);
-					} else {
-						// if the variable definition is correct
-						if (p->current_origin<p->text_buffer->size) {
-							for (int k = v->start_in_tokens; k <= v->end_in_tokens; k++)
-								push(p->stack, p->buffer[k + p->current_origin]);
-						}
-					}
-				}
-			}
-		} else {
-			push(p->stack, s[i]);
-			i++;
-		}
-	}
+    int i = 0;
+    while (s[i] != '\0') {
+        if (s[i] == '$') {
+            // case of a variable name
+            unichar name[100];
+            int L = 0;
+            i++;
+            while (is_variable_char(s[i])) {
+                name[L++] = s[i++];
+            }
+            name[L] = '\0';
+            if (s[i] != '$') {
+                error("Error: missing closing $ after $%S\n", name);
+            } else {
+                i++;
+                if (L == 0) {
+                    // case of $$ in order to print a $
+                    push(p->stack, '$');
+                } else {
+                    struct transduction_variable* v =
+                            get_transduction_variable(p->variables, name);
+                    if (v == NULL) {
+                        error("Error: undefined variable $%S\n", name);
+                    } else if (v->start_in_tokens == -1) {
+                        error(
+                                "Error: starting position of variable $%S undefined\n",
+                                name);
+                    } else if (v->end_in_tokens == -1) {
+                        error(
+                                "Error: end position of variable $%S undefined\n",
+                                name);
+                    } else if (v->start_in_tokens > v->end_in_tokens) {
+                        error(
+                                "Error: end position before starting position for variable $%S\n",
+                                name);
+                    } else {
+                        // if the variable definition is correct
+                        if (p->current_origin<p->text_buffer->size) {
+                            for (int k = v->start_in_tokens; k <= v->end_in_tokens; k++)
+                                push(p->stack, p->buffer[k + p->current_origin]);
+                        }
+                    }
+                }
+            }
+        } else {
+            push(p->stack, s[i]);
+            i++;
+        }
+    }
 }
 
 void emit_output(struct fst2txt_parameters* p, unichar* s, int pos) {
-	if (s != NULL) {
-		if (p->current_insertions != NULL && p->output_policy == MERGE_OUTPUTS) {
-			/* In REPLACE mode, there will be only one big output, so there is
-			 * no need for all those subtle calculus */
-			int CR_shift = 0;
-			if ((p->convLFtoCRLF != 0) && (pos + p->current_origin < p->text_buffer->size)) {
-				for (int i = p->current_origin; i < pos + p->current_origin; i++) {
-					if (p->buffer[i] == '\n') {
-						CR_shift++;
-					}
-				}
-			}
-			/* In case the match contains several insertions, we have to take their lengths
-			 * into account for the next one */
-			int output_shift=0;
-			for (int i=0;i<p->current_insertions->nbelems;i+=4) {
-				output_shift=output_shift+p->current_insertions->tab[i+3]-p->current_insertions->tab[i+2];
-			}
-			/* If there is a need to compute offsets, we store the position of the insertion */
-			vector_int_add(p->current_insertions, p->CR_shift + CR_shift + pos
-					+ p->current_origin + p->absolute_offset, p->fst2txt_abstract_allocator);
-			vector_int_add(p->current_insertions, p->CR_shift + CR_shift + pos
-					+ p->current_origin + p->absolute_offset, p->fst2txt_abstract_allocator);
-			vector_int_add(p->current_insertions, CR_shift + pos
-					+ p->new_absolute_origin+output_shift, p->fst2txt_abstract_allocator);
-			vector_int_add(p->current_insertions, CR_shift + pos
-					+ p->new_absolute_origin + u_strlen(s)+output_shift, p->fst2txt_abstract_allocator);
-		}
-		push_output_string(p, s);
-	}
+    if (s != NULL) {
+        if (p->current_insertions != NULL && p->output_policy == MERGE_OUTPUTS) {
+            /* In REPLACE mode, there will be only one big output, so there is
+             * no need for all those subtle calculus */
+            int CR_shift = 0;
+            if ((p->convLFtoCRLF != 0) && (pos + p->current_origin < p->text_buffer->size)) {
+                for (int i = p->current_origin; i < pos + p->current_origin; i++) {
+                    if (p->buffer[i] == '\n') {
+                        CR_shift++;
+                    }
+                }
+            }
+            /* In case the match contains several insertions, we have to take their lengths
+             * into account for the next one */
+            int output_shift=0;
+            for (int i=0;i<p->current_insertions->nbelems;i+=4) {
+                output_shift=output_shift+p->current_insertions->tab[i+3]-p->current_insertions->tab[i+2];
+            }
+            /* If there is a need to compute offsets, we store the position of the insertion */
+            vector_int_add(p->current_insertions, p->CR_shift + CR_shift + pos
+                    + p->current_origin + p->absolute_offset, p->fst2txt_abstract_allocator);
+            vector_int_add(p->current_insertions, p->CR_shift + CR_shift + pos
+                    + p->current_origin + p->absolute_offset, p->fst2txt_abstract_allocator);
+            vector_int_add(p->current_insertions, CR_shift + pos
+                    + p->new_absolute_origin+output_shift, p->fst2txt_abstract_allocator);
+            vector_int_add(p->current_insertions, CR_shift + pos
+                    + p->new_absolute_origin + u_strlen(s)+output_shift, p->fst2txt_abstract_allocator);
+        }
+        push_output_string(p, s);
+    }
 }
 
 
 static void parse_text(struct fst2txt_parameters* p) {
-	fill_buffer(p->text_buffer, p->text_buffer->MAXIMUM_BUFFER_SIZE, p->keepCR, p->f_input);
-	int debut = p->fst2->initial_states[1];
-	p->variables = new_Variables(p->fst2->input_variables);
-	int n_blocks = 0;
-	u_printf("Block %d", n_blocks);
-	int within_tag = 0;
-	if (p->output_policy == MERGE_OUTPUTS /* && p->f_out_offsets!=NULL*/) {
-		p->insertions = new_vector_int(2048, p->fst2txt_abstract_allocator);
-		p->current_insertions = new_vector_int(2048, p->fst2txt_abstract_allocator);
-	}
-	p->v_out_offsets = new_vector_offset();
-	/* The following test used to be a <, but now it's a <= because of the {$} tag
-	 * that may be used even if the end of the text has already been reached */
-	while (p->current_origin <= p->text_buffer->size) {
-		clean_allocator(p->pa.prv_alloc_vector_int_inside_token);
-		if (!p->text_buffer->end_of_file && p->current_origin
-			> (p->text_buffer->size - MINIMAL_SIZE_PRELOADED_TEXT)) {
-			/* If we must change of block, we update the absolute offset, and we fill the
-			 * buffer. */
-			p->absolute_offset = p->absolute_offset + p->current_origin;
-			fill_buffer_keepCR_option(p->text_buffer, p->current_origin, p->keepCR, p->f_input);
-			p->current_origin = 0;
-			n_blocks++;
-			u_printf("\rBlock %d        ", n_blocks);
-		}
-		p->output[0] = '\0';
-		empty(p->stack);
-		p->input_length = 0;
-		if (p->output_policy == MERGE_OUTPUTS) {
-			p->insertions->nbelems = 0;
-			p->current_insertions->nbelems = 0;
-		}
-		if (p->buffer[p->current_origin] == '{') {
-			within_tag = 1;
-		}
-		else if (p->buffer[p->current_origin] == '}') {
-			within_tag = 0;
-		}
-		else if (!within_tag && (p->buffer[p->current_origin] != ' '
-			|| p->space_policy == START_WITH_SPACE)) {
-			// we don't start a match on a space
-			unichar mot_token_buffer[MOT_BUFFER_TOKEN_SIZE];
-			scan_graph(0, debut, 0, 0, NULL, mot_token_buffer, p);
-		}
-		if (p->output_policy == MERGE_OUTPUTS) {
-			/* If there was an insertion, we have to note it */
-			if (p->insertions != NULL && p->insertions->nbelems != 0) {
-				for (int i = 0; i < p->insertions->nbelems; i = i + 4) {
-					vector_offset_add(p->v_out_offsets, p->insertions->tab[i],
-						p->insertions->tab[i + 1],
-						p->insertions->tab[i + 2],
-						p->insertions->tab[i + 3]);
-				}
-			}
-		}
-		else if (p->output_policy == REPLACE_OUTPUTS && p->input_length != 0) {
-			int a = p->current_origin + p->CR_shift + p->absolute_offset;
-			int b = a + p->input_length;
-			int output_length = u_strlen(p->output);
-			int diff = 0;
-			int i, j;
+    fill_buffer(p->text_buffer, p->text_buffer->MAXIMUM_BUFFER_SIZE, p->keepCR, p->f_input);
+    int debut = p->fst2->initial_states[1];
+    p->variables = new_Variables(p->fst2->input_variables);
+    int n_blocks = 0;
+    u_printf("Block %d", n_blocks);
+    int within_tag = 0;
+    if (p->output_policy == MERGE_OUTPUTS /* && p->f_out_offsets!=NULL*/) {
+        p->insertions = new_vector_int(2048, p->fst2txt_abstract_allocator);
+        p->current_insertions = new_vector_int(2048, p->fst2txt_abstract_allocator);
+    }
+    p->v_out_offsets = new_vector_offset();
+    /* The following test used to be a <, but now it's a <= because of the {$} tag
+     * that may be used even if the end of the text has already been reached */
+    while (p->current_origin <= p->text_buffer->size) {
+        clean_allocator(p->pa.prv_alloc_vector_int_inside_token);
+        if (!p->text_buffer->end_of_file && p->current_origin
+            > (p->text_buffer->size - MINIMAL_SIZE_PRELOADED_TEXT)) {
+            /* If we must change of block, we update the absolute offset, and we fill the
+             * buffer. */
+            p->absolute_offset = p->absolute_offset + p->current_origin;
+            fill_buffer_keepCR_option(p->text_buffer, p->current_origin, p->keepCR, p->f_input);
+            p->current_origin = 0;
+            n_blocks++;
+            u_printf("\rBlock %d        ", n_blocks);
+        }
+        p->output[0] = '\0';
+        empty(p->stack);
+        p->input_length = 0;
+        if (p->output_policy == MERGE_OUTPUTS) {
+            p->insertions->nbelems = 0;
+            p->current_insertions->nbelems = 0;
+        }
+        if (p->buffer[p->current_origin] == '{') {
+            within_tag = 1;
+        }
+        else if (p->buffer[p->current_origin] == '}') {
+            within_tag = 0;
+        }
+        else if (!within_tag && (p->buffer[p->current_origin] != ' '
+            || p->space_policy == START_WITH_SPACE)) {
+            // we don't start a match on a space
+            unichar mot_token_buffer[MOT_BUFFER_TOKEN_SIZE];
+            scan_graph(0, debut, 0, 0, NULL, mot_token_buffer, p);
+        }
+        if (p->output_policy == MERGE_OUTPUTS) {
+            /* If there was an insertion, we have to note it */
+            if (p->insertions != NULL && p->insertions->nbelems != 0) {
+                for (int i = 0; i < p->insertions->nbelems; i = i + 4) {
+                    vector_offset_add(p->v_out_offsets, p->insertions->tab[i],
+                        p->insertions->tab[i + 1],
+                        p->insertions->tab[i + 2],
+                        p->insertions->tab[i + 3]);
+                }
+            }
+        }
+        else if (p->output_policy == REPLACE_OUTPUTS && p->input_length != 0) {
+            int a = p->current_origin + p->CR_shift + p->absolute_offset;
+            int b = a + p->input_length;
+            int output_length = u_strlen(p->output);
+            int diff = 0;
+            int i, j;
 
 
-			for (i = 0; i < p->input_length; i++) {
-				if ((p->convLFtoCRLF != 0) && (p->buffer[i + p->current_origin] == '\n'))
-					b++;
-			}
-			for (i = 0, j = 0; i < p->input_length && j<output_length; i++, j++) {
-				if (!diff && p->buffer[i + p->current_origin] != p->output[j]) {
-					diff = 1;
-				}
-			}
+            for (i = 0; i < p->input_length; i++) {
+                if ((p->convLFtoCRLF != 0) && (p->buffer[i + p->current_origin] == '\n'))
+                    b++;
+            }
+            for (i = 0, j = 0; i < p->input_length && j<output_length; i++, j++) {
+                if (!diff && p->buffer[i + p->current_origin] != p->output[j]) {
+                    diff = 1;
+                }
+            }
 
-			if (p->input_length>0 && p->output[0] == '\0') {
-				/* any input deletion must be considered */
-				diff = 1;
-			}
-			if (!diff && p->output[j] != '\0') {
-				diff = 1;
-			}
-			if (diff) {
-				/* There is no need to consider fake replace that happen when
-				* normalizing quotes or dashes */
-				int c = p->new_absolute_origin;
-				int d = c + u_strlen(p->output);
-				vector_offset_add(p->v_out_offsets, a, b, c, d);
-			}
-		}
-		if (p->convLFtoCRLF == 0) {
-			u_fputs_raw(p->output, p->f_output);
-		}
-		else {
-			u_fputs(p->output, p->f_output);
-		}
-		p->new_absolute_origin = p->new_absolute_origin + u_strlen(p->output);
-		if (p->input_length == 0) {
-			// if no input was read, we go on
-			// u_fputc_raw write exactly the unichar in parameter
-			// u_fputc replace LF ('\n') by CRLF ('\r\n')
-			if (p->current_origin < p->text_buffer->size) {
-				if (p->convLFtoCRLF == 0) {
-					u_fputc_raw(p->buffer[p->current_origin], p->f_output);
-				}
-				else {
-					u_fputc(p->buffer[p->current_origin], p->f_output);
-				}
-			}
-			(p->new_absolute_origin)++;
-			if ((p->convLFtoCRLF != 0) && (p->buffer[p->current_origin] == '\n')) {
-				/* If we just have skipped a \n, we note there is an offset shift of 1 */
-				(p->CR_shift)++;
-				(p->new_absolute_origin)++;
-			}
-			(p->current_origin)++;
-		}
-		else {
-			// we increase current_origin
-			int new_origin = p->current_origin + p->input_length;
-			for (int i = p->current_origin; i < new_origin; i++) {
-				if ((p->convLFtoCRLF != 0) && (p->buffer[i] == '\n')) {
-					/* If we just have skipped a \n, we note there is an offset shift of 1 */
-					(p->CR_shift)++;
-					if (p->output_policy == MERGE_OUTPUTS) {
-						/* We consider the \n in the output only in MERGE mode */
-						(p->new_absolute_origin)++;
-					}
-				}
-			}
-			p->current_origin = new_origin;
-		}
-	}
-	u_printf("\r                           \n");
-	free_Variables(p->variables);
-	p->variables = NULL;
+            if (p->input_length>0 && p->output[0] == '\0') {
+                /* any input deletion must be considered */
+                diff = 1;
+            }
+            if (!diff && p->output[j] != '\0') {
+                diff = 1;
+            }
+            if (diff) {
+                /* There is no need to consider fake replace that happen when
+                * normalizing quotes or dashes */
+                int c = p->new_absolute_origin;
+                int d = c + u_strlen(p->output);
+                vector_offset_add(p->v_out_offsets, a, b, c, d);
+            }
+        }
+        if (p->convLFtoCRLF == 0) {
+            u_fputs_raw(p->output, p->f_output);
+        }
+        else {
+            u_fputs(p->output, p->f_output);
+        }
+        p->new_absolute_origin = p->new_absolute_origin + u_strlen(p->output);
+        if (p->input_length == 0) {
+            // if no input was read, we go on
+            // u_fputc_raw write exactly the unichar in parameter
+            // u_fputc replace LF ('\n') by CRLF ('\r\n')
+            if (p->current_origin < p->text_buffer->size) {
+                if (p->convLFtoCRLF == 0) {
+                    u_fputc_raw(p->buffer[p->current_origin], p->f_output);
+                }
+                else {
+                    u_fputc(p->buffer[p->current_origin], p->f_output);
+                }
+            }
+            (p->new_absolute_origin)++;
+            if ((p->convLFtoCRLF != 0) && (p->buffer[p->current_origin] == '\n')) {
+                /* If we just have skipped a \n, we note there is an offset shift of 1 */
+                (p->CR_shift)++;
+                (p->new_absolute_origin)++;
+            }
+            (p->current_origin)++;
+        }
+        else {
+            // we increase current_origin
+            int new_origin = p->current_origin + p->input_length;
+            for (int i = p->current_origin; i < new_origin; i++) {
+                if ((p->convLFtoCRLF != 0) && (p->buffer[i] == '\n')) {
+                    /* If we just have skipped a \n, we note there is an offset shift of 1 */
+                    (p->CR_shift)++;
+                    if (p->output_policy == MERGE_OUTPUTS) {
+                        /* We consider the \n in the output only in MERGE mode */
+                        (p->new_absolute_origin)++;
+                    }
+                }
+            }
+            p->current_origin = new_origin;
+        }
+    }
+    u_printf("\r                           \n");
+    free_Variables(p->variables);
+    p->variables = NULL;
 }
 
 
@@ -472,28 +472,28 @@ static const unichar ETIQ_FIRST_LN7[] = { '<', 'F', 'I', 'R', 'S', 'T', '>', 0 }
  * give the len of possible match
  */
 static int u_len_possible_match(const unichar* s) {
-	if ((*(s + 0)) == 0)
-		return 0;
-	if ((*(s + 1)) == 0)
-		return 1;
+    if ((*(s + 0)) == 0)
+        return 0;
+    if ((*(s + 1)) == 0)
+        return 1;
 
-	// all match with len > 1 begin with '>'
-	if ((*(s + 0)) != '<')
-		return 0;
+    // all match with len > 1 begin with '>'
+    if ((*(s + 0)) != '<')
+        return 0;
 
-	if ((*(s + 2)) == 0)
-		return 0;
-	if ((*(s + 3)) == 0)
-		return 3;
-	if ((*(s + 4)) == 0)
-		return 4;
-	if ((*(s + 5)) == 0)
-		return 5;
-	if ((*(s + 6)) == 0)
-		return 6;
-	if ((*(s + 7)) == 0)
-		return 7;
-	return 0;
+    if ((*(s + 2)) == 0)
+        return 0;
+    if ((*(s + 3)) == 0)
+        return 3;
+    if ((*(s + 4)) == 0)
+        return 4;
+    if ((*(s + 5)) == 0)
+        return 5;
+    if ((*(s + 6)) == 0)
+        return 6;
+    if ((*(s + 7)) == 0)
+        return 7;
+    return 0;
 }
 
 /*
@@ -504,846 +504,846 @@ static int u_len_possible_match(const unichar* s) {
  * we return 1 when different, 0 when equal
  */
 static inline int u_trymatch_superfast1(const unichar* a, const unichar c) {
-	if ((*(a + 0)) != (c))
-		return 1;
-	return 0;
+    if ((*(a + 0)) != (c))
+        return 1;
+    return 0;
 }
 
 static inline int u_trymatch_superfast3(const unichar* a, const unichar*b) {
-	if ((*(a + 1)) != (*(b + 1)))
-		return 1;
-	if ((*(a + 2)) != (*(b + 2)))
-		return 1;
-	return 0;
+    if ((*(a + 1)) != (*(b + 1)))
+        return 1;
+    if ((*(a + 2)) != (*(b + 2)))
+        return 1;
+    return 0;
 }
 
 static inline int u_trymatch_superfast4(const unichar* a, const unichar*b) {
-	if ((*(a + 1)) != (*(b + 1)))
-		return 1;
-	if ((*(a + 2)) != (*(b + 2)))
-		return 1;
-	if ((*(a + 3)) != (*(b + 3)))
-		return 1;
-	return 0;
+    if ((*(a + 1)) != (*(b + 1)))
+        return 1;
+    if ((*(a + 2)) != (*(b + 2)))
+        return 1;
+    if ((*(a + 3)) != (*(b + 3)))
+        return 1;
+    return 0;
 }
 
 static inline int u_trymatch_superfast5(const unichar* a, const unichar*b) {
-	if ((*(a + 1)) != (*(b + 1)))
-		return 1;
-	if ((*(a + 2)) != (*(b + 2)))
-		return 1;
-	if ((*(a + 3)) != (*(b + 3)))
-		return 1;
-	if ((*(a + 4)) != (*(b + 4)))
-		return 1;
-	return 0;
+    if ((*(a + 1)) != (*(b + 1)))
+        return 1;
+    if ((*(a + 2)) != (*(b + 2)))
+        return 1;
+    if ((*(a + 3)) != (*(b + 3)))
+        return 1;
+    if ((*(a + 4)) != (*(b + 4)))
+        return 1;
+    return 0;
 }
 
 static inline int u_trymatch_superfast6(const unichar* a, const unichar*b) {
-	if ((*(a + 1)) != (*(b + 1)))
-		return 1;
-	if ((*(a + 2)) != (*(b + 2)))
-		return 1;
-	if ((*(a + 3)) != (*(b + 3)))
-		return 1;
-	if ((*(a + 4)) != (*(b + 4)))
-		return 1;
-	if ((*(a + 5)) != (*(b + 5)))
-		return 1;
-	return 0;
+    if ((*(a + 1)) != (*(b + 1)))
+        return 1;
+    if ((*(a + 2)) != (*(b + 2)))
+        return 1;
+    if ((*(a + 3)) != (*(b + 3)))
+        return 1;
+    if ((*(a + 4)) != (*(b + 4)))
+        return 1;
+    if ((*(a + 5)) != (*(b + 5)))
+        return 1;
+    return 0;
 }
 
 static inline int u_trymatch_superfast7(const unichar* a, const unichar*b) {
-	if ((*(a + 1)) != (*(b + 1)))
-		return 1;
-	if ((*(a + 2)) != (*(b + 2)))
-		return 1;
-	if ((*(a + 3)) != (*(b + 3)))
-		return 1;
-	if ((*(a + 4)) != (*(b + 4)))
-		return 1;
-	if ((*(a + 5)) != (*(b + 5)))
-		return 1;
-	if ((*(a + 6)) != (*(b + 6)))
-		return 1;
-	return 0;
+    if ((*(a + 1)) != (*(b + 1)))
+        return 1;
+    if ((*(a + 2)) != (*(b + 2)))
+        return 1;
+    if ((*(a + 3)) != (*(b + 3)))
+        return 1;
+    if ((*(a + 4)) != (*(b + 4)))
+        return 1;
+    if ((*(a + 5)) != (*(b + 5)))
+        return 1;
+    if ((*(a + 6)) != (*(b + 6)))
+        return 1;
+    return 0;
 }
 
 static int backup(vector_int* v) {
-	if (v == NULL)
-		return 0;
-	return v->nbelems;
+    if (v == NULL)
+        return 0;
+    return v->nbelems;
 }
 
 static void restore(vector_int* v, int n) {
-	if (v == NULL) {
-		if (n != 0)
-			fatal_error("Unexpected error in restore");
-		return;
-	}
-	v->nbelems = n;
+    if (v == NULL) {
+        if (n != 0)
+            fatal_error("Unexpected error in restore");
+        return;
+    }
+    v->nbelems = n;
 }
 
 static inline int at_text_start(struct fst2txt_parameters* p, int pos) {
-	return p->absolute_offset == 0 && pos == 0 && (p->current_origin == 0
-			|| (p->current_origin == 1 && p->buffer[0] == ' '));
+    return p->absolute_offset == 0 && pos == 0 && (p->current_origin == 0
+            || (p->current_origin == 1 && p->buffer[0] == ' '));
 }
 
 static void scan_graph(
-		int n_graph, // number of current graph
-		int e, // number of current state
-		int pos, //
-		int depth, struct parsing_info** match_list,
-		unichar* word_token_buffer, struct fst2txt_parameters* p) {
-	Fst2State current_state = p->fst2->states[e];
-	int old_nb_insert;
-	if (depth > MAX_DEPTH) {
+        int n_graph, // number of current graph
+        int e, // number of current state
+        int pos, //
+        int depth, struct parsing_info** match_list,
+        unichar* word_token_buffer, struct fst2txt_parameters* p) {
+    Fst2State current_state = p->fst2->states[e];
+    int old_nb_insert;
+    if (depth > MAX_DEPTH) {
 
-		error("\n"
-			"Maximal stack size reached in graph %i!\n"
-			"Recognized more than %i tokens starting from:\n"
-			"  ", n_graph, MAX_DEPTH);
-		for (int i = 0; i < 60; i++) {
-			if ((p->current_origin + i) >= p->text_buffer->size) {
-				break;
-			}
-			error("%C", p->buffer[p->current_origin + i]);
-		}
-		error("\nSkipping match at this position, trying from next token!\n");
-		p->output[0] = '\0'; // clear output
-		p->input_length = 0; // reset taille_entree
-		empty(p->stack); // clear output stack
-		if (match_list != NULL) {
-			while (*match_list != NULL) { // free list of subgraph matches
-				struct parsing_info* la_tmp = *match_list;
-				*match_list = (*match_list)->next;
-				la_tmp->next = NULL; // to don't free the next item
-				free_parsing_info(la_tmp, &p->pa);
-			}
-		}
-		return;
-		//  exit(1); // don't exit, try at next position
-	}
-	depth++;
+        error("\n"
+            "Maximal stack size reached in graph %i!\n"
+            "Recognized more than %i tokens starting from:\n"
+            "  ", n_graph, MAX_DEPTH);
+        for (int i = 0; i < 60; i++) {
+            if ((p->current_origin + i) >= p->text_buffer->size) {
+                break;
+            }
+            error("%C", p->buffer[p->current_origin + i]);
+        }
+        error("\nSkipping match at this position, trying from next token!\n");
+        p->output[0] = '\0'; // clear output
+        p->input_length = 0; // reset taille_entree
+        empty(p->stack); // clear output stack
+        if (match_list != NULL) {
+            while (*match_list != NULL) { // free list of subgraph matches
+                struct parsing_info* la_tmp = *match_list;
+                *match_list = (*match_list)->next;
+                la_tmp->next = NULL; // to don't free the next item
+                free_parsing_info(la_tmp, &p->pa);
+            }
+        }
+        return;
+        //  exit(1); // don't exit, try at next position
+    }
+    depth++;
 
-	if (is_final_state(current_state)) {
+    if (is_final_state(current_state)) {
 
-		// if we are in a final state
-		p->stack->stack[p->stack->stack_pointer + 1] = '\0';
-		if (n_graph == 0) { // in main graph
-			if (pos >= p->input_length/*sommet>u_strlen(output)*/) {
-				// and if the recognized input is longer than the current one, it replaces it
-				u_strcpy(p->output, p->stack->stack);
-				p->input_length = (pos);
-				vector_int_copy(p->insertions, p->current_insertions, p->fst2txt_abstract_allocator);
-			}
-		} else { // in a subgraph
-			(*match_list) = insert_if_absent(pos, -1, -1, (*match_list),
-					p->stack->stack_pointer + 1, p->stack->stack, p->variables,
-					NULL, NULL, -1, -1, NULL, -1, p->current_insertions,-1,
-					&p->pa);
-		}
-	}
+        // if we are in a final state
+        p->stack->stack[p->stack->stack_pointer + 1] = '\0';
+        if (n_graph == 0) { // in main graph
+            if (pos >= p->input_length/*sommet>u_strlen(output)*/) {
+                // and if the recognized input is longer than the current one, it replaces it
+                u_strcpy(p->output, p->stack->stack);
+                p->input_length = (pos);
+                vector_int_copy(p->insertions, p->current_insertions, p->fst2txt_abstract_allocator);
+            }
+        } else { // in a subgraph
+            (*match_list) = insert_if_absent(pos, -1, -1, (*match_list),
+                    p->stack->stack_pointer + 1, p->stack->stack, p->variables,
+                    NULL, NULL, -1, -1, NULL, -1, p->current_insertions,-1,
+                    &p->pa);
+        }
+    }
 
-	int end_of_text = pos + p->current_origin == p->text_buffer->size;
-	/* The same, but tolerant if there is a remaining space */
-	int end_of_text2 = pos + p->current_origin + 1 == p->text_buffer->size
-			&& p->buffer[pos + p->current_origin] == ' ';
-	int SOMMET = p->stack->stack_pointer + 1;
-	int pos2;
-	/* If there are some letter sequence transitions like %hello, we process them */
-	if (!end_of_text && p->token_tree[e]->transition_array != NULL) {
-		if (p->buffer[pos + p->current_origin] == ' ') {
-			pos2 = pos + 1;
-			if (p->output_policy == MERGE_OUTPUTS)
-				push(p->stack, ' ');
-		}
-		/* we don't keep this line because of problems occurring in sentence tokenizing
-		 * if the return sequence is defautly considered as a separator like space
-		 else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-		 */
-		else {
-			pos2 = pos;
-		}
+    int end_of_text = pos + p->current_origin == p->text_buffer->size;
+    /* The same, but tolerant if there is a remaining space */
+    int end_of_text2 = pos + p->current_origin + 1 == p->text_buffer->size
+            && p->buffer[pos + p->current_origin] == ' ';
+    int SOMMET = p->stack->stack_pointer + 1;
+    int pos2;
+    /* If there are some letter sequence transitions like %hello, we process them */
+    if (!end_of_text && p->token_tree[e]->transition_array != NULL) {
+        if (p->buffer[pos + p->current_origin] == ' ') {
+            pos2 = pos + 1;
+            if (p->output_policy == MERGE_OUTPUTS)
+                push(p->stack, ' ');
+        }
+        /* we don't keep this line because of problems occurring in sentence tokenizing
+         * if the return sequence is defautly considered as a separator like space
+         else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+         */
+        else {
+            pos2 = pos;
+        }
 
-		int position = 0;
-		int start_pos_ = pos2;
-		unichar *token = word_token_buffer;
-		if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION || (is_letter(
-				p->buffer[pos2 + p->current_origin], p->alphabet) && (pos2
-				+ p->current_origin == 0 || !is_letter(p->buffer[pos2
-				+ p->current_origin - 1], p->alphabet)))) {
-			/* If we are in character by character mode */
-			while (pos2 + p->current_origin < p->text_buffer->size
-					&& is_letter(p->buffer[pos2 + p->current_origin],
-							p->alphabet)) {
-				token[position++] = p->buffer[(pos2++) + p->current_origin];
-				if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION) {
-					break;
-				}
-			}
-			token[position] = '\0';
-			if (position != 0 && (p->tokenization_policy
-					== CHAR_BY_CHAR_TOKENIZATION || !(is_letter(token[position
-					- 1], p->alphabet) && is_letter(p->buffer[pos2
-					+ p->current_origin], p->alphabet)))) {
-				// we proceed only if we have exactly read the 'token' sequence
-				// in both modes MERGE and REPLACE, we process the output if any
-				int SOMMET2 = p->stack->stack_pointer;
-				Transition* RES = get_matching_tags(token, p->token_tree[e],
-						p->alphabet,p->fst2txt_abstract_allocator);
-				Transition* TMP;
-				unichar* mot_token_new_recurse_buffer = NULL;
-				if (RES != NULL) {
-					// we allocate a new mot_token_buffer for the scan_graph recursion because we need preserve current
-					// token=mot_token_buffer
-					mot_token_new_recurse_buffer = (unichar*) malloc_cb(
-							MOT_BUFFER_TOKEN_SIZE * sizeof(unichar),p->fst2txt_abstract_allocator);
-					if (mot_token_new_recurse_buffer == NULL) {
-						fatal_alloc_error("scan_graph");
-					}
-				}
-				while (RES != NULL) {
-					p->stack->stack_pointer = SOMMET2;
-					Fst2Tag etiq = p->fst2->tags[RES->tag_number];
-					old_nb_insert = backup(p->current_insertions);
-					emit_output(p, etiq->output, start_pos_);
-					int longueur = u_strlen(etiq->input);
-					unichar C = token[longueur];
-					token[longueur] = '\0';
-					if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-						// if we are in MERGE mode, we add to output the char we have read
-						push_input_string(p->stack, token, 0);
-					}
-					token[longueur] = C;
-					scan_graph(n_graph, RES->state_number, pos2 - (position
-							- longueur), depth, match_list,
-							mot_token_new_recurse_buffer, p);
-					restore(p->current_insertions, old_nb_insert);
-					TMP = RES;
-					RES = RES->next;
-					free_cb(TMP,p->fst2txt_abstract_allocator);
-				}
-				if (mot_token_new_recurse_buffer != NULL) {
-					free_cb(mot_token_new_recurse_buffer,p->fst2txt_abstract_allocator);
-				}
-			}
-		}
-	}
+        int position = 0;
+        int start_pos_ = pos2;
+        unichar *token = word_token_buffer;
+        if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION || (is_letter(
+                p->buffer[pos2 + p->current_origin], p->alphabet) && (pos2
+                + p->current_origin == 0 || !is_letter(p->buffer[pos2
+                + p->current_origin - 1], p->alphabet)))) {
+            /* If we are in character by character mode */
+            while (pos2 + p->current_origin < p->text_buffer->size
+                    && is_letter(p->buffer[pos2 + p->current_origin],
+                            p->alphabet)) {
+                token[position++] = p->buffer[(pos2++) + p->current_origin];
+                if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION) {
+                    break;
+                }
+            }
+            token[position] = '\0';
+            if (position != 0 && (p->tokenization_policy
+                    == CHAR_BY_CHAR_TOKENIZATION || !(is_letter(token[position
+                    - 1], p->alphabet) && is_letter(p->buffer[pos2
+                    + p->current_origin], p->alphabet)))) {
+                // we proceed only if we have exactly read the 'token' sequence
+                // in both modes MERGE and REPLACE, we process the output if any
+                int SOMMET2 = p->stack->stack_pointer;
+                Transition* RES = get_matching_tags(token, p->token_tree[e],
+                        p->alphabet,p->fst2txt_abstract_allocator);
+                Transition* TMP;
+                unichar* mot_token_new_recurse_buffer = NULL;
+                if (RES != NULL) {
+                    // we allocate a new mot_token_buffer for the scan_graph recursion because we need preserve current
+                    // token=mot_token_buffer
+                    mot_token_new_recurse_buffer = (unichar*) malloc_cb(
+                            MOT_BUFFER_TOKEN_SIZE * sizeof(unichar),p->fst2txt_abstract_allocator);
+                    if (mot_token_new_recurse_buffer == NULL) {
+                        fatal_alloc_error("scan_graph");
+                    }
+                }
+                while (RES != NULL) {
+                    p->stack->stack_pointer = SOMMET2;
+                    Fst2Tag etiq = p->fst2->tags[RES->tag_number];
+                    old_nb_insert = backup(p->current_insertions);
+                    emit_output(p, etiq->output, start_pos_);
+                    int longueur = u_strlen(etiq->input);
+                    unichar C = token[longueur];
+                    token[longueur] = '\0';
+                    if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                        // if we are in MERGE mode, we add to output the char we have read
+                        push_input_string(p->stack, token, 0);
+                    }
+                    token[longueur] = C;
+                    scan_graph(n_graph, RES->state_number, pos2 - (position
+                            - longueur), depth, match_list,
+                            mot_token_new_recurse_buffer, p);
+                    restore(p->current_insertions, old_nb_insert);
+                    TMP = RES;
+                    RES = RES->next;
+                    free_cb(TMP,p->fst2txt_abstract_allocator);
+                }
+                if (mot_token_new_recurse_buffer != NULL) {
+                    free_cb(mot_token_new_recurse_buffer,p->fst2txt_abstract_allocator);
+                }
+            }
+        }
+    }
 
-	Transition* t = current_state->transitions;
-	while (t != NULL) {
-		p->stack->stack_pointer = SOMMET - 1;
-		// we process the transition of the current state
-		int n_etiq = t->tag_number;
-		if (n_etiq < 0) {
-			// case of a sub-graph
-			struct parsing_info* liste = NULL;
-			unichar* pile_old;
-			p->stack->stack[p->stack->stack_pointer + 1] = '\0';
-			pile_old = u_strdup(p->stack->stack);
-			vector_int* old_insertions = vector_int_dup(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
-			scan_graph((((unsigned) n_etiq) - 1),
-					p->fst2->initial_states[-n_etiq], pos, depth, &liste,
-					word_token_buffer, p);
-			free_vector_int(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
-			p->current_insertions = NULL;
-			while (liste != NULL) {
-				p->stack->stack_pointer = liste->stack_pointer - 1;
-				u_strcpy(p->stack->stack, liste->stack);
-				p->current_insertions = liste->insertions;
-				liste->insertions = NULL;
-				scan_graph(n_graph, t->state_number, liste->pos_in_tokens, depth,
-						match_list, word_token_buffer, p);
-				free_vector_int(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
-				struct parsing_info* l_tmp = liste;
-				liste = liste->next;
-				l_tmp->next = NULL; // in order not to free the next item
-				free_parsing_info(l_tmp, &p->pa);
-			}
-			u_strcpy(p->stack->stack, pile_old);
-			p->current_insertions = old_insertions;
-			free(pile_old);
-			p->stack->stack_pointer = SOMMET - 1;
-		} else {
-			// case of a normal tag
-			Fst2Tag etiq = p->fst2->tags[n_etiq];
-			unichar* contenu = etiq->input;
-			int contenu_len_possible_match = u_len_possible_match(contenu);
-			if (etiq->type == BEGIN_OUTPUT_VAR_TAG) {
-				fatal_error("Unsupported $|XXX( tags in Fst2Txt\n");
-			}
-			if (etiq->type == END_OUTPUT_VAR_TAG) {
-				fatal_error("Unsupported $|XXX) tags in Fst2Txt\n");
-			}
-			if (etiq->type == BEGIN_VAR_TAG) {
-				// case of a $a( variable tag
-				if (/*1 || */ !end_of_text) {
-					/* There is no point in trying to start a variable capture at the end of the text */
-					struct transduction_variable* L =
-							get_transduction_variable(p->variables,
-									etiq->variable);
-					if (L == NULL) {
-						fatal_error("Unknown variable: %S\n", etiq->variable);
-					}
-					if (p->buffer[pos + p->current_origin] == ' ' && pos
-							+ p->current_origin + 1 < p->text_buffer->size
-							&& p->space_policy!=START_WITH_SPACE) {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					} else
-						pos2 = pos;
-					L->start_in_tokens = pos2;
-					if (end_of_text) L->start_in_tokens=pos;
-					scan_graph(n_graph, t->state_number, pos2, depth,
-							match_list, word_token_buffer, p);
-				}
-			} else if (etiq->type == END_VAR_TAG) {
-				// case of a $a) variable tag
-				struct transduction_variable* L = get_transduction_variable(
-						p->variables, etiq->variable);
-				if (L == NULL) {
-					fatal_error("Unknown variable: %S\n", etiq->variable);
-				}
-				if (pos > 0)
-					L->end_in_tokens = pos - 1;
-				else
-					L->end_in_tokens = pos;
-				// BUG: qd changement de buffer, penser au cas start dans ancien buffer et end dans nouveau
-				scan_graph(n_graph, t->state_number, pos, depth, match_list,
-						word_token_buffer, p);
-			} else if (etiq->type == TEXT_START_TAG) {
-				// case of an empty sequence that should be matched, but only if we are at the beginning of the text
-				// in both modes MERGE and REPLACE, we process the transduction if any
-				if (at_text_start(p, pos)) {
-					old_nb_insert = backup(p->current_insertions);
-					emit_output(p, etiq->output, pos);
-					scan_graph(n_graph, t->state_number, pos, depth,
-							match_list, word_token_buffer, p);
-					restore(p->current_insertions, old_nb_insert);
-				}
-			} else if (etiq->type == TEXT_END_TAG) {
-				// case of an empty sequence that should be matched, but only if we are at the end of the text
-				// in both modes MERGE and REPLACE, we process the transduction if any
-				if (end_of_text || end_of_text2) {
-					old_nb_insert = backup(p->current_insertions);
-					emit_output(p, etiq->output, pos);
-					scan_graph(n_graph, t->state_number, pos, depth,
-							match_list, word_token_buffer, p);
-					restore(p->current_insertions, old_nb_insert);
-				}
-			} else if ((contenu_len_possible_match == 5 // <MOT> <WORD>
-						&& !u_trymatch_superfast5(contenu, ETIQ_MOT_LN5))
-					|| (contenu_len_possible_match == 6 //
-						&& !u_trymatch_superfast6(contenu, ETIQ_WORD_LN6))) {
-				// case of transition by any sequence of letters
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ' && pos
-							+ p->current_origin + 1 < p->text_buffer->size) {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					unichar* mot = word_token_buffer;
-					int position = 0;
-					int start_pos = pos2;
-					if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
-							|| ((pos2 + p->current_origin) == 0 || !is_letter(
-									p->buffer[pos2 + p->current_origin - 1],
-									p->alphabet))) {
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& is_letter(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) {
-							mot[position++] = p->buffer[(pos2++)
-									+ p->current_origin];
-						}
-						mot[position] = '\0';
-						if (position != 0) {
-							// we proceed only if we have read a letter sequence
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_output_string(p->stack, mot);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					}
-				}
-			} else if ((contenu_len_possible_match == 4) //<NB>
-					&& (!u_trymatch_superfast4(contenu, ETIQ_NB_LN4))) {
-				// case of transition by any sequence of digits
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					unichar* mot = word_token_buffer;
-					int position = 0;
-					int start_pos = pos2;
-					while (pos2 + p->current_origin < p->text_buffer->size
-							&& (p->buffer[pos2 + p->current_origin] >= '0')
-							&& (p->buffer[pos2 + p->current_origin] <= '9')) {
-						mot[position++] = p->buffer[(pos2++)
-								+ p->current_origin];
-					}
-					mot[position] = '\0';
-					if (position != 0) {
-						// we proceed only if we have read a letter sequence
-						// in both modes MERGE and REPLACE, we process the transduction if any
-						old_nb_insert = backup(p->current_insertions);
-						emit_output(p, etiq->output, start_pos);
-						if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-							// if we are in MERGE mode, we add to ouput the char we have read
-							push_output_string(p->stack, mot);
-						}
-						scan_graph(n_graph, t->state_number, pos2, depth,
-								match_list, word_token_buffer, p);
-						restore(p->current_insertions, old_nb_insert);
-					}
-				}
-			} else if ((contenu_len_possible_match == 5 // <MAJ>
-						&& !u_trymatch_superfast5(contenu, ETIQ_MAJ_LN5))
-					|| (contenu_len_possible_match == 7 // <UPPER>
-						&& !u_trymatch_superfast7(contenu, ETIQ_UPPER_LN7))) {
-				// case of upper case letter sequence
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					unichar* mot = word_token_buffer;
-					int position = 0;
-					int start_pos = pos2;
-					if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
-							|| ((pos2 + p->current_origin) == 0 || !is_letter(
-									p->buffer[pos2 + p->current_origin - 1],
-									p->alphabet))) {
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& is_upper(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) {
-							mot[position++] = p->buffer[(pos2++)
-									+ p->current_origin];
-						}
-						mot[position] = '\0';
-						if (position != 0 && !is_letter(p->buffer[pos2
-								+ p->current_origin], p->alphabet)) {
-							// we proceed only if we have read an upper case letter sequence
-							// which is not followed by a lower case letter
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_input_string(p->stack, mot, 0);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					}
-				}
-			} else if ((contenu_len_possible_match == 5 // <MIN>
-						&& !u_trymatch_superfast5(contenu, ETIQ_MIN_LN5))
-					|| (contenu_len_possible_match == 7 //<LOWER>
-						&& !u_trymatch_superfast7(contenu, ETIQ_LOWER_LN7))) {
-				// case of lower case letter sequence
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					unichar* mot = word_token_buffer;
-					int position = 0;
-					int start_pos = pos2;
-					if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
-							|| (pos2 + p->current_origin == 0 || !is_letter(
-									p->buffer[pos2 + p->current_origin - 1],
-									p->alphabet))) {
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& is_lower(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) {
-							mot[position++] = p->buffer[(pos2++)
-									+ p->current_origin];
-						}
-						mot[position] = '\0';
-						if (position != 0 && !is_letter(p->buffer[pos2
-								+ p->current_origin], p->alphabet)) {
-							// we proceed only if we have read a lower case letter sequence
-							// which is not followed by an upper case letter
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_input_string(p->stack, mot, 0);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					}
-				}
-			} else if ((contenu_len_possible_match == 5 // <PRE>
-						&& !u_trymatch_superfast5(contenu, ETIQ_PRE_LN5))
-					|| (contenu_len_possible_match == 7 // <FIRST>
-						&& !u_trymatch_superfast7(contenu, ETIQ_FIRST_LN7))) {
-				// case of a sequence beginning by an upper case letter
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					unichar* mot = word_token_buffer;
-					int position = 0;
-					int start_pos = pos2;
-					if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
-							|| (is_upper(p->buffer[pos2 + p->current_origin],
-									p->alphabet) && (pos2 + p->current_origin
-									== 0 || !is_letter(p->buffer[pos2
-									+ p->current_origin - 1], p->alphabet)))) {
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& is_letter(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) {
-							mot[position++] = p->buffer[(pos2++)
-									+ p->current_origin];
-						}
-						mot[position] = '\0';
-						if (position != 0 && !is_letter(p->buffer[pos2
-								+ p->current_origin], p->alphabet)) {
-							// we proceed only if we have read a letter sequence
-							// which is not followed by a letter
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_input_string(p->stack, mot, 0);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					}
-				}
-			} else if ((contenu_len_possible_match == 5)  // <PNC>
-					&& (!u_trymatch_superfast5(contenu, ETIQ_PNC_LN5))) {
-				// case of a punctuation sequence
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					int start_pos = pos2;
-					unichar C = p->buffer[pos2 + p->current_origin];
-					if (C == ';' || C == '!' || C == '?' || C == ':' || C
-							== 0xbf || C == 0xa1 || C == 0x0e4f || C == 0x0e5a
-							|| C == 0x0e5b || C == 0x3001 || C == 0x3002 || C
-							== 0x30fb) {
-						// in both modes MERGE and REPLACE, we process the transduction if any
-						old_nb_insert = backup(p->current_insertions);
-						emit_output(p, etiq->output, start_pos);
-						if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-							// if we are in MERGE mode, we add to ouput the char we have read
-							push(p->stack, C);
-						}
-						scan_graph(n_graph, t->state_number, pos2 + 1, depth,
-								match_list, word_token_buffer, p);
-						restore(p->current_insertions, old_nb_insert);
-					} else {
-						// we consider the case of ...
-						// BUG: if ... appears at the end of the buffer
-						if (C == '.') {
-							if ((pos2 + p->current_origin + 2)
-									< p->text_buffer->size && p->buffer[pos2
-									+ p->current_origin + 1] == '.'
-									&& p->buffer[pos2 + p->current_origin + 2]
-											== '.') {
-								old_nb_insert = backup(p->current_insertions);
-								emit_output(p, etiq->output, start_pos);
-								if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-									// if we are in MERGE mode, we add to ouput the ... we have read
-									push(p->stack, C);
-									push(p->stack, C);
-									push(p->stack, C);
-								}
-								scan_graph(n_graph, t->state_number, pos2 + 3,
-										depth, match_list, word_token_buffer, p);
-								restore(p->current_insertions, old_nb_insert);
-							} else {
-								// we consider the . as a normal punctuation sign
-								old_nb_insert = backup(p->current_insertions);
-								emit_output(p, etiq->output, start_pos);
-								if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-									// if we are in MERGE mode, we add to ouput the char we have read
-									push(p->stack, C);
-								}
-								scan_graph(n_graph, t->state_number, pos2 + 1,
-										depth, match_list, word_token_buffer, p);
-								restore(p->current_insertions, old_nb_insert);
-							}
-						}
-					}
-				}
-			} else if ((contenu_len_possible_match == 3)  // <E>
-					&& (!u_trymatch_superfast3(contenu, ETIQ_E_LN3))) {
-				// case of an empty sequence
-				// in both modes MERGE and REPLACE, we process the transduction if any
-				old_nb_insert = backup(p->current_insertions);
-				emit_output(p, etiq->output, pos);
-				scan_graph(n_graph, t->state_number, pos, depth, match_list,
-						word_token_buffer, p);
-				restore(p->current_insertions, old_nb_insert);
-			} else if ((contenu_len_possible_match == 3)
-					&& (!u_trymatch_superfast3(contenu, ETIQ_CIRC_LN3))) {
-				// case of a new line sequence
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == '\n') {
-						// in both modes MERGE and REPLACE, we process the transduction if any
-						old_nb_insert = backup(p->current_insertions);
-						emit_output(p, etiq->output, pos);
-						if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-							// if we are in MERGE mode, we add to ouput the char we have read
-							push(p->stack, '\n');
-						}
-						scan_graph(n_graph, t->state_number, pos + 1, depth,
-								match_list, word_token_buffer, p);
-						restore(p->current_insertions, old_nb_insert);
-					}
-				}
-			} else if ((contenu_len_possible_match == 1)
-					&& (!u_trymatch_superfast1(contenu, '#'))
-					&& (!(etiq->control & RESPECT_CASE_TAG_BIT_MASK))) {
-				// case of a no space condition
-				if (end_of_text || p->buffer[pos + p->current_origin] != ' ') {
-					// in both modes MERGE and REPLACE, we process the transduction if any
-					old_nb_insert = backup(p->current_insertions);
-					emit_output(p, etiq->output, pos);
-					scan_graph(n_graph, t->state_number, pos, depth,
-							match_list, word_token_buffer, p);
-					restore(p->current_insertions, old_nb_insert);
-				}
-			} else if ((contenu_len_possible_match == 1)
-					&& (!u_trymatch_superfast1(contenu, ' '))) {
-				// case of an obligatory space
-				if (!end_of_text && p->buffer[pos + p->current_origin] == ' ') {
-					// in both modes MERGE and REPLACE, we process the transduction if any
-					old_nb_insert = backup(p->current_insertions);
-					emit_output(p, etiq->output, pos);
-					if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-						// if we are in MERGE mode, we add to ouput the char we have read
-						push(p->stack, ' ');
-					}
-					scan_graph(n_graph, t->state_number, pos + 1, depth,
-							match_list, word_token_buffer, p);
-					restore(p->current_insertions, old_nb_insert);
-				}
-			} else if ((contenu_len_possible_match == 3)
-					&& (!u_trymatch_superfast5(contenu, ETIQ_L_LN3))) {
-				// case of a single letter
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					int start_pos = pos2;
-					if (is_letter(p->buffer[pos2 + p->current_origin],
-							p->alphabet)) {
-						// in both modes MERGE and REPLACE, we process the transduction if any
-						old_nb_insert = backup(p->current_insertions);
-						emit_output(p, etiq->output, start_pos);
-						if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-							// if we are in MERGE mode, we add to ouput the char we have read
-							push(p->stack, p->buffer[pos2 + p->current_origin]);
-						}
-						scan_graph(n_graph, t->state_number, pos2 + 1, depth,
-								match_list, word_token_buffer, p);
-						restore(p->current_insertions, old_nb_insert);
-					}
-				}
-			} else {
-				// case of a normal letter sequence
-				if (!end_of_text) {
-					if (p->buffer[pos + p->current_origin] == ' ') {
-						pos2 = pos + 1;
-						if (p->output_policy == MERGE_OUTPUTS)
-							push(p->stack, ' ');
-					}
-					//else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
-					else
-						pos2 = pos;
-					int start_pos__ = pos2;
-					if (etiq->control & RESPECT_CASE_TAG_BIT_MASK) {
-						// case of exact case match
-						int position = 0;
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& p->buffer[pos2 + p->current_origin]
-										== contenu[position]) {
-							pos2++;
-							position++;
-						}
-						if (contenu[position] == '\0' && position != 0
-								&& (!(is_letter(contenu[position - 1],
-										p->alphabet) && is_letter(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) || p->tokenization_policy==CHAR_BY_CHAR_TOKENIZATION)) {
-							// we proceed only if we have exactly read the contenu sequence
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos__);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_input_string(p->stack, contenu, 0);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					} else {
-						// case of variable case match
-						// the letter sequences may have been caught by the arbre_etiquette structure
-						int position = 0;
-						unichar* mot = word_token_buffer;
-						int start_pos = pos2;
-						while (pos2 + p->current_origin < p->text_buffer->size
-								&& is_equal_or_uppercase(contenu[position],
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet)) {
-							mot[position++] = p->buffer[(pos2++)
-									+ p->current_origin];
-						}
-						mot[position] = '\0';
-						if (contenu[position] == '\0' && position != 0
-								&& !(is_letter(contenu[position - 1],
-										p->alphabet) && is_letter(
-										p->buffer[pos2 + p->current_origin],
-										p->alphabet))) {
-							// we proceed only if we have exactly read the contenu sequence
-							// in both modes MERGE and REPLACE, we process the transduction if any
-							old_nb_insert = backup(p->current_insertions);
-							emit_output(p, etiq->output, start_pos);
-							if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
-								// if we are in MERGE mode, we add to ouput the char we have read
-								push_input_string(p->stack, mot, 0);
-							}
-							scan_graph(n_graph, t->state_number, pos2, depth,
-									match_list, word_token_buffer, p);
-							restore(p->current_insertions, old_nb_insert);
-						}
-					}
-				}
-			}
-		}
-		t = t->next;
-	}
+    Transition* t = current_state->transitions;
+    while (t != NULL) {
+        p->stack->stack_pointer = SOMMET - 1;
+        // we process the transition of the current state
+        int n_etiq = t->tag_number;
+        if (n_etiq < 0) {
+            // case of a sub-graph
+            struct parsing_info* liste = NULL;
+            unichar* pile_old;
+            p->stack->stack[p->stack->stack_pointer + 1] = '\0';
+            pile_old = u_strdup(p->stack->stack);
+            vector_int* old_insertions = vector_int_dup(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
+            scan_graph((((unsigned) n_etiq) - 1),
+                    p->fst2->initial_states[-n_etiq], pos, depth, &liste,
+                    word_token_buffer, p);
+            free_vector_int(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
+            p->current_insertions = NULL;
+            while (liste != NULL) {
+                p->stack->stack_pointer = liste->stack_pointer - 1;
+                u_strcpy(p->stack->stack, liste->stack);
+                p->current_insertions = liste->insertions;
+                liste->insertions = NULL;
+                scan_graph(n_graph, t->state_number, liste->pos_in_tokens, depth,
+                        match_list, word_token_buffer, p);
+                free_vector_int(p->current_insertions, p->pa.prv_alloc_vector_int_inside_token);
+                struct parsing_info* l_tmp = liste;
+                liste = liste->next;
+                l_tmp->next = NULL; // in order not to free the next item
+                free_parsing_info(l_tmp, &p->pa);
+            }
+            u_strcpy(p->stack->stack, pile_old);
+            p->current_insertions = old_insertions;
+            free(pile_old);
+            p->stack->stack_pointer = SOMMET - 1;
+        } else {
+            // case of a normal tag
+            Fst2Tag etiq = p->fst2->tags[n_etiq];
+            unichar* contenu = etiq->input;
+            int contenu_len_possible_match = u_len_possible_match(contenu);
+            if (etiq->type == BEGIN_OUTPUT_VAR_TAG) {
+                fatal_error("Unsupported $|XXX( tags in Fst2Txt\n");
+            }
+            if (etiq->type == END_OUTPUT_VAR_TAG) {
+                fatal_error("Unsupported $|XXX) tags in Fst2Txt\n");
+            }
+            if (etiq->type == BEGIN_VAR_TAG) {
+                // case of a $a( variable tag
+                if (/*1 || */ !end_of_text) {
+                    /* There is no point in trying to start a variable capture at the end of the text */
+                    struct transduction_variable* L =
+                            get_transduction_variable(p->variables,
+                                    etiq->variable);
+                    if (L == NULL) {
+                        fatal_error("Unknown variable: %S\n", etiq->variable);
+                    }
+                    if (p->buffer[pos + p->current_origin] == ' ' && pos
+                            + p->current_origin + 1 < p->text_buffer->size
+                            && p->space_policy!=START_WITH_SPACE) {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    } else
+                        pos2 = pos;
+                    L->start_in_tokens = pos2;
+                    if (end_of_text) L->start_in_tokens=pos;
+                    scan_graph(n_graph, t->state_number, pos2, depth,
+                            match_list, word_token_buffer, p);
+                }
+            } else if (etiq->type == END_VAR_TAG) {
+                // case of a $a) variable tag
+                struct transduction_variable* L = get_transduction_variable(
+                        p->variables, etiq->variable);
+                if (L == NULL) {
+                    fatal_error("Unknown variable: %S\n", etiq->variable);
+                }
+                if (pos > 0)
+                    L->end_in_tokens = pos - 1;
+                else
+                    L->end_in_tokens = pos;
+                // BUG: qd changement de buffer, penser au cas start dans ancien buffer et end dans nouveau
+                scan_graph(n_graph, t->state_number, pos, depth, match_list,
+                        word_token_buffer, p);
+            } else if (etiq->type == TEXT_START_TAG) {
+                // case of an empty sequence that should be matched, but only if we are at the beginning of the text
+                // in both modes MERGE and REPLACE, we process the transduction if any
+                if (at_text_start(p, pos)) {
+                    old_nb_insert = backup(p->current_insertions);
+                    emit_output(p, etiq->output, pos);
+                    scan_graph(n_graph, t->state_number, pos, depth,
+                            match_list, word_token_buffer, p);
+                    restore(p->current_insertions, old_nb_insert);
+                }
+            } else if (etiq->type == TEXT_END_TAG) {
+                // case of an empty sequence that should be matched, but only if we are at the end of the text
+                // in both modes MERGE and REPLACE, we process the transduction if any
+                if (end_of_text || end_of_text2) {
+                    old_nb_insert = backup(p->current_insertions);
+                    emit_output(p, etiq->output, pos);
+                    scan_graph(n_graph, t->state_number, pos, depth,
+                            match_list, word_token_buffer, p);
+                    restore(p->current_insertions, old_nb_insert);
+                }
+            } else if ((contenu_len_possible_match == 5 // <MOT> <WORD>
+                        && !u_trymatch_superfast5(contenu, ETIQ_MOT_LN5))
+                    || (contenu_len_possible_match == 6 //
+                        && !u_trymatch_superfast6(contenu, ETIQ_WORD_LN6))) {
+                // case of transition by any sequence of letters
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ' && pos
+                            + p->current_origin + 1 < p->text_buffer->size) {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    unichar* mot = word_token_buffer;
+                    int position = 0;
+                    int start_pos = pos2;
+                    if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
+                            || ((pos2 + p->current_origin) == 0 || !is_letter(
+                                    p->buffer[pos2 + p->current_origin - 1],
+                                    p->alphabet))) {
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && is_letter(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) {
+                            mot[position++] = p->buffer[(pos2++)
+                                    + p->current_origin];
+                        }
+                        mot[position] = '\0';
+                        if (position != 0) {
+                            // we proceed only if we have read a letter sequence
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_output_string(p->stack, mot);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    }
+                }
+            } else if ((contenu_len_possible_match == 4) //<NB>
+                    && (!u_trymatch_superfast4(contenu, ETIQ_NB_LN4))) {
+                // case of transition by any sequence of digits
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    unichar* mot = word_token_buffer;
+                    int position = 0;
+                    int start_pos = pos2;
+                    while (pos2 + p->current_origin < p->text_buffer->size
+                            && (p->buffer[pos2 + p->current_origin] >= '0')
+                            && (p->buffer[pos2 + p->current_origin] <= '9')) {
+                        mot[position++] = p->buffer[(pos2++)
+                                + p->current_origin];
+                    }
+                    mot[position] = '\0';
+                    if (position != 0) {
+                        // we proceed only if we have read a letter sequence
+                        // in both modes MERGE and REPLACE, we process the transduction if any
+                        old_nb_insert = backup(p->current_insertions);
+                        emit_output(p, etiq->output, start_pos);
+                        if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                            // if we are in MERGE mode, we add to ouput the char we have read
+                            push_output_string(p->stack, mot);
+                        }
+                        scan_graph(n_graph, t->state_number, pos2, depth,
+                                match_list, word_token_buffer, p);
+                        restore(p->current_insertions, old_nb_insert);
+                    }
+                }
+            } else if ((contenu_len_possible_match == 5 // <MAJ>
+                        && !u_trymatch_superfast5(contenu, ETIQ_MAJ_LN5))
+                    || (contenu_len_possible_match == 7 // <UPPER>
+                        && !u_trymatch_superfast7(contenu, ETIQ_UPPER_LN7))) {
+                // case of upper case letter sequence
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    unichar* mot = word_token_buffer;
+                    int position = 0;
+                    int start_pos = pos2;
+                    if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
+                            || ((pos2 + p->current_origin) == 0 || !is_letter(
+                                    p->buffer[pos2 + p->current_origin - 1],
+                                    p->alphabet))) {
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && is_upper(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) {
+                            mot[position++] = p->buffer[(pos2++)
+                                    + p->current_origin];
+                        }
+                        mot[position] = '\0';
+                        if (position != 0 && !is_letter(p->buffer[pos2
+                                + p->current_origin], p->alphabet)) {
+                            // we proceed only if we have read an upper case letter sequence
+                            // which is not followed by a lower case letter
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_input_string(p->stack, mot, 0);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    }
+                }
+            } else if ((contenu_len_possible_match == 5 // <MIN>
+                        && !u_trymatch_superfast5(contenu, ETIQ_MIN_LN5))
+                    || (contenu_len_possible_match == 7 //<LOWER>
+                        && !u_trymatch_superfast7(contenu, ETIQ_LOWER_LN7))) {
+                // case of lower case letter sequence
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    unichar* mot = word_token_buffer;
+                    int position = 0;
+                    int start_pos = pos2;
+                    if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
+                            || (pos2 + p->current_origin == 0 || !is_letter(
+                                    p->buffer[pos2 + p->current_origin - 1],
+                                    p->alphabet))) {
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && is_lower(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) {
+                            mot[position++] = p->buffer[(pos2++)
+                                    + p->current_origin];
+                        }
+                        mot[position] = '\0';
+                        if (position != 0 && !is_letter(p->buffer[pos2
+                                + p->current_origin], p->alphabet)) {
+                            // we proceed only if we have read a lower case letter sequence
+                            // which is not followed by an upper case letter
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_input_string(p->stack, mot, 0);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    }
+                }
+            } else if ((contenu_len_possible_match == 5 // <PRE>
+                        && !u_trymatch_superfast5(contenu, ETIQ_PRE_LN5))
+                    || (contenu_len_possible_match == 7 // <FIRST>
+                        && !u_trymatch_superfast7(contenu, ETIQ_FIRST_LN7))) {
+                // case of a sequence beginning by an upper case letter
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    unichar* mot = word_token_buffer;
+                    int position = 0;
+                    int start_pos = pos2;
+                    if (p->tokenization_policy == CHAR_BY_CHAR_TOKENIZATION
+                            || (is_upper(p->buffer[pos2 + p->current_origin],
+                                    p->alphabet) && (pos2 + p->current_origin
+                                    == 0 || !is_letter(p->buffer[pos2
+                                    + p->current_origin - 1], p->alphabet)))) {
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && is_letter(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) {
+                            mot[position++] = p->buffer[(pos2++)
+                                    + p->current_origin];
+                        }
+                        mot[position] = '\0';
+                        if (position != 0 && !is_letter(p->buffer[pos2
+                                + p->current_origin], p->alphabet)) {
+                            // we proceed only if we have read a letter sequence
+                            // which is not followed by a letter
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_input_string(p->stack, mot, 0);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    }
+                }
+            } else if ((contenu_len_possible_match == 5)  // <PNC>
+                    && (!u_trymatch_superfast5(contenu, ETIQ_PNC_LN5))) {
+                // case of a punctuation sequence
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    int start_pos = pos2;
+                    unichar C = p->buffer[pos2 + p->current_origin];
+                    if (C == ';' || C == '!' || C == '?' || C == ':' || C
+                            == 0xbf || C == 0xa1 || C == 0x0e4f || C == 0x0e5a
+                            || C == 0x0e5b || C == 0x3001 || C == 0x3002 || C
+                            == 0x30fb) {
+                        // in both modes MERGE and REPLACE, we process the transduction if any
+                        old_nb_insert = backup(p->current_insertions);
+                        emit_output(p, etiq->output, start_pos);
+                        if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                            // if we are in MERGE mode, we add to ouput the char we have read
+                            push(p->stack, C);
+                        }
+                        scan_graph(n_graph, t->state_number, pos2 + 1, depth,
+                                match_list, word_token_buffer, p);
+                        restore(p->current_insertions, old_nb_insert);
+                    } else {
+                        // we consider the case of ...
+                        // BUG: if ... appears at the end of the buffer
+                        if (C == '.') {
+                            if ((pos2 + p->current_origin + 2)
+                                    < p->text_buffer->size && p->buffer[pos2
+                                    + p->current_origin + 1] == '.'
+                                    && p->buffer[pos2 + p->current_origin + 2]
+                                            == '.') {
+                                old_nb_insert = backup(p->current_insertions);
+                                emit_output(p, etiq->output, start_pos);
+                                if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                    // if we are in MERGE mode, we add to ouput the ... we have read
+                                    push(p->stack, C);
+                                    push(p->stack, C);
+                                    push(p->stack, C);
+                                }
+                                scan_graph(n_graph, t->state_number, pos2 + 3,
+                                        depth, match_list, word_token_buffer, p);
+                                restore(p->current_insertions, old_nb_insert);
+                            } else {
+                                // we consider the . as a normal punctuation sign
+                                old_nb_insert = backup(p->current_insertions);
+                                emit_output(p, etiq->output, start_pos);
+                                if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                    // if we are in MERGE mode, we add to ouput the char we have read
+                                    push(p->stack, C);
+                                }
+                                scan_graph(n_graph, t->state_number, pos2 + 1,
+                                        depth, match_list, word_token_buffer, p);
+                                restore(p->current_insertions, old_nb_insert);
+                            }
+                        }
+                    }
+                }
+            } else if ((contenu_len_possible_match == 3)  // <E>
+                    && (!u_trymatch_superfast3(contenu, ETIQ_E_LN3))) {
+                // case of an empty sequence
+                // in both modes MERGE and REPLACE, we process the transduction if any
+                old_nb_insert = backup(p->current_insertions);
+                emit_output(p, etiq->output, pos);
+                scan_graph(n_graph, t->state_number, pos, depth, match_list,
+                        word_token_buffer, p);
+                restore(p->current_insertions, old_nb_insert);
+            } else if ((contenu_len_possible_match == 3)
+                    && (!u_trymatch_superfast3(contenu, ETIQ_CIRC_LN3))) {
+                // case of a new line sequence
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == '\n') {
+                        // in both modes MERGE and REPLACE, we process the transduction if any
+                        old_nb_insert = backup(p->current_insertions);
+                        emit_output(p, etiq->output, pos);
+                        if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                            // if we are in MERGE mode, we add to ouput the char we have read
+                            push(p->stack, '\n');
+                        }
+                        scan_graph(n_graph, t->state_number, pos + 1, depth,
+                                match_list, word_token_buffer, p);
+                        restore(p->current_insertions, old_nb_insert);
+                    }
+                }
+            } else if ((contenu_len_possible_match == 1)
+                    && (!u_trymatch_superfast1(contenu, '#'))
+                    && (!(etiq->control & RESPECT_CASE_TAG_BIT_MASK))) {
+                // case of a no space condition
+                if (end_of_text || p->buffer[pos + p->current_origin] != ' ') {
+                    // in both modes MERGE and REPLACE, we process the transduction if any
+                    old_nb_insert = backup(p->current_insertions);
+                    emit_output(p, etiq->output, pos);
+                    scan_graph(n_graph, t->state_number, pos, depth,
+                            match_list, word_token_buffer, p);
+                    restore(p->current_insertions, old_nb_insert);
+                }
+            } else if ((contenu_len_possible_match == 1)
+                    && (!u_trymatch_superfast1(contenu, ' '))) {
+                // case of an obligatory space
+                if (!end_of_text && p->buffer[pos + p->current_origin] == ' ') {
+                    // in both modes MERGE and REPLACE, we process the transduction if any
+                    old_nb_insert = backup(p->current_insertions);
+                    emit_output(p, etiq->output, pos);
+                    if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                        // if we are in MERGE mode, we add to ouput the char we have read
+                        push(p->stack, ' ');
+                    }
+                    scan_graph(n_graph, t->state_number, pos + 1, depth,
+                            match_list, word_token_buffer, p);
+                    restore(p->current_insertions, old_nb_insert);
+                }
+            } else if ((contenu_len_possible_match == 3)
+                    && (!u_trymatch_superfast5(contenu, ETIQ_L_LN3))) {
+                // case of a single letter
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    int start_pos = pos2;
+                    if (is_letter(p->buffer[pos2 + p->current_origin],
+                            p->alphabet)) {
+                        // in both modes MERGE and REPLACE, we process the transduction if any
+                        old_nb_insert = backup(p->current_insertions);
+                        emit_output(p, etiq->output, start_pos);
+                        if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                            // if we are in MERGE mode, we add to ouput the char we have read
+                            push(p->stack, p->buffer[pos2 + p->current_origin]);
+                        }
+                        scan_graph(n_graph, t->state_number, pos2 + 1, depth,
+                                match_list, word_token_buffer, p);
+                        restore(p->current_insertions, old_nb_insert);
+                    }
+                }
+            } else {
+                // case of a normal letter sequence
+                if (!end_of_text) {
+                    if (p->buffer[pos + p->current_origin] == ' ') {
+                        pos2 = pos + 1;
+                        if (p->output_policy == MERGE_OUTPUTS)
+                            push(p->stack, ' ');
+                    }
+                    //else if (buffer[pos+origine_courante]==0x0d) {pos2=pos+2;if (MODE==MERGE) empiler(0x0a);}
+                    else
+                        pos2 = pos;
+                    int start_pos__ = pos2;
+                    if (etiq->control & RESPECT_CASE_TAG_BIT_MASK) {
+                        // case of exact case match
+                        int position = 0;
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && p->buffer[pos2 + p->current_origin]
+                                        == contenu[position]) {
+                            pos2++;
+                            position++;
+                        }
+                        if (contenu[position] == '\0' && position != 0
+                                && (!(is_letter(contenu[position - 1],
+                                        p->alphabet) && is_letter(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) || p->tokenization_policy==CHAR_BY_CHAR_TOKENIZATION)) {
+                            // we proceed only if we have exactly read the contenu sequence
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos__);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_input_string(p->stack, contenu, 0);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    } else {
+                        // case of variable case match
+                        // the letter sequences may have been caught by the arbre_etiquette structure
+                        int position = 0;
+                        unichar* mot = word_token_buffer;
+                        int start_pos = pos2;
+                        while (pos2 + p->current_origin < p->text_buffer->size
+                                && is_equal_or_uppercase(contenu[position],
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet)) {
+                            mot[position++] = p->buffer[(pos2++)
+                                    + p->current_origin];
+                        }
+                        mot[position] = '\0';
+                        if (contenu[position] == '\0' && position != 0
+                                && !(is_letter(contenu[position - 1],
+                                        p->alphabet) && is_letter(
+                                        p->buffer[pos2 + p->current_origin],
+                                        p->alphabet))) {
+                            // we proceed only if we have exactly read the contenu sequence
+                            // in both modes MERGE and REPLACE, we process the transduction if any
+                            old_nb_insert = backup(p->current_insertions);
+                            emit_output(p, etiq->output, start_pos);
+                            if (p->output_policy == MERGE_OUTPUTS /*|| etiq->transduction==NULL || etiq->transduction[0]=='\0'*/) {
+                                // if we are in MERGE mode, we add to ouput the char we have read
+                                push_input_string(p->stack, mot, 0);
+                            }
+                            scan_graph(n_graph, t->state_number, pos2, depth,
+                                    match_list, word_token_buffer, p);
+                            restore(p->current_insertions, old_nb_insert);
+                        }
+                    }
+                }
+            }
+        }
+        t = t->next;
+    }
 }
 
 int not_a_letter_sequence(Fst2Tag e, Alphabet* alphabet) {
-	// we return false only if e is a letter sequence like %hello
-	if (e->control & RESPECT_CASE_TAG_BIT_MASK || e->type == BEGIN_VAR_TAG
-			|| e->type == END_VAR_TAG || e->type == BEGIN_OUTPUT_VAR_TAG
-			|| e->type == END_OUTPUT_VAR_TAG) {
-		// case of @hello $a( and $a)
-		return 1;
-	}
-	unichar* s = e->input;
-	if (!is_letter(s[0], alphabet))
-		return 1;
-	int s_len_possible_match = u_len_possible_match(s);
-	if (s_len_possible_match == 1) {
-		if ((!u_trymatch_superfast1(s, '#'))
-				|| (!u_trymatch_superfast1(s, ' ')))
-			return 1;
-	}
-	if (s_len_possible_match == 3) {
-		if ((!u_trymatch_superfast3(s, ETIQ_L_LN3)) || (!u_trymatch_superfast3(
-				s, ETIQ_E_LN3)) || (!u_trymatch_superfast3(s, ETIQ_CIRC_LN3)))
-			return 1;
-	}
+    // we return false only if e is a letter sequence like %hello
+    if (e->control & RESPECT_CASE_TAG_BIT_MASK || e->type == BEGIN_VAR_TAG
+            || e->type == END_VAR_TAG || e->type == BEGIN_OUTPUT_VAR_TAG
+            || e->type == END_OUTPUT_VAR_TAG) {
+        // case of @hello $a( and $a)
+        return 1;
+    }
+    unichar* s = e->input;
+    if (!is_letter(s[0], alphabet))
+        return 1;
+    int s_len_possible_match = u_len_possible_match(s);
+    if (s_len_possible_match == 1) {
+        if ((!u_trymatch_superfast1(s, '#'))
+                || (!u_trymatch_superfast1(s, ' ')))
+            return 1;
+    }
+    if (s_len_possible_match == 3) {
+        if ((!u_trymatch_superfast3(s, ETIQ_L_LN3)) || (!u_trymatch_superfast3(
+                s, ETIQ_E_LN3)) || (!u_trymatch_superfast3(s, ETIQ_CIRC_LN3)))
+            return 1;
+    }
 
-	// added in revision 1028
-	if (s_len_possible_match == 4) {
-		if ((!u_trymatch_superfast4(s, ETIQ_NB_LN4)))
-			return 1;
-	}
+    // added in revision 1028
+    if (s_len_possible_match == 4) {
+        if ((!u_trymatch_superfast4(s, ETIQ_NB_LN4)))
+            return 1;
+    }
 
-	if (s_len_possible_match == 5) {
-		if ((!u_trymatch_superfast5(s, ETIQ_MOT_LN5))
-				|| (!u_trymatch_superfast5(s, ETIQ_MAJ_LN5))
-				|| (!u_trymatch_superfast5(s, ETIQ_MIN_LN5))
-				|| (!u_trymatch_superfast5(s, ETIQ_PRE_LN5))
-				|| (!u_trymatch_superfast5(s, ETIQ_PNC_LN5)))
-			return 1;
-	}
+    if (s_len_possible_match == 5) {
+        if ((!u_trymatch_superfast5(s, ETIQ_MOT_LN5))
+                || (!u_trymatch_superfast5(s, ETIQ_MAJ_LN5))
+                || (!u_trymatch_superfast5(s, ETIQ_MIN_LN5))
+                || (!u_trymatch_superfast5(s, ETIQ_PRE_LN5))
+                || (!u_trymatch_superfast5(s, ETIQ_PNC_LN5)))
+            return 1;
+    }
 
-	// added in revision 4073
-	if (s_len_possible_match == 6) {
-		if (!u_trymatch_superfast6(s, ETIQ_WORD_LN6))
-			return 1;
-	}
+    // added in revision 4073
+    if (s_len_possible_match == 6) {
+        if (!u_trymatch_superfast6(s, ETIQ_WORD_LN6))
+            return 1;
+    }
 
-	if (s_len_possible_match == 7) {
-		if ((!u_trymatch_superfast7(s, ETIQ_FIRST_LN7))
-				|| (!u_trymatch_superfast7(s, ETIQ_UPPER_LN7))
-				|| (!u_trymatch_superfast7(s, ETIQ_LOWER_LN7)))
-			return 1;
-	}
+    if (s_len_possible_match == 7) {
+        if ((!u_trymatch_superfast7(s, ETIQ_FIRST_LN7))
+                || (!u_trymatch_superfast7(s, ETIQ_UPPER_LN7))
+                || (!u_trymatch_superfast7(s, ETIQ_LOWER_LN7)))
+            return 1;
+    }
 
-	return 0;
+    return 0;
 }
 
 Transition* add_tag_to_token_tree(struct fst2txt_token_tree* tree,
-		Transition* trans, struct fst2txt_parameters* p) {
-	// case 1: empty transition
-	if (trans == NULL)
-		return NULL;
-	// case 2: transition by something else that a sequence of letter like %hello
-	//         or sub-graph call
-	if (trans->tag_number < 0 || not_a_letter_sequence(
-			p->fst2->tags[trans->tag_number], p->alphabet)) {
-		trans->next = add_tag_to_token_tree(tree, trans->next, p);
-		return trans;
-	}
-	Transition* tmp = add_tag_to_token_tree(tree, trans->next, p);
-	add_tag(p->fst2->tags[trans->tag_number]->input, trans->tag_number,
-			trans->state_number, tree, p->fst2txt_abstract_allocator);
-	free_cb(trans,p->fst2txt_abstract_allocator);
-	return tmp;
+        Transition* trans, struct fst2txt_parameters* p) {
+    // case 1: empty transition
+    if (trans == NULL)
+        return NULL;
+    // case 2: transition by something else that a sequence of letter like %hello
+    //         or sub-graph call
+    if (trans->tag_number < 0 || not_a_letter_sequence(
+            p->fst2->tags[trans->tag_number], p->alphabet)) {
+        trans->next = add_tag_to_token_tree(tree, trans->next, p);
+        return trans;
+    }
+    Transition* tmp = add_tag_to_token_tree(tree, trans->next, p);
+    add_tag(p->fst2->tags[trans->tag_number]->input, trans->tag_number,
+            trans->state_number, tree, p->fst2txt_abstract_allocator);
+    free_cb(trans,p->fst2txt_abstract_allocator);
+    return tmp;
 }
 
 /**
@@ -1353,17 +1353,17 @@ Transition* add_tag_to_token_tree(struct fst2txt_token_tree* tree,
  * of tokens in a same box of a grf.
  */
 static void build_state_token_trees(struct fst2txt_parameters* p) {
-	p->n_token_trees = p->fst2->number_of_states;
-	p->token_tree = (struct fst2txt_token_tree**) malloc_cb(p->n_token_trees
-			* sizeof(struct fst2txt_token_tree*),p->fst2txt_abstract_allocator);
-	if (p->token_tree == NULL) {
-		fatal_alloc_error("build_state_token_trees\n");
-	}
-	for (int i = 0; i < p->n_token_trees; i++) {
-		p->token_tree[i] = new_fst2txt_token_tree(p->fst2txt_abstract_allocator);
-		p->fst2->states[i]->transitions = add_tag_to_token_tree(
-				p->token_tree[i], p->fst2->states[i]->transitions, p);
-	}
+    p->n_token_trees = p->fst2->number_of_states;
+    p->token_tree = (struct fst2txt_token_tree**) malloc_cb(p->n_token_trees
+            * sizeof(struct fst2txt_token_tree*),p->fst2txt_abstract_allocator);
+    if (p->token_tree == NULL) {
+        fatal_alloc_error("build_state_token_trees\n");
+    }
+    for (int i = 0; i < p->n_token_trees; i++) {
+        p->token_tree[i] = new_fst2txt_token_tree(p->fst2txt_abstract_allocator);
+        p->fst2->states[i]->transitions = add_tag_to_token_tree(
+                p->token_tree[i], p->fst2->states[i]->transitions, p);
+    }
 }
 
 } // namespace unitex

--- a/Fst2Txt_TokenTree.cpp
+++ b/Fst2Txt_TokenTree.cpp
@@ -66,7 +66,7 @@ free_cb(t,prv_alloc);
 
 /**
  * This function adds the given token to the given token tree, if not already
- * present. Then, it adds the given transition to its transition list. 
+ * present. Then, it adds the given transition to its transition list.
  */
 void add_tag(unichar* token,int tag_number,int dest_state,struct fst2txt_token_tree* tree, Abstract_allocator prv_alloc) {
 int n=get_value_index(token,tree->hash);

--- a/GeneralDerivation.cpp
+++ b/GeneralDerivation.cpp
@@ -718,8 +718,8 @@ struct rule_list* parse_rules (unichar* entry,struct utags UTAG,vector_ptr* rule
 
 
 int composition_rule_matches_entry (const struct pattern* rule,
-				     const struct dela_entry* d,U_FILE* 
-#if DDEBUG > 1                         
+				     const struct dela_entry* d,U_FILE*
+#if DDEBUG > 1
 				     debug_file
 #endif
                      ) {

--- a/GeneralDerivation.cpp
+++ b/GeneralDerivation.cpp
@@ -108,7 +108,7 @@ struct composition_rule {
 struct composition_rule* new_composition_rule ();
 void free_composition_rule (struct composition_rule*);
 struct composition_rule* copy_composition_rule (struct composition_rule*,
-						struct composition_rule*);
+                        struct composition_rule*);
 // all rules of one lexicon entry are stored in a list
 struct rule_list {
   struct composition_rule* rule;
@@ -169,11 +169,11 @@ void free_all_dic_entries(vector_ptr*);
 // this function analyses russian compound words
 //
 void analyse_compounds(const Alphabet* alph,
-		       Dictionary* d,
-			   U_FILE* words,
-		       U_FILE* result,
-		       U_FILE* debug,
-		       U_FILE* new_unknown_words,struct utags UTAG)
+               Dictionary* d,
+               U_FILE* words,
+               U_FILE* result,
+               U_FILE* debug,
+               U_FILE* new_unknown_words,struct utags UTAG)
 {
    bool* prefix;
    bool* suffix;
@@ -190,15 +190,15 @@ void analyse_compounds(const Alphabet* alph,
 // this function reads words in the word file and try analyse them
 //
 void analyse_word_list(Dictionary* d,
-			       U_FILE* words,
-			       U_FILE* result,
-			       U_FILE* debug,
-			       U_FILE* new_unknown_words,
-			       const Alphabet* alph,
-			       const bool* prefix,const bool* suffix,
-			       struct utags UTAG,
-			       vector_ptr* rules,
-			       vector_ptr* entries)
+                   U_FILE* words,
+                   U_FILE* result,
+                   U_FILE* debug,
+                   U_FILE* new_unknown_words,
+                   const Alphabet* alph,
+                   const bool* prefix,const bool* suffix,
+                   struct utags UTAG,
+                   vector_ptr* rules,
+                   vector_ptr* entries)
 {
   u_printf("Analysing russian unknown words...\n");
   int n=0;
@@ -251,10 +251,10 @@ int analyse_word(const unichar* mot,Dictionary* d,U_FILE* debug,U_FILE* result_f
   }
   struct decomposed_word_list* tmp = l;
   while ( tmp != NULL ) {
-	  if (debug!=NULL) {
-	     u_fprintf(debug,"%S = %S\n",mot,tmp->element->decomposition);
-	  }
-	  u_fprintf(result_file,"%S\n",tmp->element->dela_line);
+      if (debug!=NULL) {
+         u_fprintf(debug,"%S = %S\n",mot,tmp->element->decomposition);
+      }
+      u_fprintf(result_file,"%S\n",tmp->element->dela_line);
      tmp=tmp->suivant;
   }
   free_decomposed_word_list(l);
@@ -383,36 +383,36 @@ void parse_condition (const unichar* condition, pattern* patterns)
       pattern[0] = '\0';
       int k = 0;
       while (condition[i] != '>' && condition[i] != '\0') {
-	if (condition[i] == '+') { // grammatical code positive
-	  pattern[k] = '\0';
-	  save_pattern(&patterns[j++],YesNo,type,pattern);
-	  YesNo = 1;
-	  type = 'g';
-	  i++;
-	  k = 0;
-	}
-	else if (condition[i] == '-') { // grammatical code negative
-	  pattern[k] = '\0';
-	  save_pattern(&patterns[j++],YesNo,type,pattern);
-	  YesNo = 0;
-	  type = 'g';
-	  i++;
-	  k = 0;
-	}
-	else if (condition[i] == ':') { // flexional code
-	  pattern[k] = '\0';
-	  save_pattern(&patterns[j++],YesNo,type,pattern);
-	  YesNo = 1;
-	  type = 'f';
-	  i++;
-	  k = 0;
-	}
-	pattern[k++] = condition[i];
+    if (condition[i] == '+') { // grammatical code positive
+      pattern[k] = '\0';
+      save_pattern(&patterns[j++],YesNo,type,pattern);
+      YesNo = 1;
+      type = 'g';
+      i++;
+      k = 0;
+    }
+    else if (condition[i] == '-') { // grammatical code negative
+      pattern[k] = '\0';
+      save_pattern(&patterns[j++],YesNo,type,pattern);
+      YesNo = 0;
+      type = 'g';
+      i++;
+      k = 0;
+    }
+    else if (condition[i] == ':') { // flexional code
+      pattern[k] = '\0';
+      save_pattern(&patterns[j++],YesNo,type,pattern);
+      YesNo = 1;
+      type = 'f';
+      i++;
+      k = 0;
+    }
+    pattern[k++] = condition[i];
         i++;
       }
       if (pattern[0] != '\0')
-	pattern[k] = '\0';
-	save_pattern(&patterns[j++],YesNo,type,pattern);
+    pattern[k] = '\0';
+    save_pattern(&patterns[j++],YesNo,type,pattern);
     }
     else { // don't know if it is necessary to have concrete words or something else
     }
@@ -451,7 +451,7 @@ void free_composition_rule (struct composition_rule* t)
 }
 
 struct composition_rule* copy_composition_rule (struct composition_rule* a,
-						struct composition_rule* b)
+                        struct composition_rule* b)
 {
   for (int i = 0; i < MAX_NUMBER_OF_COMPOSITION_RULES; i++) {
     u_strcpy(a->before[i].string, b->before[i].string);
@@ -550,32 +550,32 @@ void parse_then_code (const unichar* then_code, struct change_code* then)
       i++;
     if (then_code[i] == ';') {
       if (state == SUBSTR_ACT) {
- 	then->substr_act[k] = '\0';
-	k = 0;
-	state = UNDO_ACT;
+    then->substr_act[k] = '\0';
+    k = 0;
+    state = UNDO_ACT;
       }
       else if (state == SUBSTR_NEXT) {
- 	then->substr_next[k] = '\0';
-	k = 0;
-	state = UNDO_NEXT;
+    then->substr_next[k] = '\0';
+    k = 0;
+    state = UNDO_NEXT;
       }
     }
     else if (then_code[i] == '.') { // begin of codes
       if (state == SUBSTR_ACT) {
-	then->substr_act[k] = '\0';
-	k = 0;
+    then->substr_act[k] = '\0';
+    k = 0;
       }
       else if (state == SUBSTR_NEXT) {
-	then->substr_next[k] = '\0';
-	k = 0;
+    then->substr_next[k] = '\0';
+    k = 0;
       }
       else if (state == UNDO_ACT) {
-	then->undo_substr_act[k] = '\0';
-	k = 0;
+    then->undo_substr_act[k] = '\0';
+    k = 0;
       }
       else if (state == UNDO_NEXT) {
-	then->undo_substr_next[k] = '\0';
-	k = 0;
+    then->undo_substr_next[k] = '\0';
+    k = 0;
       }
       state = CODE;
     }
@@ -588,15 +588,15 @@ void parse_then_code (const unichar* then_code, struct change_code* then)
       i++;
       int j = 0;
       while (then_code[i] != '>')
-	then->repl[j++] = then_code[i++];
+    then->repl[j++] = then_code[i++];
       then->repl[j] = '\0';
     }
     else if (state == CODE && then_code[i] == '+') { // feature to be added
       i++;
       int j = 0;
       while (then_code[i] != '+' && then_code[i] != '-'
-	     && then_code[i] != '\0') {
-	then->add[j++] = then_code[i];
+         && then_code[i] != '\0') {
+    then->add[j++] = then_code[i];
         i++;
       }
       then->add[j] = '\0';
@@ -605,8 +605,8 @@ void parse_then_code (const unichar* then_code, struct change_code* then)
       i++;
       int j = 0;
       while (then_code[i] != '+' && then_code[i] != '-'
-	     && then_code[i] != '\0') {
-	then->del[j++] = then_code[i];
+         && then_code[i] != '\0') {
+    then->del[j++] = then_code[i];
         i++;
       }
       then->del[j] = '\0';
@@ -646,66 +646,66 @@ struct rule_list* parse_rules (unichar* entry,struct utags UTAG,vector_ptr* rule
   for (int i = 0; entry[i] != '\0'; i++) {
     if ( state != BEGIN ) { // inside a rule
       if (entry[i] == '\\')
-	i++; // unescaping escaped chars in rule
+    i++; // unescaping escaped chars in rule
       if (entry[i] == ')') {
-	// end of rule
- 	struct composition_rule* rule = new_composition_rule();
-	beforcond[bcpos] = '\0';
-	aftercond[acpos] = '\0';
-	then_code[tpos]  = '\0';
-	parse_condition(beforcond, rule->before);
-	parse_condition(aftercond, rule->after);
-	parse_then_code(then_code, &rule->then);
-	bcpos = acpos = tpos = 0;
-	if (actual_list_pos->rule != 0) { // not first rule
-	  struct rule_list* tmp = new_rule_list(rules);
-	  actual_list_pos->next = tmp;
-	  actual_list_pos = tmp;
-	}
-	actual_list_pos->rule = rule;
-	state = BEGIN;
+    // end of rule
+    struct composition_rule* rule = new_composition_rule();
+    beforcond[bcpos] = '\0';
+    aftercond[acpos] = '\0';
+    then_code[tpos]  = '\0';
+    parse_condition(beforcond, rule->before);
+    parse_condition(aftercond, rule->after);
+    parse_then_code(then_code, &rule->then);
+    bcpos = acpos = tpos = 0;
+    if (actual_list_pos->rule != 0) { // not first rule
+      struct rule_list* tmp = new_rule_list(rules);
+      actual_list_pos->next = tmp;
+      actual_list_pos = tmp;
+    }
+    actual_list_pos->rule = rule;
+    state = BEGIN;
       }
       else if (state == BEFORE_COND) {
-	// condition before
-	if (entry[i] == '#')
-	  state = AFTER_COND;
-	else
-	  beforcond[bcpos++] = entry[i];
+    // condition before
+    if (entry[i] == '#')
+      state = AFTER_COND;
+    else
+      beforcond[bcpos++] = entry[i];
       }
       else if (state == AFTER_COND) {
-	// condition after
-	if (entry[i] == '=')
-	  state = THEN;
-	else
-	  aftercond[acpos++] = entry[i];
+    // condition after
+    if (entry[i] == '=')
+      state = THEN;
+    else
+      aftercond[acpos++] = entry[i];
       }
       else if (state == THEN)
-	// then-code
-	then_code[tpos++] = entry[i];
+    // then-code
+    then_code[tpos++] = entry[i];
     }
     else { // not inside a rule
       if (entry[i] == '+') {
-	unichar tmp[MAX_DICT_LINE_LENGTH];
-	int j;
-	for (j = i+1; ((entry[j] != '+') &&
-		       (entry[j] != ':') &&
-		       (entry[j] != '(') &&
-		       (entry[j] != '\0')); j++)
-	  tmp[j-(i+1)] = entry[j];
-	tmp[j-(i+1)] = '\0';
-	if ((!u_strcmp(tmp, UTAG.PREFIX)) ||
-	    (!u_strcmp(tmp, UTAG.SUFFIX))) {
-	  i = j-1;
-	}
-	else if (!u_strcmp(tmp, UTAG.RULE)) {
-	  i = j; // including '('
-	  state = BEFORE_COND;
-	}
-	else {
-	  cleaned_entry[k++] = entry[i];
-	}
+    unichar tmp[MAX_DICT_LINE_LENGTH];
+    int j;
+    for (j = i+1; ((entry[j] != '+') &&
+               (entry[j] != ':') &&
+               (entry[j] != '(') &&
+               (entry[j] != '\0')); j++)
+      tmp[j-(i+1)] = entry[j];
+    tmp[j-(i+1)] = '\0';
+    if ((!u_strcmp(tmp, UTAG.PREFIX)) ||
+        (!u_strcmp(tmp, UTAG.SUFFIX))) {
+      i = j-1;
+    }
+    else if (!u_strcmp(tmp, UTAG.RULE)) {
+      i = j; // including '('
+      state = BEFORE_COND;
+    }
+    else {
+      cleaned_entry[k++] = entry[i];
+    }
       } else {
-	cleaned_entry[k++] = entry[i];
+    cleaned_entry[k++] = entry[i];
       }
     }
   }
@@ -718,9 +718,9 @@ struct rule_list* parse_rules (unichar* entry,struct utags UTAG,vector_ptr* rule
 
 
 int composition_rule_matches_entry (const struct pattern* rule,
-				     const struct dela_entry* d,U_FILE*
+                     const struct dela_entry* d,U_FILE*
 #if DDEBUG > 1
-				     debug_file
+                     debug_file
 #endif
                      ) {
   int ok = 1;
@@ -735,45 +735,45 @@ int composition_rule_matches_entry (const struct pattern* rule,
 #if DDEBUG > 1
     {
       if (rule[i].type == 'f')
-	u_strcat(tmp, ":");
+    u_strcat(tmp, ":");
       else if (rule[i].YesNo)
-	u_strcat(tmp, "+");
+    u_strcat(tmp, "+");
       else
-	u_strcat(tmp, "-");
+    u_strcat(tmp, "-");
       u_strcat(tmp, rule[i].string);
     }
 #endif
     if (rule[i].YesNo) { // rule '+' => pattern must be in entry, too
       if (rule[i].type == 'g') {
-	if (dic_entry_contain_gram_code(d,rule[i].string))
-	  continue; // rule matched, try next one
-	ok = 0;
+    if (dic_entry_contain_gram_code(d,rule[i].string))
+      continue; // rule matched, try next one
+    ok = 0;
       }
       else if (rule[i].type == 'f') {
-	if (dic_entry_contain_inflectional_code(d,rule[i].string)) {
-	  // rule matched, try next one, but mark flex codes as matched
-	  flex_code_already_matched = 2;
-	  continue;
-	}
-	else if (flex_code_already_matched == 2) {
-	  // no matter if any flex code already matched
-	  continue;
-	}
-	else {
-	  // no-matches before first match
-	  flex_code_already_matched = 0;
-	}
+    if (dic_entry_contain_inflectional_code(d,rule[i].string)) {
+      // rule matched, try next one, but mark flex codes as matched
+      flex_code_already_matched = 2;
+      continue;
+    }
+    else if (flex_code_already_matched == 2) {
+      // no matter if any flex code already matched
+      continue;
+    }
+    else {
+      // no-matches before first match
+      flex_code_already_matched = 0;
+    }
       }
     }
     else { // rule '-' => pattern must not be in entry
       if (rule[i].type == 'g') {
-	if (dic_entry_contain_gram_code(d,rule[i].string))
-	  ok = 0;
+    if (dic_entry_contain_gram_code(d,rule[i].string))
+      ok = 0;
       }
       else if (rule[i].type == 'f') {
-	// implemented although not possible in rule syntax
-	if (dic_entry_contain_inflectional_code(d,rule[i].string))
-	  ok = 0;
+    // implemented although not possible in rule syntax
+    if (dic_entry_contain_inflectional_code(d,rule[i].string))
+      ok = 0;
       }
     }
   }
@@ -816,7 +816,7 @@ void substring_operation (unichar* affix, const unichar* rule)
     i = 0; // now index of affix
     while (affix[i] != '\0') {
       if (i >= n)
-	new_affix[j++] = affix[i];
+    new_affix[j++] = affix[i];
       i++;
     }
     new_affix[j] = '\0';
@@ -910,21 +910,21 @@ codes[j]='\0';
 // this function explores the dictionary to decompose the word mot
 //
 void explore_state (int offset,
-		    unichar* current_component,
-		    int pos_in_current_component,
-		    const unichar* original_word,
-		    const unichar* remaining_word,
-		    int pos_in_remaining_word,
-		    const unichar* decomposition,
-		    const unichar* lemma_prefix,
-		    struct decomposed_word_list** L,
-		    int n_decomp,
-		    struct rule_list* rule_list_called,
-		    const struct dela_entry* dic_entr_called,
-		    Dictionary* d,
-		    const bool* prefix,const bool* suffix,const Alphabet* alphabet,
-		    U_FILE* debug_file,struct utags UTAG,
-		    vector_ptr* rules,vector_ptr* entries,Ustring* ustr,int base) {
+            unichar* current_component,
+            int pos_in_current_component,
+            const unichar* original_word,
+            const unichar* remaining_word,
+            int pos_in_remaining_word,
+            const unichar* decomposition,
+            const unichar* lemma_prefix,
+            struct decomposed_word_list** L,
+            int n_decomp,
+            struct rule_list* rule_list_called,
+            const struct dela_entry* dic_entr_called,
+            Dictionary* d,
+            const bool* prefix,const bool* suffix,const Alphabet* alphabet,
+            U_FILE* debug_file,struct utags UTAG,
+            vector_ptr* rules,vector_ptr* entries,Ustring* ustr,int base) {
 int final,n_transitions,inf_number;
 int z=save_output(ustr);
 offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
@@ -942,273 +942,273 @@ if (final) { // if we are in a terminal state
       struct list_ustring* l = d->inf->codes[inf_number];
       while ( l != 0 ) {
 
-//	int one_rule_already_matched = 0; // one rule matched each entry is enough
+//  int one_rule_already_matched = 0; // one rule matched each entry is enough
 
-	Ustring* entry=new_Ustring(MAX_DICT_LINE_LENGTH);
-	uncompress_entry(current_component, l->string, entry);
+    Ustring* entry=new_Ustring(MAX_DICT_LINE_LENGTH);
+    uncompress_entry(current_component, l->string, entry);
 
 #if DDEBUG > 0
-	{
-	  u_fprintf(debug_file,": %S\n",entry);
-	}
+    {
+      u_fprintf(debug_file,": %S\n",entry);
+    }
 #endif
 
-	struct dela_entry* dic_entr = new_dic_entry(entry->str,entries);
-	unichar lemma_prefix_new[MAX_DICT_LINE_LENGTH];
-	struct rule_list* rule_list_new = 0;
-	unichar next_remaining_word[MAX_WORD_LENGTH];
+    struct dela_entry* dic_entr = new_dic_entry(entry->str,entries);
+    unichar lemma_prefix_new[MAX_DICT_LINE_LENGTH];
+    struct rule_list* rule_list_new = 0;
+    unichar next_remaining_word[MAX_WORD_LENGTH];
 
-	struct rule_list* rule_list = 0;
-	if (prefix_is_valid(inf_number,prefix) || suffix_is_valid(inf_number,suffix))
-	  rule_list = parse_rules(entry->str,UTAG,rules);
-	else {
-	  rule_list = new_rule_list(rules);
-	  rule_list->rule = new_composition_rule();
-	}
-	// entry is now cleaned from rules for composition and derivation
+    struct rule_list* rule_list = 0;
+    if (prefix_is_valid(inf_number,prefix) || suffix_is_valid(inf_number,suffix))
+      rule_list = parse_rules(entry->str,UTAG,rules);
+    else {
+      rule_list = new_rule_list(rules);
+      rule_list->rule = new_composition_rule();
+    }
+    // entry is now cleaned from rules for composition and derivation
 
-	// log decomposition of word
-	// ("cleaned" entries for better overview)
-	unichar decomposition_new[MAX_DICT_LINE_LENGTH];
-	u_strcpy(decomposition_new, decomposition);
-	if (decomposition_new[0] != '\0') u_strcat(decomposition_new, " +++ ");
-	u_strcat(decomposition_new, entry->str);
+    // log decomposition of word
+    // ("cleaned" entries for better overview)
+    unichar decomposition_new[MAX_DICT_LINE_LENGTH];
+    u_strcpy(decomposition_new, decomposition);
+    if (decomposition_new[0] != '\0') u_strcat(decomposition_new, " +++ ");
+    u_strcat(decomposition_new, entry->str);
 
 
-	// loop on all composition_rules called
-	struct rule_list* called = rule_list_called;
-	do { // while ( rule_list* called != 0 )
+    // loop on all composition_rules called
+    struct rule_list* called = rule_list_called;
+    do { // while ( rule_list* called != 0 )
 
-// 	  if (one_rule_already_matched)
-// 	    break;
+//    if (one_rule_already_matched)
+//      break;
 
- 	  struct composition_rule* rule_called
-	    = ( called != 0 ) ? called->rule : 0; // may be undefined
+      struct composition_rule* rule_called
+        = ( called != 0 ) ? called->rule : 0; // may be undefined
 
-	  // loop on all actual composition_rules
-	  struct rule_list* r_list = rule_list;
- 	  while ( r_list != 0 ) {
+      // loop on all actual composition_rules
+      struct rule_list* r_list = rule_list;
+      while ( r_list != 0 ) {
 
-// 	    if (one_rule_already_matched)
-// 	      break;
+//      if (one_rule_already_matched)
+//        break;
 
-	    struct composition_rule* rule = r_list->rule; // ever defined, see upwards
+        struct composition_rule* rule = r_list->rule; // ever defined, see upwards
 
-	    if (remaining_word[pos_in_remaining_word]=='\0' &&
-		// we have explored the entire original word
-		((((dic_entr_called != 0) &&
-		   composition_rule_matches_entry(rule->before, dic_entr_called,debug_file))  &&
-		  ((rule_called != 0) &&
-		   composition_rule_matches_entry(rule_called->after, dic_entr,debug_file))) ||
-		 // and we have a valid right component, i.e. rules match
-		 ((dic_entr_called == 0) &&  // or a simple entry (i.e. no prefix),
-		  (! affix_is_valid(inf_number,prefix,suffix))) // but no affix
-		 )
-		)  {
+        if (remaining_word[pos_in_remaining_word]=='\0' &&
+        // we have explored the entire original word
+        ((((dic_entr_called != 0) &&
+           composition_rule_matches_entry(rule->before, dic_entr_called,debug_file))  &&
+          ((rule_called != 0) &&
+           composition_rule_matches_entry(rule_called->after, dic_entr,debug_file))) ||
+         // and we have a valid right component, i.e. rules match
+         ((dic_entr_called == 0) &&  // or a simple entry (i.e. no prefix),
+          (! affix_is_valid(inf_number,prefix,suffix))) // but no affix
+         )
+        )  {
 
-//	      one_rule_already_matched = 1;
+//        one_rule_already_matched = 1;
 
-	      unichar inflected[MAX_WORD_LENGTH];
-	      unichar lemma[MAX_WORD_LENGTH];
-	      unichar codes[MAX_DICT_LINE_LENGTH];
-	      tokenize_DELA_line_into_3_parts(entry->str, inflected, lemma, codes);
-	      free_Ustring(entry);
+          unichar inflected[MAX_WORD_LENGTH];
+          unichar lemma[MAX_WORD_LENGTH];
+          unichar codes[MAX_DICT_LINE_LENGTH];
+          tokenize_DELA_line_into_3_parts(entry->str, inflected, lemma, codes);
+          free_Ustring(entry);
 
-	      /* generating new lexicon entry */
-	      unichar new_dela_line[MAX_DICT_LINE_LENGTH];
+          /* generating new lexicon entry */
+          unichar new_dela_line[MAX_DICT_LINE_LENGTH];
 
-	      /* word form */
-	      u_strcpy(new_dela_line, original_word);
-	      u_strcat(new_dela_line, ",");
+          /* word form */
+          u_strcpy(new_dela_line, original_word);
+          u_strcat(new_dela_line, ",");
 
-	      /* lemma */                           // lemmatize word
-	      if (rule->then.repl[0] == '\0'	    // if there are no replace codes
-		  && (rule_called != 0              // either in actual nor in preceeding rule
-		      && rule_called->then.repl[0] == '\0')) {
-		u_strcat(new_dela_line, lemma_prefix);
-		unichar affix[MAX_WORD_LENGTH];
-		u_strcpy(affix, lemma);
-		substring_operation(affix, rule->then.substr_act);
-		if (rule_called != 0 && rule_called->then.undo_substr_next[0] != '\0')
-		  substring_operation(affix, rule_called->then.undo_substr_next);
-		u_strcat(new_dela_line, affix);
-	      } else {
-		u_strcat(new_dela_line, original_word);
-	      }
+          /* lemma */                           // lemmatize word
+          if (rule->then.repl[0] == '\0'        // if there are no replace codes
+          && (rule_called != 0              // either in actual nor in preceeding rule
+              && rule_called->then.repl[0] == '\0')) {
+        u_strcat(new_dela_line, lemma_prefix);
+        unichar affix[MAX_WORD_LENGTH];
+        u_strcpy(affix, lemma);
+        substring_operation(affix, rule->then.substr_act);
+        if (rule_called != 0 && rule_called->then.undo_substr_next[0] != '\0')
+          substring_operation(affix, rule_called->then.undo_substr_next);
+        u_strcat(new_dela_line, affix);
+          } else {
+        u_strcat(new_dela_line, original_word);
+          }
 
-	      /* codes */
-	      u_strcat(new_dela_line,".");
-	      if (rule->then.repl[0] != '\0') {            // replacing codes by
-		u_strcat(new_dela_line,rule->then.repl);   // suffix' ones
-	      }
-	      else if (rule_called == 0) { // prohibit SGV
-		u_strcat(new_dela_line,codes);
-	      }
-	      else if (rule_called->then.repl[0] != '\0') {
-		u_strcat(new_dela_line,rule_called->then.repl); // prefix' ones
-	      }
-	      // replace replaces all and blocks adding and deleting
-	      // maybe this is not optimal ???
-	      else {
-		if (rule_called->then.add[0] != '\0') {        // add codes
-		  if (!dic_entry_contain_gram_code(dic_entr, rule_called->then.add)) {
-		    bool done = 0;
-		    unichar tmp[MAX_COMPOSITION_RULE_LENGTH];
-		    int j = 0;
-		    for (int i = 0; codes[i] != '\0'; i++) {
-		      if (codes[i] == ':' && (!done)) {
-			tmp[j++] = '+';
-			tmp[j] = '\0';
-			u_strcat(new_dela_line,tmp);
-			u_strcat(new_dela_line,rule_called->then.add);
-			done = 1;
-			j = 0;
-		      }
-		      tmp[j++] = codes[i];
-		    }
-		    tmp[j] = '\0';
-		    u_strcat(new_dela_line,tmp);
-		    if (!done) {
-		      u_strcat(new_dela_line,"+");
-		      u_strcat(new_dela_line,rule_called->then.add);
-		    }
-		  } else {
-		    u_strcat(new_dela_line,codes);
-		  }
-		} else if (rule_called->then.del[0] != '\0') { // delete codes
+          /* codes */
+          u_strcat(new_dela_line,".");
+          if (rule->then.repl[0] != '\0') {            // replacing codes by
+        u_strcat(new_dela_line,rule->then.repl);   // suffix' ones
+          }
+          else if (rule_called == 0) { // prohibit SGV
+        u_strcat(new_dela_line,codes);
+          }
+          else if (rule_called->then.repl[0] != '\0') {
+        u_strcat(new_dela_line,rule_called->then.repl); // prefix' ones
+          }
+          // replace replaces all and blocks adding and deleting
+          // maybe this is not optimal ???
+          else {
+        if (rule_called->then.add[0] != '\0') {        // add codes
+          if (!dic_entry_contain_gram_code(dic_entr, rule_called->then.add)) {
+            bool done = 0;
+            unichar tmp[MAX_COMPOSITION_RULE_LENGTH];
+            int j = 0;
+            for (int i = 0; codes[i] != '\0'; i++) {
+              if (codes[i] == ':' && (!done)) {
+            tmp[j++] = '+';
+            tmp[j] = '\0';
+            u_strcat(new_dela_line,tmp);
+            u_strcat(new_dela_line,rule_called->then.add);
+            done = 1;
+            j = 0;
+              }
+              tmp[j++] = codes[i];
+            }
+            tmp[j] = '\0';
+            u_strcat(new_dela_line,tmp);
+            if (!done) {
+              u_strcat(new_dela_line,"+");
+              u_strcat(new_dela_line,rule_called->then.add);
+            }
+          } else {
+            u_strcat(new_dela_line,codes);
+          }
+        } else if (rule_called->then.del[0] != '\0') { // delete codes
 
-		} else {
-		  u_strcat(new_dela_line,codes);
-		}
-	      }
+        } else {
+          u_strcat(new_dela_line,codes);
+        }
+          }
 
 #if DDEBUG > 0
-	      {
+          {
             u_fprintf(debug_file,"= %S\n",new_dela_line);
-	      }
+          }
 #endif
 
-	      struct decomposed_word* wd = new_decomposed_word();
-	      wd->n_parts = n_decomp;
-	      u_strcpy(wd->decomposition,decomposition_new);
-	      u_strcpy(wd->dela_line,new_dela_line);
-	      struct decomposed_word_list* wdl=new_decomposed_word_list();
-	      // unshift actual decomposition to decomposition list L
-	      wdl->element = wd;
-	      wdl->suivant = (*L);
-	      (*L) = wdl;
+          struct decomposed_word* wd = new_decomposed_word();
+          wd->n_parts = n_decomp;
+          u_strcpy(wd->decomposition,decomposition_new);
+          u_strcpy(wd->dela_line,new_dela_line);
+          struct decomposed_word_list* wdl=new_decomposed_word_list();
+          // unshift actual decomposition to decomposition list L
+          wdl->element = wd;
+          wdl->suivant = (*L);
+          (*L) = wdl;
 
-	    } // end if end of word and valid right component
-	    else if
-	      // beginning or middle of word: explore the rest of the original word
-	      (prefix_is_valid(inf_number,prefix) &&
-	       check_is_valid(UTAG.PREFIX, dic_entr) &&
-	       // but only if the current component was a valid left one
-	       // we go on with the next component
-	       (
-		(n_decomp == 1) // prefix as first part of a word: no rule matching
-		||
-		(               // prefix in the middle of a word
-		 (rule_called &&
-		  composition_rule_matches_entry(rule_called->after, dic_entr,debug_file)) &&
-		 (dic_entr_called &&
-		  composition_rule_matches_entry(rule->before, dic_entr_called,debug_file))
-		)
-	       )) {
+        } // end if end of word and valid right component
+        else if
+          // beginning or middle of word: explore the rest of the original word
+          (prefix_is_valid(inf_number,prefix) &&
+           check_is_valid(UTAG.PREFIX, dic_entr) &&
+           // but only if the current component was a valid left one
+           // we go on with the next component
+           (
+        (n_decomp == 1) // prefix as first part of a word: no rule matching
+        ||
+        (               // prefix in the middle of a word
+         (rule_called &&
+          composition_rule_matches_entry(rule_called->after, dic_entr,debug_file)) &&
+         (dic_entr_called &&
+          composition_rule_matches_entry(rule->before, dic_entr_called,debug_file))
+        )
+           )) {
 
-//	      one_rule_already_matched = 1;
+//        one_rule_already_matched = 1;
 
-	      u_strcpy(lemma_prefix_new, lemma_prefix);
-	      unichar affix[MAX_WORD_LENGTH];
-	      u_strcpy(affix, current_component);
-	      if (rule_called != 0 && rule_called->then.undo_substr_next[0] != '\0') {
+          u_strcpy(lemma_prefix_new, lemma_prefix);
+          unichar affix[MAX_WORD_LENGTH];
+          u_strcpy(affix, current_component);
+          if (rule_called != 0 && rule_called->then.undo_substr_next[0] != '\0') {
             substring_operation(affix, rule_called->then.undo_substr_next);
             u_fprintf(debug_file,"yes\n");
-	      }
-	      substring_operation(affix, rule->then.substr_act);
-	      u_strcat(lemma_prefix_new, affix);
-	      int j = 0;
-	      for (int i = pos_in_remaining_word; remaining_word[i] != '\0'; i++) {
+          }
+          substring_operation(affix, rule->then.substr_act);
+          u_strcat(lemma_prefix_new, affix);
+          int j = 0;
+          for (int i = pos_in_remaining_word; remaining_word[i] != '\0'; i++) {
             next_remaining_word[j++] = remaining_word[i];
          }
-	      next_remaining_word[j] = '\0';
-	      if (rule->then.substr_next[0] != '\0') {
+          next_remaining_word[j] = '\0';
+          if (rule->then.substr_next[0] != '\0') {
             substring_operation(next_remaining_word, rule->then.substr_next);
 #if DDEBUG > 0
             {
                u_fprintf(debug_file,"| %S|%S\n",affix,next_remaining_word);
             }
 #endif
-	      }
+          }
 
 #if DDEBUG > 0
-	      {
+          {
             u_fprintf(debug_file,"- %S\n",entry);
-	      }
+          }
 #endif
-	      struct rule_list* tmp = new_rule_list(rules);
-	      tmp->rule = new_composition_rule();
-	      copy_composition_rule(tmp->rule, rule);
-	      tmp->next = 0;
-	      if ( rule_list_new == 0 ) {
+          struct rule_list* tmp = new_rule_list(rules);
+          tmp->rule = new_composition_rule();
+          copy_composition_rule(tmp->rule, rule);
+          tmp->next = 0;
+          if ( rule_list_new == 0 ) {
             rule_list_new = tmp;
-	      }
-	      else {
+          }
+          else {
             struct rule_list* trl = rule_list_new;
             while ( trl->next != 0 ) {
                trl=trl->next;
             }
             trl->next = tmp;
-	      }
+          }
 
-	    }
-	    else {
-	      // no valid suffix nor prefix
-	    }
+        }
+        else {
+          // no valid suffix nor prefix
+        }
 
-	    r_list = r_list->next;
-	  } // while ( rule_list* r_list != 0 )
+        r_list = r_list->next;
+      } // while ( rule_list* r_list != 0 )
 
-	  if ( called != 0 )
-	    called = called->next;
-	} while ( called != 0 );
+      if ( called != 0 )
+        called = called->next;
+    } while ( called != 0 );
 
-	// prefix found, try to decomposite rest of word
-	if ( rule_list_new != 0 && dic_entr != 0 ) {
-	  unichar next_component[MAX_WORD_LENGTH];
+    // prefix found, try to decomposite rest of word
+    if ( rule_list_new != 0 && dic_entr != 0 ) {
+      unichar next_component[MAX_WORD_LENGTH];
 #if DDEBUG > 0
-	  {
-	    u_fprintf(debug_file,"> %S\n",next_remaining_word);
-	  }
+      {
+        u_fprintf(debug_file,"> %S\n",next_remaining_word);
+      }
 #endif
-	  Ustring* foo=new_Ustring();
-	  explore_state(d->initial_state_offset,
-			next_component,
-			0,
-			original_word,
-			next_remaining_word,
-			0,
-			decomposition_new,
-			lemma_prefix_new,
-			L,
-			n_decomp+1,
-			rule_list_new,
-			dic_entr,
-			d,prefix,suffix,alphabet,debug_file,UTAG,rules,entries,foo,0);
-	  free_Ustring(foo);
-	}
-	else {
-// 	  free_dic_entry(dic_entr);
-// 	  free_rule_list(rule_list);
-	}
+      Ustring* foo=new_Ustring();
+      explore_state(d->initial_state_offset,
+            next_component,
+            0,
+            original_word,
+            next_remaining_word,
+            0,
+            decomposition_new,
+            lemma_prefix_new,
+            L,
+            n_decomp+1,
+            rule_list_new,
+            dic_entr,
+            d,prefix,suffix,alphabet,debug_file,UTAG,rules,entries,foo,0);
+      free_Ustring(foo);
+    }
+    else {
+//    free_dic_entry(dic_entr);
+//    free_rule_list(rule_list);
+    }
 
-	l = l->next;
+    l = l->next;
 
       } // end of while (token_list* l != 0)
 
     } // end of word length >= 1
   }
-	base=ustr->len;
+    base=ustr->len;
   if (remaining_word[pos_in_remaining_word]=='\0') {
     // if we have finished, we return
 //     free_dic_entry(dic_entr_called);
@@ -1219,23 +1219,23 @@ if (final) { // if we are in a terminal state
   unichar c;
   int adr;
   for (int i=0;i<n_transitions;i++) {
-	  offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
+      offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
     if (is_equal_or_uppercase(c,remaining_word[pos_in_remaining_word],alphabet)
-	|| is_equal_or_uppercase(remaining_word[pos_in_remaining_word],c,alphabet)) {
+    || is_equal_or_uppercase(remaining_word[pos_in_remaining_word],c,alphabet)) {
       current_component[pos_in_current_component] = c;
       explore_state(adr,
-		    current_component,
-		    pos_in_current_component+1,
-		    original_word,
-		    remaining_word,
-		    pos_in_remaining_word+1,
-		    decomposition,
-		    lemma_prefix,
-		    L,
-		    n_decomp,
-		    rule_list_called,
-		    dic_entr_called,
-		    d,prefix,suffix,alphabet,debug_file,UTAG,rules,entries,ustr,base);
+            current_component,
+            pos_in_current_component+1,
+            original_word,
+            remaining_word,
+            pos_in_remaining_word+1,
+            decomposition,
+            lemma_prefix,
+            L,
+            n_decomp,
+            rule_list_called,
+            dic_entr_called,
+            d,prefix,suffix,alphabet,debug_file,UTAG,rules,entries,ustr,base);
     }
     restore_output(z,ustr);
   }

--- a/GermanCompounds.cpp
+++ b/GermanCompounds.cpp
@@ -225,7 +225,7 @@ correct_word[0]='\0';
 struct german_word_decomposition_list* l=NULL;
 Ustring* ustr=new_Ustring();
 explore_state_german(d->initial_state_offset,correct_word,0,mot,0,decomposition,dela_line,&l,1,
-		left,right,alphabet,d,ustr,0);
+        left,right,alphabet,d,ustr,0);
 free_Ustring(ustr);
 if (l==NULL) {
    return 0;
@@ -408,7 +408,7 @@ if (original_word[pos_in_original_word]=='\0') {
 unichar c;
 int adr;
 for (int i=0;i<n_transitions;i++) {
-	offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
+    offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
   if (is_equal_or_uppercase(c,original_word[pos_in_original_word],alphabet)
       || is_equal_or_uppercase(original_word[pos_in_original_word],c,alphabet)) {
     current_component[pos_in_current_component]=c;

--- a/Grf2Fst2.cpp
+++ b/Grf2Fst2.cpp
@@ -259,8 +259,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Grf2Fst2,lopts_Grf2Fst2,
    case 'd': strcpy(infos->repository,options.vars()->optarg); break;
    case 1: infos->debug=1; break;
    case 'V': only_verify_arguments = true;
-             break;   
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Grf2Fst2[index].name);
@@ -271,7 +271,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Grf2Fst2,lopts_Grf2Fst2,
                 error("Empty input_encoding argument\n");
                 free(named);
                 free_compilation_info(infos);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(infos->vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
@@ -279,7 +279,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Grf2Fst2,lopts_Grf2Fst2,
                 error("Empty output_encoding argument\n");
                 free(named);
                 free_compilation_info(infos);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(infos->vec.encoding_output),&(infos->vec.bom_output),options.vars()->optarg);
              break;
@@ -316,13 +316,13 @@ if (options.vars()->optind!=argc-1) {
    error("Invalid arguments: rerun with --help\n");
    free(named);
    free_compilation_info(infos);
-   return USAGE_ERROR_CODE;  
+   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
   // freeing all allocated memory
   free(named);
-  free_compilation_info(infos);  
+  free_compilation_info(infos);
   return SUCCESS_RETURN_CODE;
 }
 
@@ -334,7 +334,7 @@ if (alph[0]!='\0') {
   if (infos->alphabet==NULL) {
     error("Cannot load alphabet file %s\n",alph);
     free_compilation_info(infos);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 
@@ -347,7 +347,7 @@ if ((infos->fst2=u_fopen(&(infos->vec),fst2_file_name,U_WRITE))==NULL) {
    error("Cannot open file %s\n",fst2_file_name);
    free_alphabet(infos->alphabet);
    free_compilation_info(infos);
-   return DEFAULT_ERROR_CODE; 
+   return DEFAULT_ERROR_CODE;
 }
 u_fprintf(infos->fst2,"0000000000\n");
 int result=compile_grf(argv[options.vars()->optind],infos);

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -54,11 +54,11 @@ namespace unitex {
 
 
 static size_t around_needed_size(size_t needed_size) {
-	size_t alloc_size = 256;
-	while (alloc_size < needed_size) {
-		alloc_size *= 2;
-	}
-	return alloc_size;
+    size_t alloc_size = 256;
+    while (alloc_size < needed_size) {
+        alloc_size *= 2;
+    }
+    return alloc_size;
 }
 
 
@@ -67,49 +67,49 @@ static size_t around_needed_size(size_t needed_size) {
  * Allocates and Reallocate , initializes and returns a compilation information structure.
  */
 static void reallocate_int_buffer(int** buffer, size_t *buffer_allocated_size, size_t needed_size) {
-	if (needed_size <= (*buffer_allocated_size)) {
-		return;
-	}
-	size_t new_alloc_size = around_needed_size(needed_size);
-	int* new_buffer = ((*buffer) == NULL) ? ((int*)malloc(new_alloc_size*sizeof(int))) :
-		                                    ((int*)realloc(*buffer, new_alloc_size*sizeof(int)));
-	if (new_buffer == NULL) {
-		fatal_alloc_error("reallocate_int_buffer");
-	}
-	*buffer = new_buffer;
-	*buffer_allocated_size = new_alloc_size;
+    if (needed_size <= (*buffer_allocated_size)) {
+        return;
+    }
+    size_t new_alloc_size = around_needed_size(needed_size);
+    int* new_buffer = ((*buffer) == NULL) ? ((int*)malloc(new_alloc_size*sizeof(int))) :
+                                            ((int*)realloc(*buffer, new_alloc_size*sizeof(int)));
+    if (new_buffer == NULL) {
+        fatal_alloc_error("reallocate_int_buffer");
+    }
+    *buffer = new_buffer;
+    *buffer_allocated_size = new_alloc_size;
 }
 
 static void free_reallocate_int_buffer(int** buffer)
 {
-	if ((*buffer) != NULL) {
-		free(*buffer);
-	}
-	*buffer = NULL;
+    if ((*buffer) != NULL) {
+        free(*buffer);
+    }
+    *buffer = NULL;
 }
 
 
 static inline void reallocate_unichar_buffer(unichar** buffer, size_t *buffer_allocated_size, size_t needed_size) {
-	if (needed_size <= (*buffer_allocated_size)) {
-		return;
-	}
-	size_t new_alloc_size = around_needed_size(needed_size);
-	unichar* new_buffer = ((*buffer) == NULL) ? ((unichar*)malloc(new_alloc_size*sizeof(unichar))) :
-		((unichar*)realloc(*buffer, new_alloc_size*sizeof(unichar)));
-	if (new_buffer == NULL) {
-		fatal_alloc_error("reallocate_unichar_buffer");
-	}
-	*buffer = new_buffer;
-	*buffer_allocated_size = new_alloc_size;
+    if (needed_size <= (*buffer_allocated_size)) {
+        return;
+    }
+    size_t new_alloc_size = around_needed_size(needed_size);
+    unichar* new_buffer = ((*buffer) == NULL) ? ((unichar*)malloc(new_alloc_size*sizeof(unichar))) :
+        ((unichar*)realloc(*buffer, new_alloc_size*sizeof(unichar)));
+    if (new_buffer == NULL) {
+        fatal_alloc_error("reallocate_unichar_buffer");
+    }
+    *buffer = new_buffer;
+    *buffer_allocated_size = new_alloc_size;
 }
 
 
 static inline void free_reallocate_unichar_buffer(unichar** buffer)
 {
-	if ((*buffer) != NULL) {
-		free(*buffer);
-	}
-	*buffer = NULL;
+    if ((*buffer) != NULL) {
+        free(*buffer);
+    }
+    *buffer = NULL;
 }
 
 #if (!(defined(DEBUGGING_ALLOCATE))) && (defined(_DEBUG) || (defined(DEBUG)) || defined(VALGRIND_DBG))
@@ -119,38 +119,38 @@ static inline void free_reallocate_unichar_buffer(unichar** buffer)
 #ifdef DEBUGGING_ALLOCATE
 
 static unichar* choose_allocated_or_stack_unichar_buffer(unichar* /*stack_buffer*/, size_t /*stack_buffer_size*/, size_t needed_size) {
-	unsigned char* buf_allocate = (unsigned char*)malloc((needed_size*sizeof(unichar)) + sizeof(size_t));
-	*((size_t*)buf_allocate) = needed_size;
-	unichar* ret_buffer = (unichar*)(buf_allocate + sizeof(size_t));
-	return ret_buffer;
+    unsigned char* buf_allocate = (unsigned char*)malloc((needed_size*sizeof(unichar)) + sizeof(size_t));
+    *((size_t*)buf_allocate) = needed_size;
+    unichar* ret_buffer = (unichar*)(buf_allocate + sizeof(size_t));
+    return ret_buffer;
 }
 
 static void free_choosen_allocated_or_stack_unichar_buffer(unichar* used_buffer, unichar* /*stack_buffer*/) {
-	unsigned char* buf_allocate = ((unsigned char*)used_buffer)-sizeof(size_t);
-	size_t needed_size = *((size_t*)buf_allocate);
-	size_t len_string = u_strlen(used_buffer);
-	if (len_string >= needed_size) {
-		fatal_error("buffer smaller than expected on free_choosen_allocated_or_stack_unichar_buffer\n");
-	}
-	free(buf_allocate);
+    unsigned char* buf_allocate = ((unsigned char*)used_buffer)-sizeof(size_t);
+    size_t needed_size = *((size_t*)buf_allocate);
+    size_t len_string = u_strlen(used_buffer);
+    if (len_string >= needed_size) {
+        fatal_error("buffer smaller than expected on free_choosen_allocated_or_stack_unichar_buffer\n");
+    }
+    free(buf_allocate);
 }
 #else
 // uses DEFAULT_UNICHAR_TMP_BUFFER_SIZE
 static unichar* choose_allocated_or_stack_unichar_buffer(unichar* stack_buffer, size_t stack_buffer_size, size_t needed_size) {
-	if (needed_size < stack_buffer_size)
-		return stack_buffer;
-	unichar* allocated_buffer = (unichar*)malloc(needed_size * sizeof(unichar));
-	if (allocated_buffer == NULL) {
-		fatal_alloc_error("reallocate_unichar_buffer");
-	}
-	return allocated_buffer;
+    if (needed_size < stack_buffer_size)
+        return stack_buffer;
+    unichar* allocated_buffer = (unichar*)malloc(needed_size * sizeof(unichar));
+    if (allocated_buffer == NULL) {
+        fatal_alloc_error("reallocate_unichar_buffer");
+    }
+    return allocated_buffer;
 }
 
 
 static inline void free_choosen_allocated_or_stack_unichar_buffer(unichar* used_buffer, unichar* stack_buffer) {
-	if ((used_buffer != stack_buffer) && (used_buffer != NULL)) {
-		free(used_buffer);
-	}
+    if ((used_buffer != stack_buffer) && (used_buffer != NULL)) {
+        free(used_buffer);
+    }
 }
 #endif
 
@@ -245,13 +245,13 @@ u_fprintf(f," \n");
 void write_graph(U_FILE* f,SingleGraph graph,int n,unichar* name,char* full_name) {
 u_fprintf(f,"%d ",n);
 while ((*name)!='\0' && (*name)!=2) {
-	u_fputc(*name,f);
-	name++;
+    u_fputc(*name,f);
+    name++;
 }
 if (full_name!=NULL) {
-	/* In debug mode, we add the full file name, separated by char #1,
-	 * but if the graph is empty, we don't print the full name */
-	u_fprintf(f,"%C%s",1,(graph->number_of_states==0)?"":full_name);
+    /* In debug mode, we add the full file name, separated by char #1,
+     * but if the graph is empty, we don't print the full name */
+    u_fprintf(f,"%C%s",1,(graph->number_of_states==0)?"":full_name);
 }
 u_fprintf(f,"\n");
 /* By convention, the empty automaton is represented by an initial state with no
@@ -312,37 +312,37 @@ int abs_path_name_warning=0; // 1 windows, 2 unix
 temp[0]='\0'; // necessary if we have an absolute path name
 int shift=0;
 if (infos->graph_names->value[n][0]==':') {
-	shift++;
-	if (infos->graph_names->value[n][1]=='$') {
-		/* If we have a graph call using a named repository */
-		shift++;
-		Ustring* foo=new_Ustring();
-		for (unichar* s=infos->graph_names->value[n]+shift;(*s!=':' && *s!='/' && *s!='\\' && *s!=0x02);s++,shift++) {
-			if (!is_variable_char(*s)) {
-				fatal_error("Invalid repository name in graph call: %S\n",infos->graph_names->value[n]);
-			}
-			u_strcat(foo,*s);
-		}
-		/* We skip the final file separator */
-		shift++;
-		int index=get_value_index(foo->str,infos->named_repositories,DONT_INSERT);
-		if (index==-1) {
-			fatal_error("Undefined repository name: %S\n",foo->str);
-		}
-		char* repository=(char*)(infos->named_repositories->value[index]);
-		u_strcpy(temp,repository);
-		free_Ustring(foo);
-	} else {
-		/* If the graph is located in the default repository, then we must test if
-		 * the repository is defined. If not, an absolute path is tried
-		 * starting with '/' resp. '\\'. This enables absolute path names
-		 * under Unixes. */
-		u_strcpy(temp,infos->repository);
-		if (infos->repository[0]=='\0') {
-			abs_path_name_warning=2;
-		}
-	}
-	offset=(int)u_strlen(temp);
+    shift++;
+    if (infos->graph_names->value[n][1]=='$') {
+        /* If we have a graph call using a named repository */
+        shift++;
+        Ustring* foo=new_Ustring();
+        for (unichar* s=infos->graph_names->value[n]+shift;(*s!=':' && *s!='/' && *s!='\\' && *s!=0x02);s++,shift++) {
+            if (!is_variable_char(*s)) {
+                fatal_error("Invalid repository name in graph call: %S\n",infos->graph_names->value[n]);
+            }
+            u_strcat(foo,*s);
+        }
+        /* We skip the final file separator */
+        shift++;
+        int index=get_value_index(foo->str,infos->named_repositories,DONT_INSERT);
+        if (index==-1) {
+            fatal_error("Undefined repository name: %S\n",foo->str);
+        }
+        char* repository=(char*)(infos->named_repositories->value[index]);
+        u_strcpy(temp,repository);
+        free_Ustring(foo);
+    } else {
+        /* If the graph is located in the default repository, then we must test if
+         * the repository is defined. If not, an absolute path is tried
+         * starting with '/' resp. '\\'. This enables absolute path names
+         * under Unixes. */
+        u_strcpy(temp,infos->repository);
+        if (infos->repository[0]=='\0') {
+            abs_path_name_warning=2;
+        }
+    }
+    offset=(int)u_strlen(temp);
 }
 #ifndef _NOT_UNDER_WINDOWS
 else if (test4abs_windows_path_name(infos->graph_names->value[n])) {
@@ -363,12 +363,12 @@ else {
 }
 int l=u_strlen(temp)-1;
 if (l>=0 && temp[l]!=':' && temp[l]!='/' && temp[l]!='\\') {
-	u_strcat(temp,":");
+    u_strcat(temp,":");
 }
 u_strcat(temp,infos->graph_names->value[n]+shift);
 int pos2=u_strrchr(temp,(unichar)0x02);
 if (pos2!=-1) {
-	temp[pos2]='\0';
+    temp[pos2]='\0';
 }
 u_strcat(temp,".grf");
 /* Finally, we turn the file name into ISO-8859-1 */
@@ -649,14 +649,14 @@ if (u_ends_with(dest,".grf")) {
  */
 static int only_spaces(const unichar* input,int *pos) {
 if (*pos!=0 || input[0]=='\0') {
-	return 0;
+    return 0;
 }
 int f=0;
 while (input[f]==' ') {
-	f++;
+    f++;
 }
 if (input[f]!='\0') {
-	return 0;
+    return 0;
 }
 *pos=f;
 return 1;
@@ -675,8 +675,8 @@ static int process_box_line_token(const unichar* input,int *pos,
                                   struct fifo* tokens,
                                   int n,struct compilation_info* infos) {
 if (only_spaces(input,pos)) {
-	put_ptr(tokens,u_strdup("<E>"));
-	return 0;
+    put_ptr(tokens,u_strdup("<E>"));
+    return 0;
 }
 if (input[*pos]=='\0') {
    fatal_error("Empty string in process_box_line_token\n");
@@ -728,7 +728,7 @@ if (input[*pos]=='+') {
 if (input[*pos]==' ') {
    (*pos)++;
    if (infos->strict_tokenization) {
-	   put_ptr(tokens,u_strdup(" "));
+       put_ptr(tokens,u_strdup(" "));
    }
    return 0;
 }
@@ -744,8 +744,8 @@ if (input[*pos]=='\\') {
       /* If we have \x where x is not a \ neither a " */
       get_character(input,pos,token);
       if (token[0]=='#') {
-    	  /* Special case of \# that must be compiled as "#" */
-    	  u_strcpy(token,"@#");
+          /* Special case of \# that must be compiled as "#" */
+          u_strcpy(token,"@#");
       }
       put_ptr(tokens,u_strdup(token));
       return 0;
@@ -815,24 +815,24 @@ unichar* token=(unichar*)take_ptr(u_tokens);
 unichar tmp_stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
 int is_an_output=(output!=NULL && output[0]!='\0');
 if (!must_keep_output && is_an_output && !u_strcmp(token,"<E>") && output[1]==DEBUG_INFO_COORD_MARK) {
-	/* We don't want to produce debug outputs for <E> that had no actual
-	 * outputs, in order not to introduce <E> loop mess, but we want to keep
-	 * <E> associated to metas symbols $a( $< ... */
-	is_an_output=0;
+    /* We don't want to produce debug outputs for <E> that had no actual
+     * outputs, in order not to introduce <E> loop mess, but we want to keep
+     * <E> associated to metas symbols $a( $< ... */
+    is_an_output=0;
 }
 if (token[0]==':' && token[1]!='\0') {
    /* If we have a subgraph call */
-	int graph_number=get_value_index(&(token[1]),infos->graph_names);
-	if (infos->debug) {
-		/* In debug mode, we generate two <E> tags: one before and
-		 * one after the graph call */
-		unichar* tmp=choose_allocated_or_stack_unichar_buffer(tmp_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE,u_strlen(output)+0x80);
-		create_graph_call_debug_tag(tmp,output,graph_number,1);
-		reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens)+1);
-		i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
-		free_choosen_allocated_or_stack_unichar_buffer(tmp,tmp_stack);
-	}
-	else if (is_an_output) {
+    int graph_number=get_value_index(&(token[1]),infos->graph_names);
+    if (infos->debug) {
+        /* In debug mode, we generate two <E> tags: one before and
+         * one after the graph call */
+        unichar* tmp=choose_allocated_or_stack_unichar_buffer(tmp_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE,u_strlen(output)+0x80);
+        create_graph_call_debug_tag(tmp,output,graph_number,1);
+        reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens)+1);
+        i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
+        free_choosen_allocated_or_stack_unichar_buffer(tmp,tmp_stack);
+    }
+    else if (is_an_output) {
       error("WARNING in %S: ignoring output associated to subgraph call %S\n",
             infos->graph_names->value[current_graph],token);
    }
@@ -843,15 +843,15 @@ if (token[0]==':' && token[1]!='\0') {
    reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens) + 1);
    i_tokens[(*n_tokens)++]=-graph_number;
    free(token);
-	if (infos->debug) {
-		/* In debug mode, we generate two <E> tags: one before and
-		 * one after the graph call */
-		unichar* tmp=choose_allocated_or_stack_unichar_buffer(tmp_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE,u_strlen(output)+0x80);
-		create_graph_call_debug_tag(tmp,output,graph_number,0);
-		reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens) + 1);
-		i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
-		free_choosen_allocated_or_stack_unichar_buffer(tmp,tmp_stack);
-	}
+    if (infos->debug) {
+        /* In debug mode, we generate two <E> tags: one before and
+         * one after the graph call */
+        unichar* tmp=choose_allocated_or_stack_unichar_buffer(tmp_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE,u_strlen(output)+0x80);
+        create_graph_call_debug_tag(tmp,output,graph_number,0);
+        reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens) + 1);
+        i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
+        free_choosen_allocated_or_stack_unichar_buffer(tmp,tmp_stack);
+    }
    return i_tokens;
 }
 if (is_an_output) {
@@ -860,16 +860,16 @@ if (is_an_output) {
    u_sprintf(tmp,"%S/%S",token,output);
    /* In debug mode, we have to add the input */
    if (infos->debug && must_add_token_to_debug) {
-	   int start=0;
-	   if (token[0]=='@' && token[1]!='\0') {
-		   /* double-quoted token are prefixed by @, so we have to remove this
-		    * @ in the debug output */
-		   start++;
-	   }
-	   u_strcat(tmp,token+start);
-	   int size=u_strlen(tmp);
-	   tmp[size]=DEBUG_INFO_END_MARK;
-	   tmp[size+1]='\0';
+       int start=0;
+       if (token[0]=='@' && token[1]!='\0') {
+           /* double-quoted token are prefixed by @, so we have to remove this
+            * @ in the debug output */
+           start++;
+       }
+       u_strcat(tmp,token+start);
+       int size=u_strlen(tmp);
+       tmp[size]=DEBUG_INFO_END_MARK;
+       tmp[size+1]='\0';
    }
    reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens) + 1);
    i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
@@ -886,30 +886,30 @@ while (!is_empty(u_tokens)) {
    if (token[0]==':' && token[1]!='\0') {
       fatal_error("%S: unexpected subgraph call in token_sequence_2_integer_sequence\n",
             infos->graph_names->value[current_graph]);
-	  break;
+      break;
    }
    unichar* tmp = choose_allocated_or_stack_unichar_buffer(tmp_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, (u_strlen(token) * 2) + u_strlen(output) + 0x80);
    u_sprintf(tmp,"%S",token);
    if (infos->debug) {
-	   /* In debug mode, we have to add an output, but only the part with the
-	    * debug info */
-	   u_strcat(tmp,"/");
-	   unichar foo[2]={DEBUG_INFO_OUTPUT_MARK,0};
-	   u_strcat(tmp,foo);
-	   int i;
-	   for (i=u_strlen(output)-1;output[i]!=DEBUG_INFO_COORD_MARK;i--) {
-	   }
-	   u_strcat(tmp,output+i);
-	   int start=0;
-	   if (token[0]=='@' && token[1]!='\0') {
-		   /* double-quoted token are prefixed by @, so we have to remove this
-		    * @ in the debug output */
-		   start++;
-	   }
-	   u_strcat(tmp,token+start);
-	   int size=u_strlen(tmp);
-	   tmp[size]=DEBUG_INFO_END_MARK;
-	   tmp[size+1]='\0';
+       /* In debug mode, we have to add an output, but only the part with the
+        * debug info */
+       u_strcat(tmp,"/");
+       unichar foo[2]={DEBUG_INFO_OUTPUT_MARK,0};
+       u_strcat(tmp,foo);
+       int i;
+       for (i=u_strlen(output)-1;output[i]!=DEBUG_INFO_COORD_MARK;i--) {
+       }
+       u_strcat(tmp,output+i);
+       int start=0;
+       if (token[0]=='@' && token[1]!='\0') {
+           /* double-quoted token are prefixed by @, so we have to remove this
+            * @ in the debug output */
+           start++;
+       }
+       u_strcat(tmp,token+start);
+       int size=u_strlen(tmp);
+       tmp[size]=DEBUG_INFO_END_MARK;
+       tmp[size+1]='\0';
    }
    reallocate_int_buffer(&i_tokens, &size_alloc_i_token, (*n_tokens) + 1);
    i_tokens[(*n_tokens)++]=get_value_index(tmp,infos->tags);
@@ -945,20 +945,20 @@ for (int i=0;i<transitions->nbelems;i++) {
 static struct fifo* insert_sharp_tags(struct fifo* fifo) {
 struct fifo* res=new_fifo();
 if (is_empty(fifo)) {
-	fatal_error("Unexpected empty fifo in insert_sharp_tags");
+    fatal_error("Unexpected empty fifo in insert_sharp_tags");
 }
 unichar* ptr=(unichar*)take_ptr(fifo);
 put_ptr(res,ptr);
 int last_token_was_normal=u_strcmp(ptr,"#") && u_strcmp(ptr,"@ ") && u_strcmp(ptr," ");
 int current_token_is_normal;
 while (!is_empty(fifo)) {
-	ptr=(unichar*)take_ptr(fifo);
-	current_token_is_normal=u_strcmp(ptr,"#") && u_strcmp(ptr,"@ ") && u_strcmp(ptr," ");
-	if (last_token_was_normal && current_token_is_normal) {
-		put_ptr(res,u_strdup("#"));
-	}
-	put_ptr(res,ptr);
-	last_token_was_normal=current_token_is_normal;
+    ptr=(unichar*)take_ptr(fifo);
+    current_token_is_normal=u_strcmp(ptr,"#") && u_strcmp(ptr,"@ ") && u_strcmp(ptr," ");
+    if (last_token_was_normal && current_token_is_normal) {
+        put_ptr(res,u_strdup("#"));
+    }
+    put_ptr(res,ptr);
+    last_token_was_normal=current_token_is_normal;
 }
 
 
@@ -985,21 +985,21 @@ while (result==0 && input[*pos]!='\0') {
    result=process_box_line_token(input,pos,sequence,n,infos);
 }
 if (infos->strict_tokenization) {
-	/* If needed, we insert # tags where there were no spaces */
-	sequence=insert_sharp_tags(sequence);
+    /* If needed, we insert # tags where there were no spaces */
+    sequence=insert_sharp_tags(sequence);
 }
 int* sequence_ent;
 int n_tokens;
 if (!infos->debug) {
-	sequence_ent=token_sequence_2_integer_sequence(sequence,output,infos,&n_tokens,n,1,0);
+    sequence_ent=token_sequence_2_integer_sequence(sequence,output,infos,&n_tokens,n,1,0);
 } else {
-	unichar output2stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
-	// added debug info take less than 80 unichar
-	unichar*output2 = choose_allocated_or_stack_unichar_buffer(output2stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, u_strlen(output) + 0x80);
-	u_strcpy(output2,output);
-	add_debug_infos(output2,n,state->box_number,line);
-	sequence_ent=token_sequence_2_integer_sequence(sequence,output2,infos,&n_tokens,n,1,0);
-	free_choosen_allocated_or_stack_unichar_buffer(output2, output2stack);
+    unichar output2stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
+    // added debug info take less than 80 unichar
+    unichar*output2 = choose_allocated_or_stack_unichar_buffer(output2stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, u_strlen(output) + 0x80);
+    u_strcpy(output2,output);
+    add_debug_infos(output2,n,state->box_number,line);
+    sequence_ent=token_sequence_2_integer_sequence(sequence,output2,infos,&n_tokens,n,1,0);
+    free_choosen_allocated_or_stack_unichar_buffer(output2, output2stack);
 }
 free_fifo(sequence);
 write_transitions(graph,sequence_ent,transitions,current_state,n_tokens);
@@ -1020,11 +1020,11 @@ int token[2];
 int i;
 int n=0;
 if (debug_output[0]!='\0' && u_strcmp(input,"$]")) {
-	put_ptr(tmp,u_strdup("<E>"));
-	int* i_token1=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
-	*(token + n) = *i_token1;
-	n++;
-	free_reallocate_int_buffer(&i_token1);
+    put_ptr(tmp,u_strdup("<E>"));
+    int* i_token1=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
+    *(token + n) = *i_token1;
+    n++;
+    free_reallocate_int_buffer(&i_token1);
 }
 put_ptr(tmp,u_strdup(input));
 int* i_token2=token_sequence_2_integer_sequence(tmp,NULL,infos,&i,current_graph,0,0);
@@ -1032,11 +1032,11 @@ int* i_token2=token_sequence_2_integer_sequence(tmp,NULL,infos,&i,current_graph,
 n++;
 free_reallocate_int_buffer(&i_token2);
 if (debug_output[0]!='\0' && !u_strcmp(input,"$]")) {
-	put_ptr(tmp,u_strdup("<E>"));
-	int* i_token3=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
-	*(token + n) = *i_token3;
-	n++;
-	free_reallocate_int_buffer(&i_token3);
+    put_ptr(tmp,u_strdup("<E>"));
+    int* i_token3=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
+    *(token + n) = *i_token3;
+    n++;
+    free_reallocate_int_buffer(&i_token3);
 }
 free_fifo(tmp);
 write_transitions(graph,token,transitions,current_state,n);
@@ -1050,85 +1050,85 @@ write_transitions(graph,token,transitions,current_state,n);
  * if not.
  */
 static void check_dollar_sequence(int current_graph,struct compilation_info* infos,
-									unichar* s) {
+                                    unichar* s) {
 int foo;
 unichar c;
 unichar* ptr=s;
 if (s[0]=='\0') {
-	/* $$ is fine */
-	return;
+    /* $$ is fine */
+    return;
 }
 if (u_sscanf(s,"{%d}%C",&foo,&c)==1) {
-	/* If we have a valid weight sequence */
-	return;
+    /* If we have a valid weight sequence */
+    return;
 }
 /* Any other sequence should start with a variable name */
 while (is_variable_char(*s)) {s++;}
 if (*s=='\0') {
-	/* $a$ is fine */
-	return;
+    /* $a$ is fine */
+    return;
 }
 if (*s!='.') {
-	char name[FILENAME_MAX];
-	get_absolute_name(NULL,name,current_graph,infos);
-	fatal_error("Graph %s: invalid $...$ sequence in output:\n$%S$\n",name,ptr);
+    char name[FILENAME_MAX];
+    get_absolute_name(NULL,name,current_graph,infos);
+    fatal_error("Graph %s: invalid $...$ sequence in output:\n$%S$\n",name,ptr);
 }
 s++;
 if (u_starts_with(s,"EQUAL=")
-		|| u_starts_with(s,"EQUALcC=")
-		|| u_starts_with(s,"UNEQUAL=")
-		|| u_starts_with(s,"SUBSTR.")
-		|| u_starts_with(s,"NOT_SUBSTR.")
-		|| u_starts_with(s,"UNEQUALcC=")) {
-	while ((*s)!='=') s++;
-	s++;
-	if ((*s)=='#') {
-		/* If we have a comparison to a constant string, any string is acceptable,
-		 * so it's a success
-		 */
-		return;
-	}
-	if ((*s)=='\0') {
-		char name[FILENAME_MAX];
-		get_absolute_name(NULL,name,current_graph,infos);
-		fatal_error("Graph %s: empty variable name in output:\n$%S$\n",name,ptr);
-	}
-	while ((*s)!='\0') {
-		if (!is_variable_char(*s)) {
-			char name[FILENAME_MAX];
-			get_absolute_name(NULL,name,current_graph,infos);
-			fatal_error("Graph %s: invalid variable name in output:\n$%S$\n",name,ptr);
-		}
-		s++;
-	}
-	/* Everything is ok */
-	return;
+        || u_starts_with(s,"EQUALcC=")
+        || u_starts_with(s,"UNEQUAL=")
+        || u_starts_with(s,"SUBSTR.")
+        || u_starts_with(s,"NOT_SUBSTR.")
+        || u_starts_with(s,"UNEQUALcC=")) {
+    while ((*s)!='=') s++;
+    s++;
+    if ((*s)=='#') {
+        /* If we have a comparison to a constant string, any string is acceptable,
+         * so it's a success
+         */
+        return;
+    }
+    if ((*s)=='\0') {
+        char name[FILENAME_MAX];
+        get_absolute_name(NULL,name,current_graph,infos);
+        fatal_error("Graph %s: empty variable name in output:\n$%S$\n",name,ptr);
+    }
+    while ((*s)!='\0') {
+        if (!is_variable_char(*s)) {
+            char name[FILENAME_MAX];
+            get_absolute_name(NULL,name,current_graph,infos);
+            fatal_error("Graph %s: invalid variable name in output:\n$%S$\n",name,ptr);
+        }
+        s++;
+    }
+    /* Everything is ok */
+    return;
 }
 if (!u_strcmp(s,"EQ=")) {
-	char name[FILENAME_MAX];
-	get_absolute_name(NULL,name,current_graph,infos);
-	fatal_error("Graph %s: missing code value in output:\n$%S$\n",name,ptr);
+    char name[FILENAME_MAX];
+    get_absolute_name(NULL,name,current_graph,infos);
+    fatal_error("Graph %s: missing code value in output:\n$%S$\n",name,ptr);
 }
 if (!u_strcmp(s,"CODE.ATTR=")) {
-	char name[FILENAME_MAX];
-	get_absolute_name(NULL,name,current_graph,infos);
-	fatal_error("Graph %s: missing attribute value in output:\n$%S$\n",name,ptr);
+    char name[FILENAME_MAX];
+    get_absolute_name(NULL,name,current_graph,infos);
+    fatal_error("Graph %s: missing attribute value in output:\n$%S$\n",name,ptr);
 }
 if (!u_strcmp(s,"SET")
-		|| !u_strcmp(s,"UNSET")
-		|| u_starts_with(s,"EQ=")
-		|| !u_strcmp(s,"INFLECTED")
-		|| !u_strcmp(s,"LEMMA")
-		|| !u_strcmp(s,"CODE")
-		|| !u_strcmp(s,"CODE.GRAM")
-		|| !u_strcmp(s,"CODE.SEM")
-		|| !u_strcmp(s,"CODE.FLEX")
-		|| !u_strcmp(s,"TO_LOWER")
-		|| !u_strcmp(s,"TO_UPPER")
-		|| !u_strcmp(s,"TO_FIRSTUPPER")
-		|| u_starts_with(s,"CODE.ATTR=")) {
-	/* Valid sequence */
-	return;
+        || !u_strcmp(s,"UNSET")
+        || u_starts_with(s,"EQ=")
+        || !u_strcmp(s,"INFLECTED")
+        || !u_strcmp(s,"LEMMA")
+        || !u_strcmp(s,"CODE")
+        || !u_strcmp(s,"CODE.GRAM")
+        || !u_strcmp(s,"CODE.SEM")
+        || !u_strcmp(s,"CODE.FLEX")
+        || !u_strcmp(s,"TO_LOWER")
+        || !u_strcmp(s,"TO_UPPER")
+        || !u_strcmp(s,"TO_FIRSTUPPER")
+        || u_starts_with(s,"CODE.ATTR=")) {
+    /* Valid sequence */
+    return;
 }
 char name[FILENAME_MAX];
 get_absolute_name(NULL,name,current_graph,infos);
@@ -1141,28 +1141,28 @@ fatal_error("Graph %s: invalid $...$ sequence in output:\n$%S$\n",name,ptr);
  * a fatal error if necessary.
  */
 static void check_output_validity(int current_graph,struct compilation_info* infos,
-									unichar* output) {
+                                    unichar* output) {
 if (output[0]=='\0') return;
 int i=0;
 Ustring* foo=new_Ustring();
 while (output[i]!='\0') {
-	if (output[i]!='$') {
-		i++;
-	} else {
-		i++;
-		empty(foo);
-		while (output[i]!='\0' && output[i]!='$') {
-			u_strcat(foo,output[i]);
-			i++;
-		}
-		if (output[i]=='\0') {
-			char name[FILENAME_MAX];
-			get_absolute_name(NULL,name,current_graph,infos);
-			fatal_error("Graph %s: invalid output with no closing $:\n%S\n",name,output);
-		}
-		check_dollar_sequence(current_graph,infos,foo->str);
-		i++;
-	}
+    if (output[i]!='$') {
+        i++;
+    } else {
+        i++;
+        empty(foo);
+        while (output[i]!='\0' && output[i]!='$') {
+            u_strcat(foo,output[i]);
+            i++;
+        }
+        if (output[i]=='\0') {
+            char name[FILENAME_MAX];
+            get_absolute_name(NULL,name,current_graph,infos);
+            fatal_error("Graph %s: invalid output with no closing $:\n%S\n",name,output);
+        }
+        check_dollar_sequence(current_graph,infos,foo->str);
+        i++;
+    }
 }
 free_Ustring(foo);
 }
@@ -1204,15 +1204,15 @@ if ((length>2 && box_content[0]=='$' &&
    unichar* debug_output = choose_allocated_or_stack_unichar_buffer(debug_output_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, working_buffer_size);
    debug_output[0]='\0';
    if (infos->debug) {
-	   /* As a normal variable/context tag has no output, we have
-	    * to create a <E> tag associated to this output */
-	   unichar foo[2]={DEBUG_INFO_OUTPUT_MARK,0};
-	   u_strcat(debug_output,foo);
-	   add_debug_infos(debug_output,n,state->box_number,0);
-	   u_strcat(debug_output,box_content);
-	   int size=u_strlen(debug_output);
-	   debug_output[size]=DEBUG_INFO_END_MARK;
-	   debug_output[size+1]='\0';
+       /* As a normal variable/context tag has no output, we have
+        * to create a <E> tag associated to this output */
+       unichar foo[2]={DEBUG_INFO_OUTPUT_MARK,0};
+       u_strcat(debug_output,foo);
+       add_debug_infos(debug_output,n,state->box_number,0);
+       u_strcat(debug_output,box_content);
+       int size=u_strlen(debug_output);
+       debug_output[size]=DEBUG_INFO_END_MARK;
+       debug_output[size+1]='\0';
    }
    process_variable_or_context(graph,input,transitions,current_state,infos,n,debug_output);
    free_choosen_allocated_or_stack_unichar_buffer(input,input_stack);
@@ -1224,12 +1224,12 @@ unichar* output = choose_allocated_or_stack_unichar_buffer(output_stack, DEFAULT
 /* Otherwise, we deal with the output of the box, if any */
 int shift=0;
 if (infos->debug) {
-	shift=1;
-	output[0]=DEBUG_INFO_OUTPUT_MARK;
+    shift=1;
+    output[0]=DEBUG_INFO_OUTPUT_MARK;
 }
 split_input_output(box_content,input,output+shift);
 if (infos->check_outputs) {
-	check_output_validity(n,infos,output+shift);
+    check_output_validity(n,infos,output+shift);
 }
 /* And we process the box input */
 int pos=0;
@@ -1250,19 +1250,19 @@ free_choosen_allocated_or_stack_unichar_buffer(output, output_stack);
 static int test_range(unichar* s,int *m,int *n) {
 int len=0;
 if (1==u_sscanf(s,"$[%d]$%n",m,&len) && (*m)>=0 && s[len]=='\0') {
-	*n=*m;
-	return 1;
+    *n=*m;
+    return 1;
 }
 if (1==u_sscanf(s,"$[%d,]$%n",m,&len) && (*m)>=0 && s[len]=='\0') {
-	*n=-1;
-	return 1;
+    *n=-1;
+    return 1;
 }
 if (2==u_sscanf(s,"$[%d,%d]$%n",m,n,&len) && (*m)>=0 && (*n)>=0 && s[len]=='\0') {
-	return 1;
+    return 1;
 }
 if (1==u_sscanf(s,"$[,%d]$%n",n,&len) && (*n)>=0 && s[len]=='\0') {
-	*m=1;
-	return 1;
+    *m=1;
+    return 1;
 }
 return 0;
 }
@@ -1273,41 +1273,41 @@ return 0;
  */
 static void do_box_range_expansion(Grf* grf,ReverseTransitions* reverse,int box,int m,int n) {
 if (m==0) {
-	/* We first deal with the case of m=0 by adding transitions to skip the box */
-	m=1;
-	vector_int* v=reverse->t[box];
-	for (int i=0;i<v->nbelems;i++) {
-		int previous_state=v->tab[i];
-		for (int j=0;j<grf->states[box]->transitions->nbelems;j++) {
-			int dest_state=grf->states[box]->transitions->tab[j];
-			vector_int_add_if_absent(grf->states[previous_state]->transitions,dest_state);
-		}
-	}
+    /* We first deal with the case of m=0 by adding transitions to skip the box */
+    m=1;
+    vector_int* v=reverse->t[box];
+    for (int i=0;i<v->nbelems;i++) {
+        int previous_state=v->tab[i];
+        for (int j=0;j<grf->states[box]->transitions->nbelems;j++) {
+            int dest_state=grf->states[box]->transitions->tab[j];
+            vector_int_add_if_absent(grf->states[previous_state]->transitions,dest_state);
+        }
+    }
 }
 /* First, we set the m mandatory copies of the box */
 int current=box;
 for (int i=1;i<m;i++) {
-	/* We copy the current box */
-	GrfState* current_state=grf->states[current];
-	GrfState* s=cpy_grf_state(grf->states[current]);
-	/* And we replace all its transitions to a single transition to the new one */
-	current=add_GrfState(grf,s);
-	current_state->transitions->nbelems=0;
-	vector_int_add(current_state->transitions,current);
+    /* We copy the current box */
+    GrfState* current_state=grf->states[current];
+    GrfState* s=cpy_grf_state(grf->states[current]);
+    /* And we replace all its transitions to a single transition to the new one */
+    current=add_GrfState(grf,s);
+    current_state->transitions->nbelems=0;
+    vector_int_add(current_state->transitions,current);
 }
 /* Then, if n=-1 (no max limit), we just have to add a loop and return */
 if (n==-1) {
-	vector_int_add(grf->states[current]->transitions,current);
-	return;
+    vector_int_add(grf->states[current]->transitions,current);
+    return;
 }
 /* Otherwise, we add up to n boxes */
 for (int i=m;i<n;i++) {
-	/* We copy the current box */
-	GrfState* current_state=grf->states[current];
-	GrfState* s=cpy_grf_state(grf->states[current]);
-	/* And we just add a transition to the new one */
-	current=add_GrfState(grf,s);
-	vector_int_add(current_state->transitions,current);
+    /* We copy the current box */
+    GrfState* current_state=grf->states[current];
+    GrfState* s=cpy_grf_state(grf->states[current]);
+    /* And we just add a transition to the new one */
+    current=add_GrfState(grf,s);
+    vector_int_add(current_state->transitions,current);
 }
 }
 
@@ -1329,47 +1329,47 @@ static void expand_box_ranges(Grf* grf) {
 ReverseTransitions* reverse=compute_reverse_transitions(grf);
 int n=grf->n_states;
 for (int i=2;i<n;i++) {
-	GrfState* s=grf->states[i];
-	int m=1,n_=1;
-	vector_ptr* lines=tokenize_box_content(s->box_content);
-	unichar* last=(unichar*)lines->tab[lines->nbelems-1];
-	if (last[0]=='/') {
-		/* If the last line starts with a slash, then the box has an output,
-		 * and we look for a range expression */
-		if (last[1]=='$' && last[2]=='[') {
-			int pos=3;
-			while (last[pos]!='\0' && last[pos]!='$') {
-				pos++;
-			}
-			if (last[pos]=='$') {
-				/* We don't care if the end of line was found, it's not
-				 * our business here */
-				unichar old=last[pos+1];
-				last[pos+1]='\0';
-				int ok=test_range(last+1,&m,&n_);
-				if (!ok || (m==0 && n_==0) || (n_!=-1 && n_<m)) {
-					fatal_error("Invalid range expression: %S\n",last+1);
-				}
-				/* If we have a valid range, we first test if the box has a
-				 * loop to itself, which would be an error */
-				if (-1!=vector_int_contains(s->transitions,i)) {
-					fatal_error("A box with a range %S cannot have a loop to itself\n",last+1);
-				}
-				last[pos+1]=old;
-								/* Then we adjust the output of the box */
-				int j=u_strlen(s->box_content)-u_strlen(last);
-				pos++;
-				do {
-					s->box_content[j++]=last[pos++];
-				} while (last[pos-1]!='\0');
-				s->box_content[j-1]='"';
-				s->box_content[j]='\0';
-				/* Now we can actually duplicate the box */
-				do_box_range_expansion(grf,reverse,i,m,n_);
-			}
-		}
-	}
-	free_vector_ptr(lines,free);
+    GrfState* s=grf->states[i];
+    int m=1,n_=1;
+    vector_ptr* lines=tokenize_box_content(s->box_content);
+    unichar* last=(unichar*)lines->tab[lines->nbelems-1];
+    if (last[0]=='/') {
+        /* If the last line starts with a slash, then the box has an output,
+         * and we look for a range expression */
+        if (last[1]=='$' && last[2]=='[') {
+            int pos=3;
+            while (last[pos]!='\0' && last[pos]!='$') {
+                pos++;
+            }
+            if (last[pos]=='$') {
+                /* We don't care if the end of line was found, it's not
+                 * our business here */
+                unichar old=last[pos+1];
+                last[pos+1]='\0';
+                int ok=test_range(last+1,&m,&n_);
+                if (!ok || (m==0 && n_==0) || (n_!=-1 && n_<m)) {
+                    fatal_error("Invalid range expression: %S\n",last+1);
+                }
+                /* If we have a valid range, we first test if the box has a
+                 * loop to itself, which would be an error */
+                if (-1!=vector_int_contains(s->transitions,i)) {
+                    fatal_error("A box with a range %S cannot have a loop to itself\n",last+1);
+                }
+                last[pos+1]=old;
+                                /* Then we adjust the output of the box */
+                int j=u_strlen(s->box_content)-u_strlen(last);
+                pos++;
+                do {
+                    s->box_content[j++]=last[pos++];
+                } while (last[pos-1]!='\0');
+                s->box_content[j-1]='"';
+                s->box_content[j]='\0';
+                /* Now we can actually duplicate the box */
+                do_box_range_expansion(grf,reverse,i,m,n_);
+            }
+        }
+    }
+    free_vector_ptr(lines,free);
 }
 free_ReverseTransitions(reverse);
 }
@@ -1383,47 +1383,47 @@ static void save_compiled_fst2(char* name,Fst2* fst2,struct compilation_info* in
 Ustring* ustr=new_Ustring();
 int n=infos->current_saved_graph;
 for (int i=0;i<fst2->number_of_graphs;i++) {
-	/* We indicate that we have a graph that is part of a .fst2 */
-	vector_int_add(infos->part_of_precompiled_fst2,1);
-	if (i==0) {
-		u_fprintf(infos->fst2,"-%d %s\n",n++,name);
-	} else {
-		u_fprintf(infos->fst2,"-%d %s:<%S>\n",n++,name,fst2->graph_names[i+1]);
-	}
-	int N=fst2->initial_states[i+1];
-	for (int j=0;j<fst2->number_of_states_per_graphs[i+1];j++) {
-		Fst2State s=fst2->states[N+j];
-		if (!is_final_state(s)) {
-			u_fprintf(infos->fst2,": ");
-		} else {
-			u_fprintf(infos->fst2,"t ");
-		}
-		Transition* t=s->transitions;
-		while (t!=NULL) {
-			if (t->tag_number<0) {
-				u_fprintf(infos->fst2,"-%d ",(infos->current_saved_graph-1)-t->tag_number);
-				//error("** -%d **\n",(infos->current_saved_graph-1)-t->tag_number);
-			} else {
-				empty(ustr);
-				Fst2Tag tag=fst2->tags[t->tag_number];
-				if (tag->control & RESPECT_CASE_TAG_BIT_MASK) {
-				   u_strcat(ustr,"@");
-				}
-				u_strcatf(ustr,"%S",tag->input);
-				if (tag->morphological_filter!=NULL) {
-					u_strcatf(ustr,"%S",tag->morphological_filter);
-				}
-				if (tag->output!=NULL) {
-					u_strcatf(ustr,"/%S",tag->output);
-				}
-				u_fprintf(infos->fst2,"%d ",get_value_index(ustr->str,infos->tags));
-			}
-			u_fprintf(infos->fst2,"%d ",t->state_number-N);
-			t=t->next;
-		}
-		u_fprintf(infos->fst2,"\n");
-	}
-	u_fprintf(infos->fst2,"f \n");
+    /* We indicate that we have a graph that is part of a .fst2 */
+    vector_int_add(infos->part_of_precompiled_fst2,1);
+    if (i==0) {
+        u_fprintf(infos->fst2,"-%d %s\n",n++,name);
+    } else {
+        u_fprintf(infos->fst2,"-%d %s:<%S>\n",n++,name,fst2->graph_names[i+1]);
+    }
+    int N=fst2->initial_states[i+1];
+    for (int j=0;j<fst2->number_of_states_per_graphs[i+1];j++) {
+        Fst2State s=fst2->states[N+j];
+        if (!is_final_state(s)) {
+            u_fprintf(infos->fst2,": ");
+        } else {
+            u_fprintf(infos->fst2,"t ");
+        }
+        Transition* t=s->transitions;
+        while (t!=NULL) {
+            if (t->tag_number<0) {
+                u_fprintf(infos->fst2,"-%d ",(infos->current_saved_graph-1)-t->tag_number);
+                //error("** -%d **\n",(infos->current_saved_graph-1)-t->tag_number);
+            } else {
+                empty(ustr);
+                Fst2Tag tag=fst2->tags[t->tag_number];
+                if (tag->control & RESPECT_CASE_TAG_BIT_MASK) {
+                   u_strcat(ustr,"@");
+                }
+                u_strcatf(ustr,"%S",tag->input);
+                if (tag->morphological_filter!=NULL) {
+                    u_strcatf(ustr,"%S",tag->morphological_filter);
+                }
+                if (tag->output!=NULL) {
+                    u_strcatf(ustr,"/%S",tag->output);
+                }
+                u_fprintf(infos->fst2,"%d ",get_value_index(ustr->str,infos->tags));
+            }
+            u_fprintf(infos->fst2,"%d ",t->state_number-N);
+            t=t->next;
+        }
+        u_fprintf(infos->fst2,"\n");
+    }
+    u_fprintf(infos->fst2,"f \n");
 }
 free_Ustring(ustr);
 }
@@ -1443,59 +1443,59 @@ SingleGraph graph=new_SingleGraph();
 /* We get the absolute path of the graph */
 get_absolute_name(&n_caller,name,n,infos);
 if (n_caller!=-1) {
-	get_absolute_name(NULL,called_from,n_caller,infos);
+    get_absolute_name(NULL,called_from,n_caller,infos);
 }
 char* full_name=NULL;
 if (infos->debug) {
-	full_name=name;
+    full_name=name;
 }
 infos->current_saved_graph++;
 vector_int_add(infos->renumber,infos->current_saved_graph);
 char foo[FILENAME_MAX];
 get_extension(name,foo);
 if (foo[0]=='\0') {
-	strcat(name,".grf");
+    strcat(name,".grf");
 }
 Grf* grf=NULL;
 if (fexists(name)) {
-	grf=load_Grf(&(infos->vec),name);
+    grf=load_Grf(&(infos->vec),name);
 }
 if (grf==NULL) {
-	/* If we can't load the .grf, maybe we should try the .fst2 */
-	remove_extension(name,name_fst2);
-	strcat(name_fst2,".fst2");
-	Fst2* fst2=NULL;
-	if (n!=1 && fexists(name_fst2)) {
-		/* We don't try to load the .fst2 for the main graph */
-		fst2=load_fst2(&(infos->vec),name_fst2,1);
-		if (fst2==NULL) {
-			error("Cannot load %s\n",name_fst2);
-			write_graph(infos->fst2,graph,-n,infos->graph_names->value[n],full_name);
-			free_SingleGraph(graph,NULL);
-			vector_int_add(infos->part_of_precompiled_fst2,0);
-			if (n==1) return 0;
-			return 1;
-		}
-	} else {
-		error("Cannot open graph %s\n",name);
-		if (called_from[0]!='\0') {
-			error("which is called from %s\n",called_from);
-		}
-		write_graph(infos->fst2,graph,-n,infos->graph_names->value[n],full_name);
-		free_SingleGraph(graph,NULL);
-		vector_int_add(infos->part_of_precompiled_fst2,0);
-		if (n==1) return 0;
-		return 1;
-	}
-	if (infos->verbose_name_grf!=0) {
-		u_printf("Loading compiled graph %s\n",name_fst2);
-	}
-	save_compiled_fst2(name_fst2,fst2,infos);
-	/* -1 because we already made infos->current_saved_graph++ */
-	infos->current_saved_graph+=(fst2->number_of_graphs-1);
-	free_Fst2(fst2);
-	free_SingleGraph(graph,NULL);
-	return 1;
+    /* If we can't load the .grf, maybe we should try the .fst2 */
+    remove_extension(name,name_fst2);
+    strcat(name_fst2,".fst2");
+    Fst2* fst2=NULL;
+    if (n!=1 && fexists(name_fst2)) {
+        /* We don't try to load the .fst2 for the main graph */
+        fst2=load_fst2(&(infos->vec),name_fst2,1);
+        if (fst2==NULL) {
+            error("Cannot load %s\n",name_fst2);
+            write_graph(infos->fst2,graph,-n,infos->graph_names->value[n],full_name);
+            free_SingleGraph(graph,NULL);
+            vector_int_add(infos->part_of_precompiled_fst2,0);
+            if (n==1) return 0;
+            return 1;
+        }
+    } else {
+        error("Cannot open graph %s\n",name);
+        if (called_from[0]!='\0') {
+            error("which is called from %s\n",called_from);
+        }
+        write_graph(infos->fst2,graph,-n,infos->graph_names->value[n],full_name);
+        free_SingleGraph(graph,NULL);
+        vector_int_add(infos->part_of_precompiled_fst2,0);
+        if (n==1) return 0;
+        return 1;
+    }
+    if (infos->verbose_name_grf!=0) {
+        u_printf("Loading compiled graph %s\n",name_fst2);
+    }
+    save_compiled_fst2(name_fst2,fst2,infos);
+    /* -1 because we already made infos->current_saved_graph++ */
+    infos->current_saved_graph+=(fst2->number_of_graphs-1);
+    free_Fst2(fst2);
+    free_SingleGraph(graph,NULL);
+    return 1;
 }
 if (n==1 || infos->verbose_name_grf!=0) {
   u_printf("Compiling graph %s\n",/*infos->graph_names->value[n]*/name);
@@ -1518,9 +1518,9 @@ for (i=0;i<grf->n_states;i++) {
    /* To preserve previous behavior (for log consistency), we mirror the
     * transition list */
    for (int x=0,y=grf->states[i]->transitions->nbelems-1;x<y;x++,y--) {
-	   int tmp=grf->states[i]->transitions->tab[x];
-	   grf->states[i]->transitions->tab[x]=grf->states[i]->transitions->tab[y];
-	   grf->states[i]->transitions->tab[y]=tmp;
+       int tmp=grf->states[i]->transitions->tab[x];
+       grf->states[i]->transitions->tab[x]=grf->states[i]->transitions->tab[y];
+       grf->states[i]->transitions->tab[y]=tmp;
    }
    process_grf_state(grf->states[i]->box_content+1,grf->states[i]->transitions,graph,i,n,infos,grf->states[i]);
 }
@@ -1657,19 +1657,19 @@ u_fprintf(fst2,"f\n");
  */
 void renumber_graph_calls(Fst2* fst2,vector_int* renumber,vector_int* part_of_precompiled_fst2) {
 for (int i=1;i<=fst2->number_of_graphs;i++) {
-	if (part_of_precompiled_fst2->tab[i]) continue;
-	int n=fst2->number_of_states_per_graphs[i]+fst2->initial_states[i];
-	for (int j=fst2->initial_states[i];j<n;j++) {
-		Fst2State s=fst2->states[j];
-		s->transitions=reverse_list(s->transitions);
-		Transition* t=s->transitions;
-		while (t!=NULL) {
-			if (t->tag_number<0) {
-				t->tag_number=-(renumber->tab[-(t->tag_number)]);
-			}
-			t=t->next;
-		}
-	}
+    if (part_of_precompiled_fst2->tab[i]) continue;
+    int n=fst2->number_of_states_per_graphs[i]+fst2->initial_states[i];
+    for (int j=fst2->initial_states[i];j<n;j++) {
+        Fst2State s=fst2->states[j];
+        s->transitions=reverse_list(s->transitions);
+        Transition* t=s->transitions;
+        while (t!=NULL) {
+            if (t->tag_number<0) {
+                t->tag_number=-(renumber->tab[-(t->tag_number)]);
+            }
+            t=t->next;
+        }
+    }
 }
 }
 

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -71,7 +71,7 @@ static void reallocate_int_buffer(int** buffer, size_t *buffer_allocated_size, s
 		return;
 	}
 	size_t new_alloc_size = around_needed_size(needed_size);
-	int* new_buffer = ((*buffer) == NULL) ? ((int*)malloc(new_alloc_size*sizeof(int))) : 
+	int* new_buffer = ((*buffer) == NULL) ? ((int*)malloc(new_alloc_size*sizeof(int))) :
 		                                    ((int*)realloc(*buffer, new_alloc_size*sizeof(int)));
 	if (new_buffer == NULL) {
 		fatal_alloc_error("reallocate_int_buffer");
@@ -1180,7 +1180,7 @@ if (transitions->nbelems==0) {
     * graph is cleaned, so it's not necessary to process it. */
    return;
 }
-int length = u_strlen(box_content); 
+int length = u_strlen(box_content);
 size_t working_buffer_size = (size_t)(length + 0x80);
 unichar input_stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
 unichar* input = choose_allocated_or_stack_unichar_buffer(input_stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, working_buffer_size);

--- a/GrfBeauty.cpp
+++ b/GrfBeauty.cpp
@@ -53,33 +53,33 @@ namespace unitex {
 typedef enum {SINGLE,PAIR,LEMON,SEQUENTIAL} GroupType;
 
 typedef struct {
-	int parent;
-	int width;
-	int height;
-	int start;
-	int end;
-	GroupType type;
-	vector_int* subgroups;
+    int parent;
+    int width;
+    int height;
+    int start;
+    int end;
+    GroupType type;
+    vector_int* subgroups;
 } BoxGroup;
 
 
 typedef struct {
-	int n;
-	struct list_int** to_restore;
-	struct list_int** to_remove;
+    int n;
+    struct list_int** to_restore;
+    struct list_int** to_remove;
 } TransitionModifs;
 
 
 static TransitionModifs* new_TransitionModifs(int n) {
 TransitionModifs* t=(TransitionModifs*)malloc(sizeof(TransitionModifs));
 if (t==NULL) {
-	fatal_alloc_error("new_TransitionModifs");
+    fatal_alloc_error("new_TransitionModifs");
 }
 t->n=n;
 t->to_restore=(struct list_int**)calloc(n,sizeof(struct list_int*));
 t->to_remove=(struct list_int**)calloc(n,sizeof(struct list_int*));
 if (t->to_restore==NULL || t->to_remove==NULL) {
-	fatal_alloc_error("new_TransitionModifs");
+    fatal_alloc_error("new_TransitionModifs");
 }
 return t;
 }
@@ -88,8 +88,8 @@ return t;
 static void free_TransitionModifs(TransitionModifs* t) {
 if (t==NULL) return;
 for (int i=0;i<t->n;i++) {
-	free_list_int(t->to_restore[i]);
-	free_list_int(t->to_remove[i]);
+    free_list_int(t->to_restore[i]);
+    free_list_int(t->to_remove[i]);
 }
 free(t->to_restore);
 free(t->to_remove);
@@ -101,11 +101,11 @@ static void resize(TransitionModifs* t,int n) {
 t->to_restore=(struct list_int**)realloc(t->to_restore,n*sizeof(struct list_int*));
 t->to_remove=(struct list_int**)realloc(t->to_remove,n*sizeof(struct list_int*));
 if (t->to_restore==NULL || t->to_remove==NULL) {
-	fatal_alloc_error("resize");
+    fatal_alloc_error("resize");
 }
 for (int i=t->n;i<n;i++) {
-	t->to_restore[i]=NULL;
-	t->to_remove[i]=NULL;
+    t->to_restore[i]=NULL;
+    t->to_remove[i]=NULL;
 }
 t->n=n;
 }
@@ -138,15 +138,15 @@ s->box_content[0]='\0';
 /* To remove outgoing transitions, we have to remove
  * incoming transition from n in other states */
 for (int i=0;i<s->transitions->nbelems;i++) {
-	int dest=s->transitions->tab[i];
-	vector_int_remove(r->t[dest],n);
+    int dest=s->transitions->tab[i];
+    vector_int_remove(r->t[dest],n);
 }
 /* We indicate that the state has no outgoing transition anymore */
 s->transitions->nbelems=0;
 /* And we do the same for incoming transitions */
 for (int i=0;i<r->t[n]->nbelems;i++) {
-	int src=r->t[n]->tab[i];
-	vector_int_remove(grf->states[src]->transitions,n);
+    int src=r->t[n]->tab[i];
+    vector_int_remove(grf->states[src]->transitions,n);
 }
 r->t[n]->nbelems=0;
 }
@@ -159,31 +159,31 @@ r->t[n]->nbelems=0;
 static void remove_isolated_boxes(Grf* grf) {
 int* renumber=(int*)malloc(grf->n_states*sizeof(int));
 if (renumber==NULL) {
-	fatal_alloc_error("remove_isolated_boxes");
+    fatal_alloc_error("remove_isolated_boxes");
 }
 for (int i=0;i<grf->n_states;i++) {
-	renumber[i]=i;
+    renumber[i]=i;
 }
 for (int i=0;i<grf->n_states;/* No i++ here, not a mistake */) {
-	if (grf->states[i]->box_content[0]=='\0') {
-		free_GrfState(grf->states[i]);
-		grf->states[i]=NULL;
-		(grf->n_states)--;
-		if (i!=grf->n_states) {
-			/* If there is a state to swap with */
-			grf->states[i]=grf->states[grf->n_states];
-			grf->states[grf->n_states]=NULL;
-			renumber[grf->n_states]=i;
-			continue;
-		}
-	}
-	i++;
+    if (grf->states[i]->box_content[0]=='\0') {
+        free_GrfState(grf->states[i]);
+        grf->states[i]=NULL;
+        (grf->n_states)--;
+        if (i!=grf->n_states) {
+            /* If there is a state to swap with */
+            grf->states[i]=grf->states[grf->n_states];
+            grf->states[grf->n_states]=NULL;
+            renumber[grf->n_states]=i;
+            continue;
+        }
+    }
+    i++;
 }
 for (int i=0;i<grf->n_states;i++) {
-	vector_int* v=grf->states[i]->transitions;
-	for (int j=0;j<v->nbelems;j++) {
-		v->tab[j]=renumber[v->tab[j]];
-	}
+    vector_int* v=grf->states[i]->transitions;
+    for (int j=0;j<v->nbelems;j++) {
+        v->tab[j]=renumber[v->tab[j]];
+    }
 }
 free(renumber);
 }
@@ -197,33 +197,33 @@ free(renumber);
 static void merge_case_equivalent_boxes(Grf* grf,Alphabet* alph) {
 ReverseTransitions* reverse_transitions=compute_reverse_transitions(grf);
 for (int i=2;i<grf->n_states-1;i++) {
-	GrfState* a=grf->states[i];
-	if (a->box_content[0]=='\0') {
-		continue;
-	}
-	for (int j=i+1;j<grf->n_states;j++) {
-		GrfState* b=grf->states[j];
-		if (b->box_content[0]=='\0') {
-			continue;
-		}
-		int isolate_j=0;
-		if (have_same_transitions(grf,i,j,reverse_transitions)) {
-			if (is_equal_or_uppercase_qp(a->box_content,b->box_content,alph)) {
-				/* We have to remove state b */
-				isolate_j=1;
-			} else if (is_equal_or_uppercase_qp(b->box_content,a->box_content,alph)) {
-				/* We have to remove state a, but not to perturb the algorithm,
-				 * we will swap a and b's content, and actually remove b */
-				unichar* tmp=a->box_content;
-				a->box_content=b->box_content;
-				b->box_content=tmp;
-				isolate_j=1;
-			}
-			if (isolate_j) {
-				isolate_state(grf,j,reverse_transitions);
-			}
-		}
-	}
+    GrfState* a=grf->states[i];
+    if (a->box_content[0]=='\0') {
+        continue;
+    }
+    for (int j=i+1;j<grf->n_states;j++) {
+        GrfState* b=grf->states[j];
+        if (b->box_content[0]=='\0') {
+            continue;
+        }
+        int isolate_j=0;
+        if (have_same_transitions(grf,i,j,reverse_transitions)) {
+            if (is_equal_or_uppercase_qp(a->box_content,b->box_content,alph)) {
+                /* We have to remove state b */
+                isolate_j=1;
+            } else if (is_equal_or_uppercase_qp(b->box_content,a->box_content,alph)) {
+                /* We have to remove state a, but not to perturb the algorithm,
+                 * we will swap a and b's content, and actually remove b */
+                unichar* tmp=a->box_content;
+                a->box_content=b->box_content;
+                b->box_content=tmp;
+                isolate_j=1;
+            }
+            if (isolate_j) {
+                isolate_state(grf,j,reverse_transitions);
+            }
+        }
+    }
 }
 free_ReverseTransitions(reverse_transitions);
 }
@@ -237,54 +237,54 @@ free_ReverseTransitions(reverse_transitions);
 static void merge_pseudo_case_equivalent_boxes(Grf* grf,Alphabet* alph) {
 ReverseTransitions* reverse_transitions=compute_reverse_transitions(grf);
 for (int i=2;i<grf->n_states-1;i++) {
-	GrfState* a=grf->states[i];
-	if (a->box_content[0]=='\0') {
-		continue;
-	}
-	for (int j=i+1;j<grf->n_states;j++) {
-		GrfState* b=grf->states[j];
-		if (b->box_content[0]=='\0') {
-			continue;
-		}
-		int isolate_j=0;
-		if (have_same_incoming_transitions(i,j,reverse_transitions)) {
-			isolate_j=1; /* 1 means incoming */
-		} else if (have_same_outgoing_transitions(a,b)) {
-			isolate_j=2; /* 2 means outgoing */
-		}
-		if (isolate_j) {
-			if (is_equal_or_uppercase_qp(a->box_content,b->box_content,alph)) {
-				/* We have to remove state b */
-			} else if (is_equal_or_uppercase_qp(b->box_content,a->box_content,alph)) {
-				/* We have to remove state a, but not to perturb the algorithm,
-				 * we will swap a and b's content, and actually remove b */
-				unichar* tmp=a->box_content;
-				a->box_content=b->box_content;
-				b->box_content=tmp;
-			} else {
-				/* We won't merge a and b after all */
-				isolate_j=0;
-			}
-			if (isolate_j) {
-				if (isolate_j==1) {
-					/* a and b have same incoming transitions, so we merge the
-					 * outgoing ones */
-					for (int k=0;k<b->transitions->nbelems;k++) {
-						vector_int_add_if_absent(a->transitions,b->transitions->tab[k]);
-						int dest=b->transitions->tab[k];
-						vector_int_add_if_absent(reverse_transitions->t[dest],i);
-					}
-				} else {
-					/* We have to merge the incoming transitions */
-					for (int k=0;k<reverse_transitions->t[j]->nbelems;k++) {
-						GrfState* src=grf->states[reverse_transitions->t[j]->tab[k]];
-						vector_int_add_if_absent(src->transitions,i);
-					}
-				}
-				isolate_state(grf,j,reverse_transitions);
-			}
-		}
-	}
+    GrfState* a=grf->states[i];
+    if (a->box_content[0]=='\0') {
+        continue;
+    }
+    for (int j=i+1;j<grf->n_states;j++) {
+        GrfState* b=grf->states[j];
+        if (b->box_content[0]=='\0') {
+            continue;
+        }
+        int isolate_j=0;
+        if (have_same_incoming_transitions(i,j,reverse_transitions)) {
+            isolate_j=1; /* 1 means incoming */
+        } else if (have_same_outgoing_transitions(a,b)) {
+            isolate_j=2; /* 2 means outgoing */
+        }
+        if (isolate_j) {
+            if (is_equal_or_uppercase_qp(a->box_content,b->box_content,alph)) {
+                /* We have to remove state b */
+            } else if (is_equal_or_uppercase_qp(b->box_content,a->box_content,alph)) {
+                /* We have to remove state a, but not to perturb the algorithm,
+                 * we will swap a and b's content, and actually remove b */
+                unichar* tmp=a->box_content;
+                a->box_content=b->box_content;
+                b->box_content=tmp;
+            } else {
+                /* We won't merge a and b after all */
+                isolate_j=0;
+            }
+            if (isolate_j) {
+                if (isolate_j==1) {
+                    /* a and b have same incoming transitions, so we merge the
+                     * outgoing ones */
+                    for (int k=0;k<b->transitions->nbelems;k++) {
+                        vector_int_add_if_absent(a->transitions,b->transitions->tab[k]);
+                        int dest=b->transitions->tab[k];
+                        vector_int_add_if_absent(reverse_transitions->t[dest],i);
+                    }
+                } else {
+                    /* We have to merge the incoming transitions */
+                    for (int k=0;k<reverse_transitions->t[j]->nbelems;k++) {
+                        GrfState* src=grf->states[reverse_transitions->t[j]->tab[k]];
+                        vector_int_add_if_absent(src->transitions,i);
+                    }
+                }
+                isolate_state(grf,j,reverse_transitions);
+            }
+        }
+    }
 }
 free_ReverseTransitions(reverse_transitions);
 }
@@ -300,7 +300,7 @@ free_ReverseTransitions(reverse_transitions);
 /*
 static int need_a_space(unichar a,unichar b,Alphabet* alph) {
 if (is_letter(a,alph)) {
-	return is_letter(b,alph) || u_is_digit(b);
+    return is_letter(b,alph) || u_is_digit(b);
 }
 return u_is_digit(a) && is_letter(b,alph);
 }
@@ -333,47 +333,47 @@ static void merge_box_pair(Grf* grf,Alphabet* alph) {
 ReverseTransitions* reverse_transitions=compute_reverse_transitions(grf);
 int merge;
 do {
-	// We have to loop, since a merge may introduce new possibilities
-	merge=0;
-	for (int i=2;i<grf->n_states-1;i++) {
-		GrfState* a=grf->states[i];
-		if (a->box_content[0]=='\0') {
-			continue;
-		}
-		for (int j=2;j<grf->n_states;j++) {
-			if (i==j) continue;
-			GrfState* b=grf->states[j];
-			if (b->box_content[0]=='\0') {
-				continue;
-			}
-			if (a->transitions->nbelems!=1 || a->transitions->tab[0]!=j) continue;
-			if (reverse_transitions->t[j]->nbelems!=1 || reverse_transitions->t[j]->tab[0]!=i) continue;
-			if (!just_one_line(a) || !just_one_line(b)) continue;
-			merge=1;
-			// Remember that the contents are double quoted, so we want
-			// to have "abc" + "def" => "abc def"
-			//
-			int size_a=u_strlen(a->box_content);
-			a->box_content=(unichar*)realloc(a->box_content,sizeof(unichar)*(size_a+u_strlen(b->box_content)));
-			if (a->box_content==NULL) {
-				fatal_alloc_error("merge_box_pair");
-			}
-			if (need_a_space(a->box_content[size_a-2],b->box_content[1],alph)) {
-				a->box_content[size_a-1]=' ';
-			} else {
-				size_a--;
-			}
-			u_strcpy(a->box_content+size_a,b->box_content+1);
-			// Now we have to remove a->b (done by isolate_state)
-			// and give b's outgoing transitions to a
-			for (int k=0;k<b->transitions->nbelems;k++) {
-				vector_int_add_if_absent(a->transitions,b->transitions->tab[k]);
-				vector_int_add_if_absent(reverse_transitions->t[b->transitions->tab[k]],i);
-			}
-			isolate_state(grf,j,reverse_transitions);
+    // We have to loop, since a merge may introduce new possibilities
+    merge=0;
+    for (int i=2;i<grf->n_states-1;i++) {
+        GrfState* a=grf->states[i];
+        if (a->box_content[0]=='\0') {
+            continue;
+        }
+        for (int j=2;j<grf->n_states;j++) {
+            if (i==j) continue;
+            GrfState* b=grf->states[j];
+            if (b->box_content[0]=='\0') {
+                continue;
+            }
+            if (a->transitions->nbelems!=1 || a->transitions->tab[0]!=j) continue;
+            if (reverse_transitions->t[j]->nbelems!=1 || reverse_transitions->t[j]->tab[0]!=i) continue;
+            if (!just_one_line(a) || !just_one_line(b)) continue;
+            merge=1;
+            // Remember that the contents are double quoted, so we want
+            // to have "abc" + "def" => "abc def"
+            //
+            int size_a=u_strlen(a->box_content);
+            a->box_content=(unichar*)realloc(a->box_content,sizeof(unichar)*(size_a+u_strlen(b->box_content)));
+            if (a->box_content==NULL) {
+                fatal_alloc_error("merge_box_pair");
+            }
+            if (need_a_space(a->box_content[size_a-2],b->box_content[1],alph)) {
+                a->box_content[size_a-1]=' ';
+            } else {
+                size_a--;
+            }
+            u_strcpy(a->box_content+size_a,b->box_content+1);
+            // Now we have to remove a->b (done by isolate_state)
+            // and give b's outgoing transitions to a
+            for (int k=0;k<b->transitions->nbelems;k++) {
+                vector_int_add_if_absent(a->transitions,b->transitions->tab[k]);
+                vector_int_add_if_absent(reverse_transitions->t[b->transitions->tab[k]],i);
+            }
+            isolate_state(grf,j,reverse_transitions);
 
-		}
-	}
+        }
+    }
 } while (merge);
 free_ReverseTransitions(reverse_transitions);
 }
@@ -388,26 +388,26 @@ free_ReverseTransitions(reverse_transitions);
 static void merge_boxes_with_same_transition(Grf* grf) {
 ReverseTransitions* reverse_transitions=compute_reverse_transitions(grf);
 for (int i=2;i<grf->n_states-1;i++) {
-	GrfState* a=grf->states[i];
-	if (a->box_content[0]=='\0') {
-		continue;
-	}
-	for (int j=i+1;j<grf->n_states;j++) {
-		GrfState* b=grf->states[j];
-		if (b->box_content[0]=='\0') {
-			continue;
-		}
-		if (have_same_transitions(grf,i,j,reverse_transitions)) {
-			int size_a=u_strlen(a->box_content);
-			a->box_content=(unichar*)realloc(a->box_content,sizeof(unichar)*(size_a+u_strlen(b->box_content)));
-			if (a->box_content==NULL) {
-				fatal_alloc_error("merge_boxes_with_same_transition");
-			}
-			a->box_content[size_a-1]='+';
-			u_strcpy(a->box_content+size_a,b->box_content+1);
-			isolate_state(grf,j,reverse_transitions);
-		}
-	}
+    GrfState* a=grf->states[i];
+    if (a->box_content[0]=='\0') {
+        continue;
+    }
+    for (int j=i+1;j<grf->n_states;j++) {
+        GrfState* b=grf->states[j];
+        if (b->box_content[0]=='\0') {
+            continue;
+        }
+        if (have_same_transitions(grf,i,j,reverse_transitions)) {
+            int size_a=u_strlen(a->box_content);
+            a->box_content=(unichar*)realloc(a->box_content,sizeof(unichar)*(size_a+u_strlen(b->box_content)));
+            if (a->box_content==NULL) {
+                fatal_alloc_error("merge_boxes_with_same_transition");
+            }
+            a->box_content[size_a-1]='+';
+            u_strcpy(a->box_content+size_a,b->box_content+1);
+            isolate_state(grf,j,reverse_transitions);
+        }
+    }
 }
 free_ReverseTransitions(reverse_transitions);
 }
@@ -421,40 +421,40 @@ free_ReverseTransitions(reverse_transitions);
 static void replace_transition_by_E(Grf* grf) {
 ReverseTransitions* reverse_transitions=compute_reverse_transitions(grf);
 for (int i=2;i<grf->n_states-1;i++) {
-	GrfState* B=grf->states[i];
-	if (B->box_content[0]=='\0') {
-		continue;
-	}
-	int ok=(B->transitions->nbelems!=0 && reverse_transitions->t[i]->nbelems!=0);
-	for (int x=0;x<reverse_transitions->t[i]->nbelems;x++) {
-		int A_x=reverse_transitions->t[i]->tab[x];
-		for (int y=0;y<B->transitions->nbelems;y++) {
-			int C_j=B->transitions->tab[y];
-			if (-1==vector_int_contains(grf->states[A_x]->transitions,C_j)) {
-				ok=0;
-				goto out;
-			}
-		}
-	}
-	out:
-	if (ok) {
-		/* We can add <E> to B's content */
-		Ustring* tmp=new_Ustring();
-		u_strcpy(tmp,"\"<E>+");
-		u_strcat(tmp,B->box_content+1);
-		free(B->box_content);
-		B->box_content=tmp->str;
-		tmp->str=NULL;
-		free_Ustring(tmp);
-		for (int x=0;x<reverse_transitions->t[i]->nbelems;x++) {
-			int A_x=reverse_transitions->t[i]->tab[x];
-			for (int y=0;y<B->transitions->nbelems;y++) {
-				int C_j=B->transitions->tab[y];
-				vector_int_remove(grf->states[A_x]->transitions,C_j);
-				vector_int_remove(reverse_transitions->t[C_j],A_x);
-			}
-		}
-	}
+    GrfState* B=grf->states[i];
+    if (B->box_content[0]=='\0') {
+        continue;
+    }
+    int ok=(B->transitions->nbelems!=0 && reverse_transitions->t[i]->nbelems!=0);
+    for (int x=0;x<reverse_transitions->t[i]->nbelems;x++) {
+        int A_x=reverse_transitions->t[i]->tab[x];
+        for (int y=0;y<B->transitions->nbelems;y++) {
+            int C_j=B->transitions->tab[y];
+            if (-1==vector_int_contains(grf->states[A_x]->transitions,C_j)) {
+                ok=0;
+                goto out;
+            }
+        }
+    }
+    out:
+    if (ok) {
+        /* We can add <E> to B's content */
+        Ustring* tmp=new_Ustring();
+        u_strcpy(tmp,"\"<E>+");
+        u_strcat(tmp,B->box_content+1);
+        free(B->box_content);
+        B->box_content=tmp->str;
+        tmp->str=NULL;
+        free_Ustring(tmp);
+        for (int x=0;x<reverse_transitions->t[i]->nbelems;x++) {
+            int A_x=reverse_transitions->t[i]->tab[x];
+            for (int y=0;y<B->transitions->nbelems;y++) {
+                int C_j=B->transitions->tab[y];
+                vector_int_remove(grf->states[A_x]->transitions,C_j);
+                vector_int_remove(reverse_transitions->t[C_j],A_x);
+            }
+        }
+    }
 }
 free_ReverseTransitions(reverse_transitions);
 }
@@ -476,11 +476,11 @@ mark[current_state]=2;
 vector_int* transitions=grf->states[current_state]->transitions;
 vector_int* copy=vector_int_dup(transitions);
 for (int i=0;i<copy->nbelems;i++) {
-	int dest_state=copy->tab[i];
-	if (!remove_back_transitions(grf,dest_state,mark,t)) {
-		vector_int_remove(transitions,dest_state);
-		to_restore(t,current_state,dest_state);
-	}
+    int dest_state=copy->tab[i];
+    if (!remove_back_transitions(grf,dest_state,mark,t)) {
+        vector_int_remove(transitions,dest_state);
+        to_restore(t,current_state,dest_state);
+    }
 }
 free_vector_int(copy);
 mark[current_state]=1;
@@ -496,8 +496,8 @@ if (mark[state]==1) return;
 mark[state]=1;
 vector_int* transitions=grf->states[state]->transitions;
 for (int i=0;i<transitions->nbelems;i++) {
-	int dest=transitions->tab[i];
-	explore_accessibility(grf,dest,mark);
+    int dest=transitions->tab[i];
+    explore_accessibility(grf,dest,mark);
 }
 }
 
@@ -510,8 +510,8 @@ if (mark[state]==1) return;
 mark[state]=1;
 vector_int* transitions=reverse->t[state];
 for (int i=0;i<transitions->nbelems;i++) {
-	int dest=transitions->tab[i];
-	explore_coaccessibility(reverse,dest,mark);
+    int dest=transitions->tab[i];
+    explore_coaccessibility(reverse,dest,mark);
 }
 }
 
@@ -522,20 +522,20 @@ for (int i=0;i<transitions->nbelems;i++) {
 static void deal_with_non_coaccessibility(Grf* grf,int* mark,TransitionModifs* t) {
 ReverseTransitions* reverse=compute_reverse_transitions(grf);
 for (int i=0;i<grf->n_states;i++) {
-	mark[i]=0;
+    mark[i]=0;
 }
 explore_coaccessibility(reverse,1,mark);
 free_ReverseTransitions(reverse);
 /* Now we can remove transitions */
 for (int i=0;i<grf->n_states;i++) {
-	vector_int* transitions=grf->states[i]->transitions;
-	for (int j=transitions->nbelems-1;j>=0;j--) {
-		int dest=transitions->tab[j];
-		if (!mark[dest]) {
-			to_restore(t,j,dest);
-			vector_int_remove(transitions,dest);
-		}
-	}
+    vector_int* transitions=grf->states[i]->transitions;
+    for (int j=transitions->nbelems-1;j>=0;j--) {
+        int dest=transitions->tab[j];
+        if (!mark[dest]) {
+            to_restore(t,j,dest);
+            vector_int_remove(transitions,dest);
+        }
+    }
 }
 }
 
@@ -543,20 +543,20 @@ for (int i=0;i<grf->n_states;i++) {
 static void compute_ranks(Grf* grf,int* rank) {
 rank[0]=0;
 for (int i=1;i<grf->n_states;i++) {
-	rank[i]=-1;
+    rank[i]=-1;
 }
 struct fifo* f=new_fifo();
 put_int(f,0);
 int state;
 while (!is_empty(f)) {
-	state=take_int(f);
-	vector_int* transitions=grf->states[state]->transitions;
-	for (int i=0;i<transitions->nbelems;i++) {
-		int dest=transitions->tab[i];
-		if (rank[dest]!=-1) continue;
-		rank[dest]=rank[state]+1;
-		put_int(f,dest);
-	}
+    state=take_int(f);
+    vector_int* transitions=grf->states[state]->transitions;
+    for (int i=0;i<transitions->nbelems;i++) {
+        int dest=transitions->tab[i];
+        if (rank[dest]!=-1) continue;
+        rank[dest]=rank[state]+1;
+        put_int(f,dest);
+    }
 }
 free_fifo(f);
 }
@@ -576,22 +576,22 @@ ReverseTransitions* reverse=compute_reverse_transitions(grf);
  * Case 1: a transition to a lesser ranked state
  */
 for (int state=0;state<grf->n_states;state++) {
-	vector_int* transitions=grf->states[state]->transitions;
-	if (transitions->nbelems==1) {
-		/* If there is only one outgoing transition, there is nothing to do */
-		continue;
-	}
-	for (int i=transitions->nbelems-1;transitions->nbelems>1 && i>=0;i--) {
-		/* transitions->nbelems>1: we want to keep at least one transition */
-		int dest=transitions->tab[i];
-		if (rank[dest]<(rank[state]+1)) {
-			//error("pb 1 between %S and %S\n",grf->states[state]->box_content,grf->states[dest]->box_content);
-			to_restore(t,state,dest);
-			vector_int_remove(transitions,dest);
-			vector_int_remove(reverse->t[dest],state);
-			continue;
-		}
-	}
+    vector_int* transitions=grf->states[state]->transitions;
+    if (transitions->nbelems==1) {
+        /* If there is only one outgoing transition, there is nothing to do */
+        continue;
+    }
+    for (int i=transitions->nbelems-1;transitions->nbelems>1 && i>=0;i--) {
+        /* transitions->nbelems>1: we want to keep at least one transition */
+        int dest=transitions->tab[i];
+        if (rank[dest]<(rank[state]+1)) {
+            //error("pb 1 between %S and %S\n",grf->states[state]->box_content,grf->states[dest]->box_content);
+            to_restore(t,state,dest);
+            vector_int_remove(transitions,dest);
+            vector_int_remove(reverse->t[dest],state);
+            continue;
+        }
+    }
 }
 /**
  * Before going on, we have to update ranks.
@@ -601,38 +601,38 @@ compute_ranks(grf,rank);
  * Case 2: good rank. We have to check if dest has other incoming transitions
  */
 for (int state=0;state<grf->n_states;state++) {
-	vector_int* transitions=grf->states[state]->transitions;
-	if (transitions->nbelems==1) {
-		continue;
-	}
-	for (int i=transitions->nbelems-1;i>=0;i--) {
-		int dest=transitions->tab[i];
-		if (rank[dest]==(rank[state]+1)) {
-			if (reverse->t[dest]->nbelems>1) {
-				//error("pb 2 between %S and %S\n",grf->states[state]->box_content,grf->states[dest]->box_content);
-				/* For every state X that has a transition to the dest one, we remove this
-				 * transition if W has at least one other outgoing transition
-				 */
-				for (int j=0;j<reverse->t[dest]->nbelems;j++) {
-					int Xindex=reverse->t[dest]->tab[j];
-					GrfState* X=grf->states[Xindex];
-					if (X->transitions->nbelems>1) {
-						//t[Xindex]=sorted_insert(dest,t[Xindex]);
-						to_restore(t,Xindex,dest);
-						vector_int_remove(X->transitions,dest);
-						vector_int_remove(reverse->t[dest],Xindex);
-					}
-				}
-			}
-		}
-	}
+    vector_int* transitions=grf->states[state]->transitions;
+    if (transitions->nbelems==1) {
+        continue;
+    }
+    for (int i=transitions->nbelems-1;i>=0;i--) {
+        int dest=transitions->tab[i];
+        if (rank[dest]==(rank[state]+1)) {
+            if (reverse->t[dest]->nbelems>1) {
+                //error("pb 2 between %S and %S\n",grf->states[state]->box_content,grf->states[dest]->box_content);
+                /* For every state X that has a transition to the dest one, we remove this
+                 * transition if W has at least one other outgoing transition
+                 */
+                for (int j=0;j<reverse->t[dest]->nbelems;j++) {
+                    int Xindex=reverse->t[dest]->tab[j];
+                    GrfState* X=grf->states[Xindex];
+                    if (X->transitions->nbelems>1) {
+                        //t[Xindex]=sorted_insert(dest,t[Xindex]);
+                        to_restore(t,Xindex,dest);
+                        vector_int_remove(X->transitions,dest);
+                        vector_int_remove(reverse->t[dest],Xindex);
+                    }
+                }
+            }
+        }
+    }
 }
 free_ReverseTransitions(reverse);
 }
 
 
 static int* compute_factorizing_states(Grf* grf,int start,int end,ReverseTransitions* reverse,
-									int *n_factorizing_states);
+                                    int *n_factorizing_states);
 
 
 /**
@@ -641,7 +641,7 @@ static int* compute_factorizing_states(Grf* grf,int start,int end,ReverseTransit
 enum {UNVISITED,BEING_VISITED,VISITED};
 
 static int check_states(Grf* grf,TransitionModifs* t,int state,char* mark_global,
-						char* mark_local,int end,ReverseTransitions* reverse) {
+                        char* mark_local,int end,ReverseTransitions* reverse) {
 if (state==end) return 1;
 if (mark_global[state]) return 0;
 if (mark_local[state]==BEING_VISITED || mark_local[state]==VISITED) return 1;
@@ -649,36 +649,36 @@ mark_local[state]=BEING_VISITED;
 vector_int* transitions=grf->states[state]->transitions;
 struct list_int* to_be_removed=NULL;
 for (int i=0;i<transitions->nbelems;i++) {
-	int dest=transitions->tab[i];
-	if (!check_states(grf,t,dest,mark_global,mark_local,end,reverse)) {
-		/* If we find a transition to a state globally marked, then
-		 * we have found a transition to be removed, and replaced by a fake
-		 * one to the end state of the current group.
-		 */
-		to_be_removed=head_insert(dest,to_be_removed);
-	}
+    int dest=transitions->tab[i];
+    if (!check_states(grf,t,dest,mark_global,mark_local,end,reverse)) {
+        /* If we find a transition to a state globally marked, then
+         * we have found a transition to be removed, and replaced by a fake
+         * one to the end state of the current group.
+         */
+        to_be_removed=head_insert(dest,to_be_removed);
+    }
 }
 /* Finally, we actually remove the transitions */
 if (to_be_removed!=NULL) {
-	/* If there is at least one transition to remove, then we have
-	 * to add a fake transition to the end of the subgroup
-	 */
-	int already_a_real_transition_to_end=(-1!=vector_int_contains(transitions,end));
-	vector_int_add_if_absent(transitions,end);
-	vector_int_add_if_absent(reverse->t[end],state);
-	if (!already_a_real_transition_to_end) {
-		to_remove(t,state,end);
-	}
+    /* If there is at least one transition to remove, then we have
+     * to add a fake transition to the end of the subgroup
+     */
+    int already_a_real_transition_to_end=(-1!=vector_int_contains(transitions,end));
+    vector_int_add_if_absent(transitions,end);
+    vector_int_add_if_absent(reverse->t[end],state);
+    if (!already_a_real_transition_to_end) {
+        to_remove(t,state,end);
+    }
 }
 while (to_be_removed!=NULL) {
-	vector_int_remove(transitions,to_be_removed->n);
-	vector_int_remove(reverse->t[to_be_removed->n],state);
-	//(*t)[state]=sorted_insert(to_be_removed->n,(*t)[state]);
-	to_restore(t,state,to_be_removed->n);
-	struct list_int* tmp=to_be_removed;
-	to_be_removed=to_be_removed->next;
-	tmp->next=NULL;
-	free_list_int(tmp);
+    vector_int_remove(transitions,to_be_removed->n);
+    vector_int_remove(reverse->t[to_be_removed->n],state);
+    //(*t)[state]=sorted_insert(to_be_removed->n,(*t)[state]);
+    to_restore(t,state,to_be_removed->n);
+    struct list_int* tmp=to_be_removed;
+    to_be_removed=to_be_removed->next;
+    tmp->next=NULL;
+    free_list_int(tmp);
 }
 mark_local[state]=VISITED;
 return 1;
@@ -687,7 +687,7 @@ return 1;
 
 static void get_last_states_before_end(Grf* grf,int current,int end,struct list_int* *list);
 static void ensure_graph_form_rec(Grf* grf,TransitionModifs* t,ReverseTransitions* reverse,
-		                          int start,int end);
+                                  int start,int end);
 
 /**
  * This function considers a list of states that all have a transition to state #end. It
@@ -695,19 +695,19 @@ static void ensure_graph_form_rec(Grf* grf,TransitionModifs* t,ReverseTransition
  * only this single state that will have a transition to state #end.
  */
 static int lemonize(Grf* grf,struct list_int* subends,int end,ReverseTransitions* reverse,
-					TransitionModifs* t) {
+                    TransitionModifs* t) {
 int n=grf->n_states;
 (grf->n_states)++;
 /* We enlarge the state array */
 grf->states=(GrfState**)realloc(grf->states,grf->n_states*sizeof(GrfState*));
 if (grf->states==NULL) {
-	fatal_alloc_error("lemonize");
+    fatal_alloc_error("lemonize");
 }
 /* We also have to enlarge reverse */
 reverse->n++;
 reverse->t=(vector_int**)realloc(reverse->t,reverse->n*sizeof(vector_int*));
 if (reverse->t==NULL) {
-	fatal_alloc_error("lemonize");
+    fatal_alloc_error("lemonize");
 }
 reverse->t[n]=new_vector_int();
 /* And also *t */
@@ -720,22 +720,22 @@ vector_int_add(state->transitions,end);
 vector_int_add(reverse->t[end],n);
 /* And we replace transitions to state #end by transitions to state #n */
 while (subends!=NULL) {
-	/* We remove the old transition */
-	vector_int_remove(grf->states[subends->n]->transitions,end);
-	vector_int_remove(reverse->t[end],subends->n);
-	/*error("lemonizing between %S and %S\n",grf->states[subends->n]->box_content,
-			grf->states[end]->box_content);
-	*/
-	int was_a_t_one=was_one_to_remove(t,subends->n,end);
-	//error("was a t one=%d\n",was_a_t_one);
-	/* Replacing it by the new one */
-	vector_int_add(grf->states[subends->n]->transitions,n);
-	vector_int_add(reverse->t[n],subends->n);
-	if (was_a_t_one) {
-		//(*t)[subends->n]=sorted_insert(n,(*t)[subends->n]);
-		to_remove(t,subends->n,n);
-	}
-	subends=subends->next;
+    /* We remove the old transition */
+    vector_int_remove(grf->states[subends->n]->transitions,end);
+    vector_int_remove(reverse->t[end],subends->n);
+    /*error("lemonizing between %S and %S\n",grf->states[subends->n]->box_content,
+            grf->states[end]->box_content);
+    */
+    int was_a_t_one=was_one_to_remove(t,subends->n,end);
+    //error("was a t one=%d\n",was_a_t_one);
+    /* Replacing it by the new one */
+    vector_int_add(grf->states[subends->n]->transitions,n);
+    vector_int_add(reverse->t[n],subends->n);
+    if (was_a_t_one) {
+        //(*t)[subends->n]=sorted_insert(n,(*t)[subends->n]);
+        to_remove(t,subends->n,n);
+    }
+    subends=subends->next;
 }
 return n;
 }
@@ -745,45 +745,45 @@ return n;
  * Here, we are sure, that there is no factorizing state between start and end.
  */
 static void ensure_graph_form_lemon(Grf* grf,TransitionModifs* t,ReverseTransitions* reverse,
-		                          int start,int end) {
+                                  int start,int end) {
 char* mark_global=(char*)calloc(grf->n_states,sizeof(char));
 if (mark_global==NULL) {
-	fatal_alloc_error("ensure_graph_form_lemon");
+    fatal_alloc_error("ensure_graph_form_lemon");
 }
 char* mark_local=(char*)calloc(grf->n_states,sizeof(char));
 if (mark_local==NULL) {
-	fatal_alloc_error("ensure_graph_form_lemon");
+    fatal_alloc_error("ensure_graph_form_lemon");
 }
 vector_int* transitions=grf->states[start]->transitions;
 for (int i=0;i<transitions->nbelems;i++) {
-	memset(mark_local,0,grf->n_states);
-	check_states(grf,t,transitions->tab[i],mark_global,mark_local,end,reverse);
-	for (int j=0;j<grf->n_states;j++) {
-		if (mark_local[j]) {
-			mark_local[j]=0;
-			mark_global[j]=1;
-		}
-	}
+    memset(mark_local,0,grf->n_states);
+    check_states(grf,t,transitions->tab[i],mark_global,mark_local,end,reverse);
+    for (int j=0;j<grf->n_states;j++) {
+        if (mark_local[j]) {
+            mark_local[j]=0;
+            mark_global[j]=1;
+        }
+    }
 }
 free(mark_global);
 free(mark_local);
 
 /* We do recursively the same on subgroups */
 for (int i=0;i<transitions->nbelems;i++) {
-	int substart=transitions->tab[i];
-	struct list_int* subends=NULL;
-	get_last_states_before_end(grf,substart,end,&subends);
-	if (subends==NULL) {
-		fatal_error("Unexpected empty list in ensure_graph_form_lemon\n");
-	}
-	int subend;
-	if (subends->next==NULL) {
-		subend=subends->n;
-	} else {
-		subend=lemonize(grf,subends,end,reverse,t);
-	}
-	free_list_int(subends);
-	ensure_graph_form_rec(grf,t,reverse,substart,subend);
+    int substart=transitions->tab[i];
+    struct list_int* subends=NULL;
+    get_last_states_before_end(grf,substart,end,&subends);
+    if (subends==NULL) {
+        fatal_error("Unexpected empty list in ensure_graph_form_lemon\n");
+    }
+    int subend;
+    if (subends->next==NULL) {
+        subend=subends->n;
+    } else {
+        subend=lemonize(grf,subends,end,reverse,t);
+    }
+    free_list_int(subends);
+    ensure_graph_form_rec(grf,t,reverse,substart,subend);
 }
 }
 
@@ -791,15 +791,15 @@ for (int i=0;i<transitions->nbelems;i++) {
  * General case.
  */
 static void ensure_graph_form_rec(Grf* grf,TransitionModifs* t,ReverseTransitions* reverse,
-		                          int start,int end) {
+                                  int start,int end) {
 int n_factorizing_states;
 if (start==end) return;
 int* factorizing=compute_factorizing_states(grf,start,end,reverse,&n_factorizing_states);
 if (factorizing==NULL) {
-	fatal_error("Cannot compute factorizing states in ensure_graph_form_rec\n");
+    fatal_error("Cannot compute factorizing states in ensure_graph_form_rec\n");
 }
 for (int i=0;i<n_factorizing_states-1;i++) {
-	ensure_graph_form_lemon(grf,t,reverse,factorizing[i],factorizing[i+1]);
+    ensure_graph_form_lemon(grf,t,reverse,factorizing[i],factorizing[i+1]);
 }
 free(factorizing);
 }
@@ -836,7 +836,7 @@ static TransitionModifs* compute_ignorable_or_artificial_transitions(Grf* grf) {
 TransitionModifs* t=new_TransitionModifs(grf->n_states);
 int* mark=(int*)calloc(grf->n_states,sizeof(int));
 if (mark==NULL) {
-	fatal_alloc_error("compute_ignorable_transitions");
+    fatal_alloc_error("compute_ignorable_transitions");
 }
 /* First, we remove back transitions */
 remove_back_transitions(grf,0,mark,t);
@@ -859,24 +859,24 @@ return t;
 static int* get_concerned_states(Grf* grf,int start,int end,ReverseTransitions* reverse,int *n) {
 int* accessible=(int*)calloc(grf->n_states,sizeof(int));
 if (accessible==NULL) {
-	fatal_alloc_error("compute_factorizing_states");
+    fatal_alloc_error("compute_factorizing_states");
 }
 int* coaccessible=(int*)calloc(grf->n_states,sizeof(int));
 if (coaccessible==NULL) {
-	fatal_alloc_error("compute_factorizing_states");
+    fatal_alloc_error("compute_factorizing_states");
 }
 int* concerned=(int*)malloc(grf->n_states*sizeof(int));
 if (concerned==NULL) {
-	fatal_alloc_error("compute_factorizing_states");
+    fatal_alloc_error("compute_factorizing_states");
 }
 explore_accessibility(grf,start,accessible);
 explore_coaccessibility(reverse,end,coaccessible);
 if (!accessible[end] || !coaccessible[start]) {
-	free(accessible);
-	free(coaccessible);
-	if (!accessible[end]) error("accessibility ooops on state %S\n",grf->states[end]->box_content);
-	if (!coaccessible[start]) error("coaccessibility ooops on state %S\n",grf->states[start]->box_content);
-	return NULL;
+    free(accessible);
+    free(coaccessible);
+    if (!accessible[end]) error("accessibility ooops on state %S\n",grf->states[end]->box_content);
+    if (!coaccessible[start]) error("coaccessibility ooops on state %S\n",grf->states[start]->box_content);
+    return NULL;
 }
 /* If there is no problem, we reuse the accessible array to return the result.
  * By convention, we place start and end at positions 0 and 1 */
@@ -884,10 +884,10 @@ int j=2;
 concerned[0]=start;
 concerned[1]=end;
 for (int i=0;i<grf->n_states;i++) {
-	if (i==start || i==end) continue;
-	if (accessible[i] && coaccessible[i]) {
-		concerned[j++]=i;
-	}
+    if (i==start || i==end) continue;
+    if (accessible[i] && coaccessible[i]) {
+        concerned[j++]=i;
+    }
 }
 *n=j;
 free(accessible);
@@ -903,19 +903,19 @@ return concerned;
 static void topological_sort(int* subgraph,int n,Grf* grf) {
 int* incoming=(int*)calloc(grf->n_states,sizeof(int));
 if (incoming==NULL) {
-	fatal_alloc_error("topological_sort");
+    fatal_alloc_error("topological_sort");
 }
 for (int i=0;i<n;i++) {
-	/* We must only take into account transitions from concerned states */
-	int state=subgraph[i];
-	vector_int* transitions=grf->states[state]->transitions;
-	for (int j=0;j<transitions->nbelems;j++) {
-		incoming[transitions->tab[j]]++;
-	}
+    /* We must only take into account transitions from concerned states */
+    int state=subgraph[i];
+    vector_int* transitions=grf->states[state]->transitions;
+    for (int j=0;j<transitions->nbelems;j++) {
+        incoming[transitions->tab[j]]++;
+    }
 }
 int* renumber=(int*)malloc(n*sizeof(int));
 if (renumber==NULL) {
-	fatal_alloc_error("topological_sort");
+    fatal_alloc_error("topological_sort");
 }
 int q;
 for (q=0;q<n;q++) {
@@ -926,7 +926,7 @@ for (q=0;q<n;q++) {
       old++;
    }
    if (old==n) {
-	   fatal_error("old>n should not happen in topological_sort\n");
+       fatal_error("old>n should not happen in topological_sort\n");
    }
    renumber[old]=q;
    incoming[subgraph[old]]=-1;
@@ -938,10 +938,10 @@ for (q=0;q<n;q++) {
    }
 }
 for (int i=0;i<n;i++) {
-	incoming[renumber[i]]=subgraph[i];
+    incoming[renumber[i]]=subgraph[i];
 }
 for (int i=0;i<n;i++) {
-	subgraph[i]=incoming[i];
+    subgraph[i]=incoming[i];
 }
 free(renumber);
 free(incoming);
@@ -954,27 +954,27 @@ free(incoming);
  * end.
  */
 static int* compute_factorizing_states(Grf* grf,int start,int end,ReverseTransitions* reverse,
-										int *n_factorizing_states) {
+                                        int *n_factorizing_states) {
 int n;
 int* subgraph=get_concerned_states(grf,start,end,reverse,&n);
 if (subgraph==NULL) {
-	error("Cannot compute concerned states between _%S_ and _%S_\n",grf->states[start]->box_content,
-				grf->states[end]->box_content);
-	return NULL;
+    error("Cannot compute concerned states between _%S_ and _%S_\n",grf->states[start]->box_content,
+                grf->states[end]->box_content);
+    return NULL;
 }
 topological_sort(subgraph,n,grf);
 int* factorizing=(int*)malloc(grf->n_states*sizeof(int));
 if (factorizing==NULL) {
-	fatal_alloc_error("compute_factorizing_states");
+    fatal_alloc_error("compute_factorizing_states");
 }
 for (int i=0;i<grf->n_states;i++) {
-	factorizing[i]=1;
+    factorizing[i]=1;
 }
 for (int i=0;i<n;i++) {
    for (int j=1;j<n;j++) {
-	   int src_state=subgraph[i];
-	   int dest_state=subgraph[j];
-	   int direct_transition=(-1!=vector_int_contains(grf->states[src_state]->transitions,dest_state));
+       int src_state=subgraph[i];
+       int dest_state=subgraph[j];
+       int direct_transition=(-1!=vector_int_contains(grf->states[src_state]->transitions,dest_state));
       if (direct_transition) {
          for (int k=i+1;k<j;k++) {
             /* We can do this only because we have performed a
@@ -986,13 +986,13 @@ for (int i=0;i<n;i++) {
 }
 int* result=(int*)malloc(grf->n_states*sizeof(int));
 if (result==NULL) {
-	fatal_alloc_error("compute_factorizing_states");
+    fatal_alloc_error("compute_factorizing_states");
 }
 *n_factorizing_states=0;
 for (int i=0;i<n;i++) {
-	if (factorizing[subgraph[i]]) {
-		result[(*n_factorizing_states)++]=subgraph[i];
-	}
+    if (factorizing[subgraph[i]]) {
+        result[(*n_factorizing_states)++]=subgraph[i];
+    }
 }
 free(factorizing);
 free(subgraph);
@@ -1003,7 +1003,7 @@ return result;
 static BoxGroup* new_BoxGroup(GroupType type,int start,int end) {
 BoxGroup* g=(BoxGroup*)malloc(sizeof(BoxGroup));
 if (g==NULL) {
-	fatal_alloc_error("new_BoxGroup");
+    fatal_alloc_error("new_BoxGroup");
 }
 g->type=type;
 g->start=start;
@@ -1020,8 +1020,8 @@ free(g);
 
 
 static int process_group(Grf* grf,int parent_group,int start,int end,TransitionModifs* t,
-					vector_ptr* groups,ReverseTransitions* reverse,
-					int* box_width,int* box_height);
+                    vector_ptr* groups,ReverseTransitions* reverse,
+                    int* box_width,int* box_height);
 
 /**
  * This function explores the graph from state #current until transitions
@@ -1029,16 +1029,16 @@ static int process_group(Grf* grf,int parent_group,int start,int end,TransitionM
  */
 static void get_last_states_before_end(Grf* grf,int current,int end,struct list_int* *list) {
 if (current==end) {
-	*list=sorted_insert(end,*list);
-	return;
+    *list=sorted_insert(end,*list);
+    return;
 }
 vector_int* t=grf->states[current]->transitions;
 if (vector_int_contains(t,end)!=-1) {
-	*list=sorted_insert(current,*list);
-	return;
+    *list=sorted_insert(current,*list);
+    return;
 }
 for (int i=0;i<t->nbelems;i++) {
-	get_last_states_before_end(grf,t->tab[i],end,list);
+    get_last_states_before_end(grf,t->tab[i],end,list);
 }
 }
 
@@ -1051,10 +1051,10 @@ static int get_last_state_before_end(Grf* grf,int current,int end) {
 struct list_int* l=NULL;
 get_last_states_before_end(grf,current,end,&l);
 if (l==NULL) {
-	fatal_error("Unexpected empty list in get_last_state_before_end\n");
+    fatal_error("Unexpected empty list in get_last_state_before_end\n");
 }
 if (l->next!=NULL) {
-	fatal_error("Unexpected list size >1 in get_last_state_before_end\n");
+    fatal_error("Unexpected list size >1 in get_last_state_before_end\n");
 }
 int n=l->n;
 free_list_int(l);
@@ -1073,17 +1073,17 @@ return (a>b)?a:b;
  * of several subgroups.
  */
 static int process_lemon_group(Grf* grf,int parent_group,int start,int end,TransitionModifs* t,
-					vector_ptr* groups,ReverseTransitions* reverse,
-					int* box_width,int* box_height) {
+                    vector_ptr* groups,ReverseTransitions* reverse,
+                    int* box_width,int* box_height) {
 /* First case, a subgraph made of only two linked states: start --> end */
 if (-1!=vector_int_contains(grf->states[start]->transitions,end)) {
-	int current_group=groups->nbelems;
-	BoxGroup* group=new_BoxGroup(PAIR,start,end);
-	group->parent=parent_group;
-	group->width=box_width[start]+WIDTH_MARGIN+box_width[end];
-	group->height=max(box_height[start],box_height[end]);
-	vector_ptr_add(groups,group);
-	return current_group;
+    int current_group=groups->nbelems;
+    BoxGroup* group=new_BoxGroup(PAIR,start,end);
+    group->parent=parent_group;
+    group->width=box_width[start]+WIDTH_MARGIN+box_width[end];
+    group->height=max(box_height[start],box_height[end]);
+    vector_ptr_add(groups,group);
+    return current_group;
 }
 int current_group=groups->nbelems;
 BoxGroup* group=new_BoxGroup(LEMON,start,end);
@@ -1095,14 +1095,14 @@ vector_int* transitions=grf->states[start]->transitions;
 int max_width=0;
 int height=0;
 for (int i=0;i<transitions->nbelems;i++) {
-	int subend=get_last_state_before_end(grf,transitions->tab[i],end);
-	int subgroup_index=process_group(grf,current_group,transitions->tab[i],subend,t,groups,
-									reverse,box_width,box_height);
-	if (subgroup_index==-1) return -1;
-	vector_int_add(group->subgroups,subgroup_index);
-	BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
-	if (subgroup->width>max_width) max_width=subgroup->width;
-	height=height+subgroup->height+HEIGHT_MARGIN;
+    int subend=get_last_state_before_end(grf,transitions->tab[i],end);
+    int subgroup_index=process_group(grf,current_group,transitions->tab[i],subend,t,groups,
+                                    reverse,box_width,box_height);
+    if (subgroup_index==-1) return -1;
+    vector_int_add(group->subgroups,subgroup_index);
+    BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
+    if (subgroup->width>max_width) max_width=subgroup->width;
+    height=height+subgroup->height+HEIGHT_MARGIN;
 }
 height=height-HEIGHT_MARGIN;
 group->width=group->width+max_width;
@@ -1122,33 +1122,33 @@ return current_group;
  * happen if the given grf has not been fully cleaned by compute_ignorable_transitions.
  */
 static int process_group(Grf* grf,int parent_group,int start,int end,TransitionModifs* t,
-					vector_ptr* groups,ReverseTransitions* reverse,
-					int* box_width,int* box_height) {
+                    vector_ptr* groups,ReverseTransitions* reverse,
+                    int* box_width,int* box_height) {
 if (start==end) {
-	/* If we have a single state, then it is a group of size 1 for whose
-	 * we can set a width and a height */
-	int current_group=groups->nbelems;
-	BoxGroup* group=new_BoxGroup(SINGLE,start,end);
-	group->parent=parent_group;
-	group->width=box_width[start];
-	group->height=box_height[start];
-	vector_ptr_add(groups,group);
-	return current_group;
+    /* If we have a single state, then it is a group of size 1 for whose
+     * we can set a width and a height */
+    int current_group=groups->nbelems;
+    BoxGroup* group=new_BoxGroup(SINGLE,start,end);
+    group->parent=parent_group;
+    group->width=box_width[start];
+    group->height=box_height[start];
+    vector_ptr_add(groups,group);
+    return current_group;
 }
 /* Otherwise, we compute factorizing states between parent_start and parent_end */
 int n_factorizing;
 int* factorizing=compute_factorizing_states(grf,start,end,reverse,&n_factorizing);
 if (factorizing==NULL) {
-	error("Cannot compute factorizing states between _%S_ and _%S_\n",grf->states[start]->box_content,
-			grf->states[end]->box_content);
-	return -1;
+    error("Cannot compute factorizing states between _%S_ and _%S_\n",grf->states[start]->box_content,
+            grf->states[end]->box_content);
+    return -1;
 }
 if (n_factorizing==2) {
-	/* If there are none other factorizing states that the start and end ones,
-	 * then we can directly call process_lemon_group */
-	free(factorizing);
-	return process_lemon_group(grf,parent_group,start,end,t,groups,reverse,
-								box_width,box_height);
+    /* If there are none other factorizing states that the start and end ones,
+     * then we can directly call process_lemon_group */
+    free(factorizing);
+    return process_lemon_group(grf,parent_group,start,end,t,groups,reverse,
+                                box_width,box_height);
 }
 int current_group=groups->nbelems;
 BoxGroup* group=new_BoxGroup(SEQUENTIAL,start,end);
@@ -1157,30 +1157,30 @@ group->width=0;
 group->height=0;
 vector_ptr_add(groups,group);
 for (int i=1;i<n_factorizing;i++) {
-	int BB=factorizing[i];
-	int subgroup_index=process_lemon_group(grf,current_group,factorizing[i-1],factorizing[i],t,
-									groups,reverse,box_width,box_height);
-	vector_int_add(group->subgroups,subgroup_index);
-	if (subgroup_index==-1) {
-		free(factorizing);
-		return 0;
-	}
-	BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
-	/* In a group made of successive lemon ones, some factorizing states
-	 * are included in two lemons. For instance, if we have
-	 *
-	 * A --lemon--> B --lemon--> C
-	 *
-	 * the width of A->C should be width(A->B)+width(B->C)-width(B), because
-	 * B's width is taken twice into account in both A->B and B->C
-	 */
-	group->width=group->width+subgroup->width;
-	if (BB!=end) {
-		group->width=group->width-box_width[BB];
-	}
-	if (subgroup->height>group->height) {
-		group->height=subgroup->height;
-	}
+    int BB=factorizing[i];
+    int subgroup_index=process_lemon_group(grf,current_group,factorizing[i-1],factorizing[i],t,
+                                    groups,reverse,box_width,box_height);
+    vector_int_add(group->subgroups,subgroup_index);
+    if (subgroup_index==-1) {
+        free(factorizing);
+        return 0;
+    }
+    BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
+    /* In a group made of successive lemon ones, some factorizing states
+     * are included in two lemons. For instance, if we have
+     *
+     * A --lemon--> B --lemon--> C
+     *
+     * the width of A->C should be width(A->B)+width(B->C)-width(B), because
+     * B's width is taken twice into account in both A->B and B->C
+     */
+    group->width=group->width+subgroup->width;
+    if (BB!=end) {
+        group->width=group->width-box_width[BB];
+    }
+    if (subgroup->height>group->height) {
+        group->height=subgroup->height;
+    }
 }
 free(factorizing);
 return current_group;
@@ -1193,95 +1193,95 @@ return current_group;
  *  are the width and height of the given group.
  */
 static void place_groups(Grf* grf,int n,int shiftX,int shiftY,vector_ptr* groups,
-						int* is_placed,int* box_width,int* box_height) {
+                        int* is_placed,int* box_width,int* box_height) {
 BoxGroup* bg=(BoxGroup*)groups->tab[n];
 GrfState* box_start=grf->states[bg->start];
 GrfState* box_end=grf->states[bg->end];
 /* Whatever happen, we must place the start box on the left, at mid-height */
 if (!is_placed[bg->start]) {
-	is_placed[bg->start]=1;
-	box_start->x=shiftX;
-	box_start->y=shiftY+bg->height/2;
+    is_placed[bg->start]=1;
+    box_start->x=shiftX;
+    box_start->y=shiftY+bg->height/2;
 }
 if (bg->type==SINGLE) {
-	/* A single box is a group with start==end, so we're done */
-	return;
+    /* A single box is a group with start==end, so we're done */
+    return;
 }
 /* If we have a multi-box group, we must place the end box
  * on the right, at mid-height */
 if (!is_placed[bg->end]) {
-	is_placed[bg->end]=1;
-	box_end->x=shiftX+bg->width-box_width[bg->end];
-	box_end->y=shiftY+bg->height/2;
+    is_placed[bg->end]=1;
+    box_end->x=shiftX+bg->width-box_width[bg->end];
+    box_end->y=shiftY+bg->height/2;
 }
 if (bg->type==PAIR) {
-	/* Once we have placed start and end, we're done if the subgroup is a pair one */
-	return;
+    /* Once we have placed start and end, we're done if the subgroup is a pair one */
+    return;
 }
 /* Now, we have to place the content of the group */
 if (bg->type==SEQUENTIAL) {
-	/* If we have a group sequence, we first align all the factorizing states */
-	int currentX=box_start->x;
-	for (int i=0;i<bg->subgroups->nbelems;i++) {
-		int subgroup_index=bg->subgroups->tab[i];
-		BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
-		if (!is_placed[subgroup->start]) {
-			GrfState* sub_start=grf->states[subgroup->start];
-			sub_start->x=currentX;
-			sub_start->y=box_start->y;
-			is_placed[subgroup->start]=1;
-		}
-		currentX=currentX+subgroup->width-box_width[subgroup->end];
-		if (!is_placed[subgroup->end]) {
-			GrfState* sub_end=grf->states[subgroup->end];
-			sub_end->x=currentX;
-			sub_end->y=box_start->y;
-			is_placed[subgroup->end]=1;
-		}
-	}
-	/* Now, we recursively place all the subgroups */
-	currentX=shiftX;
-	for (int i=0;i<bg->subgroups->nbelems;i++) {
-		int subgroup_index=bg->subgroups->tab[i];
-		BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
-		int y=shiftY+(bg->height-subgroup->height)/2;
-		place_groups(grf,subgroup_index,currentX,y,groups,is_placed,box_width,box_height);
-		currentX=currentX+subgroup->width-box_width[subgroup->end];
-	}
-	return;
+    /* If we have a group sequence, we first align all the factorizing states */
+    int currentX=box_start->x;
+    for (int i=0;i<bg->subgroups->nbelems;i++) {
+        int subgroup_index=bg->subgroups->tab[i];
+        BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
+        if (!is_placed[subgroup->start]) {
+            GrfState* sub_start=grf->states[subgroup->start];
+            sub_start->x=currentX;
+            sub_start->y=box_start->y;
+            is_placed[subgroup->start]=1;
+        }
+        currentX=currentX+subgroup->width-box_width[subgroup->end];
+        if (!is_placed[subgroup->end]) {
+            GrfState* sub_end=grf->states[subgroup->end];
+            sub_end->x=currentX;
+            sub_end->y=box_start->y;
+            is_placed[subgroup->end]=1;
+        }
+    }
+    /* Now, we recursively place all the subgroups */
+    currentX=shiftX;
+    for (int i=0;i<bg->subgroups->nbelems;i++) {
+        int subgroup_index=bg->subgroups->tab[i];
+        BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
+        int y=shiftY+(bg->height-subgroup->height)/2;
+        place_groups(grf,subgroup_index,currentX,y,groups,is_placed,box_width,box_height);
+        currentX=currentX+subgroup->width-box_width[subgroup->end];
+    }
+    return;
 }
 /* If we have a lemon group, we place all the subgroups */
 int currentY=shiftY;
 shiftX=shiftX+box_width[bg->start]+WIDTH_MARGIN;
 for (int i=0;i<bg->subgroups->nbelems;i++) {
-	int subgroup_index=bg->subgroups->tab[i];
-	BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
-	place_groups(grf,subgroup_index,shiftX,currentY,groups,is_placed,box_width,box_height);
-	currentY=currentY+subgroup->height+HEIGHT_MARGIN;
+    int subgroup_index=bg->subgroups->tab[i];
+    BoxGroup* subgroup=(BoxGroup*)groups->tab[subgroup_index];
+    place_groups(grf,subgroup_index,shiftX,currentY,groups,is_placed,box_width,box_height);
+    currentY=currentY+subgroup->height+HEIGHT_MARGIN;
 }
 }
 
 
 static void compute_box_dimensions(Grf* grf,int* box_width,int* box_height) {
 for (int i=0;i<grf->n_states;i++) {
-	vector_ptr* lines=tokenize_box_content(grf->states[i]->box_content);
-	if (lines==NULL) {
-		fatal_error("Unexpected NULL lines in compute_box_dimensions for box content %S\n",
-				grf->states[i]->box_content);
-	}
-	int max_line=0;
-	for (int j=0;j<lines->nbelems;j++) {
-		int tmp=u_strlen((unichar*)(lines->tab[j]));
-		if (tmp>max_line) max_line=tmp;
-	}
-	if (i==1) {
-		box_width[i]=20;
-		box_height[i]=20;
-	} else {
-		box_width[i]=WIDTH_PER_CHAR*max_line;
-		box_height[i]=HEIGHT_PER_CHAR*lines->nbelems;
-	}
-	free_vector_ptr(lines,free);
+    vector_ptr* lines=tokenize_box_content(grf->states[i]->box_content);
+    if (lines==NULL) {
+        fatal_error("Unexpected NULL lines in compute_box_dimensions for box content %S\n",
+                grf->states[i]->box_content);
+    }
+    int max_line=0;
+    for (int j=0;j<lines->nbelems;j++) {
+        int tmp=u_strlen((unichar*)(lines->tab[j]));
+        if (tmp>max_line) max_line=tmp;
+    }
+    if (i==1) {
+        box_width[i]=20;
+        box_height[i]=20;
+    } else {
+        box_width[i]=WIDTH_PER_CHAR*max_line;
+        box_height[i]=HEIGHT_PER_CHAR*lines->nbelems;
+    }
+    free_vector_ptr(lines,free);
 }
 }
 
@@ -1297,11 +1297,11 @@ TransitionModifs * t=compute_ignorable_or_artificial_transitions(grf);
 vector_ptr* groups=new_vector_ptr(grf->n_states);
 int* box_width=(int*)malloc(grf->n_states*sizeof(int));
 if (box_width==NULL) {
-	fatal_alloc_error("organize_boxes");
+    fatal_alloc_error("organize_boxes");
 }
 int* box_height=(int*)malloc(grf->n_states*sizeof(int));
 if (box_height==NULL) {
-	fatal_alloc_error("organize_boxes");
+    fatal_alloc_error("organize_boxes");
 }
 compute_box_dimensions(grf,box_width,box_height);
 /* Now we do the job */
@@ -1310,35 +1310,35 @@ process_group(grf,-1,0,1,t,groups,reverse,box_width,box_height);
 free_ReverseTransitions(reverse);
 int* is_placed=(int*)calloc(grf->n_states,sizeof(int));
 if (is_placed==NULL) {
-	fatal_alloc_error("organize_boxes");
+    fatal_alloc_error("organize_boxes");
 }
 place_groups(grf,0,40,40,groups,is_placed,box_width,box_height);
 u_sprintf(grf->size,"SIZE %d %d",((BoxGroup*)groups->tab[0])->width+4*WIDTH_MARGIN,
-		((BoxGroup*)groups->tab[0])->height+4*HEIGHT_MARGIN);
+        ((BoxGroup*)groups->tab[0])->height+4*HEIGHT_MARGIN);
 free(is_placed);
 free(box_width);
 free(box_height);
 /* We restore the ignored transitions */
 for (int i=0;i<grf->n_states;i++) {
-	vector_int* transitions=grf->states[i]->transitions;
-	struct list_int* tmp=t->to_restore[i];
-	while (tmp!=NULL) {
-		if (-1==vector_int_contains(transitions,tmp->n)) {
-			/* If the transition does not exist, we add it */
-			vector_int_add(transitions,tmp->n);
-		}
-		tmp=tmp->next;
-	}
+    vector_int* transitions=grf->states[i]->transitions;
+    struct list_int* tmp=t->to_restore[i];
+    while (tmp!=NULL) {
+        if (-1==vector_int_contains(transitions,tmp->n)) {
+            /* If the transition does not exist, we add it */
+            vector_int_add(transitions,tmp->n);
+        }
+        tmp=tmp->next;
+    }
 }
 /* And remove the added fake ones */
 for (int i=0;i<grf->n_states;i++) {
-	vector_int* transitions=grf->states[i]->transitions;
-	struct list_int* tmp=t->to_remove[i];
-	while (tmp!=NULL) {
-		/* If the transition exists, we remove it */
-		vector_int_remove(transitions,tmp->n);
-		tmp=tmp->next;
-	}
+    vector_int* transitions=grf->states[i]->transitions;
+    struct list_int* tmp=t->to_remove[i];
+    while (tmp!=NULL) {
+        /* If the transition exists, we remove it */
+        vector_int_remove(transitions,tmp->n);
+        tmp=tmp->next;
+    }
 }
 /* And we clean our stuffs */
 free_vector_ptr(groups,(void(*)(void*))free_BoxGroup);
@@ -1350,7 +1350,7 @@ void clean_useless_states(Grf* grf) {
 int* accessible=(int*)calloc(grf->n_states,sizeof(int));
 int* coaccessible=(int*)calloc(grf->n_states,sizeof(int));
 if (accessible==NULL || coaccessible==NULL) {
-	fatal_alloc_error("beautify");
+    fatal_alloc_error("beautify");
 }
 explore_accessibility(grf,0,accessible);
 ReverseTransitions* reverse=compute_reverse_transitions(grf);
@@ -1358,27 +1358,27 @@ explore_coaccessibility(reverse,1,coaccessible);
 /* Here, we reuse the accessible array as a 'state to remove' one */
 int* to_remove=accessible;
 for (int i=0;i<grf->n_states;i++) {
-	to_remove[i]=!(accessible[i]&&coaccessible[i]);
+    to_remove[i]=!(accessible[i]&&coaccessible[i]);
 }
 for (int i=0;i<grf->n_states;i++) {
-	GrfState* s=grf->states[i];
-	if (to_remove[i]) {
-		/* We clear the transition list of a state to be removed */
-		s->transitions->nbelems=0;
-		/* And we set its content to the empty string, to that we can
-		 *  invoke remove_isolated_boxes */
-		s->box_content[0]='\0';
-	} else {
-		/* And we remove transitions to removed states */
-		for (int j=0;j<s->transitions->nbelems;) {
-			int val=s->transitions->tab[j];
-			if (to_remove[val]) {
-				vector_int_remove(s->transitions,val);
-			} else {
-				j++;
-			}
-		}
-	}
+    GrfState* s=grf->states[i];
+    if (to_remove[i]) {
+        /* We clear the transition list of a state to be removed */
+        s->transitions->nbelems=0;
+        /* And we set its content to the empty string, to that we can
+         *  invoke remove_isolated_boxes */
+        s->box_content[0]='\0';
+    } else {
+        /* And we remove transitions to removed states */
+        for (int j=0;j<s->transitions->nbelems;) {
+            int val=s->transitions->tab[j];
+            if (to_remove[val]) {
+                vector_int_remove(s->transitions,val);
+            } else {
+                j++;
+            }
+        }
+    }
 }
 free_ReverseTransitions(reverse);
 free(accessible);

--- a/GrfDiff.cpp
+++ b/GrfDiff.cpp
@@ -98,8 +98,8 @@ UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff,lopts_GrfDiff,&index))) {
    switch(val) {
    case 'V': only_verify_arguments = true;
-             break;    
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 1: {
 	   strcpy(output,options.vars()->optarg);
@@ -119,7 +119,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff,lopts_GrfDiff,&i
              break;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_GrfDiff[index].name);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;

--- a/GrfDiff.cpp
+++ b/GrfDiff.cpp
@@ -86,8 +86,8 @@ const struct option_TS lopts_GrfDiff[] = {
  */
 int main_GrfDiff(int argc,char* const argv[]) {
 if (argc==1) {
-	usage();
-	return SUCCESS_RETURN_CODE;
+    usage();
+    return SUCCESS_RETURN_CODE;
 }
 
 VersatileEncodingConfig vec=VEC_DEFAULT;
@@ -102,8 +102,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff,lopts_GrfDiff,&i
    case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 1: {
-	   strcpy(output,options.vars()->optarg);
-	   break;
+       strcpy(output,options.vars()->optarg);
+       break;
    }
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
@@ -139,13 +139,13 @@ if (only_verify_arguments) {
 
 U_FILE* f=U_STDOUT;
 if (output[0]!='\0') {
-	/* Since the output is supposed to be a diff-like one, there is no point
-	 * in outputing in a variable encoding, so we force UTF8 */
-	f=u_fopen(UTF8,output,U_WRITE);
-	if (f==NULL) {
-		error("Cannot create file %s\n",output);
+    /* Since the output is supposed to be a diff-like one, there is no point
+     * in outputing in a variable encoding, so we force UTF8 */
+    f=u_fopen(UTF8,output,U_WRITE);
+    if (f==NULL) {
+        error("Cannot create file %s\n",output);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 Grf* a=load_Grf(&vec,argv[options.vars()->optind]);
@@ -158,7 +158,7 @@ if (a==NULL) {
 
 Grf* b=load_Grf(&vec,argv[options.vars()->optind+1]);
 if (b==NULL) {
-	free_Grf(a);
+    free_Grf(a);
   if (f!=U_STDOUT) {
     u_fclose(f);
   }

--- a/GrfDiff3.cpp
+++ b/GrfDiff3.cpp
@@ -82,8 +82,8 @@ const struct option_TS lopts_GrfDiff3[]= {
  */
 int main_GrfDiff3(int argc,char* const argv[]) {
 if (argc==1) {
-	usage();
-	return SUCCESS_RETURN_CODE;
+    usage();
+    return SUCCESS_RETURN_CODE;
 }
 
 VersatileEncodingConfig vec=VEC_DEFAULT;
@@ -100,12 +100,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff3,lopts_GrfDiff3,
      case 'h': usage();
                return SUCCESS_RETURN_CODE;
      case 1: {
-  	   strcpy(output,options.vars()->optarg);
-  	   break;
+       strcpy(output,options.vars()->optarg);
+       break;
      }
      case 2: {
-  	   strcpy(conflicts,options.vars()->optarg);
-  	   break;
+       strcpy(conflicts,options.vars()->optarg);
+       break;
      }
      case 3: only_cosmetics=1; break;
      case 'k': if (options.vars()->optarg[0]=='\0') {
@@ -142,24 +142,24 @@ if (only_verify_arguments) {
 
 U_FILE* f=U_STDOUT;
 if (output[0]!='\0') {
-	f=u_fopen(&vec,output,U_WRITE);
-	if (f==NULL) {
-		error("Cannot create file %s\n",output);
+    f=u_fopen(&vec,output,U_WRITE);
+    if (f==NULL) {
+        error("Cannot create file %s\n",output);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 U_FILE* f_conflicts=NULL;
 if (conflicts[0]!='\0') {
-	/* There is no point in encoding the conflict file in UTF16 */
-	f_conflicts=u_fopen(UTF8,conflicts,U_WRITE);
-	if (f_conflicts==NULL) {
+    /* There is no point in encoding the conflict file in UTF16 */
+    f_conflicts=u_fopen(UTF8,conflicts,U_WRITE);
+    if (f_conflicts==NULL) {
     error("Cannot create file %s\n",conflicts);
     if (f!=U_STDOUT) {
      u_fclose(f);
     }
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 Grf* mine=load_Grf(&vec,argv[options.vars()->optind]);
@@ -174,7 +174,7 @@ if (mine==NULL) {
 
 Grf* base=load_Grf(&vec,argv[options.vars()->optind+1]);
 if (base==NULL) {
-	free_Grf(mine);
+    free_Grf(mine);
   u_fclose(f_conflicts);
   if (f!=U_STDOUT) {
    u_fclose(f);
@@ -185,7 +185,7 @@ if (base==NULL) {
 Grf* other=load_Grf(&vec,argv[options.vars()->optind+2]);
 if (other==NULL) {
   free_Grf(base);
-	free_Grf(mine);
+    free_Grf(mine);
   u_fclose(f_conflicts);
   if (f!=U_STDOUT) {
    u_fclose(f);
@@ -196,19 +196,19 @@ if (other==NULL) {
 int res=diff3(f,f_conflicts,mine,base,other,only_cosmetics);
 
 if (f!=U_STDOUT) {
-	u_fclose(f);
-	if (res!=0) {
-		/* If the diff3 failed, we must remove the file */
-		af_remove(output);
-	}
+    u_fclose(f);
+    if (res!=0) {
+        /* If the diff3 failed, we must remove the file */
+        af_remove(output);
+    }
 }
 
 if (f_conflicts!=NULL) {
-	u_fclose(f_conflicts);
-	if (res==0) {
-		/* If the diff3 succeeded, we must remove the file */
-		af_remove(conflicts);
-	}
+    u_fclose(f_conflicts);
+    if (res==0) {
+        /* If the diff3 succeeded, we must remove the file */
+        af_remove(conflicts);
+    }
 }
 
 free_Grf(mine);

--- a/GrfDiff3.cpp
+++ b/GrfDiff3.cpp
@@ -96,8 +96,8 @@ UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff3,lopts_GrfDiff3,&index))) {
    switch(val) {
      case 'V': only_verify_arguments = true;
-               break;    
-     case 'h': usage(); 
+               break;
+     case 'h': usage();
                return SUCCESS_RETURN_CODE;
      case 1: {
   	   strcpy(output,options.vars()->optarg);
@@ -122,7 +122,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfDiff3,lopts_GrfDiff3,
                break;
      case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                            error("Missing argument for option --%s\n",lopts_GrfDiff3[index].name);
-               return USAGE_ERROR_CODE;                           
+               return USAGE_ERROR_CODE;
      case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                            error("Invalid option --%s\n",options.vars()->optarg);
                return USAGE_ERROR_CODE;
@@ -184,7 +184,7 @@ if (base==NULL) {
 
 Grf* other=load_Grf(&vec,argv[options.vars()->optind+2]);
 if (other==NULL) {
-  free_Grf(base);  
+  free_Grf(base);
 	free_Grf(mine);
   u_fclose(f_conflicts);
   if (f!=U_STDOUT) {

--- a/GrfSvn_lib.cpp
+++ b/GrfSvn_lib.cpp
@@ -128,19 +128,19 @@ vector_ptr_add(diff->diff_ops,d);
  */
 static int diff3_grf_strings(unichar* mine,unichar* base,unichar* other,unichar* result) {
 if (!u_strcmp(mine,base)) {
-	/* If I didn't modify the string, then the other one version can be taken into account */
-	u_strcpy(result,other);
-	return 0;
+    /* If I didn't modify the string, then the other one version can be taken into account */
+    u_strcpy(result,other);
+    return 0;
 }
 if (!u_strcmp(other,base)) {
-	/* If my version differs but not the other's one, we take my version */
-	u_strcpy(result,mine);
-	return 0;
+    /* If my version differs but not the other's one, we take my version */
+    u_strcpy(result,mine);
+    return 0;
 }
 if (!u_strcmp(mine,other)) {
-	/* If both versions differ from the base one but are the same, there is no conflict */
-	u_strcpy(result,mine);
-	return 0;
+    /* If both versions differ from the base one but are the same, there is no conflict */
+    u_strcpy(result,mine);
+    return 0;
 }
 /* Conflict */
 return 1;
@@ -151,11 +151,11 @@ return 1;
  * Performs a diff3 on property values. Returns 0 in case of success, 1 otherwise.
  */
 static int diff3_grf_property(const char* property,unichar* mine,unichar* base,unichar* other,
-		unichar* result,U_FILE* f_conflicts,int *conflict) {
+        unichar* result,U_FILE* f_conflicts,int *conflict) {
 int res;
 if (1==(res=diff3_grf_strings(mine,base,other,result))) {
-	*conflict=1;
-	if (f_conflicts!=NULL) u_fprintf(f_conflicts,"PROPERTY %s\n",property);
+    *conflict=1;
+    if (f_conflicts!=NULL) u_fprintf(f_conflicts,"PROPERTY %s\n",property);
 }
 return res;
 }
@@ -167,7 +167,7 @@ return res;
  * conflicts, it returns 1 and conflict descriptions are written to f.
  */
 static void merge_grf_headers(Grf* mine,Grf* base,Grf* other,Grf* result,
-		U_FILE* f_conflicts,int *conflict) {
+        U_FILE* f_conflicts,int *conflict) {
 diff3_grf_property("SIZE",mine->size,base->size,other->size,result->size,f_conflicts,conflict);
 diff3_grf_property("FONT",mine->font,base->font,other->font,result->font,f_conflicts,conflict);
 diff3_grf_property("OFONT",mine->ofont,base->ofont,other->ofont,result->ofont,f_conflicts,conflict);
@@ -193,20 +193,20 @@ diff3_grf_property("PORIENT",mine->porient,base->porient,other->porient,result->
  * It looks for a conflicting box move in other.
  */
 static void test_conflicting_move(GrfDiff* base_other,Grf* mine,Grf* other,int base_index,
-		int mine_index,U_FILE* f_conflicts,int *conflict) {
+        int mine_index,U_FILE* f_conflicts,int *conflict) {
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_MOVED || op->box_base!=base_index) continue;
-	/* We have found a box move, but it may (miraculously) be the same in
-	 * mine and other */
-	GrfState* mine_box=mine->states[mine_index];
-	GrfState* other_box=other->states[op->box_dest];
-	if (mine_box->x==other_box->x && mine_box->y==other_box->y) return;
-	*conflict=1;
-	if (f_conflicts!=NULL) {
-		u_fprintf(f_conflicts,"MOVE %d %d %d\n",mine_index,base_index,op->box_dest);
-		return;
-	}
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_MOVED || op->box_base!=base_index) continue;
+    /* We have found a box move, but it may (miraculously) be the same in
+     * mine and other */
+    GrfState* mine_box=mine->states[mine_index];
+    GrfState* other_box=other->states[op->box_dest];
+    if (mine_box->x==other_box->x && mine_box->y==other_box->y) return;
+    *conflict=1;
+    if (f_conflicts!=NULL) {
+        u_fprintf(f_conflicts,"MOVE %d %d %d\n",mine_index,base_index,op->box_dest);
+        return;
+    }
 }
 }
 
@@ -217,23 +217,23 @@ for (int i=0;i<base_other->diff_ops->nbelems;i++) {
  * a content change, or a transition add.
  */
 static void test_conflicting_removal(int removed_in_mine,int base_index,GrfDiff* diff,
-		U_FILE* f_conflicts,int *conflict) {
+        U_FILE* f_conflicts,int *conflict) {
 for (int i=0;i<diff->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
-	switch (op->op_type) {
-	case DIFF_BOX_CONTENT_CHANGED:
-	case DIFF_BOX_MOVED:
-	case DIFF_TRANSITION_ADDED: {
-		if (op->box_base==base_index) {
-			*conflict=1;
-			if (f_conflicts!=NULL) {
-				u_fprintf(f_conflicts,"REMOVAL_IN_%s %d\n",removed_in_mine?"MINE":"OTHER",base_index);
-			}
-		}
-		break;
-	}
-	default: break;
-	}
+    DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
+    switch (op->op_type) {
+    case DIFF_BOX_CONTENT_CHANGED:
+    case DIFF_BOX_MOVED:
+    case DIFF_TRANSITION_ADDED: {
+        if (op->box_base==base_index) {
+            *conflict=1;
+            if (f_conflicts!=NULL) {
+                u_fprintf(f_conflicts,"REMOVAL_IN_%s %d\n",removed_in_mine?"MINE":"OTHER",base_index);
+            }
+        }
+        break;
+    }
+    default: break;
+    }
 }
 }
 
@@ -243,24 +243,24 @@ for (int i=0;i<diff->diff_ops->nbelems;i++) {
  * base_mine or base_other.
  */
 static void process_box_moves(Grf* mine,Grf* other,
-		Grf* result,GrfDiff* base_mine,GrfDiff* base_other) {
+        Grf* result,GrfDiff* base_mine,GrfDiff* base_other) {
 /* Box moves in mine */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_MOVED) continue;
-	GrfState* dest=result->states[op->box_base];
-	GrfState* src=mine->states[op->box_dest];
-	dest->x=src->x;
-	dest->y=src->y;
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_MOVED) continue;
+    GrfState* dest=result->states[op->box_base];
+    GrfState* src=mine->states[op->box_dest];
+    dest->x=src->x;
+    dest->y=src->y;
 }
 /* Box moves in other */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_MOVED) continue;
-	GrfState* dest=result->states[op->box_base];
-	GrfState* src=other->states[op->box_dest];
-	dest->x=src->x;
-	dest->y=src->y;
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_MOVED) continue;
+    GrfState* dest=result->states[op->box_base];
+    GrfState* src=other->states[op->box_dest];
+    dest->x=src->x;
+    dest->y=src->y;
 }
 }
 
@@ -270,7 +270,7 @@ for (int i=0;i<base_other->diff_ops->nbelems;i++) {
  */
 static int contains(vector_ptr* v,unichar* s) {
 for (int i=0;i<v->nbelems;i++) {
-	if (!u_strcmp(s,(unichar*)v->tab[i])) return 1;
+    if (!u_strcmp(s,(unichar*)v->tab[i])) return 1;
 }
 return 0;
 }
@@ -281,11 +281,11 @@ return 0;
  */
 static void replace_by_NULL(vector_ptr* v,unichar* s) {
 for (int i=0;i<v->nbelems;i++) {
-	if (!u_strcmp(s,(unichar*)v->tab[i])) {
-		free(v->tab[i]);
-		v->tab[i]=NULL;
-		return;
-	}
+    if (!u_strcmp(s,(unichar*)v->tab[i])) {
+        free(v->tab[i]);
+        v->tab[i]=NULL;
+        return;
+    }
 }
 }
 
@@ -299,43 +299,43 @@ static int merge_box_lines(vector_ptr* mine,vector_ptr* base,vector_ptr* other) 
 unichar* last_mine=(unichar*)mine->tab[mine->nbelems-1];
 unichar* last_other=(unichar*)other->tab[other->nbelems-1];
 if (last_mine[0]=='/' && last_other[0]=='/' && u_strcmp(last_mine,last_other)) {
-	return 1;
+    return 1;
 }
 /* First, we remove from all three vectors strings that have been removed
  * either in mine or other */
 for (int i=0;i<base->nbelems;i++) {
-	unichar* s=(unichar*)base->tab[i];
-	if (!contains(mine,s)) {
-		replace_by_NULL(other,s);
-		free(s);
-		base->tab[i]=NULL;
-	} else if (!contains(other,s)) {
-		replace_by_NULL(mine,s);
-		free(s);
-		base->tab[i]=NULL;
-	}
+    unichar* s=(unichar*)base->tab[i];
+    if (!contains(mine,s)) {
+        replace_by_NULL(other,s);
+        free(s);
+        base->tab[i]=NULL;
+    } else if (!contains(other,s)) {
+        replace_by_NULL(mine,s);
+        free(s);
+        base->tab[i]=NULL;
+    }
 }
 /* Then, we add all new strings from mine and other */
 for (int i=0;i<mine->nbelems;i++) {
-	unichar* s=(unichar*)mine->tab[i];
-	if (s!=NULL && !contains(base,s)) {
-		vector_ptr_add(base,u_strdup(s));
-	}
+    unichar* s=(unichar*)mine->tab[i];
+    if (s!=NULL && !contains(base,s)) {
+        vector_ptr_add(base,u_strdup(s));
+    }
 }
 for (int i=0;i<other->nbelems;i++) {
-	unichar* s=(unichar*)other->tab[i];
-	if (s!=NULL && !contains(base,s)) {
-		vector_ptr_add(base,u_strdup(s));
-	}
+    unichar* s=(unichar*)other->tab[i];
+    if (s!=NULL && !contains(base,s)) {
+        vector_ptr_add(base,u_strdup(s));
+    }
 }
 /* Finally, we look for an output. If any, we place it at the end of the vector */
 for (int i=0;i<base->nbelems;i++) {
-	unichar* s=(unichar*)base->tab[i];
-	if (s!=NULL && s[0]=='/') {
-		base->tab[i]=NULL;
-		vector_ptr_add(base,s);
-		break;
-	}
+    unichar* s=(unichar*)base->tab[i];
+    if (s!=NULL && s[0]=='/') {
+        base->tab[i]=NULL;
+        vector_ptr_add(base,s);
+        break;
+    }
 }
 return 0;
 }
@@ -348,44 +348,44 @@ return 0;
  */
 static int merge_box_contents(unichar* *dest,unichar* mine,unichar* other) {
 if (!u_strcmp(mine,other)) {
-	/* If (miraculously) mine and other are the same, there is no need
-	 * to perform a complicated merge */
-	free(*dest);
-	*dest=u_strdup(mine);
-	return 0;
+    /* If (miraculously) mine and other are the same, there is no need
+     * to perform a complicated merge */
+    free(*dest);
+    *dest=u_strdup(mine);
+    return 0;
 }
 vector_ptr* v_base=tokenize_box_content(*dest);
 if (v_base==NULL) {
-	fatal_error(2,"Invalid box content in 'base' file:\n%S\n",*dest);
+    fatal_error(2,"Invalid box content in 'base' file:\n%S\n",*dest);
 }
 vector_ptr* v_mine=tokenize_box_content(mine);
 if (v_mine==NULL) {
-	free_vector_ptr(v_base,free);
-	fatal_error(2,"Invalid box content in 'mine' file:\n%S\n",mine);
+    free_vector_ptr(v_base,free);
+    fatal_error(2,"Invalid box content in 'mine' file:\n%S\n",mine);
 }
 vector_ptr* v_other=tokenize_box_content(other);
 if (v_other==NULL) {
-	free_vector_ptr(v_base,free);
-	free_vector_ptr(v_mine,free);
-	fatal_error(2,"Invalid box content in 'other' file:\n%S\n",other);
+    free_vector_ptr(v_base,free);
+    free_vector_ptr(v_mine,free);
+    fatal_error(2,"Invalid box content in 'other' file:\n%S\n",other);
 }
 free(*dest);
 *dest=NULL;
 int ret=merge_box_lines(v_mine,v_base,v_other);
 if (ret==0) {
-	Ustring* s=new_Ustring();
-	u_strcat(s,'"');
-	for (int i=0;i<v_base->nbelems;i++) {
-		unichar* line=(unichar*)v_base->tab[i];
-		if (line==NULL) continue;
-		if (s->len!=1 && line[0]!='/') {
-			u_strcat(s,'+');
-		}
-		u_strcat(s,line);
-	}
-	u_strcat(s,'"');
-	*dest=u_strdup(s->str);
-	free_Ustring(s);
+    Ustring* s=new_Ustring();
+    u_strcat(s,'"');
+    for (int i=0;i<v_base->nbelems;i++) {
+        unichar* line=(unichar*)v_base->tab[i];
+        if (line==NULL) continue;
+        if (s->len!=1 && line[0]!='/') {
+            u_strcat(s,'+');
+        }
+        u_strcat(s,line);
+    }
+    u_strcat(s,'"');
+    *dest=u_strdup(s->str);
+    free_Ustring(s);
 }
 free_vector_ptr(v_base,free);
 free_vector_ptr(v_mine,free);
@@ -400,65 +400,65 @@ return ret;
  * merged, unless there is a conflict on the box output.
  */
 static void process_box_content_changes(Grf* mine,Grf* other,
-		Grf* result,GrfDiff* base_mine,GrfDiff* base_other,
-		U_FILE* f_conflict,int *conflict) {
+        Grf* result,GrfDiff* base_mine,GrfDiff* base_other,
+        U_FILE* f_conflict,int *conflict) {
 /* Box content changes in mine */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_CONTENT_CHANGED) continue;
-	int j;
-	DiffOp* op2=NULL;
-	/* We look for a content change on the same box in other */
-	for (j=0;j<base_other->diff_ops->nbelems;j++) {
-		op2=(DiffOp*)base_other->diff_ops->tab[j];
-		if (op2->op_type!=DIFF_BOX_CONTENT_CHANGED
-				|| op2->box_base!=op->box_base) {
-			op2=NULL;
-			continue;
-		}
-		break;
-	}
-	GrfState* dest=result->states[op->box_base];
-	GrfState* mine_state=mine->states[op->box_dest];
-	if (op2!=NULL) {
-		GrfState* other_state=other->states[op2->box_dest];
-		if (1==merge_box_contents(&(dest->box_content),mine_state->box_content,other_state->box_content)) {
-			*conflict=1;
-			if (f_conflict!=NULL) u_fprintf(f_conflict,"CONTENT %d %d %d\n",op->box_dest,op->box_base,op2->box_dest);
-		}
-	} else {
-		free(dest->box_content);
-		dest->box_content=u_strdup(mine_state->box_content);
-	}
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_CONTENT_CHANGED) continue;
+    int j;
+    DiffOp* op2=NULL;
+    /* We look for a content change on the same box in other */
+    for (j=0;j<base_other->diff_ops->nbelems;j++) {
+        op2=(DiffOp*)base_other->diff_ops->tab[j];
+        if (op2->op_type!=DIFF_BOX_CONTENT_CHANGED
+                || op2->box_base!=op->box_base) {
+            op2=NULL;
+            continue;
+        }
+        break;
+    }
+    GrfState* dest=result->states[op->box_base];
+    GrfState* mine_state=mine->states[op->box_dest];
+    if (op2!=NULL) {
+        GrfState* other_state=other->states[op2->box_dest];
+        if (1==merge_box_contents(&(dest->box_content),mine_state->box_content,other_state->box_content)) {
+            *conflict=1;
+            if (f_conflict!=NULL) u_fprintf(f_conflict,"CONTENT %d %d %d\n",op->box_dest,op->box_base,op2->box_dest);
+        }
+    } else {
+        free(dest->box_content);
+        dest->box_content=u_strdup(mine_state->box_content);
+    }
 }
 /* Box content changes in other */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_CONTENT_CHANGED) continue;
-	int j;
-	DiffOp* op2=NULL;
-	/* We look for a content change on the same box in mine */
-	for (j=0;j<base_mine->diff_ops->nbelems;j++) {
-		op2=(DiffOp*)base_mine->diff_ops->tab[j];
-		if (op2->op_type!=DIFF_BOX_CONTENT_CHANGED
-				|| op2->box_base!=op->box_base) {
-			op2=NULL;
-			continue;
-		}
-		break;
-	}
-	GrfState* dest=result->states[op->box_base];
-	GrfState* other_state=other->states[op->box_dest];
-	if (op2!=NULL) {
-		GrfState* mine_state=other->states[op2->box_dest];
-		if (1==merge_box_contents(&(dest->box_content),other_state->box_content,mine_state->box_content)) {
-			*conflict=1;
-			if (f_conflict!=NULL) u_fprintf(f_conflict,"CONTENT %d %d %d\n",op->box_dest,op->box_base,op2->box_dest);
-		}
-	} else {
-		free(dest->box_content);
-		dest->box_content=u_strdup(other_state->box_content);
-	}
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_CONTENT_CHANGED) continue;
+    int j;
+    DiffOp* op2=NULL;
+    /* We look for a content change on the same box in mine */
+    for (j=0;j<base_mine->diff_ops->nbelems;j++) {
+        op2=(DiffOp*)base_mine->diff_ops->tab[j];
+        if (op2->op_type!=DIFF_BOX_CONTENT_CHANGED
+                || op2->box_base!=op->box_base) {
+            op2=NULL;
+            continue;
+        }
+        break;
+    }
+    GrfState* dest=result->states[op->box_base];
+    GrfState* other_state=other->states[op->box_dest];
+    if (op2!=NULL) {
+        GrfState* mine_state=other->states[op2->box_dest];
+        if (1==merge_box_contents(&(dest->box_content),other_state->box_content,mine_state->box_content)) {
+            *conflict=1;
+            if (f_conflict!=NULL) u_fprintf(f_conflict,"CONTENT %d %d %d\n",op->box_dest,op->box_base,op2->box_dest);
+        }
+    } else {
+        free(dest->box_content);
+        dest->box_content=u_strdup(other_state->box_content);
+    }
 }
 
 }
@@ -468,7 +468,7 @@ static void add_grf_state(GrfState** *t,int *size,GrfState* s) {
 (*size)++;
 *t=(GrfState**)realloc(*t,(*size)*sizeof(GrfState*));
 if (*t==NULL) {
-	fatal_alloc_error("add_grf_state");
+    fatal_alloc_error("add_grf_state");
 }
 (*t)[(*size)-1]=s;
 }
@@ -481,17 +481,17 @@ if (*t==NULL) {
 static void process_added_transitions(Grf* result,GrfDiff* base_mine,GrfDiff* base_other) {
 /* Transitions added in mine */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type!=DIFF_TRANSITION_ADDED) continue;
-	GrfState* dest=result->states[op->box_base];
-	vector_int_add_if_absent(dest->transitions,op->box_dest);
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type!=DIFF_TRANSITION_ADDED) continue;
+    GrfState* dest=result->states[op->box_base];
+    vector_int_add_if_absent(dest->transitions,op->box_dest);
 }
 /* Transitions added in other */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_TRANSITION_ADDED) continue;
-	GrfState* dest=result->states[op->box_base];
-	vector_int_add_if_absent(dest->transitions,op->box_dest);
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_TRANSITION_ADDED) continue;
+    GrfState* dest=result->states[op->box_base];
+    vector_int_add_if_absent(dest->transitions,op->box_dest);
 }
 }
 
@@ -503,17 +503,17 @@ for (int i=0;i<base_other->diff_ops->nbelems;i++) {
 static void process_removed_transitions(Grf* result,GrfDiff* base_mine,GrfDiff* base_other) {
 /* Transitions removed in mine */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type!=DIFF_TRANSITION_REMOVED) continue;
-	GrfState* dest=result->states[op->box_base];
-	vector_int_remove(dest->transitions,op->box_dest);
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type!=DIFF_TRANSITION_REMOVED) continue;
+    GrfState* dest=result->states[op->box_base];
+    vector_int_remove(dest->transitions,op->box_dest);
 }
 /* Transitions removed in other */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_TRANSITION_REMOVED) continue;
-	GrfState* dest=result->states[op->box_base];
-	vector_int_remove(dest->transitions,op->box_dest);
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_TRANSITION_REMOVED) continue;
+    GrfState* dest=result->states[op->box_base];
+    vector_int_remove(dest->transitions,op->box_dest);
 }
 }
 
@@ -534,57 +534,57 @@ int n_states_before=result->n_states;
  *                            ==n  => added state #i has number n in result */
 int* added_states_new_indices=(int*)malloc(src->n_states*sizeof(int));
 if (added_states_new_indices==NULL) {
-	fatal_alloc_error("process_added_states");
+    fatal_alloc_error("process_added_states");
 }
 for (int i=0;i<src->n_states;i++) {
-	added_states_new_indices[i]=-1;
+    added_states_new_indices[i]=-1;
 }
 for (int i=0;i<diff->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_ADDED) continue;
-	/* The index of an added box is stored in the box_dest field */
-	GrfState* added_state=src->states[op->box_dest];
-	add_grf_state(&(result->states),&(result->n_states),cpy_grf_state(added_state));
-	added_states_new_indices[op->box_dest]=result->n_states-1;
+    DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_ADDED) continue;
+    /* The index of an added box is stored in the box_dest field */
+    GrfState* added_state=src->states[op->box_dest];
+    add_grf_state(&(result->states),&(result->n_states),cpy_grf_state(added_state));
+    added_states_new_indices[op->box_dest]=result->n_states-1;
 }
 /* Now, we renumber transitions outgoing from added states */
 for (int i=n_states_before;i<result->n_states;i++) {
-	GrfState* s=result->states[i];
-	for (int j=0;j<s->transitions->nbelems;j++) {
-		int n=s->transitions->tab[j];
-		if (added_states_new_indices[n]!=-1) {
-			/* If the transition points to an added state, we replace
-			 * the state number by the new one, relative to result */
-			s->transitions->tab[j]=added_states_new_indices[n];
-		} else {
-			/* If the transition did point to a state that was copied
-			 * into result, we just have to use the state index as
-			 * numbered in the base graph, that is supposed to have been
-			 * copied into result */
-			s->transitions->tab[j]=diff->dest_to_base[n];
-		}
-	}
+    GrfState* s=result->states[i];
+    for (int j=0;j<s->transitions->nbelems;j++) {
+        int n=s->transitions->tab[j];
+        if (added_states_new_indices[n]!=-1) {
+            /* If the transition points to an added state, we replace
+             * the state number by the new one, relative to result */
+            s->transitions->tab[j]=added_states_new_indices[n];
+        } else {
+            /* If the transition did point to a state that was copied
+             * into result, we just have to use the state index as
+             * numbered in the base graph, that is supposed to have been
+             * copied into result */
+            s->transitions->tab[j]=diff->dest_to_base[n];
+        }
+    }
 }
 /* Finally, we explore src transitions outgoing from non added states, since
  * they may have transitions pointing to added states that must be taken
  * into account */
 for (int i=0;i<src->n_states;i++) {
-	if (added_states_new_indices[i]!=-1) {
-		/* Added states have already been handled */
-		continue;
-	}
-	GrfState* s=src->states[i];
-	for (int j=0;j<s->transitions->nbelems;j++) {
-		if (added_states_new_indices[s->transitions->tab[j]]!=-1) {
-			/* If the transition points from a state #i to an
-			 * added state #j, we have to find the result
-			 * equivalent of i and j */
-			int result_src_index=diff->dest_to_base[i];
-			int result_dst_index=added_states_new_indices[s->transitions->tab[j]];
-			GrfState* result_state=result->states[result_src_index];
-			vector_int_add_if_absent(result_state->transitions,result_dst_index);
-		}
-	}
+    if (added_states_new_indices[i]!=-1) {
+        /* Added states have already been handled */
+        continue;
+    }
+    GrfState* s=src->states[i];
+    for (int j=0;j<s->transitions->nbelems;j++) {
+        if (added_states_new_indices[s->transitions->tab[j]]!=-1) {
+            /* If the transition points from a state #i to an
+             * added state #j, we have to find the result
+             * equivalent of i and j */
+            int result_src_index=diff->dest_to_base[i];
+            int result_dst_index=added_states_new_indices[s->transitions->tab[j]];
+            GrfState* result_state=result->states[result_src_index];
+            vector_int_add_if_absent(result_state->transitions,result_dst_index);
+        }
+    }
 }
 free(added_states_new_indices);
 }
@@ -597,68 +597,68 @@ free(added_states_new_indices);
 static void process_removed_states(Grf* result,GrfDiff* base_mine,GrfDiff* base_other) {
 int* renumber=(int*)malloc(result->n_states*sizeof(int));
 if (renumber==NULL) {
-	fatal_alloc_error("process_removed_states");
+    fatal_alloc_error("process_removed_states");
 }
 for (int i=0;i<result->n_states;i++) {
-	renumber[i]=i;
+    renumber[i]=i;
 }
 /* We mark and free boxes removed in mine */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_REMOVED) continue;
-	free_GrfState(result->states[op->box_base]);
-	result->states[op->box_base]=NULL;
-	renumber[op->box_base]=-1;
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_REMOVED) continue;
+    free_GrfState(result->states[op->box_base]);
+    result->states[op->box_base]=NULL;
+    renumber[op->box_base]=-1;
 }
 /* The same with boxes removed in other */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type!=DIFF_BOX_REMOVED) continue;
-	free_GrfState(result->states[op->box_base]);
-	result->states[op->box_base]=NULL;
-	renumber[op->box_base]=-1;
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type!=DIFF_BOX_REMOVED) continue;
+    free_GrfState(result->states[op->box_base]);
+    result->states[op->box_base]=NULL;
+    renumber[op->box_base]=-1;
 }
 /* Now we have to swap states in order to avoid NULL holes in
  * result's state array */
 for (int i=0;i<result->n_states;i++) {
-	if (result->states[i]!=NULL) continue;
-	/* If we have a NULL state, we must swap it with a non NULL
-	 * one found at the end of the array, if any */
-	int j;
-	for (j=result->n_states-1;j>i;j--) {
-		if (result->states[j]!=NULL) break;
-	}
-	if (j==-1 || j==i) {
-		/* If we have found no non NULL state in the end of the array,
-		 * it means that we have finished */
-		break;
-	}
-	/* Now, we can switch state #j in position i */
-	result->states[i]=result->states[j];
-	result->states[j]=NULL;
-	renumber[j]=i;
+    if (result->states[i]!=NULL) continue;
+    /* If we have a NULL state, we must swap it with a non NULL
+     * one found at the end of the array, if any */
+    int j;
+    for (j=result->n_states-1;j>i;j--) {
+        if (result->states[j]!=NULL) break;
+    }
+    if (j==-1 || j==i) {
+        /* If we have found no non NULL state in the end of the array,
+         * it means that we have finished */
+        break;
+    }
+    /* Now, we can switch state #j in position i */
+    result->states[i]=result->states[j];
+    result->states[j]=NULL;
+    renumber[j]=i;
 }
 /* Finally, we have to renumber or remove transitions */
 for (int i=0;i<result->n_states;i++) {
-	GrfState* s=result->states[i];
-	if (s==NULL) {
-		/* We update the number of states */
-		result->n_states=i;
-		break;
-	}
-	for (int j=0;j<s->transitions->nbelems;/* no j++ here, it's not an error */) {
-		if (renumber[s->transitions->tab[j]]!=-1) {
-			/* Just have to renumber */
-			s->transitions->tab[j]=renumber[s->transitions->tab[j]];
-			/* Don't forget to move on */
-			j++;
-		} else {
-			/* We have to removal transition #j */
-			vector_int_remove(s->transitions,j);
-			/* No move on, since the new transition #j must have to be considered
-			 * as well */
-		}
-	}
+    GrfState* s=result->states[i];
+    if (s==NULL) {
+        /* We update the number of states */
+        result->n_states=i;
+        break;
+    }
+    for (int j=0;j<s->transitions->nbelems;/* no j++ here, it's not an error */) {
+        if (renumber[s->transitions->tab[j]]!=-1) {
+            /* Just have to renumber */
+            s->transitions->tab[j]=renumber[s->transitions->tab[j]];
+            /* Don't forget to move on */
+            j++;
+        } else {
+            /* We have to removal transition #j */
+            vector_int_remove(s->transitions,j);
+            /* No move on, since the new transition #j must have to be considered
+             * as well */
+        }
+    }
 }
 free(renumber);
 }
@@ -671,8 +671,8 @@ free(renumber);
  * changes.
  */
 static void merge_grf_states(Grf* mine,Grf* base,Grf* other,
-		Grf* result,GrfDiff* base_mine,GrfDiff* base_other,
-		U_FILE* f_conflict,int *conflict) {
+        Grf* result,GrfDiff* base_mine,GrfDiff* base_other,
+        U_FILE* f_conflict,int *conflict) {
 /* First, we copy the base graph, and then we will apply all transformations to it */
 cpy_grf_states(result,base);
 process_box_moves(mine,other,result,base_mine,base_other);
@@ -694,33 +694,33 @@ process_removed_states(result,base_mine,base_other);
  * conflicts, it returns 1 and conflict descriptions are written to f.
  */
 static void try_to_merge_grf_states(GrfDiff* base_mine,GrfDiff* base_other,Grf* mine,Grf* base,Grf* other,
-		Grf* result,U_FILE* f_conflicts,int *conflict) {
+        Grf* result,U_FILE* f_conflicts,int *conflict) {
 /* First, we try to detect unresolvable conflict cases:
  * 1) a box that has moved differently in base and other
  * 2) a box that has been removed from a graph and modified in the other
  *    (content change, move, transition(s) added)
  */
 for (int i=0;i<base_mine->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
-	if (op->op_type==DIFF_BOX_MOVED) {
-		test_conflicting_move(base_other,mine,other,op->box_base,op->box_dest,f_conflicts,conflict);
-	} else if (op->op_type==DIFF_BOX_REMOVED) {
-		test_conflicting_removal(1,op->box_base,base_other,f_conflicts,conflict);
-	}
+    DiffOp* op=(DiffOp*)base_mine->diff_ops->tab[i];
+    if (op->op_type==DIFF_BOX_MOVED) {
+        test_conflicting_move(base_other,mine,other,op->box_base,op->box_dest,f_conflicts,conflict);
+    } else if (op->op_type==DIFF_BOX_REMOVED) {
+        test_conflicting_removal(1,op->box_base,base_other,f_conflicts,conflict);
+    }
 }
 /* Box move conflicts can only occur when there are box moves in both base_mine
  * and base_other, but in order to detect conflicts dued to removed boxes, we have
  * now to consider boxes that have been removed in other, since in the previous loop,
  * we only looked at boxes removed in mine. */
 for (int i=0;i<base_other->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
-	if (op->op_type==DIFF_BOX_REMOVED) {
-		test_conflicting_removal(0,op->box_base,base_mine,f_conflicts,conflict);
-	}
+    DiffOp* op=(DiffOp*)base_other->diff_ops->tab[i];
+    if (op->op_type==DIFF_BOX_REMOVED) {
+        test_conflicting_removal(0,op->box_base,base_mine,f_conflicts,conflict);
+    }
 }
 if (*conflict) {
-	/* If there are unresolvable conflicts, we can't merge graphs so we have finished */
-	return;
+    /* If there are unresolvable conflicts, we can't merge graphs so we have finished */
+    return;
 }
 merge_grf_states(mine,base,other,result,base_mine,base_other,f_conflicts,conflict);
 }
@@ -733,8 +733,8 @@ merge_grf_states(mine,base,other,result,base_mine,base_other,f_conflicts,conflic
 static int only_cosmetic_changes(int only_cosmetics,GrfDiff* diff) {
 if (!only_cosmetics) return 1;
 for (int i=0;i<diff->diff_ops->nbelems;i++) {
-	DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
-	if (op->op_type!=DIFF_PROPERTY && op->op_type!=DIFF_BOX_MOVED) return 0;
+    DiffOp* op=(DiffOp*)diff->diff_ops->tab[i];
+    if (op->op_type!=DIFF_PROPERTY && op->op_type!=DIFF_BOX_MOVED) return 0;
 }
 return 1;
 }
@@ -749,38 +749,38 @@ GrfDiff* base_mine=grf_diff(base,mine);
 GrfDiff* base_other=grf_diff(base,other);
 GrfDiff* mine_other=grf_diff(mine,other);
 if (base_mine->diff_ops->nbelems==0 && only_cosmetic_changes(only_cosmetics,base_other)) {
-	/* base==mine ? => return other */
-	free_GrfDiff(base_mine);
-	free_GrfDiff(base_other);
-	free_GrfDiff(mine_other);
-	return dup_Grf(other);
+    /* base==mine ? => return other */
+    free_GrfDiff(base_mine);
+    free_GrfDiff(base_other);
+    free_GrfDiff(mine_other);
+    return dup_Grf(other);
 }
 if (base_other->diff_ops->nbelems==0 && only_cosmetic_changes(only_cosmetics,base_mine)) {
-	/* base==other ? => return mine */
-	free_GrfDiff(base_mine);
-	free_GrfDiff(base_other);
-	free_GrfDiff(mine_other);
-	return dup_Grf(mine);
+    /* base==other ? => return mine */
+    free_GrfDiff(base_mine);
+    free_GrfDiff(base_other);
+    free_GrfDiff(mine_other);
+    return dup_Grf(mine);
 }
 if (mine_other->diff_ops->nbelems==0) {
-	/* mine==other ? => return mine */
-	/* Note that we don't test cosmetic changes if mine=other, because
-	 * in case of equality, reporting a conflict is always pointless */
-	free_GrfDiff(base_mine);
-	free_GrfDiff(base_other);
-	free_GrfDiff(mine_other);
-	return dup_Grf(mine);
+    /* mine==other ? => return mine */
+    /* Note that we don't test cosmetic changes if mine=other, because
+     * in case of equality, reporting a conflict is always pointless */
+    free_GrfDiff(base_mine);
+    free_GrfDiff(base_other);
+    free_GrfDiff(mine_other);
+    return dup_Grf(mine);
 }
 if (!only_cosmetic_changes(only_cosmetics,base_mine)
-	|| !only_cosmetic_changes(only_cosmetics,base_other)) {
-	/* If there is a non cosmetic change, we report a conflict, which
-	 * may be abusive if the non cosmetic changes are the same and could
-	 * eventually be merged, but this rare case may not be worth the coding
-	 * effort */
-	free_GrfDiff(base_mine);
-	free_GrfDiff(base_other);
-	free_GrfDiff(mine_other);
-	return NULL;
+    || !only_cosmetic_changes(only_cosmetics,base_other)) {
+    /* If there is a non cosmetic change, we report a conflict, which
+     * may be abusive if the non cosmetic changes are the same and could
+     * eventually be merged, but this rare case may not be worth the coding
+     * effort */
+    free_GrfDiff(base_mine);
+    free_GrfDiff(base_other);
+    free_GrfDiff(mine_other);
+    return NULL;
 }
 
 /* If we have to compare and merge different grf, we only need
@@ -793,8 +793,8 @@ try_to_merge_grf_states(base_mine,base_other,mine,base,other,result,f_conflicts,
 free_GrfDiff(base_mine);
 free_GrfDiff(base_other);
 if (conflict) {
-	free_Grf(result);
-	result=NULL;
+    free_Grf(result);
+    result=NULL;
 }
 return result;
 }
@@ -835,14 +835,14 @@ if (d->base_to_dest==NULL) fatal_alloc_error("new_GrfDiff");
 d->base_to_dest[0]=0;
 d->base_to_dest[1]=1;
 for (int i=2;i<n_base;i++) {
-	d->base_to_dest[i]=-1;
+    d->base_to_dest[i]=-1;
 }
 d->dest_to_base=(int*)malloc(n_dest*sizeof(int));
 if (d->dest_to_base==NULL) fatal_alloc_error("new_GrfDiff");
 d->dest_to_base[0]=0;
 d->dest_to_base[1]=1;
 for (int i=2;i<n_dest;i++) {
-	d->dest_to_base[i]=-1;
+    d->dest_to_base[i]=-1;
 }
 /* Initializing reverse transition arrays */
 d->reverse_transitions_base=compute_reverse_transitions(base);
@@ -875,36 +875,36 @@ vector_int* v_dest=diff->reverse_transitions_dest->t[dest];
 /* First, we test if all base transitions are included in dest ones,
  * ignoring the loop transition, if any */
 for (int i=0;i<v_base->nbelems;i++) {
-	if (v_base->tab[i]==base) {
-		/* We skip loop transitions */
-		continue;
-	}
-	int renumbered_incoming_state=diff->base_to_dest[v_base->tab[i]];
-	if (renumbered_incoming_state==-1) {
-		/* If we have an incoming transition from an unknown box,
-		 * we have no hope to succeed */
-		return 0;
-	}
-	if (-1==vector_int_contains(v_dest,renumbered_incoming_state)) {
-		return 0;
-	}
+    if (v_base->tab[i]==base) {
+        /* We skip loop transitions */
+        continue;
+    }
+    int renumbered_incoming_state=diff->base_to_dest[v_base->tab[i]];
+    if (renumbered_incoming_state==-1) {
+        /* If we have an incoming transition from an unknown box,
+         * we have no hope to succeed */
+        return 0;
+    }
+    if (-1==vector_int_contains(v_dest,renumbered_incoming_state)) {
+        return 0;
+    }
 }
 /* Then we test if all dest transitions are included in base ones,
  * ignoring the loop transition, if any */
 for (int i=0;i<v_dest->nbelems;i++) {
-	if (v_dest->tab[i]==dest) {
-		/* We skip loop transitions */
-		continue;
-	}
-	int renumbered_incoming_state=diff->dest_to_base[v_dest->tab[i]];
-	if (renumbered_incoming_state==-1) {
-		/* If we have an incoming transition from an unknown box,
-		 * we have no hope to succeed */
-		return 0;
-	}
-	if (-1==vector_int_contains(v_base,renumbered_incoming_state)) {
-		return 0;
-	}
+    if (v_dest->tab[i]==dest) {
+        /* We skip loop transitions */
+        continue;
+    }
+    int renumbered_incoming_state=diff->dest_to_base[v_dest->tab[i]];
+    if (renumbered_incoming_state==-1) {
+        /* If we have an incoming transition from an unknown box,
+         * we have no hope to succeed */
+        return 0;
+    }
+    if (-1==vector_int_contains(v_base,renumbered_incoming_state)) {
+        return 0;
+    }
 }
 return 1;
 }
@@ -915,50 +915,50 @@ return 1;
  * The comparison ignore loop transitions, and takes renumbering into account.
  */
 static int same_outgoing_transitions(GrfDiff* diff,GrfState* base,GrfState* dest,
-		int base_index,int dest_index) {
+        int base_index,int dest_index) {
 /* First, we test if all base transitions are included in dest ones,
  * ignoring the loop transition, if any */
 for (int i=0;i<base->transitions->nbelems;i++) {
-	if (base->transitions->tab[i]==base_index) {
-		/* We skip loop transitions */
-		continue;
-	}
-	int renumbered_outgoing_state=diff->base_to_dest[base->transitions->tab[i]];
-	if (renumbered_outgoing_state==-1) {
-		/* If we have an outgoing transition to an unknown box,
-		 * we have no hope to succeed */
-		return 0;
-	}
-	int j;
-	for (j=0;j<dest->transitions->nbelems;j++) {
-		if (renumbered_outgoing_state==dest->transitions->tab[j]) break;
-	}
-	if (j==dest->transitions->nbelems) {
-		/* Fail to find ? */
-		return 0;
-	}
+    if (base->transitions->tab[i]==base_index) {
+        /* We skip loop transitions */
+        continue;
+    }
+    int renumbered_outgoing_state=diff->base_to_dest[base->transitions->tab[i]];
+    if (renumbered_outgoing_state==-1) {
+        /* If we have an outgoing transition to an unknown box,
+         * we have no hope to succeed */
+        return 0;
+    }
+    int j;
+    for (j=0;j<dest->transitions->nbelems;j++) {
+        if (renumbered_outgoing_state==dest->transitions->tab[j]) break;
+    }
+    if (j==dest->transitions->nbelems) {
+        /* Fail to find ? */
+        return 0;
+    }
 }
 /* Then, we test if all dest transitions are included in base ones,
  * ignoring the loop transition, if any */
 for (int i=0;i<dest->transitions->nbelems;i++) {
-	if (dest->transitions->tab[i]==dest_index) {
-		/* We skip loop transitions */
-		continue;
-	}
-	int renumbered_outgoing_state=diff->dest_to_base[dest->transitions->tab[i]];
-	if (renumbered_outgoing_state==-1) {
-		/* If we have an outgoing transition to an unknown box,
-		 * we have no hope to succeed */
-		return 0;
-	}
-	int j;
-	for (j=0;j<base->transitions->nbelems;j++) {
-		if (renumbered_outgoing_state==base->transitions->tab[j]) break;
-	}
-	if (j==base->transitions->nbelems) {
-		/* Fail to find ? */
-		return 0;
-	}
+    if (dest->transitions->tab[i]==dest_index) {
+        /* We skip loop transitions */
+        continue;
+    }
+    int renumbered_outgoing_state=diff->dest_to_base[dest->transitions->tab[i]];
+    if (renumbered_outgoing_state==-1) {
+        /* If we have an outgoing transition to an unknown box,
+         * we have no hope to succeed */
+        return 0;
+    }
+    int j;
+    for (j=0;j<base->transitions->nbelems;j++) {
+        if (renumbered_outgoing_state==base->transitions->tab[j]) break;
+    }
+    if (j==base->transitions->nbelems) {
+        /* Fail to find ? */
+        return 0;
+    }
 }
 return 1;
 }
@@ -970,53 +970,53 @@ return 1;
  * matched. Returns the number of matching box pairs.
  */
 static int find_correspondance(GrfDiff* diff,Grf* base,Grf* dest,
-		int coord,     /* compare coordinates */
-		int content,   /* compare box content */
-		int incoming,  /* compare incoming transitions */
-		int outgoing,  /* compare outgoing transitions */
-		int index,     /* compare box indices in .grf files */
-		int ignore_comment_boxes
-		) {
+        int coord,     /* compare coordinates */
+        int content,   /* compare box content */
+        int incoming,  /* compare incoming transitions */
+        int outgoing,  /* compare outgoing transitions */
+        int index,     /* compare box indices in .grf files */
+        int ignore_comment_boxes
+        ) {
 int n=0;
 for (int i=2;i<diff->size_base_to_dest;i++) {
-	if (diff->base_to_dest[i]!=-1) {
-		/* If the base state has already been matched, we ignore it */
-		continue;
-	}
-	GrfState* base_state=base->states[i];
-	for (int j=2;j<diff->size_dest_to_base;j++) {
-		if (diff->dest_to_base[j]!=-1) {
-			/* If the dest box has already been matched, we ignore it */
-			continue;
-		}
-		GrfState* dest_state=dest->states[j];
-		int base_is_comment_box=base_state->transitions->nbelems==0
-				&& diff->reverse_transitions_base->t[i]->nbelems==0;
-		int dest_is_comment_box=dest_state->transitions->nbelems==0
-				&& diff->reverse_transitions_dest->t[j]->nbelems==0;
-		if (ignore_comment_boxes && (base_is_comment_box || dest_is_comment_box)) continue;
-		if (coord && (base_state->x!=dest_state->x || base_state->y!=dest_state->y)) {
-			continue;
-		}
-		if (content && u_strcmp(base_state->box_content,dest_state->box_content)) {
-			continue;
-		}
-		if (incoming && !same_incoming_transitions(diff,i,j)) {
-			continue;
-		}
-		if (outgoing && !same_outgoing_transitions(diff,base_state,dest_state,i,j)) {
-			continue;
-		}
-		if (index && i!=j) {
-			continue;
-		}
-		/* If we get there, we have matched all the required criteria,
-		 * so we have matching boxes */
-		diff->base_to_dest[i]=j;
-		diff->dest_to_base[j]=i;
-		n++;
-		break;
-	}
+    if (diff->base_to_dest[i]!=-1) {
+        /* If the base state has already been matched, we ignore it */
+        continue;
+    }
+    GrfState* base_state=base->states[i];
+    for (int j=2;j<diff->size_dest_to_base;j++) {
+        if (diff->dest_to_base[j]!=-1) {
+            /* If the dest box has already been matched, we ignore it */
+            continue;
+        }
+        GrfState* dest_state=dest->states[j];
+        int base_is_comment_box=base_state->transitions->nbelems==0
+                && diff->reverse_transitions_base->t[i]->nbelems==0;
+        int dest_is_comment_box=dest_state->transitions->nbelems==0
+                && diff->reverse_transitions_dest->t[j]->nbelems==0;
+        if (ignore_comment_boxes && (base_is_comment_box || dest_is_comment_box)) continue;
+        if (coord && (base_state->x!=dest_state->x || base_state->y!=dest_state->y)) {
+            continue;
+        }
+        if (content && u_strcmp(base_state->box_content,dest_state->box_content)) {
+            continue;
+        }
+        if (incoming && !same_incoming_transitions(diff,i,j)) {
+            continue;
+        }
+        if (outgoing && !same_outgoing_transitions(diff,base_state,dest_state,i,j)) {
+            continue;
+        }
+        if (index && i!=j) {
+            continue;
+        }
+        /* If we get there, we have matched all the required criteria,
+         * so we have matching boxes */
+        diff->base_to_dest[i]=j;
+        diff->dest_to_base[j]=i;
+        n++;
+        break;
+    }
 }
 return n;
 }
@@ -1034,44 +1034,44 @@ static void compare_matching_boxes(GrfDiff* diff,Grf* base,Grf* dest,int base_in
 GrfState* base_state=base->states[base_index];
 GrfState* dest_state=dest->states[dest_index];
 if (base_state->x!=dest_state->x || base_state->y!=dest_state->y) {
-	add_diff_box_moved(diff,base_index,dest_index);
+    add_diff_box_moved(diff,base_index,dest_index);
 }
 if (u_strcmp(base_state->box_content,dest_state->box_content)) {
-	add_diff_box_content_changed(diff,base_index,dest_index);
+    add_diff_box_content_changed(diff,base_index,dest_index);
 }
 /* We look for all transitions that are in base and not in dest */
 for (int i=0;i<base_state->transitions->nbelems;i++) {
-	int renumbered_dest_state=diff->base_to_dest[base_state->transitions->tab[i]];
-	if (renumbered_dest_state==-1) {
-		/* Transitions to unmatched states are ignored here */
-		continue;
-	}
-	int j;
-	for (j=0;j<dest_state->transitions->nbelems;j++) {
-		if (renumbered_dest_state==dest_state->transitions->tab[j]) break;
-	}
-	if (j==dest_state->transitions->nbelems) {
-		/* Transition not found ? */
-		add_diff_transition_removed(diff,base_index,base_state->transitions->tab[i],
-				dest_index,renumbered_dest_state);
-	}
+    int renumbered_dest_state=diff->base_to_dest[base_state->transitions->tab[i]];
+    if (renumbered_dest_state==-1) {
+        /* Transitions to unmatched states are ignored here */
+        continue;
+    }
+    int j;
+    for (j=0;j<dest_state->transitions->nbelems;j++) {
+        if (renumbered_dest_state==dest_state->transitions->tab[j]) break;
+    }
+    if (j==dest_state->transitions->nbelems) {
+        /* Transition not found ? */
+        add_diff_transition_removed(diff,base_index,base_state->transitions->tab[i],
+                dest_index,renumbered_dest_state);
+    }
 }
 /* And we look for all transitions that are in dest and not in base */
 for (int i=0;i<dest_state->transitions->nbelems;i++) {
-	int renumbered_base_state=diff->dest_to_base[dest_state->transitions->tab[i]];
-	if (renumbered_base_state==-1) {
-		/* Transitions to unmatched states are ignored here */
-		continue;
-	}
-	int j;
-	for (j=0;j<base_state->transitions->nbelems;j++) {
-		if (renumbered_base_state==base_state->transitions->tab[j]) break;
-	}
-	if (j==base_state->transitions->nbelems) {
-		/* Transition not found ? */
-		add_diff_transition_added(diff,base_index,renumbered_base_state,
-				dest_index,dest_state->transitions->tab[i]);
-	}
+    int renumbered_base_state=diff->dest_to_base[dest_state->transitions->tab[i]];
+    if (renumbered_base_state==-1) {
+        /* Transitions to unmatched states are ignored here */
+        continue;
+    }
+    int j;
+    for (j=0;j<base_state->transitions->nbelems;j++) {
+        if (renumbered_base_state==base_state->transitions->tab[j]) break;
+    }
+    if (j==base_state->transitions->nbelems) {
+        /* Transition not found ? */
+        add_diff_transition_added(diff,base_index,renumbered_base_state,
+                dest_index,dest_state->transitions->tab[i]);
+    }
 }
 }
 
@@ -1079,10 +1079,10 @@ for (int i=0;i<dest_state->transitions->nbelems;i++) {
 static void show_matching_boxes(GrfDiff* diff,Grf* base,Grf* dest) {
 error("-------------------------------------\n");
 for (int i=0;i<diff->size_base_to_dest;i++) {
-	if (diff->base_to_dest[i]!=-1) {
-		error("match %d/%S => %d/%S\n",i,base->states[i]->box_content,
-				diff->base_to_dest[i],dest->states[diff->base_to_dest[i]]->box_content);
-	}
+    if (diff->base_to_dest[i]!=-1) {
+        error("match %d/%S => %d/%S\n",i,base->states[i]->box_content,
+                diff->base_to_dest[i],dest->states[diff->base_to_dest[i]]->box_content);
+    }
 }
 }
 */
@@ -1103,40 +1103,40 @@ int n;
  * fail at one time and succeed later, since transitions to unmatched boxes
  * are ignored */
 do {
-	n=0;
-	/* content+transitions+index */
-	n+=find_correspondance(diff,base,dest,0,1,1,1,1,1);
-	/* content+transitions */
-	n+=find_correspondance(diff,base,dest,0,1,1,1,0,1);
-	/* transitions */
-	n+=find_correspondance(diff,base,dest,0,0,1,1,0,1);
-	/* content+incoming transitions */
-	n+=find_correspondance(diff,base,dest,0,1,1,0,0,1);
-	/* content+outgoing transitions */
-	n+=find_correspondance(diff,base,dest,0,1,0,1,0,1);
-	/* incoming transitions+index */
-	n+=find_correspondance(diff,base,dest,0,0,1,0,1,1);
-	/* outgoing transitions+index */
-	n+=find_correspondance(diff,base,dest,0,0,0,1,1,1);
-	/* Last chance, content+index, but only on non comment boxes */
-	n+=find_correspondance(diff,base,dest,0,1,0,0,1,1);
+    n=0;
+    /* content+transitions+index */
+    n+=find_correspondance(diff,base,dest,0,1,1,1,1,1);
+    /* content+transitions */
+    n+=find_correspondance(diff,base,dest,0,1,1,1,0,1);
+    /* transitions */
+    n+=find_correspondance(diff,base,dest,0,0,1,1,0,1);
+    /* content+incoming transitions */
+    n+=find_correspondance(diff,base,dest,0,1,1,0,0,1);
+    /* content+outgoing transitions */
+    n+=find_correspondance(diff,base,dest,0,1,0,1,0,1);
+    /* incoming transitions+index */
+    n+=find_correspondance(diff,base,dest,0,0,1,0,1,1);
+    /* outgoing transitions+index */
+    n+=find_correspondance(diff,base,dest,0,0,0,1,1,1);
+    /* Last chance, content+index, but only on non comment boxes */
+    n+=find_correspondance(diff,base,dest,0,1,0,0,1,1);
 } while (n!=0);
 
 for (int i=0;i<diff->size_base_to_dest;i++) {
-	if (diff->base_to_dest[i]==-1) {
-		add_diff_box_removed(diff,i);
-	}
+    if (diff->base_to_dest[i]==-1) {
+        add_diff_box_removed(diff,i);
+    }
 }
 for (int i=0;i<diff->size_dest_to_base;i++) {
-	if (diff->dest_to_base[i]==-1) {
-		add_diff_box_added(diff,i);
-	}
+    if (diff->dest_to_base[i]==-1) {
+        add_diff_box_added(diff,i);
+    }
 }
 /* Finally, we compare boxes that match */
 for (int i=0;i<diff->size_base_to_dest;i++) {
-	if (diff->base_to_dest[i]!=-1) {
-		compare_matching_boxes(diff,base,dest,i,diff->base_to_dest[i]);
-	}
+    if (diff->base_to_dest[i]!=-1) {
+        compare_matching_boxes(diff,base,dest,i,diff->base_to_dest[i]);
+    }
 }
 }
 
@@ -1182,7 +1182,7 @@ return diff;
  */
 void print_diff(U_FILE* f,GrfDiff* diff) {
 for (int i=0;i<diff->diff_ops->nbelems;i++) {
-	print_diff_op(f,(DiffOp*)(diff->diff_ops->tab[i]));
+    print_diff_op(f,(DiffOp*)(diff->diff_ops->tab[i]));
 }
 }
 

--- a/GrfSvn_lib.h
+++ b/GrfSvn_lib.h
@@ -32,46 +32,46 @@
 namespace unitex {
 
 typedef enum {
-	DIFF_PROPERTY='P',
-	DIFF_BOX_MOVED='M',
-	DIFF_BOX_CONTENT_CHANGED='C',
-	DIFF_BOX_ADDED='A',
-	DIFF_BOX_REMOVED='R',
-	DIFF_TRANSITION_ADDED='T',
-	DIFF_TRANSITION_REMOVED='X'
+    DIFF_PROPERTY='P',
+    DIFF_BOX_MOVED='M',
+    DIFF_BOX_CONTENT_CHANGED='C',
+    DIFF_BOX_ADDED='A',
+    DIFF_BOX_REMOVED='R',
+    DIFF_TRANSITION_ADDED='T',
+    DIFF_TRANSITION_REMOVED='X'
 } DiffOpType;
 
 typedef struct {
-	/* Diff operation type */
-	DiffOpType op_type;
-	/* If we have a difference on properties, we need the property name */
-	char property[16];
-	/* Box concerned by the diff operation, with its number in the
-	 * base grf and the one in the dest grf */
-	int box_base;
-	int box_dest;
-	/* If we have a transition change, the origin of the transition is the
-	 * current box, and its destination is dest. As for the box id,
-	 * we store the destination state with its base and dest numbers */
-	int dest_base;
-	int dest_dest;
+    /* Diff operation type */
+    DiffOpType op_type;
+    /* If we have a difference on properties, we need the property name */
+    char property[16];
+    /* Box concerned by the diff operation, with its number in the
+     * base grf and the one in the dest grf */
+    int box_base;
+    int box_dest;
+    /* If we have a transition change, the origin of the transition is the
+     * current box, and its destination is dest. As for the box id,
+     * we store the destination state with its base and dest numbers */
+    int dest_base;
+    int dest_dest;
 } DiffOp;
 
 
 typedef struct {
-	/* The diff operations */
-	vector_ptr* diff_ops;
-	/* A renumber array indicating for each base state its corresponding
-	 * state in the dest grf, or -1 if the box was deleted */
-	int* base_to_dest;
-	int size_base_to_dest;
-	/* A renumber array indicating for dest base state its corresponding
-	 * state in the base grf, or -1 if the box was added */
-	int* dest_to_base;
-	int size_dest_to_base;
-	/* We also need reverse transitions */
-	ReverseTransitions* reverse_transitions_base;
-	ReverseTransitions* reverse_transitions_dest;
+    /* The diff operations */
+    vector_ptr* diff_ops;
+    /* A renumber array indicating for each base state its corresponding
+     * state in the dest grf, or -1 if the box was deleted */
+    int* base_to_dest;
+    int size_base_to_dest;
+    /* A renumber array indicating for dest base state its corresponding
+     * state in the base grf, or -1 if the box was added */
+    int* dest_to_base;
+    int size_dest_to_base;
+    /* We also need reverse transitions */
+    ReverseTransitions* reverse_transitions_base;
+    ReverseTransitions* reverse_transitions_dest;
 } GrfDiff;
 
 

--- a/GrfTest.cpp
+++ b/GrfTest.cpp
@@ -175,7 +175,7 @@ UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfTest,lopts_GrfTest,&index))) {
    switch(val) {
    case 'V': only_verify_arguments = true;
-             break;    
+             break;
    case 'h': usage();
              return_value = SUCCESS_RETURN_CODE;
              goto end;
@@ -189,7 +189,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfTest,lopts_GrfTest,&i
                 if (dic_list==NULL) {
                   alloc_error("main_GrfTest");
                   return_value = USAGE_ERROR_CODE;
-                  goto end;                  
+                  goto end;
                 }
                 if ((*dic_list) != '\0') {
                   strcat(dic_list, ";");
@@ -210,7 +210,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_GrfTest,lopts_GrfTest,&i
    case 'q': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_encoding argument\n");
                 return_value = USAGE_ERROR_CODE;
-                goto end;                
+                goto end;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -245,7 +245,7 @@ if (options.vars()->optind==argc) {
   /* If there is no .grf we report no error, in order not
    * to block test procedures if the program is called with *.grf
    * on an empty directory */
-  return_value = SUCCESS_RETURN_CODE; 
+  return_value = SUCCESS_RETURN_CODE;
   goto end;
 }
 
@@ -266,7 +266,7 @@ if (output[0]!='\0') {
   if (f_output==NULL) {
     error("Cannot open output file %s\n",output);
     return_value = DEFAULT_ERROR_CODE;
-    goto end;    
+    goto end;
   }
 }
 char txt[FILENAME_MAX];
@@ -409,7 +409,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
     if (f==NULL) {
       error("Cannot create file %s\n",txt);
       return_value = DEFAULT_ERROR_CODE;
-      goto end;      
+      goto end;
     }
     u_fputs(t->text,f);
     u_fclose(f);
@@ -425,7 +425,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
       error("The following command has failed for graph %s:\n%s\n",argv[i],line);
       free_command_line_alloc(line);
       return_value = DEFAULT_ERROR_CODE;
-      goto end;      
+      goto end;
     }
     if (invoker_Dico!=NULL) {
       if (invoke(invoker_Dico)) {
@@ -433,7 +433,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
         error("The following command has failed for graph %s:\n%s\n",argv[i],line);
         free_command_line_alloc(line);
         return_value = DEFAULT_ERROR_CODE;
-        goto end;        
+        goto end;
       }
     }
     /* We have to adjust Locate parameters for the current test */
@@ -444,17 +444,17 @@ for (int i=options.vars()->optind;i<argc;i++) {
     default: {
       error("Internal error: invalid output policy in unit test\n");
       return_value = DEFAULT_ERROR_CODE;
-      goto end;      
+      goto end;
      }
     }
     switch(t->match_policy) {
       case SHORTEST_MATCHES: add_argument(invoker_Locate,"-S"); break;
       case LONGEST_MATCHES: add_argument(invoker_Locate,"-L"); break;
       case ALL_MATCHES: add_argument(invoker_Locate,"-A"); break;
-      default: { 
+      default: {
         error("Internal error: invalid match policy in unit test\n");
         return_value = DEFAULT_ERROR_CODE;
-        goto end;   
+        goto end;
       }
     }
     if (invoke(invoker_Locate)) {
@@ -462,7 +462,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
       error("The following command has failed for graph %s:\n%s\n",argv[i],line);
       free_command_line_alloc(line);
       return_value = DEFAULT_ERROR_CODE;
-      goto end;      
+      goto end;
     }
     /* And we clean Locate parameters for the next test */
     remove_last_argument(invoker_Locate);
@@ -472,7 +472,7 @@ for (int i=options.vars()->optind;i<argc;i++) {
       error("The following command has failed for graph %s:\n%s\n",argv[i],line);
       free_command_line_alloc(line);
       return_value = DEFAULT_ERROR_CODE;
-      goto end;      
+      goto end;
     }
     if (!check_test_results(t,concord,argv[i],f_output)) return_value=DEFAULT_ERROR_CODE;
   }

--- a/GrfTest_lib.cpp
+++ b/GrfTest_lib.cpp
@@ -32,10 +32,10 @@
 namespace unitex {
 
 GrfUnitTest* new_GrfUnitTest(unichar* text,int start,int end,int must_match,
-		OutputPolicy output_policy,MatchPolicy match_policy,unichar* output) {
+        OutputPolicy output_policy,MatchPolicy match_policy,unichar* output) {
 GrfUnitTest* t=(GrfUnitTest*)malloc(sizeof(GrfUnitTest));
 if (t==NULL) {
-	fatal_alloc_error("new_GrfUnitTest");
+    fatal_alloc_error("new_GrfUnitTest");
 }
 t->text=u_strdup(text);
 t->start=start;
@@ -57,7 +57,7 @@ free(test);
 
 
 static int valid_values(unichar a,unichar b,int *must_match,OutputPolicy *output_policy,
-				MatchPolicy *match_policy) {
+                MatchPolicy *match_policy) {
 *must_match=1;
 switch (a) {
 case 'N': *must_match=0; *output_policy=IGNORE_OUTPUTS; break;
@@ -86,7 +86,7 @@ empty(error_msg);
 GrfUnitTest* res=NULL;
 vector_ptr* lines=tokenize_box_content(box_content);
 if (lines==NULL || lines->nbelems==0) {
-	fatal_error("get_grf_unit_test: cannot tokenize line:%S\n",box_content);
+    fatal_error("get_grf_unit_test: cannot tokenize line:%S\n",box_content);
 }
 unichar* tmp;
 unichar a,b;
@@ -94,8 +94,8 @@ int n,start,end;
 unichar* text=NULL;
 unichar* output=NULL;
 if (lines->nbelems==1) {
-	/* A test box must contains at least 2 lines */
-	goto end;
+    /* A test box must contains at least 2 lines */
+    goto end;
 }
 tmp=(unichar*)lines->tab[0];
 if (!u_starts_with(tmp,GRF_UNIT_TEST_PFX)) goto end;
@@ -103,56 +103,56 @@ int must_match;
 OutputPolicy output_policy;
 MatchPolicy match_policy;
 if (2!=u_sscanf(tmp,GRF_UNIT_TEST_PFX"%C:%C@%n",&a,&b,&n) || tmp[n]!='\0'
-		|| !valid_values(a,b,&must_match,&output_policy,&match_policy)) {
-	u_sprintf(error_msg,"Invalid unit test first line: __%S__\n",tmp);
-	u_strcatf(error_msg,"It should be of the form %sx:y@ with x=[NIMR] and y=[SLA]\n",GRF_UNIT_TEST_PFX);
-	goto end;
+        || !valid_values(a,b,&must_match,&output_policy,&match_policy)) {
+    u_sprintf(error_msg,"Invalid unit test first line: __%S__\n",tmp);
+    u_strcatf(error_msg,"It should be of the form %sx:y@ with x=[NIMR] and y=[SLA]\n",GRF_UNIT_TEST_PFX);
+    goto end;
 }
 if (lines->nbelems!=3 && (output_policy==MERGE_OUTPUTS || output_policy==REPLACE_OUTPUTS)) {
-	u_sprintf(error_msg,"Missing output line in unit test requiring output: %S %S\n",tmp,(unichar*)(lines->tab[1]));
-	goto end;
+    u_sprintf(error_msg,"Missing output line in unit test requiring output: %S %S\n",tmp,(unichar*)(lines->tab[1]));
+    goto end;
 }
 tmp=(unichar*)lines->tab[1];
 text=u_strdup(tmp);
 n=0;
 if (P_OK!=parse_string(tmp,&n,text,"<") || tmp[n]=='\0') {
-	u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
-	u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
-	goto end;
+    u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
+    u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
+    goto end;
 }
 u_strcat(text," ");
 start=u_strlen(text);
 n++;
 if (P_OK!=parse_string(tmp,&n,text+start,">") || text[start]=='\0') {
-	u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
-	u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
-	goto end;
+    u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
+    u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
+    goto end;
 }
 n++;
 end=u_strlen(text);
 u_strcat(text," ");
 if (tmp[n]!='\0' && P_OK!=parse_string(tmp,&n,text+end+1,P_EMPTY)) {
-	u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
-	u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
-	goto end;
+    u_sprintf(error_msg,"Invalid unit test second line: __%S__\n",tmp);
+    u_strcatf(error_msg,"It should be of the form xxx<yyy>zzz\n");
+    goto end;
 }
 if (lines->nbelems!=2) {
-	if (lines->nbelems!=3) {
-		u_sprintf(error_msg,"Invalid unit test with too many lines\n");
-		goto end;
-	}
-	/* If there is an output */
-	tmp=(unichar*)lines->tab[2];
-	if (output_policy!=MERGE_OUTPUTS && output_policy!=REPLACE_OUTPUTS) {
-		u_sprintf(error_msg,"Invalid unit test with unexpected output: __%S__\n",tmp);
-		goto end;
-	}
-	output=u_strdup(tmp);
-	n=0;
-	if (P_OK!=parse_string(tmp,&n,output,P_EMPTY)) {
-		u_sprintf(error_msg,"Invalid unit test output line: __%S__\n",tmp);
-		goto end;
-	}
+    if (lines->nbelems!=3) {
+        u_sprintf(error_msg,"Invalid unit test with too many lines\n");
+        goto end;
+    }
+    /* If there is an output */
+    tmp=(unichar*)lines->tab[2];
+    if (output_policy!=MERGE_OUTPUTS && output_policy!=REPLACE_OUTPUTS) {
+        u_sprintf(error_msg,"Invalid unit test with unexpected output: __%S__\n",tmp);
+        goto end;
+    }
+    output=u_strdup(tmp);
+    n=0;
+    if (P_OK!=parse_string(tmp,&n,output,P_EMPTY)) {
+        u_sprintf(error_msg,"Invalid unit test output line: __%S__\n",tmp);
+        goto end;
+    }
 }
 res=new_GrfUnitTest(text,start,end,must_match,output_policy,match_policy,output);
 end:
@@ -170,32 +170,32 @@ return res;
  */
 vector_ptr* get_grf_unit_tests(Grf* grf,const char* grf_name,U_FILE* f_error) {
 if (grf==NULL) {
-	fatal_alloc_error("Unexpected NULL grf in get_grf_unit_tests\n");
+    fatal_alloc_error("Unexpected NULL grf in get_grf_unit_tests\n");
 }
 vector_ptr* tests=new_vector_ptr();
 ReverseTransitions* reverse=compute_reverse_transitions(grf);
 Ustring* msg=new_Ustring(128);
 int first=1;
 for (int i=2;i<grf->n_states;i++) {
-	/* A test box must be a comment one */
-	if (grf->states[i]->transitions->nbelems!=0 || reverse->t[i]->nbelems!=0) continue;
-	GrfUnitTest* test=get_grf_unit_test(grf->states[i]->box_content,msg);
-	if (msg->str[0]!='\0') {
-		if (first) {
-			u_fprintf(f_error,"Error in graph %s:\n",grf_name);
-			first=0;
-		}
-		u_fputs(msg->str,f_error);
-	}
-	if (test!=NULL) {
-		vector_ptr_add(tests,test);
-	}
+    /* A test box must be a comment one */
+    if (grf->states[i]->transitions->nbelems!=0 || reverse->t[i]->nbelems!=0) continue;
+    GrfUnitTest* test=get_grf_unit_test(grf->states[i]->box_content,msg);
+    if (msg->str[0]!='\0') {
+        if (first) {
+            u_fprintf(f_error,"Error in graph %s:\n",grf_name);
+            first=0;
+        }
+        u_fputs(msg->str,f_error);
+    }
+    if (test!=NULL) {
+        vector_ptr_add(tests,test);
+    }
 }
 free_Ustring(msg);
 free_ReverseTransitions(reverse);
 if (tests->nbelems==0) {
-	free_vector_ptr(tests,(void(*)(void*))free_GrfUnitTest);
-	return NULL;
+    free_vector_ptr(tests,(void(*)(void*))free_GrfUnitTest);
+    return NULL;
 }
 return tests;
 }
@@ -209,42 +209,42 @@ return tests;
 int check_test_results(GrfUnitTest* t,const char* concord,const char* grf,U_FILE* f_error) {
 U_FILE* f=u_fopen(UTF16_LE,concord,U_READ);
 if (f==NULL) {
-	u_fprintf(f_error,"Error for graph %s:\nCannot open concordance file %s\n",grf,concord);
-	return 0;
+    u_fprintf(f_error,"Error for graph %s:\nCannot open concordance file %s\n",grf,concord);
+    return 0;
 }
 int match=0,start,end,n,quite_match=0;
 Ustring* line=new_Ustring(128);
 unichar* bad=NULL;
 while (EOF!=readline(line,f)) {
-	u_sscanf(line->str,"%d%d%n",&start,&end,&n);
-	if (t->must_match==0 && start==t->start && end==t->end) {
-		/* If we have a match when we did not want, we are done */
-		u_fprintf(f_error,"Test failed in graph %s:\n",grf);
-		u_fprintf(f_error,"\"%S\" matched when it was not supposed to\n\n",t->text);
-		match=1;
-		break;
-	}
-	if (t->must_match && start==t->start && end==t->end) {
-		quite_match=1;
-		/* We have a match, we must test the output, if any */
-		if (t->expected_output==NULL || !u_strcmp(t->expected_output,line->str+n)) {
-			match=1;
-			break;
-		} else {
-			free(bad);
-			bad=u_strdup(line->str+n);
-		}
-	}
+    u_sscanf(line->str,"%d%d%n",&start,&end,&n);
+    if (t->must_match==0 && start==t->start && end==t->end) {
+        /* If we have a match when we did not want, we are done */
+        u_fprintf(f_error,"Test failed in graph %s:\n",grf);
+        u_fprintf(f_error,"\"%S\" matched when it was not supposed to\n\n",t->text);
+        match=1;
+        break;
+    }
+    if (t->must_match && start==t->start && end==t->end) {
+        quite_match=1;
+        /* We have a match, we must test the output, if any */
+        if (t->expected_output==NULL || !u_strcmp(t->expected_output,line->str+n)) {
+            match=1;
+            break;
+        } else {
+            free(bad);
+            bad=u_strdup(line->str+n);
+        }
+    }
 }
 if (!match && t->must_match) {
-	if (quite_match) {
-		u_fprintf(f_error,"Test failed in graph %s:\n",grf);
-		u_fprintf(f_error,"\"%S\" was matched but with bad output \"%S\" (expected=\"%S\")\n\n",
-				t->text,bad,t->expected_output);
-	} else {
-		u_fprintf(f_error,"Test failed in graph %s:\n",grf);
-		u_fprintf(f_error,"\"%S\" was not matched\n\n",t->text);
-	}
+    if (quite_match) {
+        u_fprintf(f_error,"Test failed in graph %s:\n",grf);
+        u_fprintf(f_error,"\"%S\" was matched but with bad output \"%S\" (expected=\"%S\")\n\n",
+                t->text,bad,t->expected_output);
+    } else {
+        u_fprintf(f_error,"Test failed in graph %s:\n",grf);
+        u_fprintf(f_error,"\"%S\" was not matched\n\n",t->text);
+    }
 }
 free_Ustring(line);
 free(bad);

--- a/GrfTest_lib.h
+++ b/GrfTest_lib.h
@@ -36,12 +36,12 @@ namespace unitex {
 #define GRF_UNIT_TEST_PFX "@TEST:"
 
 typedef struct {
-	unichar* text;
-	int start,end;
-	int must_match;
-	OutputPolicy output_policy;
-	MatchPolicy match_policy;
-	unichar* expected_output;
+    unichar* text;
+    int start,end;
+    int must_match;
+    OutputPolicy output_policy;
+    MatchPolicy match_policy;
+    unichar* expected_output;
 } GrfUnitTest;
 
 

--- a/Grf_lib.cpp
+++ b/Grf_lib.cpp
@@ -82,7 +82,7 @@ grf->metadata=new_vector_ptr(1);
 grf->n_states=0;
 grf->states=NULL;
 if (create_default_header) {
-	set_default_header_values(grf);
+    set_default_header_values(grf);
 }
 return grf;
 }
@@ -147,7 +147,7 @@ free(s);
 void free_Grf(Grf* grf) {
 if (grf==NULL) return;
 for (int i=0;i<grf->n_states;i++) {
-	free_GrfState(grf->states[i]);
+    free_GrfState(grf->states[i]);
 }
 free_vector_ptr(grf->metadata,free);
 free(grf->states);
@@ -160,13 +160,13 @@ free(grf);
  */
 int add_GrfState(Grf* grf,GrfState* s) {
 if (grf==NULL || s==NULL) {
-	fatal_error("Unexpected NULL error in add_GrfState\n");
+    fatal_error("Unexpected NULL error in add_GrfState\n");
 }
 int n=grf->n_states;
 (grf->n_states)++;
 grf->states=(GrfState**)realloc(grf->states,grf->n_states*sizeof(GrfState*));
 if (grf->states==NULL) {
-	fatal_alloc_error("add_GrfState");
+    fatal_alloc_error("add_GrfState");
 }
 grf->states[n]=s;
 return n;
@@ -203,21 +203,21 @@ static int read_grf_state(U_FILE* f,Ustring* line,int n,Grf* grf) {
 if (EOF==readline(line,f) || line->len < 2) return 0;
 unsigned int pos=0;
 if (line->str[pos]=='s') {
-	/* Old stuff: s at line start used to mean that the box was selected.
-	 * We can ignore this */
-	pos++;
+    /* Old stuff: s at line start used to mean that the box was selected.
+     * We can ignore this */
+    pos++;
 }
 if (line->str[pos]!='"') return 0;
 unsigned int start_pos=pos;
 pos++;
 while (pos<line->len && line->str[pos]!='"') {
-	if (line->str[pos]=='\\') pos++;
-	pos++;
+    if (line->str[pos]=='\\') pos++;
+    pos++;
 }
 if (++pos>=line->len) {
-	/* Reached the end of line ? It's an error. We use a ++ since
-	 * a valid grf line should always have a space after the box content */
-	return 0;
+    /* Reached the end of line ? It's an error. We use a ++ since
+     * a valid grf line should always have a space after the box content */
+    return 0;
 }
 unichar c=line->str[pos];
 if (c!=' ') return 0;
@@ -229,18 +229,18 @@ pos++;
 int shift;
 int n_transitions;
 if (3!=u_sscanf(line->str+pos,"%d%d%d%n",
-		&(grf->states[n]->x),
-		&(grf->states[n]->y),
-		&n_transitions,
-		&shift)) return 0;
+        &(grf->states[n]->x),
+        &(grf->states[n]->y),
+        &n_transitions,
+        &shift)) return 0;
 pos=pos+shift;
 int dest;
 for (int i=0;i<n_transitions;i++) {
-	if (1!=u_sscanf(line->str+pos,"%d%n",
-			&dest,
-			&shift)) return 0;
-	vector_int_add(grf->states[n]->transitions,dest);
-	pos=pos+shift;
+    if (1!=u_sscanf(line->str+pos,"%d%n",
+            &dest,
+            &shift)) return 0;
+    vector_int_add(grf->states[n]->transitions,dest);
+    pos=pos+shift;
 }
 return 1;
 }
@@ -258,18 +258,18 @@ return 1;
  */
 static int read_metadata(Ustring* line,U_FILE* f,Grf* grf) {
 while (EOF!=readline(line,f)) {
-	if (!u_strcmp(line->str,"#")) return 1;
-	unichar* value=u_strchr(line->str,'=');
-	if (value==NULL) return 0;
-	*value='\0';
-	value++;
-	for (int i=0;i<grf->metadata->nbelems;i=i+2) {
-		if (!u_strcmp((unichar*)(grf->metadata->tab[i]),line->str)) {
-			return 0;
-		}
-	}
-	vector_ptr_add(grf->metadata,u_strdup(line->str));
-	vector_ptr_add(grf->metadata,u_strdup(value));
+    if (!u_strcmp(line->str,"#")) return 1;
+    unichar* value=u_strchr(line->str,'=');
+    if (value==NULL) return 0;
+    *value='\0';
+    value++;
+    for (int i=0;i<grf->metadata->nbelems;i=i+2) {
+        if (!u_strcmp((unichar*)(grf->metadata->tab[i]),line->str)) {
+            return 0;
+        }
+    }
+    vector_ptr_add(grf->metadata,u_strdup(line->str));
+    vector_ptr_add(grf->metadata,u_strdup(value));
 }
 return 0;
 }
@@ -284,9 +284,9 @@ if (f==NULL) return NULL;
 Ustring* line=new_Ustring();
 Grf* grf=new_Grf();
 if (EOF==readline(line,f)/* || u_strcmp(line->str,"#Unigraph")*/) {
-	/* The test has been removed because of backward compatibility problems
-	 * with old graphs starting with old header lines */
-	goto error;
+    /* The test has been removed because of backward compatibility problems
+     * with old graphs starting with old header lines */
+    goto error;
 }
 if (!read_grf_header_line(f,line,grf->size)) goto error;
 if (!read_grf_header_line(f,line,grf->font)) goto error;
@@ -309,12 +309,12 @@ if (!read_metadata(line,f,grf)) goto error;
 if (!read_grf_n_states(f,line,&(grf->n_states))) goto error;
 grf->states=(GrfState**)calloc(grf->n_states,sizeof(GrfState*));
 if (grf->states==NULL) {
-	fatal_alloc_error("load_Grf");
+    fatal_alloc_error("load_Grf");
 }
 for (int i=0;i<grf->n_states;i++) {
-	if (!read_grf_state(f,line,i,grf)) {
-		goto error;
-	}
+    if (!read_grf_state(f,line,i,grf)) {
+        goto error;
+    }
 }
 goto end;
 error:
@@ -350,17 +350,17 @@ u_fprintf(f,"%S\n",grf->drst);
 u_fprintf(f,"%S\n",grf->fits);
 u_fprintf(f,"%S\n",grf->porient);
 for (int i=0;i<grf->metadata->nbelems;i=i+2) {
-	u_fprintf(f,"%S=%S\n",grf->metadata->tab[i],grf->metadata->tab[i+1]);
+    u_fprintf(f,"%S=%S\n",grf->metadata->tab[i],grf->metadata->tab[i+1]);
 }
 u_fprintf(f,"#\n");
 u_fprintf(f,"%d\n",grf->n_states);
 for (int i=0;i<grf->n_states;i++) {
-	u_fprintf(f,"%S %d %d %d ",grf->states[i]->box_content,grf->states[i]->x,grf->states[i]->y,
-			grf->states[i]->transitions->nbelems);
-	for (int j=0;j<grf->states[i]->transitions->nbelems;j++) {
-		u_fprintf(f,"%d ",grf->states[i]->transitions->tab[j]);
-	}
-	u_fprintf(f,"\n");
+    u_fprintf(f,"%S %d %d %d ",grf->states[i]->box_content,grf->states[i]->x,grf->states[i]->y,
+            grf->states[i]->transitions->nbelems);
+    for (int j=0;j<grf->states[i]->transitions->nbelems;j++) {
+        u_fprintf(f,"%d ",grf->states[i]->transitions->tab[j]);
+    }
+    u_fprintf(f,"\n");
 }
 }
 
@@ -402,7 +402,7 @@ u_strcpy(dst->drst,src->drst);
 u_strcpy(dst->fits,src->fits);
 u_strcpy(dst->porient,src->porient);
 for (int i=0;i<src->metadata->nbelems;i++) {
-	vector_ptr_add(dst->metadata,u_strdup((unichar*)(src->metadata->tab[i])));
+    vector_ptr_add(dst->metadata,u_strdup((unichar*)(src->metadata->tab[i])));
 }
 }
 
@@ -412,16 +412,16 @@ for (int i=0;i<src->metadata->nbelems;i++) {
  */
 void cpy_grf_states(Grf* dst,Grf* src) {
 if (dst->states!=NULL)  {
-	for (int i=0;i<dst->n_states;i++) {
-		free_GrfState(dst->states[i]);
-	}
-	free(dst->states);
+    for (int i=0;i<dst->n_states;i++) {
+        free_GrfState(dst->states[i]);
+    }
+    free(dst->states);
 }
 dst->n_states=src->n_states;
 dst->states=(GrfState**)malloc(dst->n_states*sizeof(GrfState*));
 if (dst->states==NULL) fatal_alloc_error("cmp_grf_states");
 for (int i=0;i<dst->n_states;i++) {
-	dst->states[i]=cpy_grf_state(src->states[i]);
+    dst->states[i]=cpy_grf_state(src->states[i]);
 }
 }
 
@@ -443,18 +443,18 @@ return dst;
  */
 static int read_sequence(unichar stop,unichar* content,int *pos,Ustring* tmp) {
 while (content[*pos]!='\0' && content[*pos]!=stop) {
-	if (content[*pos]=='\\') {
-		u_strcat(tmp,'\\');
-		(*pos)++;
-		if (content[*pos]=='\0') return 0;
-	}
-	u_strcat(tmp,content[*pos]);
-	(*pos)++;
+    if (content[*pos]=='\\') {
+        u_strcat(tmp,'\\');
+        (*pos)++;
+        if (content[*pos]=='\0') return 0;
+    }
+    u_strcat(tmp,content[*pos]);
+    (*pos)++;
 }
 if (content[*pos]==stop) {
-	(*pos)++;
-	u_strcat(tmp,stop);
-	return 1;
+    (*pos)++;
+    u_strcat(tmp,stop);
+    return 1;
 }
 return 0;
 }
@@ -467,33 +467,33 @@ return 0;
 static int read_quoted_sequence(unichar* content,int *pos,Ustring* tmp) {
 int state=0;
 while (content[*pos]!='\0') {
-	unichar c=content[*pos];
-	u_strcat(tmp,c);
-	switch(state) {
-	case 0: {
-		if (c=='\\') state=1;
-		break;
-	}
-	case 1: {
-		if (c=='"') {
-			(*pos)++;
-			return 1;
-		}
-		if (c=='\\') state=2;
-		else state=0;
-		break;
-	}
-	case 2: {
-		if (c=='\\') state=3;
-		else state=0;
-		break;
-	}
-	case 3: {
-		state=0;
-		break;
-	}
-	}
-	(*pos)++;
+    unichar c=content[*pos];
+    u_strcat(tmp,c);
+    switch(state) {
+    case 0: {
+        if (c=='\\') state=1;
+        break;
+    }
+    case 1: {
+        if (c=='"') {
+            (*pos)++;
+            return 1;
+        }
+        if (c=='\\') state=2;
+        else state=0;
+        break;
+    }
+    case 2: {
+        if (c=='\\') state=3;
+        else state=0;
+        break;
+    }
+    case 3: {
+        state=0;
+        break;
+    }
+    }
+    (*pos)++;
 }
 return 0;
 }
@@ -508,30 +508,30 @@ return 0;
 static int read_box_line(vector_ptr* v,unichar* content,int *pos,Ustring* tmp) {
 empty(tmp);
 while (content[*pos]!='\0' && content[*pos]!='/' && content[*pos]!='+') {
-	switch (content[*pos]) {
-	case '<': if (!read_sequence('>',content,pos,tmp)) return 0; break;
-	case '{': if (!read_sequence('}',content,pos,tmp)) return 0; break;
-	case '\\': {
-		u_strcat(tmp,'\\');
-		(*pos)++;
-		if (content[*pos]=='\0') {
-			return 0;
-		}
-		u_strcat(tmp,content[*pos]);
-		(*pos)++;
-		if (content[(*pos)-1]=='"' && ((*pos)-3<0 || content[(*pos)-3]!='\\')) {
-			/* If we have just read \" (and not \\\") then the box line contains
-			 * a double quoted sequence that we have to read */
-			if (!read_quoted_sequence(content,pos,tmp)) return 0;
-		}
-		break;
-	}
-	default: u_strcat(tmp,content[*pos]); (*pos)++; break;
-	}
+    switch (content[*pos]) {
+    case '<': if (!read_sequence('>',content,pos,tmp)) return 0; break;
+    case '{': if (!read_sequence('}',content,pos,tmp)) return 0; break;
+    case '\\': {
+        u_strcat(tmp,'\\');
+        (*pos)++;
+        if (content[*pos]=='\0') {
+            return 0;
+        }
+        u_strcat(tmp,content[*pos]);
+        (*pos)++;
+        if (content[(*pos)-1]=='"' && ((*pos)-3<0 || content[(*pos)-3]!='\\')) {
+            /* If we have just read \" (and not \\\") then the box line contains
+             * a double quoted sequence that we have to read */
+            if (!read_quoted_sequence(content,pos,tmp)) return 0;
+        }
+        break;
+    }
+    default: u_strcat(tmp,content[*pos]); (*pos)++; break;
+    }
 }
 vector_ptr_add(v,u_strdup(tmp->str));
 if (content[*pos]=='+') {
-	(*pos)++;
+    (*pos)++;
 }
 return 1;
 }
@@ -551,8 +551,8 @@ if (s[pos++]!='$') return 0;
 if (s[pos]=='|') pos++;
 while (is_variable_char(s[pos])) pos++;
 if (!is_variable_char(s[pos-1])) {
-	/* Empty variable  name ? */
-	return 0;
+    /* Empty variable  name ? */
+    return 0;
 }
 if (s[pos]!='(' && s[pos]!=')') return 0;
 return s[pos+1]=='\0';
@@ -576,26 +576,26 @@ int l=u_strlen(content);
 /* We remove the ending double quote */
 content[l-1]='\0';
 if (!u_strcmp(content+1,"$<") || !u_strcmp(content+1,"$>")
-	|| !u_strcmp(content+1,"$[") || !u_strcmp(content+1,"$![") || !u_strcmp(content+1,"$]")
-	|| is_variable_box(content+1)) {
-	vector_ptr_add(v,u_strdup(content+1));
-	content[l-1]='"';
-	return v;
+    || !u_strcmp(content+1,"$[") || !u_strcmp(content+1,"$![") || !u_strcmp(content+1,"$]")
+    || is_variable_box(content+1)) {
+    vector_ptr_add(v,u_strdup(content+1));
+    content[l-1]='"';
+    return v;
 }
 Ustring* s=new_Ustring();
 int pos=1;
 while (content[pos]!='\0') {
-	if (content[pos]=='/') {
-		/* If we have found the output, we can copy it rawly and finish */
-		vector_ptr_add(v,u_strdup(content+pos));
-		break;
-	}
-	if (!read_box_line(v,content,&pos,s)) {
-		free_Ustring(s);
-		free_vector_ptr(v,free);
-		content[l-1]='"';
-		return NULL;
-	}
+    if (content[pos]=='/') {
+        /* If we have found the output, we can copy it rawly and finish */
+        vector_ptr_add(v,u_strdup(content+pos));
+        break;
+    }
+    if (!read_box_line(v,content,&pos,s)) {
+        free_Ustring(s);
+        free_vector_ptr(v,free);
+        content[l-1]='"';
+        return NULL;
+    }
 }
 content[l-1]='"';
 free_Ustring(s);
@@ -609,26 +609,26 @@ return v;
 ReverseTransitions* compute_reverse_transitions(Grf* g) {
 ReverseTransitions* reverse=(ReverseTransitions*)malloc(sizeof(ReverseTransitions));
 if (reverse==NULL) {
-	fatal_alloc_error("compute_reverse_transitions");
+    fatal_alloc_error("compute_reverse_transitions");
 }
 reverse->n=g->n_states;
 reverse->t=(vector_int**)malloc(g->n_states*sizeof(vector_int*));
 if (reverse->t==NULL) {
-	fatal_alloc_error("compute_reverse_transitions");
+    fatal_alloc_error("compute_reverse_transitions");
 }
 for (int i=0;i<g->n_states;i++) {
-	reverse->t[i]=new_vector_int(1);
+    reverse->t[i]=new_vector_int(1);
 }
 for (int i=0;i<g->n_states;i++) {
-	GrfState* s=g->states[i];
-	for (int j=0;j<s->transitions->nbelems;j++) {
-		if ((s->transitions->tab[j] < 0) || (s->transitions->tab[j] >= reverse->n)) {
-		  error("Invalid GRF file : invalid transition number %d\n", s->transitions->tab[j]);
-		} else
-		{
-		  vector_int_add(reverse->t[s->transitions->tab[j]],i);
-		}
-	}
+    GrfState* s=g->states[i];
+    for (int j=0;j<s->transitions->nbelems;j++) {
+        if ((s->transitions->tab[j] < 0) || (s->transitions->tab[j] >= reverse->n)) {
+          error("Invalid GRF file : invalid transition number %d\n", s->transitions->tab[j]);
+        } else
+        {
+          vector_int_add(reverse->t[s->transitions->tab[j]],i);
+        }
+    }
 }
 return reverse;
 }
@@ -637,7 +637,7 @@ return reverse;
 void free_ReverseTransitions(ReverseTransitions* r) {
 if (r==NULL) return;
 for (int i=0;i<r->n;i++) {
-	free_vector_int(r->t[i]);
+    free_vector_int(r->t[i]);
 }
 free(r->t);
 free(r);
@@ -674,7 +674,7 @@ return vector_int_equals_disorder(r->t[a],r->t[b]);
  */
 int have_same_transitions(Grf* grf,int a,int b,ReverseTransitions* r) {
 return have_same_outgoing_transitions(grf,a,b)
-	&& have_same_incoming_transitions(a,b,r);
+    && have_same_incoming_transitions(a,b,r);
 }
 
 

--- a/Grf_lib.h
+++ b/Grf_lib.h
@@ -35,57 +35,57 @@ namespace unitex {
 
 
 typedef struct {
-	unichar* box_content;
-	int x,y;
-	vector_int* transitions;
+    unichar* box_content;
+    int x,y;
+    vector_int* transitions;
 
-	/* This information is useful when manipulating sentence grfs */
-	int rank;
+    /* This information is useful when manipulating sentence grfs */
+    int rank;
 
-	/* box_number is used for artificial box duplication when
-	 * specifying something like [2;4] to indicate that the given
-	 * box can match 2, 3 or 4 times. In such a case, we will expend this
-	 * request by creating all the boxes as a human would have created them
-	 * by hand, but for consistency in debug mode, we want all those
-	 * boxes to be considered as the original unique one in the grf. So,
-	 * artificial boxes will have a number that is not their index in the
-	 * state array of the grf object.
-	 */
-	int box_number;
+    /* box_number is used for artificial box duplication when
+     * specifying something like [2;4] to indicate that the given
+     * box can match 2, 3 or 4 times. In such a case, we will expend this
+     * request by creating all the boxes as a human would have created them
+     * by hand, but for consistency in debug mode, we want all those
+     * boxes to be considered as the original unique one in the grf. So,
+     * artificial boxes will have a number that is not their index in the
+     * state array of the grf object.
+     */
+    int box_number;
 } GrfState;
 
 
 typedef struct {
-	/* For the header part, we rawly store line contents, since
-	 * there is no need to analyse them */
-	unichar size[GRF_HEADER_LINE_SIZE];
-	unichar font[GRF_HEADER_LINE_SIZE];
-	unichar ofont[GRF_HEADER_LINE_SIZE];
-	unichar bcolor[GRF_HEADER_LINE_SIZE];
-	unichar fcolor[GRF_HEADER_LINE_SIZE];
-	unichar acolor[GRF_HEADER_LINE_SIZE];
-	unichar scolor[GRF_HEADER_LINE_SIZE];
-	unichar ccolor[GRF_HEADER_LINE_SIZE];
-	unichar dboxes[GRF_HEADER_LINE_SIZE];
-	unichar dframe[GRF_HEADER_LINE_SIZE];
-	unichar ddate[GRF_HEADER_LINE_SIZE];
-	unichar dfile[GRF_HEADER_LINE_SIZE];
-	unichar ddir[GRF_HEADER_LINE_SIZE];
-	unichar drig[GRF_HEADER_LINE_SIZE];
-	unichar drst[GRF_HEADER_LINE_SIZE];
-	unichar fits[GRF_HEADER_LINE_SIZE];
-	unichar porient[GRF_HEADER_LINE_SIZE];
+    /* For the header part, we rawly store line contents, since
+     * there is no need to analyse them */
+    unichar size[GRF_HEADER_LINE_SIZE];
+    unichar font[GRF_HEADER_LINE_SIZE];
+    unichar ofont[GRF_HEADER_LINE_SIZE];
+    unichar bcolor[GRF_HEADER_LINE_SIZE];
+    unichar fcolor[GRF_HEADER_LINE_SIZE];
+    unichar acolor[GRF_HEADER_LINE_SIZE];
+    unichar scolor[GRF_HEADER_LINE_SIZE];
+    unichar ccolor[GRF_HEADER_LINE_SIZE];
+    unichar dboxes[GRF_HEADER_LINE_SIZE];
+    unichar dframe[GRF_HEADER_LINE_SIZE];
+    unichar ddate[GRF_HEADER_LINE_SIZE];
+    unichar dfile[GRF_HEADER_LINE_SIZE];
+    unichar ddir[GRF_HEADER_LINE_SIZE];
+    unichar drig[GRF_HEADER_LINE_SIZE];
+    unichar drst[GRF_HEADER_LINE_SIZE];
+    unichar fits[GRF_HEADER_LINE_SIZE];
+    unichar porient[GRF_HEADER_LINE_SIZE];
 
-	vector_ptr* metadata;
+    vector_ptr* metadata;
 
-	int n_states;
-	GrfState** states;
+    int n_states;
+    GrfState** states;
 } Grf;
 
 
 typedef struct {
-	int n;
-	vector_int** t;
+    int n;
+    vector_int** t;
 } ReverseTransitions;
 
 

--- a/HTMLCharacters.cpp
+++ b/HTMLCharacters.cpp
@@ -49,13 +49,13 @@ struct HTML_character_context {
 
 void* init_HTML_character_context()
 {
-	struct HTML_character_context* html_ctx = (struct HTML_character_context*)malloc(sizeof(struct HTML_character_context));
-	if (html_ctx==NULL)
-		fatal_alloc_error("init_HTML_character_context");
+    struct HTML_character_context* html_ctx = (struct HTML_character_context*)malloc(sizeof(struct HTML_character_context));
+    if (html_ctx==NULL)
+        fatal_alloc_error("init_HTML_character_context");
 
-	html_ctx->control_characters = init_control_characters();
-	html_ctx->normal_characters = init_normal_characters();
-	return html_ctx;
+    html_ctx->control_characters = init_control_characters();
+    html_ctx->normal_characters = init_normal_characters();
+    return html_ctx;
 }
 
 void free_HTML_character_context(void* html_ctx)
@@ -378,13 +378,13 @@ return -1;
 int analyse_hexadecimal_code(const char* sequence) {
 int value=0;
 for (int i=0;sequence[i]!='\0';i++) {
-	if (sequence[i]>='0' && sequence[i]<='9') {
-		value=value*16+(sequence[i]-'0');
-	} else if (sequence[i]>='a' && sequence[i]<='f') {
-		value=value*16+(sequence[i]-'a'+10);
-	} else if (sequence[i]>='A' && sequence[i]<='F') {
-		value=value*16+(sequence[i]-'A'+10);
-	} else return MALFORMED_HTML_CODE;
+    if (sequence[i]>='0' && sequence[i]<='9') {
+        value=value*16+(sequence[i]-'0');
+    } else if (sequence[i]>='a' && sequence[i]<='f') {
+        value=value*16+(sequence[i]-'a'+10);
+    } else if (sequence[i]>='A' && sequence[i]<='F') {
+        value=value*16+(sequence[i]-'A'+10);
+    } else return MALFORMED_HTML_CODE;
 }
 return value;
 }
@@ -398,10 +398,10 @@ return value;
 int analyse_decimal_code(const char* sequence) {
 int value=0;
 for (int i=0;sequence[i]!='\0';i++) {
-	if (sequence[i]>='0' && sequence[i]<='9') {
-		value=value*10+(sequence[i]-'0');
-	}
-	else return MALFORMED_HTML_CODE;
+    if (sequence[i]>='0' && sequence[i]<='9') {
+        value=value*10+(sequence[i]-'0');
+    }
+    else return MALFORMED_HTML_CODE;
 }
 return value;
 }
@@ -426,35 +426,35 @@ return value;
 int get_HTML_character(const void* html_ctx,const char* sequence,int decode_control_character) {
 const struct HTML_character_context* html_context=(const HTML_character_context*)html_ctx;
 if (sequence==NULL || sequence[0]=='\0') {
-	fatal_error("Internal error in get_HTML_character\n");
+    fatal_error("Internal error in get_HTML_character\n");
 }
 int value;
 if (sequence[0]!='#') {
-	/* If we have a character name */
-	value=get_normal_character_number(html_context,sequence);
-	if (value!=-1) return value;
-	/* If the character is not in the normal character set, we
-	 * look in the control character set. */
-	value=get_control_character_number(html_context,sequence);
-	if (value==-1) {
-		/* If the character is not a control character, then we
-		 * say that it is an unknown character. */
-		 return UNKNOWN_CHARACTER;
-	}
-	/* If the character is a control one, we return its value
-	 * only if we are allowed to decode it. */
-	if (decode_control_character) {
-		return value;
-	}
-	return DO_NOT_DECODE_CHARACTER;
+    /* If we have a character name */
+    value=get_normal_character_number(html_context,sequence);
+    if (value!=-1) return value;
+    /* If the character is not in the normal character set, we
+     * look in the control character set. */
+    value=get_control_character_number(html_context,sequence);
+    if (value==-1) {
+        /* If the character is not a control character, then we
+         * say that it is an unknown character. */
+         return UNKNOWN_CHARACTER;
+    }
+    /* If the character is a control one, we return its value
+     * only if we are allowed to decode it. */
+    if (decode_control_character) {
+        return value;
+    }
+    return DO_NOT_DECODE_CHARACTER;
 }
 if (sequence[1]=='x') {
-	/* If we have an hexadecimal integer */
-	return analyse_hexadecimal_code(&(sequence[2]));
+    /* If we have an hexadecimal integer */
+    return analyse_hexadecimal_code(&(sequence[2]));
 }
 if (sequence[1]>='0' && sequence[1]<='9') {
-	/* If we have a decimal integer */
-	return analyse_decimal_code(&(sequence[1]));
+    /* If we have a decimal integer */
+    return analyse_decimal_code(&(sequence[1]));
 }
 /* If the sequence is an invalid integer declaration like '#' or '#a', it is an error */
 return MALFORMED_HTML_CODE;

--- a/HTMLCharacters.h
+++ b/HTMLCharacters.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef HTMLCharactersH
 #define HTMLCharactersH
 

--- a/HashTable.cpp
+++ b/HashTable.cpp
@@ -227,8 +227,8 @@ while (list!=NULL) {
    }
 }
 }
- 
- 
+
+
 /**
  * Frees all the memory associated to the given hash table.
  */
@@ -344,7 +344,7 @@ return NULL;
  * This function inserts a key in the given table, resizing it if needed.
  * It returns a pointer on the virgin value associated to the key. No
  * test is performed to check if the key is already present in the table.
- * 
+ *
  * Note that it is the responsability of the caller to initialize
  * properly this value.
  */
@@ -367,10 +367,10 @@ return &(h->table[cell_index]->value);
  * to the table if necessary. In that case, (*ret) will contain HT_KEY_ADDED
  * and the returned value will be a virgin one to be set by the caller.
  * If the key is already in the table, (*ret) is set to HT_KEY_ALREADY_THERE.
- * 
+ *
  * Returns a pointer on the struct any that contains the value, or NULL if
  * the key is not in the table and if 'insert_policy' is set to HT_DONT_INSERT.
- * 
+ *
  * Note that you can associate a NULL value to a key. In that case, the returned
  * struct any will have its _ptr field set to NULL.
  */
@@ -426,7 +426,7 @@ return NULL;
  * This function inserts a key in the given table, resizing it if needed.
  * It returns a pointer on the virgin value associated to the key. No
  * test is performed to check if the key is already present in the table.
- * 
+ *
  * Note that it is the responsability of the caller to initialize
  * properly this value.
  */
@@ -449,10 +449,10 @@ return &(h->table[cell_index]->value);
  * to the table if necessary. In that case, (*ret) will contain HT_KEY_ADDED
  * and the returned value will be a virgin one to be set by the caller.
  * If the key is already in the table, (*ret) is set to HT_KEY_ALREADY_THERE.
- * 
+ *
  * Returns a pointer on the struct any that contains the value, or NULL if
  * the key is not in the table and if 'insert_policy' is set to HT_DONT_INSERT.
- * 
+ *
  * Note that you can associate a NULL value to a key. In that case, the returned
  * struct any will have its _ptr field set to NULL.
  */
@@ -483,10 +483,10 @@ return value;
  * If 'insert_policy' is set to HT_INSERT_IF_NEEDED, the key will be added
  * to the table if necessary. In that case, the returned value will be a virgin
  * one to be set by the caller.
- * 
+ *
  * Returns a pointer on the struct any that contains the value, or NULL if
  * the key is not in the table and if 'insert_policy' is set to HT_DONT_INSERT.
- * 
+ *
  * Note that you can associate a NULL value to a key. In that case, the returned
  * struct any will have its _ptr field set to NULL.
  */
@@ -502,10 +502,10 @@ return get_value(h,key,insert_policy,&i);
  * If 'insert_policy' is set to HT_INSERT_IF_NEEDED, the key will be added
  * to the table if necessary. In that case, the returned value will be a virgin
  * one to be set by the caller.
- * 
+ *
  * Returns a pointer on the struct any that contains the value, or NULL if
  * the key is not in the table and if 'insert_policy' is set to HT_DONT_INSERT.
- * 
+ *
  * Note that you can associate a NULL value to a key. In that case, the returned
  * struct any will have its _ptr field set to NULL.
  */

--- a/HashTable.cpp
+++ b/HashTable.cpp
@@ -36,9 +36,9 @@ namespace unitex {
  * set the capacity of hash table, verify we have a power of two
  */
 static void set_hash_capacity(struct hash_table* h,unsigned int capacity_set) {
-	h->capacity = 1;
-	while (h->capacity < capacity_set)
-		h->capacity *= 2;
+    h->capacity = 1;
+    while (h->capacity < capacity_set)
+        h->capacity *= 2;
 }
 
 

--- a/HashTable.h
+++ b/HashTable.h
@@ -46,7 +46,7 @@ namespace unitex {
  * associated to a cell of the hash table in case of collision. 'value' is
  * the value associated to the element. It is the responsability of the user
  * to know if 'value' must must interpreted as an int, a pointer, etc.
- * 
+ *
  * Note that the order of the elements in the list is undefined and may vary
  * when resizing the hash table.
  */

--- a/IOBuffer.cpp
+++ b/IOBuffer.cpp
@@ -30,7 +30,7 @@ namespace unitex {
 
 /**
  * This function put the standard output stream in unbufferized mode, so
- * that if a graphical interface listen to this stream, it will be 
+ * that if a graphical interface listen to this stream, it will be
  * synchronous. We also put the standard input stream in the same
  * mode, in order to apply our own scanf functions.
  */

--- a/IOBuffer.cpp
+++ b/IOBuffer.cpp
@@ -47,5 +47,5 @@ using namespace unitex;
 
 UNITEX_FUNC void UNITEX_CALL SetUnitexBufferMode()
 {
-	setBufferMode();
+    setBufferMode();
 }

--- a/KeyWords.cpp
+++ b/KeyWords.cpp
@@ -111,14 +111,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_KeyWords,lopts_KeyWords,
    case 'a': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty alphabet file name\n");
                 free(code);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(alph,options.vars()->optarg);
              break;
    case 'f': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty forbidden code\n");
                 free(code);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              free(code);
              code=u_strdup(options.vars()->optarg);
@@ -126,7 +126,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_KeyWords,lopts_KeyWords,
    case 'c': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty file name\n");
                 free(code);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(cdic,options.vars()->optarg);
              break;
@@ -138,14 +138,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_KeyWords,lopts_KeyWords,
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
                 free(code);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
    case 'q': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_encoding argument\n");
                 free(code);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -181,7 +181,7 @@ if (alph[0]!='\0') {
   if (alphabet==NULL) {
     error("Cannot load alphabet file %s\n",alph);
     free(code);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
   }
 }
 
@@ -212,7 +212,7 @@ if (f_output==NULL) {
   free_string_hash_ptr(keywords,(void(*)(void*))free_KeyWord_list);
   free_alphabet(alphabet);
   free(code);
-  return DEFAULT_ERROR_CODE;  
+  return DEFAULT_ERROR_CODE;
 }
 
 dump_keywords(sorted,f_output);

--- a/KeyWords.cpp
+++ b/KeyWords.cpp
@@ -187,17 +187,17 @@ if (alph[0]!='\0') {
 
 strcpy(tokens,argv[(options.vars()->optind++)]);
 if (output[0]=='\0') {
-	get_path(tokens,output);
-	strcat(output,"keywords.txt");
+    get_path(tokens,output);
+    strcat(output,"keywords.txt");
 }
 struct string_hash_ptr* keywords=load_tokens_by_freq(tokens,&vec);
 filter_non_letter_keywords(keywords,alphabet);
 if (cdic[0]!='\0') {
-	load_compound_words(cdic,&vec,keywords);
+    load_compound_words(cdic,&vec,keywords);
 }
 
 for (;options.vars()->optind!=argc;(options.vars()->optind)++) {
-	filter_keywords_with_dic(keywords,argv[options.vars()->optind],&vec,alphabet);
+    filter_keywords_with_dic(keywords,argv[options.vars()->optind],&vec,alphabet);
 }
 merge_case_equivalent_unknown_words(keywords,alphabet);
 struct string_hash* forbidden_lemmas=compute_forbidden_lemmas(keywords,code);
@@ -207,7 +207,7 @@ vector_ptr* sorted=sort_keywords(keywords);
 U_FILE* f_output=u_fopen(&vec,output,U_WRITE);
 
 if (f_output==NULL) {
-	error("Cannot write in file %s\n",output);
+    error("Cannot write in file %s\n",output);
   free_vector_ptr(sorted,(void(*)(void*))free_KeyWord_list);
   free_string_hash_ptr(keywords,(void(*)(void*))free_KeyWord_list);
   free_alphabet(alphabet);

--- a/KeyWords_lib.cpp
+++ b/KeyWords_lib.cpp
@@ -40,12 +40,12 @@ namespace unitex {
 KeyWord* new_KeyWord(int weight,unichar* sequence,KeyWord* next) {
 KeyWord* k=(KeyWord*)malloc(sizeof(KeyWord));
 if (k==NULL) {
-	fatal_alloc_error("new_KeyWord");
+    fatal_alloc_error("new_KeyWord");
 }
 k->weight=weight;
 k->sequence=u_strdup(sequence);
 if (sequence!=NULL && k->sequence==NULL) {
-	fatal_alloc_error("new_KeyWord");
+    fatal_alloc_error("new_KeyWord");
 }
 k->lemmatized=UNKNOWN_WORD;
 k->next=next;
@@ -62,9 +62,9 @@ free(k);
 
 void free_KeyWord_list(KeyWord* k) {
 while (k!=NULL) {
-	KeyWord* tmp=k;
-	k=k->next;
-	free_KeyWord(tmp);
+    KeyWord* tmp=k;
+    k=k->next;
+    free_KeyWord(tmp);
 }
 }
 
@@ -86,20 +86,20 @@ int val,pos;
  * of tokens
  */
 if (EOF==readline(line,f)) {
-	fatal_error("Invalid empty file %s\n",name);
+    fatal_error("Invalid empty file %s\n",name);
 }
 while (EOF!=readline(line,f)) {
-	if (1!=u_sscanf(line->str,"%d%n",&val,&pos)) {
-		fatal_error("Invalid line in file %s:\n%S\n",name,line->str);
-	}
-	u_strcpy(lower,line->str+pos);
-	u_tolower(lower->str);
-	int index=get_value_index(lower->str,res,INSERT_IF_NEEDED,NULL);
-	if (index==-1) {
-		fatal_error("Internal error in load_tokens_by_freq\n");
-	}
-	KeyWord* value=(KeyWord*)res->value[index];
-	res->value[index]=new_KeyWord(val,line->str+pos,value);
+    if (1!=u_sscanf(line->str,"%d%n",&val,&pos)) {
+        fatal_error("Invalid line in file %s:\n%S\n",name,line->str);
+    }
+    u_strcpy(lower,line->str+pos);
+    u_tolower(lower->str);
+    int index=get_value_index(lower->str,res,INSERT_IF_NEEDED,NULL);
+    if (index==-1) {
+        fatal_error("Internal error in load_tokens_by_freq\n");
+    }
+    KeyWord* value=(KeyWord*)res->value[index];
+    res->value[index]=new_KeyWord(val,line->str+pos,value);
 }
 free_Ustring(line);
 free_Ustring(lower);
@@ -110,13 +110,13 @@ return res;
 
 void add_keyword(KeyWord* *list,unichar* keyword,int weight) {
 if (*list==NULL) {
-	*list=new_KeyWord(weight,keyword,NULL);
-	return;
+    *list=new_KeyWord(weight,keyword,NULL);
+    return;
 }
 if (!u_strcmp((*list)->sequence,keyword)) {
-	/* The keyword is already there, we just have to update its weight */
-	(*list)->weight+=weight;
-	return;
+    /* The keyword is already there, we just have to update its weight */
+    (*list)->weight+=weight;
+    return;
 }
 add_keyword(&((*list))->next,keyword,weight);
 }
@@ -126,25 +126,25 @@ add_keyword(&((*list))->next,keyword,weight);
  * Loads a compound word file, adding each word to the keywords.
  */
 void load_compound_words(char* name,VersatileEncodingConfig* vec,
-		struct string_hash_ptr* keywords) {
+        struct string_hash_ptr* keywords) {
 U_FILE* f=u_fopen(vec,name,U_READ);
 if (f==NULL) return;
 Ustring* line=new_Ustring(256);
 Ustring* lower=new_Ustring(256);
 while (EOF!=readline(line,f)) {
-	if (line->str[0]=='{') {
-		/* We skip tags */
-		continue;
-	}
-	u_strcpy(lower,line->str);
-	u_tolower(lower->str);
-	int index=get_value_index(lower->str,keywords,INSERT_IF_NEEDED,NULL);
-	if (index==-1) {
-		fatal_error("Internal error in load_tokens_by_freq\n");
-	}
-	KeyWord* value=(KeyWord*)keywords->value[index];
-	add_keyword(&value,line->str,1);
-	keywords->value[index]=value;
+    if (line->str[0]=='{') {
+        /* We skip tags */
+        continue;
+    }
+    u_strcpy(lower,line->str);
+    u_tolower(lower->str);
+    int index=get_value_index(lower->str,keywords,INSERT_IF_NEEDED,NULL);
+    if (index==-1) {
+        fatal_error("Internal error in load_tokens_by_freq\n");
+    }
+    KeyWord* value=(KeyWord*)keywords->value[index];
+    add_keyword(&value,line->str,1);
+    keywords->value[index]=value;
 }
 free_Ustring(line);
 free_Ustring(lower);
@@ -160,14 +160,14 @@ u_fclose(f);
  */
 void filter_non_letter_keywords(struct string_hash_ptr* keywords,Alphabet* alphabet) {
 for (int i=0;i<keywords->size;i++) {
-	KeyWord* k=(KeyWord*)(keywords->value[i]);
-	while (k!=NULL) {
-		if (k->sequence!=NULL && !is_sequence_of_letters(k->sequence,alphabet)) {
-			free(k->sequence);
-			k->sequence=NULL;
-		}
-		k=k->next;
-	}
+    KeyWord* k=(KeyWord*)(keywords->value[i]);
+    while (k!=NULL) {
+        if (k->sequence!=NULL && !is_sequence_of_letters(k->sequence,alphabet)) {
+            free(k->sequence);
+            k->sequence=NULL;
+        }
+        k=k->next;
+    }
 }
 }
 
@@ -179,19 +179,19 @@ KeyWord* k=(KeyWord*)get_value(lower,keywords);
 free(lower);
 if (k==NULL) return;
 while (k!=NULL) {
-	if (k->sequence!=NULL && !u_strcmp(keyword,k->sequence)) {
-		free(k->sequence);
-		k->sequence=NULL;
-		return;
-	}
-	k=k->next;
+    if (k->sequence!=NULL && !u_strcmp(keyword,k->sequence)) {
+        free(k->sequence);
+        k->sequence=NULL;
+        return;
+    }
+    k=k->next;
 }
 }
 
 void remove_keywords(struct list_ustring* list,struct string_hash_ptr* keywords) {
 while (list!=NULL) {
-	remove_keyword(list->string,keywords);
-	list=list->next;
+    remove_keyword(list->string,keywords);
+    list=list->next;
 }
 }
 
@@ -206,20 +206,20 @@ Ustring* tmp=new_Ustring(64);
 u_sprintf(tmp,"%S.%S",e->lemma,e->semantic_codes[0]);
 KeyWord* k_lemma=(KeyWord*)get_value(tmp->str,keywords);
 if (k_lemma==NULL) {
-	k_lemma=new_KeyWord(0,tmp->str,NULL);
-	k_lemma->lemmatized=LEMMATIZED_KEYWORD;
-	get_value_index(tmp->str,keywords,INSERT_IF_NEEDED,k_lemma);
+    k_lemma=new_KeyWord(0,tmp->str,NULL);
+    k_lemma->lemmatized=LEMMATIZED_KEYWORD;
+    get_value_index(tmp->str,keywords,INSERT_IF_NEEDED,k_lemma);
 }
 /* Now, we look for all the case compatible tokens, and we add
  * their weights to the new lemmatized element
  */
 while (k_inflected!=NULL) {
-	if (k_inflected->sequence!=NULL && is_equal_or_uppercase(e->inflected,k_inflected->sequence,alphabet)) {
-		/* We have a match */
-		k_lemma->weight+=k_inflected->weight;
-		k_inflected->lemmatized=1;
-	}
-	k_inflected=k_inflected->next;
+    if (k_inflected->sequence!=NULL && is_equal_or_uppercase(e->inflected,k_inflected->sequence,alphabet)) {
+        /* We have a match */
+        k_lemma->weight+=k_inflected->weight;
+        k_inflected->lemmatized=1;
+    }
+    k_inflected=k_inflected->next;
 }
 free_Ustring(tmp);
 }
@@ -234,18 +234,18 @@ free_Ustring(tmp);
  * eats/2 + eaten/3 => eat/5
  */
 void filter_keywords_with_dic(struct string_hash_ptr* keywords,char* name,
-						VersatileEncodingConfig* vec,Alphabet* alphabet) {
+                        VersatileEncodingConfig* vec,Alphabet* alphabet) {
 U_FILE* f=u_fopen(vec,name,U_READ);
 if (f==NULL) {
-	error("Cannot load file %s\n",name);
-	return;
+    error("Cannot load file %s\n",name);
+    return;
 }
 Ustring* line=new_Ustring(128);
 while (EOF!=readline(line,f)) {
-	struct dela_entry* e=tokenize_DELAF_line(line->str);
-	if (e==NULL) continue;
-	lemmatize(e,keywords,alphabet);
-	free_dela_entry(e);
+    struct dela_entry* e=tokenize_DELAF_line(line->str);
+    if (e==NULL) continue;
+    lemmatize(e,keywords,alphabet);
+    free_dela_entry(e);
 }
 free_Ustring(line);
 u_fclose(f);
@@ -254,22 +254,22 @@ u_fclose(f);
 
 KeyWord* locate_candidate(unichar* a,KeyWord* list,Alphabet* alphabet) {
 while (list!=NULL) {
-	if (list->sequence!=NULL && list->lemmatized==UNKNOWN_WORD) {
-		/* We have a potential match */
-		if (is_equal_or_uppercase(a,list->sequence,alphabet)) {
-			/* We have a=Fogg and list->sequence=FOGG
-			 * Our candidate must be replaced by a */
-			free(list->sequence);
-			list->sequence=u_strdup(a);
-			return list;
-		}
-		if (is_equal_or_uppercase(list->sequence,a,alphabet)) {
-			/* We have a=FOGG and list->sequence=Fogg
-			 * Our candidate is already the good one to keep */
-			return list;
-		}
-	}
-	list=list->next;
+    if (list->sequence!=NULL && list->lemmatized==UNKNOWN_WORD) {
+        /* We have a potential match */
+        if (is_equal_or_uppercase(a,list->sequence,alphabet)) {
+            /* We have a=Fogg and list->sequence=FOGG
+             * Our candidate must be replaced by a */
+            free(list->sequence);
+            list->sequence=u_strdup(a);
+            return list;
+        }
+        if (is_equal_or_uppercase(list->sequence,a,alphabet)) {
+            /* We have a=FOGG and list->sequence=Fogg
+             * Our candidate is already the good one to keep */
+            return list;
+        }
+    }
+    list=list->next;
 }
 return NULL;
 }
@@ -277,19 +277,19 @@ return NULL;
 
 void merge_case_equivalent_unknown_words(struct string_hash_ptr* keywords,Alphabet* alphabet) {
 for (int i=0;i<keywords->size;i++) {
-	KeyWord* k=(KeyWord*)keywords->value[i];
-	while (k!=NULL) {
-		if (k->sequence!=NULL && k->lemmatized==UNKNOWN_WORD) {
-			/* We have found a candidate for merging */
-			KeyWord* candidate=locate_candidate(k->sequence,k->next,alphabet);
-			if (candidate!=NULL) {
-				candidate->weight+=k->weight;
-				free(k->sequence);
-				k->sequence=NULL;
-			}
-		}
-		k=k->next;
-	}
+    KeyWord* k=(KeyWord*)keywords->value[i];
+    while (k!=NULL) {
+        if (k->sequence!=NULL && k->lemmatized==UNKNOWN_WORD) {
+            /* We have found a candidate for merging */
+            KeyWord* candidate=locate_candidate(k->sequence,k->next,alphabet);
+            if (candidate!=NULL) {
+                candidate->weight+=k->weight;
+                free(k->sequence);
+                k->sequence=NULL;
+            }
+        }
+        k=k->next;
+    }
 }
 
 }
@@ -297,13 +297,13 @@ for (int i=0;i<keywords->size;i++) {
 
 void dump_keywords(vector_ptr* keywords,U_FILE* f) {
 for (int i=0;i<keywords->nbelems;i++) {
-	KeyWord* k=(KeyWord*)keywords->tab[i];
-	while (k!=NULL) {
-		if (k->sequence!=NULL && k->lemmatized!=PART_OF_A_LEMMATIZED_KEYWORD) {
-			u_fprintf(f,"%d\t%S\n",k->weight,k->sequence);
-		}
-		k=k->next;
-	}
+    KeyWord* k=(KeyWord*)keywords->tab[i];
+    while (k!=NULL) {
+        if (k->sequence!=NULL && k->lemmatized!=PART_OF_A_LEMMATIZED_KEYWORD) {
+            u_fprintf(f,"%d\t%S\n",k->weight,k->sequence);
+        }
+        k=k->next;
+    }
 }
 }
 
@@ -320,13 +320,13 @@ return (*b)->weight-(*a)->weight;
 vector_ptr* sort_keywords(struct string_hash_ptr* keywords) {
 vector_ptr* res=new_vector_ptr();
 for (int i=0;i<keywords->size;i++) {
-	KeyWord* k=(KeyWord*)(keywords->value[i]);
-	while (k!=NULL) {
-		if (k->sequence!=NULL && k->lemmatized!=PART_OF_A_LEMMATIZED_KEYWORD) {
-			vector_ptr_add(res,new_KeyWord(k->weight,k->sequence,NULL));
-		}
-		k=k->next;
-	}
+    KeyWord* k=(KeyWord*)(keywords->value[i]);
+    while (k!=NULL) {
+        if (k->sequence!=NULL && k->lemmatized!=PART_OF_A_LEMMATIZED_KEYWORD) {
+            vector_ptr_add(res,new_KeyWord(k->weight,k->sequence,NULL));
+        }
+        k=k->next;
+    }
 }
 qsort(res->tab,res->nbelems,sizeof(KeyWord*),(int(*)(const void*,const void*))cmp_keywords);
 return res;
@@ -337,8 +337,8 @@ int last_index_of(unichar* s,unichar c) {
 if (s==NULL) return -1;
 int pos=u_strlen(s)-1;
 while (pos>=0) {
-	if (s[pos]==c) return pos;
-	pos--;
+    if (s[pos]==c) return pos;
+    pos--;
 }
 return pos;
 }
@@ -353,10 +353,10 @@ int get_forbidden_keyword(KeyWord* list,unichar* code,Ustring* res) {
 if (list==NULL) return 0;
 int pos=last_index_of(list->sequence,(unichar)'.');
 if (pos!=-1 && !u_strcmp(code,list->sequence+pos+1)) {
-	/* If the forbidden code has been found */
-	u_strcpy(res,list->sequence);
-	truncate(res,pos);
-	return 1;
+    /* If the forbidden code has been found */
+    u_strcpy(res,list->sequence);
+    truncate(res,pos);
+    return 1;
 }
 return 0;
 }
@@ -370,10 +370,10 @@ int has_forbidden_lemma(KeyWord* list,struct string_hash* lemmas) {
 if (list==NULL || list->sequence==NULL) return 0;
 int pos=last_index_of(list->sequence,(unichar)'.');
 if (pos==-1) {
-	/* If the keyword is not lemmatized, we just test
-	 * if it is a forbidden lemma
-	 */
-	return (-1!=get_value_index(list->sequence,lemmas,DONT_INSERT));
+    /* If the keyword is not lemmatized, we just test
+     * if it is a forbidden lemma
+     */
+    return (-1!=get_value_index(list->sequence,lemmas,DONT_INSERT));
 }
 Ustring* tmp=new_Ustring(list->sequence);
 truncate(tmp,pos);
@@ -384,13 +384,13 @@ return index!=-1;
 
 
 static KeyWord* remove_keywords_with_forbidden_lemma_(KeyWord* list,
-							struct string_hash* lemmas) {
+                            struct string_hash* lemmas) {
 if (list==NULL) return NULL;
 if (has_forbidden_lemma(list,lemmas)) {
-	/* If the forbidden lemma has been found */
-	KeyWord* next=list->next;
-	free_KeyWord(list);
-	return remove_keywords_with_forbidden_lemma_(next,lemmas);
+    /* If the forbidden lemma has been found */
+    KeyWord* next=list->next;
+    free_KeyWord(list);
+    return remove_keywords_with_forbidden_lemma_(next,lemmas);
 }
 list->next=remove_keywords_with_forbidden_lemma_(list->next,lemmas);
 return list;
@@ -407,13 +407,13 @@ struct string_hash* compute_forbidden_lemmas(struct string_hash_ptr* keywords,un
 struct string_hash* hash=new_string_hash(DONT_USE_VALUES,DONT_ENLARGE);
 Ustring* tmp=new_Ustring();
 for (int i=0;i<keywords->size;i++) {
-	KeyWord* list=(KeyWord*)(keywords->value[i]);
-	while (list!=NULL) {
-		if (get_forbidden_keyword(list,code,tmp)) {
-			get_value_index(tmp->str,hash);
-		}
-		list=list->next;
-	}
+    KeyWord* list=(KeyWord*)(keywords->value[i]);
+    while (list!=NULL) {
+        if (get_forbidden_keyword(list,code,tmp)) {
+            get_value_index(tmp->str,hash);
+        }
+        list=list->next;
+    }
 }
 free_Ustring(tmp);
 return hash;
@@ -421,11 +421,11 @@ return hash;
 
 
 void remove_keywords_with_forbidden_lemma(struct string_hash_ptr* keywords,
-					struct string_hash* lemmas) {
+                    struct string_hash* lemmas) {
 for (int i=0;i<keywords->size;i++) {
-	KeyWord* list=(KeyWord*)(keywords->value[i]);
-	list=remove_keywords_with_forbidden_lemma_(list,lemmas);
-	keywords->value[i]=list;
+    KeyWord* list=(KeyWord*)(keywords->value[i]);
+    list=remove_keywords_with_forbidden_lemma_(list,lemmas);
+    keywords->value[i]=list;
 }
 }
 

--- a/KeyWords_lib.h
+++ b/KeyWords_lib.h
@@ -38,10 +38,10 @@ namespace unitex {
  * sequence associated to a weight information.
  */
 typedef struct keyword {
-	int weight;
-	unichar* sequence;
-	char lemmatized;
-	struct keyword* next;
+    int weight;
+    unichar* sequence;
+    char lemmatized;
+    struct keyword* next;
 } KeyWord;
 
 
@@ -50,16 +50,16 @@ void free_KeyWord(KeyWord* k);
 void free_KeyWord_list(KeyWord* k);
 struct string_hash_ptr* load_tokens_by_freq(char* name,VersatileEncodingConfig* vec);
 void load_compound_words(char* name,VersatileEncodingConfig* vec,
-		struct string_hash_ptr* keywords);
+        struct string_hash_ptr* keywords);
 void filter_non_letter_keywords(struct string_hash_ptr* keywords,Alphabet* alphabet);
 void filter_keywords_with_dic(struct string_hash_ptr* keywords,char* name,
-						VersatileEncodingConfig* vec,Alphabet* alphabet);
+                        VersatileEncodingConfig* vec,Alphabet* alphabet);
 void merge_case_equivalent_unknown_words(struct string_hash_ptr* keywords,Alphabet* alphabet);
 vector_ptr* sort_keywords(struct string_hash_ptr* keywords);
 void dump_keywords(vector_ptr* keywords,U_FILE* f);
 struct string_hash* compute_forbidden_lemmas(struct string_hash_ptr* keywords,unichar* code);
 void remove_keywords_with_forbidden_lemma(struct string_hash_ptr* keywords,
-					struct string_hash* lemmas);
+                    struct string_hash* lemmas);
 } // namespace unitex
 
 #endif

--- a/Korean.cpp
+++ b/Korean.cpp
@@ -40,7 +40,7 @@ return is_letter(c,alphabet);
 unichar Chinese_to_Hangul(unichar src,unichar* map) {
 unichar c=map[src];
 if (c!='\0') {
-	return c;
+    return c;
 }
 return src;
 }
@@ -56,7 +56,7 @@ return src;
 void Hanguls_to_Jamos(unichar* src,unichar* dest,Korean* korean,int only_syllables) {
 if (korean==NULL) {
    /* No Korean data? A simple copy will do. */
-	u_strcpy(dest,src);
+    u_strcpy(dest,src);
    return;
 }
 int ret;
@@ -107,7 +107,7 @@ for (int i=0;src[i]!='\0';i++) {
 }
 temp[j]='\0';
 if (j>1024) {
-	fatal_error("Token too long in Korean::Hanguls_to_Jamos\n");
+    fatal_error("Token too long in Korean::Hanguls_to_Jamos\n");
 }
 /* Then, we perform the syllable -> Jamo conversion */
 Hanguls_to_Jamos_internal(temp,dest,only_syllables);
@@ -121,13 +121,13 @@ Hanguls_to_Jamos_internal(temp,dest,only_syllables);
  */
 int single_HGJ_to_Jamos(unichar c,unichar* dest,Korean* korean) {
 if (u_is_Hangul_Compatility_Jamo(c) && korean!=NULL) {
-	int pos=korean->single_HCJ_to_Jamos(c,dest,0);
-	dest[pos]='\0';
-	return pos;
+    int pos=korean->single_HCJ_to_Jamos(c,dest,0);
+    dest[pos]='\0';
+    return pos;
 } else {
-	dest[0]=c;
-	dest[1]='\0';
-	return 1;
+    dest[0]=c;
+    dest[1]='\0';
+    return 1;
 }
 }
 
@@ -182,7 +182,7 @@ if (first!=0) {
    va_start(args,first);
    while ((d=va_arg(args,int))!=0) {
       result[n++]=(unichar)d;
-	  //if (n>2) error("[  %C  ] (%x)   ",d,d);
+      //if (n>2) error("[  %C  ] (%x)   ",d,d);
    }
    //error("\n");
    va_end(args);
@@ -351,7 +351,7 @@ for (int i=0;input[i]!='\0';i++) {
       continue;
    }*/
    if (c>=KR_HANGUL_SYL_START && c<=KR_HANGUL_SYL_END) {
-	   n=single_Hangul_to_Jamos(c,output,n);
+       n=single_Hangul_to_Jamos(c,output,n);
    }
    else if (!only_syllables && c>=KR_HCJ_START && c<=KR_HCJ_END) {
       n=single_HCJ_to_Jamos(c,output,n);
@@ -363,7 +363,7 @@ for (int i=0;input[i]!='\0';i++) {
 output[n]='\0';
 /*error("zzz depuis <%S> vers <",input);
 for (int i=0;output[i]!='\0';i++) {
-	error("%X ",output[i]);
+    error("%X ",output[i]);
 }
 error(">\n");*/
 return n;
@@ -393,146 +393,146 @@ int read_initial_consonants(unichar* input,int *pos_input,int *initial_consonant
 switch(input[*pos_input]) {
 /*case HCJ_KIYEOK:*/
 case SJ_IC_KIYEOK: {
-	*initial_consonant=0;
-	*hcj=HCJ_KIYEOK;
-	if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_IC_KIYEOK) {
-		*initial_consonant=1;
-		*hcj=HCJ_SSANGKIYEOK;
-		(*pos_input)++;
-	}
-	break;
+    *initial_consonant=0;
+    *hcj=HCJ_KIYEOK;
+    if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_IC_KIYEOK) {
+        *initial_consonant=1;
+        *hcj=HCJ_SSANGKIYEOK;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGKIYEOK:*/
 case SJ_IC_SSANGKIYEOK: {
-	*initial_consonant=1;
-	*hcj=HCJ_SSANGKIYEOK;
-	break;
+    *initial_consonant=1;
+    *hcj=HCJ_SSANGKIYEOK;
+    break;
 }
 /*case HCJ_NIEUN:*/
 case SJ_IC_NIEUN: {
-	*initial_consonant=2;
-	*hcj=HCJ_NIEUN;
-	break;
+    *initial_consonant=2;
+    *hcj=HCJ_NIEUN;
+    break;
 }
 /*case HCJ_TIKEUT:*/
 case SJ_IC_TIKEUT: {
-	*initial_consonant=3;
-	*hcj=HCJ_TIKEUT;
-	if (/*input[(*pos_input)+1]==HCJ_TIKEUT ||*/ input[(*pos_input)+1]==SJ_IC_TIKEUT) {
-		*initial_consonant=4;
-		*hcj=HCJ_SSANGTIKEUT;
-		(*pos_input)++;
-	}
-	break;
+    *initial_consonant=3;
+    *hcj=HCJ_TIKEUT;
+    if (/*input[(*pos_input)+1]==HCJ_TIKEUT ||*/ input[(*pos_input)+1]==SJ_IC_TIKEUT) {
+        *initial_consonant=4;
+        *hcj=HCJ_SSANGTIKEUT;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGTIKEUT:*/
 case SJ_IC_SSANGTIKEUT: {
-	*initial_consonant=4;
-	*hcj=HCJ_SSANGTIKEUT;
-	break;
+    *initial_consonant=4;
+    *hcj=HCJ_SSANGTIKEUT;
+    break;
 }
 /*case HCJ_RIEUL:*/
 case SJ_IC_RIEUL: {
-	*initial_consonant=5;
-	*hcj=HCJ_RIEUL;
-	break;
+    *initial_consonant=5;
+    *hcj=HCJ_RIEUL;
+    break;
 }
 /*case HCJ_MIEUM:*/
 case SJ_IC_MIEUM: {
-	*initial_consonant=6;
-	*hcj=HCJ_MIEUM;
-	break;
+    *initial_consonant=6;
+    *hcj=HCJ_MIEUM;
+    break;
 }
 /*case HCJ_PIEUP:*/
 case SJ_IC_PIEUP: {
-	*initial_consonant=7;
-	*hcj=HCJ_PIEUP;
-	if (/*input[(*pos_input)+1]==HCJ_PIEUP ||*/ input[(*pos_input)+1]==SJ_IC_PIEUP) {
-		*initial_consonant=8;
-		*hcj=HCJ_SSANGPIEUP;
-		(*pos_input)++;
-	}
-	break;
+    *initial_consonant=7;
+    *hcj=HCJ_PIEUP;
+    if (/*input[(*pos_input)+1]==HCJ_PIEUP ||*/ input[(*pos_input)+1]==SJ_IC_PIEUP) {
+        *initial_consonant=8;
+        *hcj=HCJ_SSANGPIEUP;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGPIEUP:*/
 case SJ_IC_SSANGPIEUP: {
-	*initial_consonant=8;
-	*hcj=HCJ_SSANGPIEUP;
-	break;
+    *initial_consonant=8;
+    *hcj=HCJ_SSANGPIEUP;
+    break;
 }
 /*case HCJ_SIOS:*/
 case SJ_IC_SIOS: {
-	*initial_consonant=9;
-	*hcj=HCJ_SIOS;
-	if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_IC_SIOS) {
-		*initial_consonant=10;
-		*hcj=HCJ_SSANGSIOS;
-		(*pos_input)++;
-	}
-	break;
+    *initial_consonant=9;
+    *hcj=HCJ_SIOS;
+    if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_IC_SIOS) {
+        *initial_consonant=10;
+        *hcj=HCJ_SSANGSIOS;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGSIOS:*/
 case SJ_IC_SSANGSIOS: {
-	*initial_consonant=10;
-	*hcj=HCJ_SSANGSIOS;
-	break;
+    *initial_consonant=10;
+    *hcj=HCJ_SSANGSIOS;
+    break;
 }
 /*case HCJ_IEUNG:*/
 case SJ_IC_IEUNG: {
-	*initial_consonant=11;
-	*hcj=HCJ_IEUNG;
-	break;
+    *initial_consonant=11;
+    *hcj=HCJ_IEUNG;
+    break;
 }
 /*case HCJ_CIEUC:*/
 case SJ_IC_CIEUC: {
-	*initial_consonant=12;
-	*hcj=HCJ_CIEUC;
-	if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_IC_CIEUC) {
-		*initial_consonant=13;
-		*hcj=HCJ_SSANGCIEUC;
-		(*pos_input)++;
-	}
-	break;
+    *initial_consonant=12;
+    *hcj=HCJ_CIEUC;
+    if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_IC_CIEUC) {
+        *initial_consonant=13;
+        *hcj=HCJ_SSANGCIEUC;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGCIEUC:*/
 case SJ_IC_SSANGCIEUC: {
-	*initial_consonant=13;
-	*hcj=HCJ_SSANGCIEUC;
-	break;
+    *initial_consonant=13;
+    *hcj=HCJ_SSANGCIEUC;
+    break;
 }
 /*case HCJ_CHIEUCH:*/
 case SJ_IC_CHIEUCH: {
-	*initial_consonant=14;
-	*hcj=HCJ_CHIEUCH;
-	break;
+    *initial_consonant=14;
+    *hcj=HCJ_CHIEUCH;
+    break;
 }
 /*case HCJ_KHIEUKH:*/
 case SJ_IC_KHIEUKH: {
-	*initial_consonant=15;
-	*hcj=HCJ_KHIEUKH;
-	break;
+    *initial_consonant=15;
+    *hcj=HCJ_KHIEUKH;
+    break;
 }
 /*case HCJ_THIEUTH:*/
 case SJ_IC_THIEUTH: {
-	*initial_consonant=16;
-	*hcj=HCJ_THIEUTH;
-	break;
+    *initial_consonant=16;
+    *hcj=HCJ_THIEUTH;
+    break;
 }
 /*case HCJ_PHIEUPH:*/
 case SJ_IC_PHIEUPH: {
-	*initial_consonant=17;
-	*hcj=HCJ_PHIEUPH;
-	break;
+    *initial_consonant=17;
+    *hcj=HCJ_PHIEUPH;
+    break;
 }
 /*case HCJ_HIEUH:*/
 case SJ_IC_HIEUH: {
-	*initial_consonant=18;
-	*hcj=HCJ_HIEUH;
-	if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_IC_KIYEOK) {
-	   *initial_consonant=15;
-	   *hcj=HCJ_KHIEUKH;
-	   (*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_IC_CIEUC) {
+    *initial_consonant=18;
+    *hcj=HCJ_HIEUH;
+    if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_IC_KIYEOK) {
+       *initial_consonant=15;
+       *hcj=HCJ_KHIEUKH;
+       (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_IC_CIEUC) {
       *initial_consonant=14;
       *hcj=HCJ_CHIEUCH;
       (*pos_input)++;
@@ -545,19 +545,19 @@ case SJ_IC_HIEUH: {
       *hcj=HCJ_PHIEUPH;
       (*pos_input)++;
    }
-	break;
+    break;
 }
 default: {
-	return KR_NO_MATCH;
+    return KR_NO_MATCH;
 }
 } /* End of switch */
 /* Now we check whether we are at the end of the  or at the end of the string */
 (*pos_input)++;
 if (input[*pos_input]=='\0') {
-	return KR_END_OF_STRING;
+    return KR_END_OF_STRING;
 }
 if (input[*pos_input]==KR_SYLLABLE_BOUND) {
-	return KR_END_OF_SYLLABLE;
+    return KR_END_OF_SYLLABLE;
 }
 /* If we have something else, we have a normal match */
 return KR_MATCH;
@@ -578,211 +578,211 @@ int read_vowels(unichar* input,int *pos_input,int *vowel,unichar *hcj) {
 switch(input[*pos_input]) {
 /*case HCJ_A:*/
 case SJ_A: {
-	*vowel=0;
-	*hcj=HCJ_A;
-	if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-		*vowel=1;
-		*hcj=HCJ_AE;
-		(*pos_input)++;
-	}
-	break;
+    *vowel=0;
+    *hcj=HCJ_A;
+    if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+        *vowel=1;
+        *hcj=HCJ_AE;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_AE:*/
 case SJ_AE: {
-	*vowel=1;
-	*hcj=HCJ_AE;
-	break;
+    *vowel=1;
+    *hcj=HCJ_AE;
+    break;
 }
 /*case HCJ_EO:*/
 case SJ_EO: {
-	*vowel=4;
-	*hcj=HCJ_EO;
-	if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-		*vowel=5;
-		*hcj=HCJ_E;
-		(*pos_input)++;
-	}
-	break;
+    *vowel=4;
+    *hcj=HCJ_EO;
+    if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+        *vowel=5;
+        *hcj=HCJ_E;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_E:*/
 case SJ_E: {
-	*vowel=5;
-	*hcj=HCJ_E;
-	break;
+    *vowel=5;
+    *hcj=HCJ_E;
+    break;
 }
 /*case HCJ_O:*/
 case SJ_O: {
-	*vowel=8;
-	*hcj=HCJ_O;
-	if (/*input[(*pos_input)+1]==HCJ_A ||*/ input[(*pos_input)+1]==SJ_A) {
-		*vowel=9;
-		*hcj=HCJ_WA;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-		*vowel=11;
-		*hcj=HCJ_OE;
-		(*pos_input)++;
-		if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
-			*vowel=10;
-			*hcj=HCJ_WAE;
-			(*pos_input)++;
-		}
-	}
-	break;
+    *vowel=8;
+    *hcj=HCJ_O;
+    if (/*input[(*pos_input)+1]==HCJ_A ||*/ input[(*pos_input)+1]==SJ_A) {
+        *vowel=9;
+        *hcj=HCJ_WA;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+        *vowel=11;
+        *hcj=HCJ_OE;
+        (*pos_input)++;
+        if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
+            *vowel=10;
+            *hcj=HCJ_WAE;
+            (*pos_input)++;
+        }
+    }
+    break;
 }
 /*case HCJ_WA:*/
 case SJ_WA: {
-	*vowel=9;
-	*hcj=HCJ_WA;
-	break;
+    *vowel=9;
+    *hcj=HCJ_WA;
+    break;
 }
 /*case HCJ_WAE:*/
 case SJ_WAE: {
-	*vowel=10;
-	*hcj=HCJ_WAE;
-	break;
+    *vowel=10;
+    *hcj=HCJ_WAE;
+    break;
 }
 /*case HCJ_OE:*/
 case SJ_OE: {
-	*vowel=11;
-	*hcj=HCJ_OE;
-	break;
+    *vowel=11;
+    *hcj=HCJ_OE;
+    break;
 }
 /*case HCJ_U:*/
 case SJ_U: {
-	*vowel=13;
-	*hcj=HCJ_U;
-	if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
-		*vowel=14;
-		*hcj=HCJ_WEO;
-		(*pos_input)++;
-		if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-			*vowel=15;
-			*hcj=HCJ_WE;
-			(*pos_input)++;
-		}
-	} else if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-		*vowel=16;
-		*hcj=HCJ_WI;
-		(*pos_input)++;
-	}
-	break;
+    *vowel=13;
+    *hcj=HCJ_U;
+    if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
+        *vowel=14;
+        *hcj=HCJ_WEO;
+        (*pos_input)++;
+        if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+            *vowel=15;
+            *hcj=HCJ_WE;
+            (*pos_input)++;
+        }
+    } else if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+        *vowel=16;
+        *hcj=HCJ_WI;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_WEO:*/
 case SJ_WEO: {
-	*vowel=14;
-	*hcj=HCJ_WEO;
-	break;
+    *vowel=14;
+    *hcj=HCJ_WEO;
+    break;
 }
 /*case HCJ_WE:*/
 case SJ_WE: {
-	*vowel=15;
-	*hcj=HCJ_WE;
-	break;
+    *vowel=15;
+    *hcj=HCJ_WE;
+    break;
 }
 /*case HCJ_WI:*/
 case SJ_WI: {
-	*vowel=16;
-	*hcj=HCJ_WI;
-	break;
+    *vowel=16;
+    *hcj=HCJ_WI;
+    break;
 }
 /*case HCJ_EU:*/
 case SJ_EU: {
-	*vowel=18;
-	*hcj=HCJ_EU;
-	if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-		*vowel=19;
-		*hcj=HCJ_YI;
-		(*pos_input)++;
-	}
-	break;
+    *vowel=18;
+    *hcj=HCJ_EU;
+    if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+        *vowel=19;
+        *hcj=HCJ_YI;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_YI:*/
 case SJ_YI: {
-	*vowel=19;
-	*hcj=HCJ_YI;
-	break;
+    *vowel=19;
+    *hcj=HCJ_YI;
+    break;
 }
 /*case HCJ_I:*/
 case SJ_I: {
-	*vowel=20;
-	*hcj=HCJ_I;
-	if (/*input[(*pos_input)+1]==HCJ_A ||*/ input[(*pos_input)+1]==SJ_A) {
-		*vowel=2;
-		*hcj=HCJ_YA;
-		(*pos_input)++;
-		if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-			*vowel=3;
-			*hcj=HCJ_YAE;
-			(*pos_input)++;
-		}
-	} else if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
-		*vowel=6;
-		*hcj=HCJ_YEO;
-		(*pos_input)++;
-		if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
-			*vowel=7;
-			*hcj=HCJ_YE;
-			(*pos_input)++;
-		}
-	} else if (/*input[(*pos_input)+1]==HCJ_O ||*/ input[(*pos_input)+1]==SJ_O) {
-		*vowel=12;
-		*hcj=HCJ_YO;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_U ||*/ input[(*pos_input)+1]==SJ_U) {
-		*vowel=17;
-		*hcj=HCJ_YU;
-		(*pos_input)++;
-	}
-	break;
+    *vowel=20;
+    *hcj=HCJ_I;
+    if (/*input[(*pos_input)+1]==HCJ_A ||*/ input[(*pos_input)+1]==SJ_A) {
+        *vowel=2;
+        *hcj=HCJ_YA;
+        (*pos_input)++;
+        if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+            *vowel=3;
+            *hcj=HCJ_YAE;
+            (*pos_input)++;
+        }
+    } else if (/*input[(*pos_input)+1]==HCJ_EO ||*/ input[(*pos_input)+1]==SJ_EO) {
+        *vowel=6;
+        *hcj=HCJ_YEO;
+        (*pos_input)++;
+        if (/*input[(*pos_input)+1]==HCJ_I ||*/ input[(*pos_input)+1]==SJ_I) {
+            *vowel=7;
+            *hcj=HCJ_YE;
+            (*pos_input)++;
+        }
+    } else if (/*input[(*pos_input)+1]==HCJ_O ||*/ input[(*pos_input)+1]==SJ_O) {
+        *vowel=12;
+        *hcj=HCJ_YO;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_U ||*/ input[(*pos_input)+1]==SJ_U) {
+        *vowel=17;
+        *hcj=HCJ_YU;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_YA:*/
 case SJ_YA: {
-	*vowel=2;
-	*hcj=HCJ_YA;
-	break;
+    *vowel=2;
+    *hcj=HCJ_YA;
+    break;
 }
 /*case HCJ_YAE:*/
 case SJ_YAE: {
-	*vowel=3;
-	*hcj=HCJ_YAE;
-	break;
+    *vowel=3;
+    *hcj=HCJ_YAE;
+    break;
 }
 /*case HCJ_YEO:*/
 case SJ_YEO: {
-	*vowel=6;
-	*hcj=HCJ_YEO;
-	break;
+    *vowel=6;
+    *hcj=HCJ_YEO;
+    break;
 }
 /*case HCJ_YE:*/
 case SJ_YE: {
-	*vowel=7;
-	*hcj=HCJ_YE;
-	break;
+    *vowel=7;
+    *hcj=HCJ_YE;
+    break;
 }
 /*case HCJ_YO:*/
 case SJ_YO: {
-	*vowel=12;
-	*hcj=HCJ_YO;
-	break;
+    *vowel=12;
+    *hcj=HCJ_YO;
+    break;
 }
 /*case HCJ_YU:*/
 case SJ_YU: {
-	*vowel=17;
-	*hcj=HCJ_YU;
-	break;
+    *vowel=17;
+    *hcj=HCJ_YU;
+    break;
 }
 default: {
-	return KR_JAMO_ERROR;
+    return KR_JAMO_ERROR;
 }
 } /* End of switch */
 /* Now we check whether we are at the end of the syllable or at the end of the string */
 (*pos_input)++;
 if (input[*pos_input]=='\0') {
-	return KR_END_OF_STRING;
+    return KR_END_OF_STRING;
 }
 if (input[*pos_input]==KR_SYLLABLE_BOUND) {
-	return KR_END_OF_SYLLABLE;
+    return KR_END_OF_SYLLABLE;
 }
 /* If we have something else, we have a normal match */
 return KR_MATCH;
@@ -806,292 +806,292 @@ return KR_MATCH;
  *       produced by the library's Hangul->Jamo function
  */
 int read_final_consonants(unichar* input,int *pos_input,int *final_consonant, unichar *hcj,
-		                  int all_sequences) {
+                          int all_sequences) {
 switch(input[*pos_input]) {
 /*case HCJ_KIYEOK:*/
 case SJ_FC_KIYEOK:
 case SJ_IC_KIYEOK: {
-	*final_consonant=1;
-	*hcj=HCJ_KIYEOK;
-	if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_FC_KIYEOK ||
-		input[(*pos_input)+1]==SJ_IC_KIYEOK) {
-		*final_consonant=2;
-		*hcj=HCJ_SSANGKIYEOK;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
-			input[(*pos_input)+1]==SJ_IC_SIOS) {
-		*final_consonant=3;
-		*hcj=HCJ_KIYEOK_SIOS;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=1;
+    *hcj=HCJ_KIYEOK;
+    if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_FC_KIYEOK ||
+        input[(*pos_input)+1]==SJ_IC_KIYEOK) {
+        *final_consonant=2;
+        *hcj=HCJ_SSANGKIYEOK;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
+            input[(*pos_input)+1]==SJ_IC_SIOS) {
+        *final_consonant=3;
+        *hcj=HCJ_KIYEOK_SIOS;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGKIYEOK:*/
 case SJ_FC_SSANGKIYEOK:
 case SJ_IC_SSANGKIYEOK: {
-	*final_consonant=2;
-	*hcj=HCJ_SSANGKIYEOK;
-	break;
+    *final_consonant=2;
+    *hcj=HCJ_SSANGKIYEOK;
+    break;
 }
 /*case HCJ_KIYEOK_SIOS:*/
 case SJ_FC_KIYEOK_SIOS: {
-	*final_consonant=3;
-	*hcj=HCJ_KIYEOK_SIOS;
-	break;
+    *final_consonant=3;
+    *hcj=HCJ_KIYEOK_SIOS;
+    break;
 }
 /*case HCJ_NIEUN:*/
 case SJ_FC_NIEUN:
 case SJ_IC_NIEUN: {
-	*final_consonant=4;
-	if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_FC_CIEUC ||
-		input[(*pos_input)+1]==SJ_IC_CIEUC) {
-		*final_consonant=5;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_HIEUH ||*/ input[(*pos_input)+1]==SJ_FC_HIEUH ||
-		input[(*pos_input)+1]==SJ_IC_HIEUH) {
-		*final_consonant=6;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=4;
+    if (/*input[(*pos_input)+1]==HCJ_CIEUC ||*/ input[(*pos_input)+1]==SJ_FC_CIEUC ||
+        input[(*pos_input)+1]==SJ_IC_CIEUC) {
+        *final_consonant=5;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_HIEUH ||*/ input[(*pos_input)+1]==SJ_FC_HIEUH ||
+        input[(*pos_input)+1]==SJ_IC_HIEUH) {
+        *final_consonant=6;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_NIEUN_CIEUC:*/
 case SJ_FC_NIEUN_CIEUC: {
-	*final_consonant=5;
-	*hcj=HCJ_NIEUN_CIEUC;
-	break;
+    *final_consonant=5;
+    *hcj=HCJ_NIEUN_CIEUC;
+    break;
 }
 /*case HCJ_NIEUN_HIEUH:*/
 case SJ_FC_NIEUN_HIEUH: {
-	*final_consonant=6;
-	*hcj=HCJ_NIEUN_HIEUH;
-	break;
+    *final_consonant=6;
+    *hcj=HCJ_NIEUN_HIEUH;
+    break;
 }
 /*case HCJ_TIKEUT:*/
 case SJ_FC_TIKEUT:
 case SJ_IC_TIKEUT: {
-	*final_consonant=7;
-	*hcj=HCJ_TIKEUT;
-	if (all_sequences && /*input[(*pos_input)+1]==HCJ_TIKEUT ||*/ (input[(*pos_input)+1]==SJ_FC_TIKEUT ||
-		input[(*pos_input)+1]==SJ_IC_TIKEUT)) {
-		(*pos_input)++;
-		*hcj=HCJ_SSANGTIKEUT;
-	}
-	break;
+    *final_consonant=7;
+    *hcj=HCJ_TIKEUT;
+    if (all_sequences && /*input[(*pos_input)+1]==HCJ_TIKEUT ||*/ (input[(*pos_input)+1]==SJ_FC_TIKEUT ||
+        input[(*pos_input)+1]==SJ_IC_TIKEUT)) {
+        (*pos_input)++;
+        *hcj=HCJ_SSANGTIKEUT;
+    }
+    break;
 }
 /*case HCJ_SSANGTIKEUT:*/
 case SJ_IC_SSANGTIKEUT: {
-	if (all_sequences) {
-		*hcj=HCJ_SSANGTIKEUT;
-	}
-	break;
+    if (all_sequences) {
+        *hcj=HCJ_SSANGTIKEUT;
+    }
+    break;
 }
 /*case HCJ_RIEUL:*/
 case SJ_FC_RIEUL:
 case SJ_IC_RIEUL:{
-	*final_consonant=8;
-	*hcj=HCJ_RIEUL;
-	if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_FC_KIYEOK ||
-		input[(*pos_input)+1]==SJ_IC_KIYEOK) {
-		*final_consonant=9;
-		*hcj=HCJ_RIEUL_KIYEOK;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_MIEUM ||*/ input[(*pos_input)+1]==SJ_FC_MIEUM ||
-		input[(*pos_input)+1]==SJ_IC_MIEUM) {
-		*final_consonant=10;
-		*hcj=HCJ_RIEUL_MIEUM;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_PIEUP ||*/ input[(*pos_input)+1]==SJ_FC_PIEUP ||
-		input[(*pos_input)+1]==SJ_IC_PIEUP) {
-		*final_consonant=11;
-		*hcj=HCJ_RIEUL_PIEUP;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
-		input[(*pos_input)+1]==SJ_IC_SIOS) {
-		*final_consonant=12;
-		*hcj=HCJ_RIEUL_SIOS;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_THIEUTH ||*/ input[(*pos_input)+1]==SJ_FC_THIEUTH ||
-		input[(*pos_input)+1]==SJ_IC_THIEUTH) {
-		*final_consonant=13;
-		*hcj=HCJ_RIEUL_THIEUTH;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_PHIEUPH ||*/ input[(*pos_input)+1]==SJ_FC_PHIEUPH ||
-		input[(*pos_input)+1]==SJ_IC_PHIEUPH) {
-		*final_consonant=14;
-		*hcj=HCJ_RIEUL_PHIEUPH;
-		(*pos_input)++;
-	} else if (/*input[(*pos_input)+1]==HCJ_HIEUH ||*/ input[(*pos_input)+1]==SJ_FC_HIEUH ||
-		input[(*pos_input)+1]==SJ_IC_HIEUH) {
-		*final_consonant=15;
-		*hcj=HCJ_RIEUL_HIEUH;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=8;
+    *hcj=HCJ_RIEUL;
+    if (/*input[(*pos_input)+1]==HCJ_KIYEOK ||*/ input[(*pos_input)+1]==SJ_FC_KIYEOK ||
+        input[(*pos_input)+1]==SJ_IC_KIYEOK) {
+        *final_consonant=9;
+        *hcj=HCJ_RIEUL_KIYEOK;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_MIEUM ||*/ input[(*pos_input)+1]==SJ_FC_MIEUM ||
+        input[(*pos_input)+1]==SJ_IC_MIEUM) {
+        *final_consonant=10;
+        *hcj=HCJ_RIEUL_MIEUM;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_PIEUP ||*/ input[(*pos_input)+1]==SJ_FC_PIEUP ||
+        input[(*pos_input)+1]==SJ_IC_PIEUP) {
+        *final_consonant=11;
+        *hcj=HCJ_RIEUL_PIEUP;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
+        input[(*pos_input)+1]==SJ_IC_SIOS) {
+        *final_consonant=12;
+        *hcj=HCJ_RIEUL_SIOS;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_THIEUTH ||*/ input[(*pos_input)+1]==SJ_FC_THIEUTH ||
+        input[(*pos_input)+1]==SJ_IC_THIEUTH) {
+        *final_consonant=13;
+        *hcj=HCJ_RIEUL_THIEUTH;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_PHIEUPH ||*/ input[(*pos_input)+1]==SJ_FC_PHIEUPH ||
+        input[(*pos_input)+1]==SJ_IC_PHIEUPH) {
+        *final_consonant=14;
+        *hcj=HCJ_RIEUL_PHIEUPH;
+        (*pos_input)++;
+    } else if (/*input[(*pos_input)+1]==HCJ_HIEUH ||*/ input[(*pos_input)+1]==SJ_FC_HIEUH ||
+        input[(*pos_input)+1]==SJ_IC_HIEUH) {
+        *final_consonant=15;
+        *hcj=HCJ_RIEUL_HIEUH;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_RIEUL_KIYEOK:*/
 case SJ_FC_RIEUL_KIYEOK: {
-	*final_consonant=9;
-	*hcj=HCJ_RIEUL_KIYEOK;
-	break;
+    *final_consonant=9;
+    *hcj=HCJ_RIEUL_KIYEOK;
+    break;
 }
 /*case HCJ_RIEUL_MIEUM:*/
 case SJ_FC_RIEUL_MIEUM: {
-	*final_consonant=10;
-	*hcj=HCJ_RIEUL_MIEUM;
-	break;
+    *final_consonant=10;
+    *hcj=HCJ_RIEUL_MIEUM;
+    break;
 }
 /*case HCJ_RIEUL_PIEUP:*/
 case SJ_FC_RIEUL_PIEUP: {
-	*final_consonant=11;
-	*hcj=HCJ_RIEUL_PIEUP;
-	break;
+    *final_consonant=11;
+    *hcj=HCJ_RIEUL_PIEUP;
+    break;
 }
 /*case HCJ_RIEUL_SIOS:*/
 case SJ_FC_RIEUL_SIOS: {
-	*final_consonant=12;
-	*hcj=HCJ_RIEUL_SIOS;
-	break;
+    *final_consonant=12;
+    *hcj=HCJ_RIEUL_SIOS;
+    break;
 }
 /*case HCJ_RIEUL_THIEUTH:*/
 case SJ_FC_RIEUL_THIEUTH: {
-	*final_consonant=13;
-	*hcj=HCJ_RIEUL_THIEUTH;
-	break;
+    *final_consonant=13;
+    *hcj=HCJ_RIEUL_THIEUTH;
+    break;
 }
 /*case HCJ_RIEUL_PHIEUPH:*/
 case SJ_FC_RIEUL_PHIEUPH: {
-	*final_consonant=14;
-	*hcj=HCJ_RIEUL_PHIEUPH;
-	break;
+    *final_consonant=14;
+    *hcj=HCJ_RIEUL_PHIEUPH;
+    break;
 }
 /*case HCJ_RIEUL_HIEUH:*/
 case SJ_FC_RIEUL_HIEUH: {
-	*final_consonant=15;
-	*hcj=HCJ_RIEUL_HIEUH;
-	break;
+    *final_consonant=15;
+    *hcj=HCJ_RIEUL_HIEUH;
+    break;
 }
 /*case HCJ_MIEUM:*/
 case SJ_FC_MIEUM:
 case SJ_IC_MIEUM: {
-	*final_consonant=16;
-	*hcj=HCJ_MIEUM;
-	break;
+    *final_consonant=16;
+    *hcj=HCJ_MIEUM;
+    break;
 }
 /*case HCJ_PIEUP:*/
 case SJ_FC_PIEUP:
 case SJ_IC_PIEUP: {
-	*final_consonant=17;
-	*hcj=HCJ_PIEUP;
-	if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
-		input[(*pos_input)+1]==SJ_IC_SIOS) {
-		*final_consonant=18;
-		*hcj=HCJ_PIEUP_SIOS;
-		(*pos_input)++;
-	} else if (all_sequences && /*input[(*pos_input)+1]==HCJ_PIEUP ||*/ (input[(*pos_input)+1]==SJ_FC_PIEUP ||
-		input[(*pos_input)+1]==SJ_IC_PIEUP)) {
-		*hcj=HCJ_SSANGPIEUP;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=17;
+    *hcj=HCJ_PIEUP;
+    if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
+        input[(*pos_input)+1]==SJ_IC_SIOS) {
+        *final_consonant=18;
+        *hcj=HCJ_PIEUP_SIOS;
+        (*pos_input)++;
+    } else if (all_sequences && /*input[(*pos_input)+1]==HCJ_PIEUP ||*/ (input[(*pos_input)+1]==SJ_FC_PIEUP ||
+        input[(*pos_input)+1]==SJ_IC_PIEUP)) {
+        *hcj=HCJ_SSANGPIEUP;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_PIEUP_SIOS:*/
 case SJ_FC_PIEUP_SIOS: {
-	*final_consonant=18;
-	*hcj=HCJ_PIEUP_SIOS;
-	break;
+    *final_consonant=18;
+    *hcj=HCJ_PIEUP_SIOS;
+    break;
 }
 /*case HCJ_SIOS:*/
 case SJ_FC_SIOS:
 case SJ_IC_SIOS: {
-	*final_consonant=19;
-	*hcj=HCJ_SIOS;
-	if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
-		input[(*pos_input)+1]==SJ_IC_SIOS) {
-		*final_consonant=20;
-		*hcj=HCJ_SSANGSIOS;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=19;
+    *hcj=HCJ_SIOS;
+    if (/*input[(*pos_input)+1]==HCJ_SIOS ||*/ input[(*pos_input)+1]==SJ_FC_SIOS ||
+        input[(*pos_input)+1]==SJ_IC_SIOS) {
+        *final_consonant=20;
+        *hcj=HCJ_SSANGSIOS;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGSIOS:*/
 case SJ_FC_SSANGSIOS:
 case SJ_IC_SSANGSIOS: {
-	*final_consonant=20;
-	*hcj=HCJ_SSANGSIOS;
-	break;
+    *final_consonant=20;
+    *hcj=HCJ_SSANGSIOS;
+    break;
 }
 /*case HCJ_IEUNG:*/
 case SJ_FC_IEUNG:
 case SJ_IC_IEUNG: {
-	*final_consonant=21;
-	*hcj=HCJ_IEUNG;
-	break;
+    *final_consonant=21;
+    *hcj=HCJ_IEUNG;
+    break;
 }
 /*case HCJ_CIEUC:*/
 case SJ_FC_CIEUC:
 case SJ_IC_CIEUC: {
-	*final_consonant=22;
-	*hcj=HCJ_CIEUC;
-	if (all_sequences && /*input[(*pos_input)+1]==HCJ_CIEUC ||*/ (input[(*pos_input)+1]==SJ_FC_CIEUC ||
-		input[(*pos_input)+1]==SJ_IC_CIEUC)) {
-		*hcj=HCJ_SSANGCIEUC;
-		(*pos_input)++;
-	}
-	break;
+    *final_consonant=22;
+    *hcj=HCJ_CIEUC;
+    if (all_sequences && /*input[(*pos_input)+1]==HCJ_CIEUC ||*/ (input[(*pos_input)+1]==SJ_FC_CIEUC ||
+        input[(*pos_input)+1]==SJ_IC_CIEUC)) {
+        *hcj=HCJ_SSANGCIEUC;
+        (*pos_input)++;
+    }
+    break;
 }
 /*case HCJ_SSANGCIEUC:*/
 case SJ_IC_SSANGCIEUC: {
-	if (all_sequences) {
-		*hcj=HCJ_SSANGCIEUC;
-	}
-	break;
+    if (all_sequences) {
+        *hcj=HCJ_SSANGCIEUC;
+    }
+    break;
 }
 /*case HCJ_CHIEUCH:*/
 case SJ_FC_CHIEUCH:
 case SJ_IC_CHIEUCH: {
-	*final_consonant=23;
-	*hcj=HCJ_CHIEUCH;
-	break;
+    *final_consonant=23;
+    *hcj=HCJ_CHIEUCH;
+    break;
 }
 /*case HCJ_KHIEUKH:*/
 case SJ_FC_KHIEUKH:
 case SJ_IC_KHIEUKH: {
-	*final_consonant=24;
-	*hcj=HCJ_KHIEUKH;
-	break;
+    *final_consonant=24;
+    *hcj=HCJ_KHIEUKH;
+    break;
 }
 /*case HCJ_THIEUTH:*/
 case SJ_FC_THIEUTH:
 case SJ_IC_THIEUTH: {
-	*final_consonant=25;
-	*hcj=HCJ_THIEUTH;
-	break;
+    *final_consonant=25;
+    *hcj=HCJ_THIEUTH;
+    break;
 }
 /*case HCJ_PHIEUPH:*/
 case SJ_FC_PHIEUPH:
 case SJ_IC_PHIEUPH: {
-	*final_consonant=26;
-	*hcj=HCJ_PHIEUPH;
-	break;
+    *final_consonant=26;
+    *hcj=HCJ_PHIEUPH;
+    break;
 }
 /*case HCJ_HIEUH:*/
 case SJ_FC_HIEUH:
 case SJ_IC_HIEUH: {
-	*final_consonant=27;
-	*hcj=HCJ_HIEUH;
-	break;
+    *final_consonant=27;
+    *hcj=HCJ_HIEUH;
+    break;
 }
 default: {
-	return KR_NO_MATCH;
+    return KR_NO_MATCH;
 }
 } /* End of switch */
 /* Now we check whether we are at the end of the syllable or at the end of the string */
 (*pos_input)++;
 if (input[*pos_input]=='\0') {
-	return KR_END_OF_STRING;
+    return KR_END_OF_STRING;
 }
 if (input[*pos_input]==KR_SYLLABLE_BOUND) {
-	return KR_END_OF_SYLLABLE;
+    return KR_END_OF_SYLLABLE;
 }
 /* If we have something else, we have a normal match. This may indicate that, after
  * the Jamo sequence, we have a non Korean character */
@@ -1109,14 +1109,14 @@ int foo;
 /* We try to read a vowel sequence */
 int ret=read_vowels(input,pos_input,&foo,hcj);
 if (ret!=KR_JAMO_ERROR) {
-	/* If a vowel sequence was found, we won */
-	return 1;
+    /* If a vowel sequence was found, we won */
+    return 1;
 }
 /* If not, we try to read a consonant sequence */
 ret=read_final_consonants(input,pos_input,&foo,hcj,1);
 if (ret!=KR_NO_MATCH) {
-	/* If a consonant sequence was found, we won */
-	return 1;
+    /* If a consonant sequence was found, we won */
+    return 1;
 }
 return 0;
 }
@@ -1132,8 +1132,8 @@ return 0;
  */
 int decode_one_Jamo_syllab(unichar* input,unichar* output,int *pos_input,int *pos_output) {
 if (input[*pos_input]=='\0') {
-	output[*pos_output]='\0';
-	return KR_END_OF_STRING;
+    output[*pos_output]='\0';
+    return KR_END_OF_STRING;
 }
 int old_pos_input=*pos_input;
 int old_pos_output=*pos_output;
@@ -1141,44 +1141,44 @@ int ret, initial_consonant, vowel, final_consonant;
 unichar hcj;
 if (input[*pos_input]==KR_SYLLABLE_BOUND) {
 
-	initial_consonant=11;
-	vowel=0;
-	final_consonant=0;
-	(*pos_input)++;
-	ret=read_initial_consonants(input,pos_input,&initial_consonant,&hcj);
-	if (ret==KR_END_OF_SYLLABLE || ret==KR_END_OF_STRING) {
-		/* If we have matched and finished, we return */
-		output[(*pos_output)++]=hcj;
-		return ret;
-	}
-	ret=read_vowels(input,pos_input,&vowel,&hcj);
-	if (ret==KR_JAMO_ERROR) {
-		/* If we can't read a vowel, then it means that the input Jamo syllable is
-		 * not correct. In such a case, we skip the syllable bound, so that
-		 * the next call to this function will read the input char by char */
-		*pos_input=old_pos_input+1;
-		*pos_output=old_pos_output;
-		return KR_END_OF_SYLLABLE;
-	}
-	if (ret!=KR_END_OF_SYLLABLE && ret != KR_END_OF_STRING) {
-		/* If we are not at the end of the sequence, we try to read
-		 * a final consonant sequence */
-		ret=read_final_consonants(input,pos_input,&final_consonant,&hcj,0);
-	}
-	int syllable=(initial_consonant*21+vowel)*28+final_consonant+0xAC00;
-	output[(*pos_output)++]=(unichar)syllable;
-	return KR_END_OF_SYLLABLE;
+    initial_consonant=11;
+    vowel=0;
+    final_consonant=0;
+    (*pos_input)++;
+    ret=read_initial_consonants(input,pos_input,&initial_consonant,&hcj);
+    if (ret==KR_END_OF_SYLLABLE || ret==KR_END_OF_STRING) {
+        /* If we have matched and finished, we return */
+        output[(*pos_output)++]=hcj;
+        return ret;
+    }
+    ret=read_vowels(input,pos_input,&vowel,&hcj);
+    if (ret==KR_JAMO_ERROR) {
+        /* If we can't read a vowel, then it means that the input Jamo syllable is
+         * not correct. In such a case, we skip the syllable bound, so that
+         * the next call to this function will read the input char by char */
+        *pos_input=old_pos_input+1;
+        *pos_output=old_pos_output;
+        return KR_END_OF_SYLLABLE;
+    }
+    if (ret!=KR_END_OF_SYLLABLE && ret != KR_END_OF_STRING) {
+        /* If we are not at the end of the sequence, we try to read
+         * a final consonant sequence */
+        ret=read_final_consonants(input,pos_input,&final_consonant,&hcj,0);
+    }
+    int syllable=(initial_consonant*21+vowel)*28+final_consonant+0xAC00;
+    output[(*pos_output)++]=(unichar)syllable;
+    return KR_END_OF_SYLLABLE;
 }
 /* We try to read a Jamo sequence that is not part of a syllable */
 if (read_jamos(input,pos_input,&hcj)) {
-	output[(*pos_output)++]=hcj;
-	if (input[*pos_input]=='\0') {
-		return KR_END_OF_STRING;
-	}
-	/* We return KR_END_OF_SYLLABLE either if there is actually one
-	 * or if there is something else after the Jamo sequence in the input, like a
-	 * latin character */
-	return KR_END_OF_SYLLABLE;
+    output[(*pos_output)++]=hcj;
+    if (input[*pos_input]=='\0') {
+        return KR_END_OF_STRING;
+    }
+    /* We return KR_END_OF_SYLLABLE either if there is actually one
+     * or if there is something else after the Jamo sequence in the input, like a
+     * latin character */
+    return KR_END_OF_SYLLABLE;
 }
 /* If we have a non Jamo character, we just output it */
 output[(*pos_output)++]=input[(*pos_input)++];
@@ -1197,7 +1197,7 @@ int res;
 while ((res=decode_one_Jamo_syllab(input,output,&pos_input,&pos_output))==KR_END_OF_SYLLABLE) {}
 output[pos_output]='\0';
 if (res==KR_JAMO_ERROR) {
-	return KR_JAMO_ERROR;
+    return KR_JAMO_ERROR;
 }
 return pos_output;
 }

--- a/Korean.h
+++ b/Korean.h
@@ -55,8 +55,8 @@ namespace unitex {
 #define KR_HANGUL_SYL_START   0xAC00
 #define KR_HANGUL_SYL_END     0xD7A3
 
-#define KR_HCJ_START		0x3130
-#define KR_HCJ_END		0x318E
+#define KR_HCJ_START        0x3130
+#define KR_HCJ_END      0x318E
 
 
 /**
@@ -65,138 +65,138 @@ namespace unitex {
  * initial and final consonant.
  */
 /* Consonants */
-#define HCJ_KIYEOK 			0x3131
-#define HCJ_SSANGKIYEOK 	0x3132
-#define HCJ_KIYEOK_SIOS		0x3133
-#define HCJ_NIEUN 			0x3134
-#define HCJ_NIEUN_CIEUC		0x3135
-#define HCJ_NIEUN_HIEUH		0x3136
-#define HCJ_TIKEUT 			0x3137
-#define HCJ_SSANGTIKEUT 	0x3138
-#define HCJ_RIEUL 			0x3139
-#define HCJ_RIEUL_KIYEOK	0x313A
-#define HCJ_RIEUL_MIEUM 	0x313B
-#define HCJ_RIEUL_PIEUP		0x313C
-#define HCJ_RIEUL_SIOS		0x313D
-#define HCJ_RIEUL_THIEUTH	0x313E
-#define HCJ_RIEUL_PHIEUPH	0x313F
-#define HCJ_RIEUL_HIEUH		0x3140
-#define HCJ_MIEUM 			0x3141
-#define HCJ_PIEUP 			0x3142
-#define HCJ_SSANGPIEUP 		0x3143
-#define HCJ_PIEUP_SIOS 		0x3144
-#define HCJ_SIOS 			0x3145
-#define HCJ_SSANGSIOS 		0x3146
-#define HCJ_IEUNG 			0x3147
-#define HCJ_CIEUC 			0x3148
-#define HCJ_SSANGCIEUC 		0x3149
-#define HCJ_CHIEUCH 		0x314A
-#define HCJ_KHIEUKH 		0x314B
-#define HCJ_THIEUTH 		0x314C
-#define HCJ_PHIEUPH 		0x314D
-#define HCJ_HIEUH 			0x314E
+#define HCJ_KIYEOK          0x3131
+#define HCJ_SSANGKIYEOK     0x3132
+#define HCJ_KIYEOK_SIOS     0x3133
+#define HCJ_NIEUN           0x3134
+#define HCJ_NIEUN_CIEUC     0x3135
+#define HCJ_NIEUN_HIEUH     0x3136
+#define HCJ_TIKEUT          0x3137
+#define HCJ_SSANGTIKEUT     0x3138
+#define HCJ_RIEUL           0x3139
+#define HCJ_RIEUL_KIYEOK    0x313A
+#define HCJ_RIEUL_MIEUM     0x313B
+#define HCJ_RIEUL_PIEUP     0x313C
+#define HCJ_RIEUL_SIOS      0x313D
+#define HCJ_RIEUL_THIEUTH   0x313E
+#define HCJ_RIEUL_PHIEUPH   0x313F
+#define HCJ_RIEUL_HIEUH     0x3140
+#define HCJ_MIEUM           0x3141
+#define HCJ_PIEUP           0x3142
+#define HCJ_SSANGPIEUP      0x3143
+#define HCJ_PIEUP_SIOS      0x3144
+#define HCJ_SIOS            0x3145
+#define HCJ_SSANGSIOS       0x3146
+#define HCJ_IEUNG           0x3147
+#define HCJ_CIEUC           0x3148
+#define HCJ_SSANGCIEUC      0x3149
+#define HCJ_CHIEUCH         0x314A
+#define HCJ_KHIEUKH         0x314B
+#define HCJ_THIEUTH         0x314C
+#define HCJ_PHIEUPH         0x314D
+#define HCJ_HIEUH           0x314E
 /* Vowels */
-#define HCJ_A 				0x314F
-#define HCJ_AE 				0x3150
-#define HCJ_YA 				0x3151
-#define HCJ_YAE 			0x3152
-#define HCJ_EO 				0x3153
-#define HCJ_E 				0x3154
-#define HCJ_YEO 			0x3155
-#define HCJ_YE 				0x3156
-#define HCJ_O 				0x3157
-#define HCJ_WA 				0x3158
-#define HCJ_WAE 			0x3159
-#define HCJ_OE 				0x315A
-#define HCJ_YO 				0x315B
-#define HCJ_U 				0x315C
-#define HCJ_WEO 			0x315D
-#define HCJ_WE 				0x315E
-#define HCJ_WI 				0x315F
-#define HCJ_YU 				0x3160
-#define HCJ_EU 				0x3161
-#define HCJ_YI 				0x3162
-#define HCJ_I 				0x3163
+#define HCJ_A               0x314F
+#define HCJ_AE              0x3150
+#define HCJ_YA              0x3151
+#define HCJ_YAE             0x3152
+#define HCJ_EO              0x3153
+#define HCJ_E               0x3154
+#define HCJ_YEO             0x3155
+#define HCJ_YE              0x3156
+#define HCJ_O               0x3157
+#define HCJ_WA              0x3158
+#define HCJ_WAE             0x3159
+#define HCJ_OE              0x315A
+#define HCJ_YO              0x315B
+#define HCJ_U               0x315C
+#define HCJ_WEO             0x315D
+#define HCJ_WE              0x315E
+#define HCJ_WI              0x315F
+#define HCJ_YU              0x3160
+#define HCJ_EU              0x3161
+#define HCJ_YI              0x3162
+#define HCJ_I               0x3163
 
 
 /**
  * Here we define the Standard Jamos used in the library
  */
 /* Initial consonants */
-#define SJ_IC_KIYEOK 		0x1100
-#define SJ_IC_SSANGKIYEOK 	0x1101
-#define SJ_IC_NIEUN 		0x1102
-#define SJ_IC_TIKEUT 		0x1103
-#define SJ_IC_SSANGTIKEUT 	0x1104
-#define SJ_IC_RIEUL 		0x1105
-#define SJ_IC_MIEUM 		0x1106
-#define SJ_IC_PIEUP 		0x1107
-#define SJ_IC_SSANGPIEUP 	0x1108
-#define SJ_IC_SIOS 			0x1109
-#define SJ_IC_SSANGSIOS 	0x110A
-#define SJ_IC_IEUNG 		0x110B
-#define SJ_IC_CIEUC 		0x110C
-#define SJ_IC_SSANGCIEUC 	0x110D
-#define SJ_IC_CHIEUCH 		0x110E
-#define SJ_IC_KHIEUKH 		0x110F
-#define SJ_IC_THIEUTH 		0x1110
-#define SJ_IC_PHIEUPH 		0x1111
-#define SJ_IC_HIEUH 		0x1112
+#define SJ_IC_KIYEOK        0x1100
+#define SJ_IC_SSANGKIYEOK   0x1101
+#define SJ_IC_NIEUN         0x1102
+#define SJ_IC_TIKEUT        0x1103
+#define SJ_IC_SSANGTIKEUT   0x1104
+#define SJ_IC_RIEUL         0x1105
+#define SJ_IC_MIEUM         0x1106
+#define SJ_IC_PIEUP         0x1107
+#define SJ_IC_SSANGPIEUP    0x1108
+#define SJ_IC_SIOS          0x1109
+#define SJ_IC_SSANGSIOS     0x110A
+#define SJ_IC_IEUNG         0x110B
+#define SJ_IC_CIEUC         0x110C
+#define SJ_IC_SSANGCIEUC    0x110D
+#define SJ_IC_CHIEUCH       0x110E
+#define SJ_IC_KHIEUKH       0x110F
+#define SJ_IC_THIEUTH       0x1110
+#define SJ_IC_PHIEUPH       0x1111
+#define SJ_IC_HIEUH         0x1112
 /* Vowels */
-#define SJ_A 				0x1161
-#define SJ_AE 				0x1162
-#define SJ_YA 				0x1163
-#define SJ_YAE 				0x1164
-#define SJ_EO 				0x1165
-#define SJ_E 				0x1166
-#define SJ_YEO 				0x1167
-#define SJ_YE 				0x1168
-#define SJ_O 				0x1169
-#define SJ_WA 				0x116A
-#define SJ_WAE 				0x116B
-#define SJ_OE 				0x116C
-#define SJ_YO 				0x116D
-#define SJ_U 				0x116E
-#define SJ_WEO 				0x116F
-#define SJ_WE 				0x1170
-#define SJ_WI 				0x1171
-#define SJ_YU 				0x1172
-#define SJ_EU 				0x1173
-#define SJ_YI 				0x1174
-#define SJ_I 				0x1175
+#define SJ_A                0x1161
+#define SJ_AE               0x1162
+#define SJ_YA               0x1163
+#define SJ_YAE              0x1164
+#define SJ_EO               0x1165
+#define SJ_E                0x1166
+#define SJ_YEO              0x1167
+#define SJ_YE               0x1168
+#define SJ_O                0x1169
+#define SJ_WA               0x116A
+#define SJ_WAE              0x116B
+#define SJ_OE               0x116C
+#define SJ_YO               0x116D
+#define SJ_U                0x116E
+#define SJ_WEO              0x116F
+#define SJ_WE               0x1170
+#define SJ_WI               0x1171
+#define SJ_YU               0x1172
+#define SJ_EU               0x1173
+#define SJ_YI               0x1174
+#define SJ_I                0x1175
 /* Final consonants */
-#define SJ_FC_KIYEOK		0x11A8
-#define SJ_FC_SSANGKIYEOK	0x11A9
-#define SJ_FC_SSANGKIYEOK	0x11A9
-#define SJ_FC_KIYEOK_SIOS	0x11AA
-#define SJ_FC_NIEUN			0x11AB
-#define SJ_FC_NIEUN_CIEUC	0x11AC
-#define SJ_FC_NIEUN_HIEUH	0x11AD
-#define SJ_FC_TIKEUT		0x11AE
-#define SJ_FC_RIEUL			0x11AF
-#define SJ_FC_RIEUL_KIYEOK	0x11B0
-#define SJ_FC_RIEUL_MIEUM 	0x11B1
-#define SJ_FC_RIEUL_PIEUP	0x11B2
-#define SJ_FC_RIEUL_SIOS	0x11B3
-#define SJ_FC_RIEUL_THIEUTH	0x11B4
-#define SJ_FC_RIEUL_PHIEUPH	0x11B5
-#define SJ_FC_RIEUL_HIEUH	0x11B6
-#define SJ_FC_MIEUM			0x11B7
-#define SJ_FC_PIEUP			0x11B8
-#define SJ_FC_PIEUP_SIOS	0x11B9
-#define SJ_FC_SIOS			0x11BA
-#define SJ_FC_SSANGSIOS		0x11BB
-#define SJ_FC_IEUNG			0x11BC
-#define SJ_FC_CIEUC			0x11BD
-#define SJ_FC_CHIEUCH		0x11BE
-#define SJ_FC_KHIEUKH		0x11BF
-#define SJ_FC_THIEUTH		0x11C0
-#define SJ_FC_PHIEUPH		0x11C1
-#define SJ_FC_HIEUH			0x11C2
+#define SJ_FC_KIYEOK        0x11A8
+#define SJ_FC_SSANGKIYEOK   0x11A9
+#define SJ_FC_SSANGKIYEOK   0x11A9
+#define SJ_FC_KIYEOK_SIOS   0x11AA
+#define SJ_FC_NIEUN         0x11AB
+#define SJ_FC_NIEUN_CIEUC   0x11AC
+#define SJ_FC_NIEUN_HIEUH   0x11AD
+#define SJ_FC_TIKEUT        0x11AE
+#define SJ_FC_RIEUL         0x11AF
+#define SJ_FC_RIEUL_KIYEOK  0x11B0
+#define SJ_FC_RIEUL_MIEUM   0x11B1
+#define SJ_FC_RIEUL_PIEUP   0x11B2
+#define SJ_FC_RIEUL_SIOS    0x11B3
+#define SJ_FC_RIEUL_THIEUTH 0x11B4
+#define SJ_FC_RIEUL_PHIEUPH 0x11B5
+#define SJ_FC_RIEUL_HIEUH   0x11B6
+#define SJ_FC_MIEUM         0x11B7
+#define SJ_FC_PIEUP         0x11B8
+#define SJ_FC_PIEUP_SIOS    0x11B9
+#define SJ_FC_SIOS          0x11BA
+#define SJ_FC_SSANGSIOS     0x11BB
+#define SJ_FC_IEUNG         0x11BC
+#define SJ_FC_CIEUC         0x11BD
+#define SJ_FC_CHIEUCH       0x11BE
+#define SJ_FC_KHIEUKH       0x11BF
+#define SJ_FC_THIEUTH       0x11C0
+#define SJ_FC_PHIEUPH       0x11C1
+#define SJ_FC_HIEUH         0x11C2
 
 
-#define SJ_RIEUL_HIEUH		0x111A
-#define SJ_PIEUP_SIOS 		0x1121
+#define SJ_RIEUL_HIEUH      0x111A
+#define SJ_PIEUP_SIOS       0x1121
 
 
 
@@ -208,9 +208,9 @@ class Korean {
     *
     * AAA BBB CCC....
     *
-    * AAA		= standard Jamo
-    * BBB		= HCJ equivalent
-    * CCC....	= single Jamo letter equivalent sequence, if AAA is a compound letter
+    * AAA       = standard Jamo
+    * BBB       = HCJ equivalent
+    * CCC....   = single Jamo letter equivalent sequence, if AAA is a compound letter
     */
    unichar* jamo_table[256];
 
@@ -231,12 +231,12 @@ public:
    struct hash_table* table;
 
    Korean(Alphabet* alph) : alphabet(NULL), table(NULL) {
-	   if (alph==NULL) {
-		   fatal_error("Unexpected NULL alphabet in Korean()\n");
-	   }
-	   if (alph->korean_equivalent_syllable==NULL) {
-	   	   fatal_error("Unexpected NULL Chinese to Hangul map in Korean()\n");
-	   }
+       if (alph==NULL) {
+           fatal_error("Unexpected NULL alphabet in Korean()\n");
+       }
+       if (alph->korean_equivalent_syllable==NULL) {
+           fatal_error("Unexpected NULL Chinese to Hangul map in Korean()\n");
+       }
       for(int i=0;i<256;i++) {
          jamo_table[i]=NULL;
          HCJ_to_SJ_table[i]=NULL;
@@ -244,7 +244,7 @@ public:
       initJamoMap();
       alphabet=alph;
       table=new_hash_table(1024,0.75f,(HASH_FUNCTION)hash_unichar,(EQUAL_FUNCTION)u_equal,
-    		  (FREE_FUNCTION)free,(FREE_FUNCTION)free,(KEYCOPY_FUNCTION)keycopy);
+              (FREE_FUNCTION)free,(FREE_FUNCTION)free,(KEYCOPY_FUNCTION)keycopy);
    };
 
    ~Korean() {
@@ -267,12 +267,12 @@ private:
 
    /* prevent GCC warning */
    Korean(const Korean&) : alphabet(NULL), table(NULL) {
-			fatal_error("Unexpected copy constructor for Korean\n");
-		}
+            fatal_error("Unexpected copy constructor for Korean\n");
+        }
    Korean& operator =(const Korean&) {
-		fatal_error("Unexpected = operator for Korean\n");
-	   return *this;
-	}
+        fatal_error("Unexpected = operator for Korean\n");
+       return *this;
+    }
 };
 
 int single_HGJ_to_Jamos(unichar c,unichar* dest,Korean* korean);

--- a/KrMwuDic.cpp
+++ b/KrMwuDic.cpp
@@ -52,7 +52,7 @@ void produce_mwu_entries(U_FILE* grf,int n_parts,struct dela_entry** entries,Mul
 int tokens_to_dela_entries(vector_ptr* line_tokens,struct dela_entry** entries,int *n_entries,Ustring* foo,int line_number);
 struct string_hash* get_codes_from_inf(const struct INF_codes* inf);
 int upgrade_entries(struct dela_entry** entries,int n_entries,Dictionary* d,
-					struct string_hash* dic_codes,Ustring* foo,int line_number);
+                    struct string_hash* dic_codes,Ustring* foo,int line_number);
 
 /**
  * Builds the .grf dictionary corresponding to the given Korean compound DELAS.
@@ -91,14 +91,14 @@ while (EOF!=readline(line,delas)) {
       entries[i]=NULL;
    }
    int OK=tokens_to_dela_entries(line_tokens,entries,&n_parts,foo,line_number)
-		   && upgrade_entries(entries,n_parts,d,dic_codes,foo,line_number);
+           && upgrade_entries(entries,n_parts,d,dic_codes,foo,line_number);
    if (OK) {
       /* If everything went OK, we can start inflecting the root of the last
        * component */
       produce_mwu_entries(grf,n_parts,entries,ctx,state_index,
             &current_state,end_state,&line_grf,subgraphs,&subgraph_Y);
    } else {
-	   n_errors++;
+       n_errors++;
    }
    /* We free the tokens as well as the 'part' and 'entries' tab */
    free_vector_ptr(line_tokens,free);
@@ -108,7 +108,7 @@ while (EOF!=readline(line,delas)) {
 }
 free_Ustring(line);
 if (n_errors>0) {
-	error("%d error%s found\n",n_errors,(n_errors>1)?"s":"");
+    error("%d error%s found\n",n_errors,(n_errors>1)?"s":"");
 }
 write_grf_end_things(grf,offset,start_state_offset,current_state,state_index);
 free_vector_int(state_index);
@@ -136,11 +136,11 @@ while (line[pos]!='\0') {
    parse_string(line,&pos,temp,P_TAB,P_EMPTY,NULL);
    vector_ptr_add(parts,u_strdup(temp));
    if (temp[0]!='\0') {
-	   u_strcat(foo,temp);
-	   u_strcat(foo,' ');
+       u_strcat(foo,temp);
+       u_strcat(foo,' ');
    }
    if (line[pos]=='\0') {
-	   break;
+       break;
    }
    pos++;
 }
@@ -248,11 +248,11 @@ for (int i=0;i<n_parts-1;i++) {
 int x=n_parts-1;
 for (int i = 0; i < forms.no_forms; i++,(*line)++) {
    (*current_state)++;
-	unichar tmp[1024];
-	/* We have to convert to Hangul the result of the inflection process that may have
-	 * produced a combination of Hangul and Jamos */
-	convert_jamo_to_hangul(forms.forms[i].form,tmp,ctx->korean);
-	Hanguls_to_Jamos(tmp,inflected_jamo,ctx->korean,0);
+    unichar tmp[1024];
+    /* We have to convert to Hangul the result of the inflection process that may have
+     * produced a combination of Hangul and Jamos */
+    convert_jamo_to_hangul(forms.forms[i].form,tmp,ctx->korean);
+    Hanguls_to_Jamos(tmp,inflected_jamo,ctx->korean,0);
    u_fprintf(grf,"\"%S\" %d %d 1 %d \n",inflected_jamo,200+x*500,20+(*line)*50,(*current_state));
    /* We must backtrack to add the transition to this state */
    fseek(grf,foo_offset,SEEK_SET);
@@ -381,8 +381,8 @@ int next(int *pos,unichar** tab,int max) {
 if (*pos==max) return 0;
 (*pos)++;
 while ((*pos)<max) {
-	if (tab[*pos][0]!='\0') return 1;
-	(*pos)++;
+    if (tab[*pos][0]!='\0') return 1;
+    (*pos)++;
 }
 return 0;
 }
@@ -399,7 +399,7 @@ return 0;
  * Returns 1 in case of success; 0 otherwise.
  */
 int tokens_to_dela_entries(vector_ptr* tokens,struct dela_entry** entries,int *n_entries,
-							Ustring* foo,int line_number) {
+                            Ustring* foo,int line_number) {
 (*n_entries)=0;
 int n=tokens->nbelems;
 if (n<=1) return 0;
@@ -408,47 +408,47 @@ unichar** tok=(unichar**)(tokens->tab);
 if (!next(&pos,tok,n)) return 0;
 Ustring* line=new_Ustring(64);
 for (;;) {
-	empty(line);
-	/* Matching { */
-	if (u_strcmp(tok[pos],"{")) {
-		goto err;
-	}
-	if (!next(&pos,tok,n)) goto err;
-	/* Matching inflected part */
-	if (!u_strcmp(tok[pos],"}")) {
-		goto err;
-	}
-	u_strcat(line,tok[pos]);
-	u_strcat(line,",");
-	if (!next(&pos,tok,n)) goto err;
-	/* Matching lemma part */
-	u_strcat(line,tok[pos]);
-	u_strcat(line,".");
-	if (!next(&pos,tok,n)) goto err;
-	/* Matching code part */
-	u_strcat(line,tok[pos]);
-	if (!next(&pos,tok,n)) goto err;
-	while (u_strcmp(tok[pos],"}")) {
-		u_strcat(line,"+");
-		u_strcat(line,tok[pos]);
-		if (!next(&pos,tok,n)) goto err;
-	}
-	/* Now, we can build the dic entry */
-	struct dela_entry* entry=tokenize_DELAF_line(line->str);
-	if (entry==NULL) goto err;
-	if (*n_entries==MAX_PARTS) {
-		fatal_error("Too many dic entries in tokens_to_dela_entries\n");
-	}
-	entries[(*n_entries)++]=entry;
-	if (entry->n_inflectional_codes!=0) {
-		error("Error at line %d: %S\n",line_number,foo->str);
-		error("Unexpected inflectional code(s)\n");
-		goto err_no_msg;
-	}
-	if (!next(&pos,tok,n)) {
-		/* If we have finished, we exit the loop */
-		break;
-	}
+    empty(line);
+    /* Matching { */
+    if (u_strcmp(tok[pos],"{")) {
+        goto err;
+    }
+    if (!next(&pos,tok,n)) goto err;
+    /* Matching inflected part */
+    if (!u_strcmp(tok[pos],"}")) {
+        goto err;
+    }
+    u_strcat(line,tok[pos]);
+    u_strcat(line,",");
+    if (!next(&pos,tok,n)) goto err;
+    /* Matching lemma part */
+    u_strcat(line,tok[pos]);
+    u_strcat(line,".");
+    if (!next(&pos,tok,n)) goto err;
+    /* Matching code part */
+    u_strcat(line,tok[pos]);
+    if (!next(&pos,tok,n)) goto err;
+    while (u_strcmp(tok[pos],"}")) {
+        u_strcat(line,"+");
+        u_strcat(line,tok[pos]);
+        if (!next(&pos,tok,n)) goto err;
+    }
+    /* Now, we can build the dic entry */
+    struct dela_entry* entry=tokenize_DELAF_line(line->str);
+    if (entry==NULL) goto err;
+    if (*n_entries==MAX_PARTS) {
+        fatal_error("Too many dic entries in tokens_to_dela_entries\n");
+    }
+    entries[(*n_entries)++]=entry;
+    if (entry->n_inflectional_codes!=0) {
+        error("Error at line %d: %S\n",line_number,foo->str);
+        error("Unexpected inflectional code(s)\n");
+        goto err_no_msg;
+    }
+    if (!next(&pos,tok,n)) {
+        /* If we have finished, we exit the loop */
+        break;
+    }
 }
 free_Ustring(line);
 return 1;
@@ -471,44 +471,44 @@ Ustring* tmp=new_Ustring(32);
 unichar* s;
 int pos;
 for (int i=0;i<inf->N;i++) {
-	l=inf->codes[i];
-	while (l!=NULL) {
-		s=l->string;
-		pos=0;
-		/* First, we locate the . */
-		while (s[pos]!='.' && s[pos]!='\0') {
-			if (s[pos]=='\\') {
-				pos++;
-				if (s[pos]=='\0') {
-					fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
-				}
-			}
-			pos++;
-		}
-		if (s[pos]=='\0') {
-			fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
-		}
-		/* Then, we read all codes */
-		while (s[pos]=='.' || s[pos]=='+') {
-			empty(tmp);
-			pos++;
-			while (s[pos]!='+'  && s[pos]!=':' && s[pos]!='\0') {
-				if (s[pos]=='\\') {
-					pos++;
-					if (s[pos]=='\0') {
-						fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
-					}
-				}
-				u_strcat(tmp,s[pos]);
-				pos++;
-			}
-			if (tmp->len==0) {
-				fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
-			}
-			get_value_index(tmp->str,h);
-		}
-		l=l->next;
-	}
+    l=inf->codes[i];
+    while (l!=NULL) {
+        s=l->string;
+        pos=0;
+        /* First, we locate the . */
+        while (s[pos]!='.' && s[pos]!='\0') {
+            if (s[pos]=='\\') {
+                pos++;
+                if (s[pos]=='\0') {
+                    fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
+                }
+            }
+            pos++;
+        }
+        if (s[pos]=='\0') {
+            fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
+        }
+        /* Then, we read all codes */
+        while (s[pos]=='.' || s[pos]=='+') {
+            empty(tmp);
+            pos++;
+            while (s[pos]!='+'  && s[pos]!=':' && s[pos]!='\0') {
+                if (s[pos]=='\\') {
+                    pos++;
+                    if (s[pos]=='\0') {
+                        fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
+                    }
+                }
+                u_strcat(tmp,s[pos]);
+                pos++;
+            }
+            if (tmp->len==0) {
+                fatal_error("Parse error in get_codes_from_inf for inf code %S\n",s);
+            }
+            get_value_index(tmp->str,h);
+        }
+        l=l->next;
+    }
 }
 free_Ustring(tmp);
 return h;
@@ -523,20 +523,20 @@ return h;
  */
 int are_compatible(struct dela_entry* e,struct dela_entry* dic,struct string_hash* dic_codes) {
 if (!u_starts_with(dic->semantic_codes[0],e->semantic_codes[0])) {
-	return 0;
+    return 0;
 }
 unichar c=dic->semantic_codes[0][u_strlen(e->semantic_codes[0])];
 if (c!='\0' && !u_is_digit(c)) {
-	/* If the codes are not exactly the same, then we look for
-	 * a digit to avoid that A may match ADV, for instance */
-	return 0;
+    /* If the codes are not exactly the same, then we look for
+     * a digit to avoid that A may match ADV, for instance */
+    return 0;
 }
 for (int i=1;i<e->n_semantic_codes;i++) {
-	if (-1!=get_value_index(e->semantic_codes[i],dic_codes)) {
-		if (!dic_entry_contain_gram_code(dic,e->semantic_codes[i])) {
-			return 0;
-		}
-	}
+    if (-1!=get_value_index(e->semantic_codes[i],dic_codes)) {
+        if (!dic_entry_contain_gram_code(dic,e->semantic_codes[i])) {
+            return 0;
+        }
+    }
 }
 return 1;
 }
@@ -549,22 +549,22 @@ void upgrade_entry(struct dela_entry* e,struct dela_entry* dic) {
 free(e->semantic_codes[0]);
 e->semantic_codes[0]=u_strdup(dic->semantic_codes[0]);
 for (int i=1;i<dic->n_semantic_codes;i++) {
-	if (!dic_entry_contain_gram_code(e,dic->semantic_codes[i])) {
-		e->semantic_codes[(e->n_semantic_codes)++]=u_strdup(dic->semantic_codes[i]);
-	}
+    if (!dic_entry_contain_gram_code(e,dic->semantic_codes[i])) {
+        e->semantic_codes[(e->n_semantic_codes)++]=u_strdup(dic->semantic_codes[i]);
+    }
 }
 /* Finally, we have to test whether the grammatical code has been duplicated or not */
 for (int i=1;i<e->n_semantic_codes;i++) {
-	if (!u_strcmp(e->semantic_codes[0],e->semantic_codes[i])) {
-		/* We remove the #i and shift the remaining codes */
-		free(e->semantic_codes[i]);
-		while (i<e->n_semantic_codes-1) {
-			e->semantic_codes[i]=e->semantic_codes[i+1];
-			i++;
-		}
-		(e->n_semantic_codes)--;
-		break;
-	}
+    if (!u_strcmp(e->semantic_codes[0],e->semantic_codes[i])) {
+        /* We remove the #i and shift the remaining codes */
+        free(e->semantic_codes[i]);
+        while (i<e->n_semantic_codes-1) {
+            e->semantic_codes[i]=e->semantic_codes[i+1];
+            i++;
+        }
+        (e->n_semantic_codes)--;
+        break;
+    }
 }
 }
 
@@ -572,15 +572,15 @@ for (int i=1;i<e->n_semantic_codes;i++) {
  * For each dic entry, this function looks up in the bin dictionary
  * to try to expand its codes. For instance, if we have an entry like
  *
- * 	ABC,.X+Y
+ *  ABC,.X+Y
  *
  * and if the binary dic contains:
  *
- * 	ABC,X08+W+Z
+ *  ABC,X08+W+Z
  *
  * then we want to obtain:
  *
- * 	ABC,X08+Y+W+Z
+ *  ABC,X08+Y+W+Z
  *
  * Note that the grammatical code (the first one) may be replaced by a longer version if found
  * in the bin dictionary. To be considered, a binary entry must contains all codes of the
@@ -591,63 +591,63 @@ for (int i=1;i<e->n_semantic_codes;i++) {
  * otherwise it returns 1.
  */
 int upgrade_entries(struct dela_entry** entries,int n_entries,Dictionary* d,
-		            struct string_hash* dic_codes,
-					Ustring* debug,int line_number) {
+                    struct string_hash* dic_codes,
+                    Ustring* debug,int line_number) {
 Ustring* line=new_Ustring(4096);
 int OK=1;
 for (int i=0;i<n_entries;i++) {
-	struct dela_entry* e=entries[i];
-	int inf_code=get_inf_code_exact_match(d,e->inflected);
-	if (inf_code==-1) {
-		/* No expansion to perform if the entry is not in the bin dictionary */
-		continue;
-	}
-	/* Now, we uncompress all the entries found in the bin */
-	vector_ptr* bin_entries=new_vector_ptr(8);
-	struct list_ustring* l=d->inf->codes[inf_code];
-	while (l!=NULL) {
-		uncompress_entry(e->inflected,l->string,line);
-		struct dela_entry* foo=tokenize_DELAF_line(line->str);
-		if (foo==NULL) {
-			error("Error at line %d: %S\n",line_number,debug->str);
-			fatal_error("Internal error in upgrade_entries\n");
-		}
-		vector_ptr_add(bin_entries,foo);
-		l=l->next;
-	}
-	/* Now, we count how many bin entries are compatible with the current one */
-	unsigned int n_compatibles=0;
-	for (int k=0;k<bin_entries->nbelems;k++) {
-		if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
-			n_compatibles++;
-		}
-	}
-	if (n_compatibles>1) {
-		OK=0;
-		error("Error at line %d: %S\n",line_number,debug->str);
-		error("Cause: several possibilities for entry {");
-		debug_print_entry(e);
-		error("}:\n");
-		for (int k=0;k<bin_entries->nbelems;k++) {
-			if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
-				debug_println_entry((struct dela_entry*)(bin_entries->tab[k]));
-			}
-		}
-	} else if (n_compatibles==1) {
-		for (int k=0;k<bin_entries->nbelems;k++) {
-			if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
-				/* We have found the only matching one, we expand it */
-				upgrade_entry(e,(struct dela_entry*)(bin_entries->tab[k]));
-			}
-		}
-	} else {
-		/* If there is no compatible entry, we don't have to expand anything */
-	}
-	/* Don't forget to free bin entries */
-	for (int k=0;k<bin_entries->nbelems;k++) {
-		free_dela_entry((struct dela_entry*)(bin_entries->tab[k]));
-	}
-	free_vector_ptr(bin_entries,NULL);
+    struct dela_entry* e=entries[i];
+    int inf_code=get_inf_code_exact_match(d,e->inflected);
+    if (inf_code==-1) {
+        /* No expansion to perform if the entry is not in the bin dictionary */
+        continue;
+    }
+    /* Now, we uncompress all the entries found in the bin */
+    vector_ptr* bin_entries=new_vector_ptr(8);
+    struct list_ustring* l=d->inf->codes[inf_code];
+    while (l!=NULL) {
+        uncompress_entry(e->inflected,l->string,line);
+        struct dela_entry* foo=tokenize_DELAF_line(line->str);
+        if (foo==NULL) {
+            error("Error at line %d: %S\n",line_number,debug->str);
+            fatal_error("Internal error in upgrade_entries\n");
+        }
+        vector_ptr_add(bin_entries,foo);
+        l=l->next;
+    }
+    /* Now, we count how many bin entries are compatible with the current one */
+    unsigned int n_compatibles=0;
+    for (int k=0;k<bin_entries->nbelems;k++) {
+        if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
+            n_compatibles++;
+        }
+    }
+    if (n_compatibles>1) {
+        OK=0;
+        error("Error at line %d: %S\n",line_number,debug->str);
+        error("Cause: several possibilities for entry {");
+        debug_print_entry(e);
+        error("}:\n");
+        for (int k=0;k<bin_entries->nbelems;k++) {
+            if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
+                debug_println_entry((struct dela_entry*)(bin_entries->tab[k]));
+            }
+        }
+    } else if (n_compatibles==1) {
+        for (int k=0;k<bin_entries->nbelems;k++) {
+            if (are_compatible(e,(struct dela_entry*)(bin_entries->tab[k]),dic_codes)) {
+                /* We have found the only matching one, we expand it */
+                upgrade_entry(e,(struct dela_entry*)(bin_entries->tab[k]));
+            }
+        }
+    } else {
+        /* If there is no compatible entry, we don't have to expand anything */
+    }
+    /* Don't forget to free bin entries */
+    for (int k=0;k<bin_entries->nbelems;k++) {
+        free_dela_entry((struct dela_entry*)(bin_entries->tab[k]));
+    }
+    free_vector_ptr(bin_entries,NULL);
 }
 free_Ustring(line);
 return OK;

--- a/LemmaTree.h
+++ b/LemmaTree.h
@@ -36,10 +36,10 @@ namespace unitex {
  * the associated final node contains a list of all the inflected forms
  * that correspond to this lemma. For instance, if the text simple word
  * dictionary contains the following lines:
- * 
+ *
  * �tres,�tre.N:mp
  * suis,�tre.V:P1s
- * 
+ *
  * then the liste "�tres", "suis" will be associated to the lemma "�tre".
  */
 struct lemma_node {

--- a/LinearAutomaton2Txt.cpp
+++ b/LinearAutomaton2Txt.cpp
@@ -65,7 +65,7 @@ return LINEAR_AUTOMATON;
 
 void insert_separators(U_FILE* f,TfstTag* current,TfstTag* next) {
 if (current->m.end_pos_in_token!=next->m.start_pos_in_token-1) {
-	u_fprintf(f," ");
+    u_fprintf(f," ");
 }
 }
 
@@ -108,7 +108,7 @@ for (int sentence=1;sentence<=tfst->N;sentence++) {
             return sentence;
          }
          TfstTag* tag=(TfstTag*)(tfst->tags->tab[l->tag_number]);
-		 u_fputs(tag->content,f);
+         u_fputs(tag->content,f);
          state=tfst->automaton->states[l->state_number];
          l=state->outgoing_transitions;
          if (l!=NULL) insert_separators(f,tag,(TfstTag*)(tfst->tags->tab[l->tag_number]));

--- a/List_int.cpp
+++ b/List_int.cpp
@@ -75,10 +75,10 @@ free_list_int(head,STANDARD_ALLOCATOR);
 /**
  * Inserts a value in a sorted list, if not already present. The
  * element that contains the value is returned.
- * 
+ *
  * NOTE: in the general case, a struct list_int is not supposed
  *       to be sorted.
- * 
+ *
  * Time-critical function: the iterative implementation is faster!
  */
 struct list_int* sorted_insert(int value,struct list_int* l,Abstract_allocator prv_alloc) {
@@ -103,14 +103,14 @@ for (tmp=l; tmp!=NULL; tmp=tmp->next) {
     return l;
   }
   last=tmp;
-} 
+}
 /* value not found in the list and there is no bigger element in the
    list: insert at the end of the list */
 tmp2=new_list_int(value,prv_alloc);
 last->next = tmp2;
 return l;
 }
-/* 
+/*
 struct list_int* sorted_insert(int value,struct list_int* l) {
 struct list_int* tmp;
 if (l==NULL) {
@@ -216,7 +216,7 @@ return a;
 
 
 /**
- * This function puts in 'a' the merge of 'a' and 'b'. The merge result 
+ * This function puts in 'a' the merge of 'a' and 'b'. The merge result
  * is returned. 'b' is not modified.
  */
 struct list_int* sorted_merge(struct list_int* a,struct list_int* b,Abstract_allocator prv_alloc) {

--- a/List_ustring.cpp
+++ b/List_ustring.cpp
@@ -108,7 +108,7 @@ free_cb(element,prv_alloc);
 /**
  * Inserts a value in a sorted list, if not already present. The
  * element that contains the value is returned.
- * 
+ *
  * NOTE: in the general case, a struct list_ustring is not supposed
  *       to be sorted.
  */
@@ -193,7 +193,7 @@ struct list_ustring* insert_at_end_of_list_with_latest(const unichar* s, struct 
   if ((*latest) == NULL) {
     *latest = new_list_ustring(s, prv_alloc);
     return *latest;
-  }	
+  }
   (*latest)->next = new_list_ustring(s, prv_alloc);
   *latest = (*latest)->next;
   return l;
@@ -206,7 +206,7 @@ struct list_ustring* insert_at_end_of_list_with_latest(const char* s, struct lis
   if ((*latest) == NULL) {
     *latest = new_list_ustring(s, prv_alloc);
     return *latest;
-  } 
+  }
   (*latest)->next = new_list_ustring(s, prv_alloc);
   *latest = (*latest)->next;
   return l;
@@ -217,7 +217,7 @@ struct list_ustring* insert_at_end_of_list_with_latest(const char* s, struct lis
  * Returns 1 if the given value is in the list; 0 otherwise.
  */
 int is_in_list(const unichar* value,
-               const struct list_ustring* l, 
+               const struct list_ustring* l,
                unichar_unichar_comparator compare) {
 if (value==NULL) {
    fatal_error("NULL string argument in is_in_list\n");
@@ -233,7 +233,7 @@ return 0;
  * Returns 1 if the given value is in the list; 0 otherwise.
  */
 int is_in_list(const char* value,
-               const struct list_ustring* l, 
+               const struct list_ustring* l,
                unichar_char_comparator compare) {
 if (value==NULL) {
    fatal_error("NULL string argument in is_in_list\n");
@@ -252,7 +252,7 @@ return 0;
  * same order.
  */
 int equal(const struct list_ustring* a,
-          const struct list_ustring* b, 
+          const struct list_ustring* b,
           unichar_unichar_comparator compare) {
 while ((a!=NULL) && (b!=NULL)) {
    if (compare(a->string,b->string)) {

--- a/LoadInf.h
+++ b/LoadInf.h
@@ -35,19 +35,19 @@ namespace unitex {
  * This structure is used to store all the INF codes of an .inf file.
  */
 struct INF_codes {
-	/* Array containing for each line of the .inf file the reversed list of its
-	 * components. For instance, if the first line contains:
-	 *
-	 * .N+NA+z1:fs,.N+Loc:fs
-	 *
-	 * codes[0] will contain the following list:
-	 *
-	 *  ".N+Loc:fs"   -->   ".N+NA+z1:fs"   -->   NULL
-	 *
-	 */
-	struct list_ustring** codes;
-	/* Number of lines in the .inf file */
-	int N;
+    /* Array containing for each line of the .inf file the reversed list of its
+     * components. For instance, if the first line contains:
+     *
+     * .N+NA+z1:fs,.N+Loc:fs
+     *
+     * codes[0] will contain the following list:
+     *
+     *  ".N+Loc:fs"   -->   ".N+NA+z1:fs"   -->   NULL
+     *
+     */
+    struct list_ustring** codes;
+    /* Number of lines in the .inf file */
+    int N;
 };
 
 

--- a/Locate.cpp
+++ b/Locate.cpp
@@ -294,7 +294,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(alph,options.vars()->optarg);
              break;
@@ -306,7 +306,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                     free_vector_ptr(injected_vars,free);
                     free_locate_trace_param(list_param_trace);
                     free(morpho_dic);
-                    return ALLOC_ERROR_CODE;                     
+                    return ALLOC_ERROR_CODE;
                   }
                 }
                 else
@@ -329,7 +329,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              selected_negation_operator=1;
              if ((strcmp(options.vars()->optarg,"minus")==0) || (strcmp(options.vars()->optarg,"-")==0)) {
@@ -358,7 +358,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'o': {
@@ -374,7 +374,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                         free_vector_ptr(injected_vars,free);
                         free_locate_trace_param(list_param_trace);
                         free(morpho_dic);
-                        return USAGE_ERROR_CODE;                        
+                        return USAGE_ERROR_CODE;
                     }
                 }
                 else
@@ -384,7 +384,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                         free_vector_ptr(injected_vars,free);
                         free_locate_trace_param(list_param_trace);
                         free(morpho_dic);
-                        return USAGE_ERROR_CODE;                        
+                        return USAGE_ERROR_CODE;
                     }
              }
              break;
@@ -394,7 +394,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case '@': if (1!=sscanf(options.vars()->optarg,"%d%c",&max_errors,&foo) || max_errors<=0) {
@@ -403,7 +403,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'C': if (1!=sscanf(options.vars()->optarg,"%d%c",&max_matches_per_subgraph,&foo) || max_matches_per_subgraph<=0) {
@@ -412,7 +412,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'P': if (1!=sscanf(options.vars()->optarg,"%d%c",&max_matches_at_token_pos,&foo) || max_matches_at_token_pos<=0) {
@@ -421,7 +421,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'H': {
@@ -441,7 +441,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(dynamicSntDir,options.vars()->optarg);
              break;
@@ -455,7 +455,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
    case 'K': is_korean=1;
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': usage();
              free_vector_ptr(injected_vars,free);
              free_locate_trace_param(list_param_trace);
@@ -466,7 +466,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
@@ -475,7 +475,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -484,7 +484,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(arabic_rules,options.vars()->optarg);
              break;
@@ -493,7 +493,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
                 free_vector_ptr(injected_vars,free);
                 free_locate_trace_param(list_param_trace);
                 free(morpho_dic);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              list_param_trace=add_locate_trace_param(list_param_trace,options.vars()->optarg);
              break;
@@ -505,7 +505,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
        free_vector_ptr(injected_vars,free);
        free_locate_trace_param(list_param_trace);
        free(morpho_dic);
-       return USAGE_ERROR_CODE;       
+       return USAGE_ERROR_CODE;
 	   }
 	   (*value)='\0';
 	   value++;
@@ -519,7 +519,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
              free_vector_ptr(injected_vars,free);
              free_locate_trace_param(list_param_trace);
              free(morpho_dic);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              free_vector_ptr(injected_vars,free);
@@ -539,7 +539,7 @@ if (options.vars()->optind!=argc-1) {
   free_vector_ptr(injected_vars,free);
   free_locate_trace_param(list_param_trace);
   free(morpho_dic);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 
 if (text[0]=='\0') {
@@ -547,14 +547,14 @@ if (text[0]=='\0') {
   free_vector_ptr(injected_vars,free);
   free_locate_trace_param(list_param_trace);
   free(morpho_dic);
-  return USAGE_ERROR_CODE; 
+  return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
   // freeing all allocated memory
   free_vector_ptr(injected_vars,free);
   free_locate_trace_param(list_param_trace);
-  free(morpho_dic);  
+  free(morpho_dic);
   return SUCCESS_RETURN_CODE;
 }
 
@@ -570,7 +570,7 @@ if (buffer_filename == NULL) {
   free_vector_ptr(injected_vars,free);
   free_locate_trace_param(list_param_trace);
   free(morpho_dic);
-  return ALLOC_ERROR_CODE;  
+  return ALLOC_ERROR_CODE;
 }
 
 char* staticSntDir = (buffer_filename + (step_filename_buffer * 0));

--- a/Locate.cpp
+++ b/Locate.cpp
@@ -192,47 +192,47 @@ const struct option_TS lopts_Locate[]= {
 
 char** new_locate_trace_param()
 {
-	char** empty_list_param_trace = (char**)malloc(sizeof(char*));
-	if (empty_list_param_trace == NULL) {
-		alloc_error("new_locate_trace_param");
+    char** empty_list_param_trace = (char**)malloc(sizeof(char*));
+    if (empty_list_param_trace == NULL) {
+        alloc_error("new_locate_trace_param");
     return NULL;
-	}
-	*empty_list_param_trace = NULL;
-	return empty_list_param_trace;
+    }
+    *empty_list_param_trace = NULL;
+    return empty_list_param_trace;
 }
 
 char** add_locate_trace_param(char** list_param_trace, const char* add_param)
 {
-	size_t i = 0;
-	while ((*(list_param_trace + i)) != NULL)
-		i++;
+    size_t i = 0;
+    while ((*(list_param_trace + i)) != NULL)
+        i++;
 
-	char** new_list_param_trace = (char**)realloc(list_param_trace,sizeof(char*)*(i+2));
-	if (new_list_param_trace == NULL) {
-		alloc_error("add_locate_trace_param");
+    char** new_list_param_trace = (char**)realloc(list_param_trace,sizeof(char*)*(i+2));
+    if (new_list_param_trace == NULL) {
+        alloc_error("add_locate_trace_param");
     return NULL;
-	}
+    }
 
-	*(new_list_param_trace + i) = strdup(add_param);
-	if ((*(new_list_param_trace + i)) == NULL) {
-		alloc_error("add_locate_trace_param");
+    *(new_list_param_trace + i) = strdup(add_param);
+    if ((*(new_list_param_trace + i)) == NULL) {
+        alloc_error("add_locate_trace_param");
     return NULL;
-	}
+    }
 
-	*(new_list_param_trace + i + 1) = NULL;
+    *(new_list_param_trace + i + 1) = NULL;
 
-	return new_list_param_trace;
+    return new_list_param_trace;
 }
 
 void free_locate_trace_param(char** list_param_trace)
 {
-	size_t i = 0;
-	while ((*(list_param_trace + i)) != NULL)
-	{
-		free(*(list_param_trace + i));
-		i++;
-	}
-	free(list_param_trace);
+    size_t i = 0;
+    while ((*(list_param_trace + i)) != NULL)
+    {
+        free(*(list_param_trace + i));
+        i++;
+    }
+    free(list_param_trace);
 }
 
 
@@ -498,21 +498,21 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Locate,lopts_Locate,&ind
              list_param_trace=add_locate_trace_param(list_param_trace,options.vars()->optarg);
              break;
    case 'v': {
-	   unichar* key=u_strdup(options.vars()->optarg);
-	   unichar* value=u_strchr(key,'=');
-	   if (value==NULL) {
-		   error("Invalid variable injection: %s\n",options.vars()->optarg);
+       unichar* key=u_strdup(options.vars()->optarg);
+       unichar* value=u_strchr(key,'=');
+       if (value==NULL) {
+           error("Invalid variable injection: %s\n",options.vars()->optarg);
        free_vector_ptr(injected_vars,free);
        free_locate_trace_param(list_param_trace);
        free(morpho_dic);
        return USAGE_ERROR_CODE;
-	   }
-	   (*value)='\0';
-	   value++;
-	   value=u_strdup(value);
-	   vector_ptr_add(injected_vars,key);
-	   vector_ptr_add(injected_vars,value);
-	   break;
+       }
+       (*value)='\0';
+       value++;
+       value=u_strdup(value);
+       vector_ptr_add(injected_vars,key);
+       vector_ptr_add(injected_vars,value);
+       break;
    }
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Locate[index].name);
@@ -566,7 +566,7 @@ size_t step_filename_buffer = (((FILENAME_MAX / 0x10) + 1) * 0x10);
 
 char* buffer_filename = (char*)malloc(step_filename_buffer * 6);
 if (buffer_filename == NULL) {
-	alloc_error("main_Locate");
+    alloc_error("main_Locate");
   free_vector_ptr(injected_vars,free);
   free_locate_trace_param(list_param_trace);
   free(morpho_dic);
@@ -697,8 +697,8 @@ if (negation_operator != NULL) {
 sprintf(tmp,"--text=%s",text_snt);
 add_argument(invoker,tmp);
 if (alphabet!=NULL && alphabet[0]!='\0') {
-	sprintf(tmp,"-a%s",alphabet);
-	add_argument(invoker,tmp);
+    sprintf(tmp,"-a%s",alphabet);
+    add_argument(invoker,tmp);
 }
 /* We set the match policy */
 switch(match_policy) {
@@ -714,24 +714,24 @@ switch (output_policy) {
 }
 /* We look for all the occurrences */
 if (n_matches_max==-1) {
-	add_argument(invoker,"--all");
+    add_argument(invoker,"--all");
 } else {
-	sprintf(tmp,"-n%d",n_matches_max);
-	add_argument(invoker,tmp);
+    sprintf(tmp,"-n%d",n_matches_max);
+    add_argument(invoker,tmp);
 }
 /* If needed, we add the -thai option */
 if (thai) {
    add_argument(invoker,"--thai");
 }
 if (md) {
-	add_argument(invoker,"-m");
-	add_argument(invoker,morpho_dic);
+    add_argument(invoker,"-m");
+    add_argument(invoker,morpho_dic);
 }
 if (protect_dic_chars) {
-	add_argument(invoker,"-p");
+    add_argument(invoker,"-p");
 }
 if (is_korean) {
-	add_argument(invoker,"-K");
+    add_argument(invoker,"-K");
 }
 if (arabic_rules && arabic_rules[0]!='\0') {
    sprintf(tmp,"--arabic_rules=%s",arabic_rules);

--- a/LocateCache.cpp
+++ b/LocateCache.cpp
@@ -37,7 +37,7 @@ namespace unitex {
 LocateCache new_LocateCache(int token,struct match_list* matches,Abstract_allocator prv_alloc) {
 LocateCache c=(LocateCache)malloc_cb(sizeof(struct locate_cache),prv_alloc);
 if (c==NULL) {
-	fatal_alloc_error("new_LocateCache");
+    fatal_alloc_error("new_LocateCache");
 }
 c->left=NULL;
 c->middle=NULL;
@@ -70,46 +70,46 @@ static void cache_match_internal(struct match_list* match,const int* tab,int sta
 int token=-1;
 struct match_list* m=match;
 if (start<=end) {
-	token=tab[start];
-	m=NULL;
+    token=tab[start];
+    m=NULL;
 }
 /* No node */
 if (*c==NULL) {
-	*c=new_LocateCache(token,m,prv_alloc);
-	if (token!=-1) {
-		cache_match_internal(match,tab,start+1,end,&((*c)->middle),prv_alloc);
-	}
-	return;
+    *c=new_LocateCache(token,m,prv_alloc);
+    if (token!=-1) {
+        cache_match_internal(match,tab,start+1,end,&((*c)->middle),prv_alloc);
+    }
+    return;
 }
 /* There is a node */
 if (token<(*c)->token) {
-	/* If we have to move on the left */
-	return cache_match_internal(match,tab,start,end,&((*c)->left),prv_alloc);
+    /* If we have to move on the left */
+    return cache_match_internal(match,tab,start,end,&((*c)->left),prv_alloc);
 }
 if (token>(*c)->token) {
-	/* If we have to move on the right */
-	return cache_match_internal(match,tab,start,end,&((*c)->right),prv_alloc);
+    /* If we have to move on the right */
+    return cache_match_internal(match,tab,start,end,&((*c)->right),prv_alloc);
 }
 /* We have the correct token */
 if (token==-1) {
-	/* If we are in a final node that already existed, we just add
-	 * the new match at the end of the match list to get the same match order as
-	 * if the cache system had not been used, but only if the match is not already present */
-	struct match_list* *ptr=&((*c)->matches);
-	struct match_list* z;
-	match->next=NULL;
-	while ((*ptr)!=NULL) {
-		z=*ptr;
-		if (compare_matches(&(z->m),&(match->m))==A_EQUALS_B &&
-				!u_strcmp(z->output,match->output)) {
-			/* We discard a match that was already in cache */
-			free_match_list_element(match,prv_alloc);
-			return;
-		}
-		ptr=&((*ptr)->next);
-	}
-	(*ptr)=match;
-	return;
+    /* If we are in a final node that already existed, we just add
+     * the new match at the end of the match list to get the same match order as
+     * if the cache system had not been used, but only if the match is not already present */
+    struct match_list* *ptr=&((*c)->matches);
+    struct match_list* z;
+    match->next=NULL;
+    while ((*ptr)!=NULL) {
+        z=*ptr;
+        if (compare_matches(&(z->m),&(match->m))==A_EQUALS_B &&
+                !u_strcmp(z->output,match->output)) {
+            /* We discard a match that was already in cache */
+            free_match_list_element(match,prv_alloc);
+            return;
+        }
+        ptr=&((*ptr)->next);
+    }
+    (*ptr)=match;
+    return;
 }
 cache_match_internal(match,tab,start+1,end,&((*c)->middle),prv_alloc);
 }
@@ -132,21 +132,21 @@ cache_match_internal(match,tab,start+1,end,c,prv_alloc);
 void explore_cache_node(const int* tab,int pos,int tab_size,LocateCache c,vector_ptr* res) {
 if (pos==tab_size || c==NULL) return;
 if (c->token==-1) {
-	/* If we have found a token sequence end mark, then we have matches to
-	 * store before trying the right node to look for longer matches. As -1 is
-	 * lower than any token value, we don't need to explore the left side */
-	vector_ptr_add(res,c->matches);
-	explore_cache_node(tab,pos,tab_size,c->right,res);
-	return;
+    /* If we have found a token sequence end mark, then we have matches to
+     * store before trying the right node to look for longer matches. As -1 is
+     * lower than any token value, we don't need to explore the left side */
+    vector_ptr_add(res,c->matches);
+    explore_cache_node(tab,pos,tab_size,c->right,res);
+    return;
 }
 int token=tab[pos];
 if (token==c->token) {
-	explore_cache_node(tab,pos+1,tab_size,c->middle,res);
-	return;
+    explore_cache_node(tab,pos+1,tab_size,c->middle,res);
+    return;
 }
 if (token<c->token) {
-	explore_cache_node(tab,pos,tab_size,c->left,res);
-	return;
+    explore_cache_node(tab,pos,tab_size,c->left,res);
+    return;
 }
 explore_cache_node(tab,pos,tab_size,c->right,res);
 }
@@ -161,7 +161,7 @@ int consult_cache(const int* tab,int start,int tab_size,LocateCache* caches,vect
 res->nbelems=0;
 int first_token=tab[start];
 if (first_token==-1) {
-	return 0;
+    return 0;
 }
 explore_cache_node(tab,start+1,tab_size,caches[first_token],res);
 return res->nbelems!=0;

--- a/LocateCache.h
+++ b/LocateCache.h
@@ -38,11 +38,11 @@ namespace unitex {
 
 
 typedef struct locate_cache {
-	struct locate_cache* left;
-	struct locate_cache* middle;
-	struct locate_cache* right;
-	int token;
-	struct match_list* matches;
+    struct locate_cache* left;
+    struct locate_cache* middle;
+    struct locate_cache* right;
+    int token;
+    struct match_list* matches;
 }* LocateCache;
 
 

--- a/LocateConstants.h
+++ b/LocateConstants.h
@@ -83,7 +83,7 @@ typedef enum {
 } TokenizationPolicy;
 
 
-/* How to behave when an output containing an invalid variable is found 
+/* How to behave when an output containing an invalid variable is found
  * with output policy!=IGNORE_OUTPUTS ? */
 typedef enum {
    EXIT_ON_VARIABLE_ERRORS,

--- a/LocateMatches.cpp
+++ b/LocateMatches.cpp
@@ -71,11 +71,11 @@ return l;
 void free_match_list_element(struct match_list* l,Abstract_allocator prv_alloc) {
   if (l==NULL) {
     return;
-  }  
+  }
   if (l->output!=NULL) {
     free_cb(l->output,prv_alloc);
   }
-    
+
   free_cb(l,prv_alloc);
 
   // protecting against dangling pointer bugs

--- a/LocatePattern.cpp
+++ b/LocatePattern.cpp
@@ -374,7 +374,7 @@ if (is_cancelling_requested() != 0) {
    free(buffer_filename);
    return 0;
 }
-	
+
 p->tags=p->fst2->tags;
 #ifdef REGEX_FACADE_ENGINE
 p->filters=new_FilterSet(p->fst2,p->alphabet);

--- a/LocatePattern.cpp
+++ b/LocatePattern.cpp
@@ -174,17 +174,17 @@ unichar** create_jamo_tags(Korean* korean,struct string_hash* tokens) {
 unichar** res=(unichar**)malloc(tokens->size*sizeof(unichar*));
 unichar foo[1024];
 for (int i=0;i<tokens->size;i++) {
-	if (!u_strcmp(tokens->value[i],"{S}")) {
-		res[i]=u_strdup("{S}");
-	} else {
-	   Hanguls_to_Jamos(tokens->value[i],foo,korean,0);
-	   res[i]=u_strdup(foo);
-	   /*error("<%S> (%x) => \n",tokens->value[i],tokens->value[i][0]);
-	   for (int j=0;foo[j]!=0;j++) {
-		   error("[ %C %x] ",foo[j],foo[j]);
-	   }
-	   error("\n");*/
-	}
+    if (!u_strcmp(tokens->value[i],"{S}")) {
+        res[i]=u_strdup("{S}");
+    } else {
+       Hanguls_to_Jamos(tokens->value[i],foo,korean,0);
+       res[i]=u_strdup(foo);
+       /*error("<%S> (%x) => \n",tokens->value[i],tokens->value[i][0]);
+       for (int j=0;foo[j]!=0;j++) {
+           error("[ %C %x] ",foo[j],foo[j]);
+       }
+       error("\n");*/
+    }
 }
 return res;
 }
@@ -208,26 +208,26 @@ U_FILE* info;
 struct locate_parameters* p=new_locate_parameters();
 
 if (stack_max>0) {
-	p->stack_max = stack_max;
+    p->stack_max = stack_max;
 }
 
 if (max_matches_at_token_pos>0) {
-	p->max_matches_at_token_pos = max_matches_at_token_pos;
+    p->max_matches_at_token_pos = max_matches_at_token_pos;
 }
 
 if (max_matches_per_subgraph>0) {
-	p->max_matches_per_subgraph = max_matches_per_subgraph;
+    p->max_matches_per_subgraph = max_matches_per_subgraph;
 }
 
 if (max_errors>0) {
-	p->max_errors = max_errors;
+    p->max_errors = max_errors;
 }
 
 size_t step_filename_buffer = (((FILENAME_MAX / 0x10) + 1) * 0x10);
 char* buffer_filename = (char*)malloc(step_filename_buffer * 3);
 if (buffer_filename == NULL)
 {
-	fatal_alloc_error("locate_pattern");
+    fatal_alloc_error("locate_pattern");
 }
 
 p->text_cod=af_open_mapfile(text_cod,MAPFILE_OPTION_READ,0);
@@ -267,7 +267,7 @@ char* morpho_bin = (buffer_filename + (step_filename_buffer * 2));
 strcpy(morpho_bin,dynamicDir);
 strcat(morpho_bin,"morpho.bin");
 if (arabic_rules!=NULL && arabic_rules[0]!='\0') {
-	load_arabic_typo_rules(vec,arabic_rules,&(p->arabic));
+    load_arabic_typo_rules(vec,arabic_rules,&(p->arabic));
 }
 out=u_fopen(vec,concord,U_WRITE);
 if (out==NULL) {
@@ -304,9 +304,9 @@ extract_semantic_codes(vec,dlf,semantic_codes);
 extract_semantic_codes(vec,dlc,semantic_codes);
 
 if (is_cancelling_requested() != 0) {
-	   error("user cancel request.\n");
-	   free_alphabet(p->alphabet);
-	   free_string_hash(semantic_codes);
+       error("user cancel request.\n");
+       free_alphabet(p->alphabet);
+       free_string_hash(semantic_codes);
        af_release_mapfile_pointer(p->text_cod,p->buffer);
        af_close_mapfile(p->text_cod);
        free_stack_unichar(p->stack);
@@ -314,8 +314,8 @@ if (is_cancelling_requested() != 0) {
        if (info!=NULL) u_fclose(info);
        u_fclose(out);
        free(buffer_filename);
-	   return 0;
-	}
+       return 0;
+    }
 
 u_printf("Loading fst2...\n");
 struct FST2_free_info fst2load_free;
@@ -334,17 +334,17 @@ if (fst2load==NULL) {
    return 0;
 }
 if (fst2load->debug) {
-	/* If Locate uses a debug fst2, we force the output mode to MERGE,
-	 * we allow ambiguous outputs and we write graph names into the
-	 * concordance file */
-	p->output_policy=MERGE_OUTPUTS;
-	p->ambiguous_output_policy=ALLOW_AMBIGUOUS_OUTPUTS;
-	p->debug=1;
-	u_fprintf(out,"#D\n");
-	u_fprintf(out,"%d\n",fst2load->number_of_graphs);
-	for (int i=0;i<fst2load->number_of_graphs;i++) {
-		u_fprintf(out,"%S\n",fst2load->graph_names[i+1]);
-	}
+    /* If Locate uses a debug fst2, we force the output mode to MERGE,
+     * we allow ambiguous outputs and we write graph names into the
+     * concordance file */
+    p->output_policy=MERGE_OUTPUTS;
+    p->ambiguous_output_policy=ALLOW_AMBIGUOUS_OUTPUTS;
+    p->debug=1;
+    u_fprintf(out,"#D\n");
+    u_fprintf(out,"%d\n",fst2load->number_of_graphs);
+    for (int i=0;i<fst2load->number_of_graphs;i++) {
+        u_fprintf(out,"%S\n",fst2load->graph_names[i+1]);
+    }
 }
 switch(p->real_output_policy) {
    case IGNORE_OUTPUTS: u_fprintf(out,"#I\n"); break;
@@ -417,7 +417,7 @@ Abstract_allocator locate_work_abstract_allocator = locate_abstract_allocator;
 p->match_cache=(LocateCache*)malloc_cb(p->tokens->size * sizeof(LocateCache),locate_work_abstract_allocator);
 memset(p->match_cache,0,p->tokens->size * sizeof(LocateCache));
 if (p->match_cache==NULL) {
-	fatal_alloc_error("locate_pattern");
+    fatal_alloc_error("locate_pattern");
 }
 
 #ifdef REGEX_FACADE_ENGINE
@@ -514,8 +514,8 @@ locate_recycle_locate_trace_info_allocator=create_abstract_allocator("locate_pat
 u_printf("Optimizing fst2...\n");
 p->optimized_states=build_optimized_fst2_states(p->input_variables,p->output_variables,p->fst2,locate_abstract_allocator);
 if (is_korean) {
-	p->korean=new Korean(p->alphabet);
-	p->jamo_tags=create_jamo_tags(p->korean,p->tokens);
+    p->korean=new Korean(p->alphabet);
+    p->jamo_tags=create_jamo_tags(p->korean,p->tokens);
 }
 p->failfast=new_bit_array(n_text_tokens,ONE_BIT);
 
@@ -540,10 +540,10 @@ if (info!=NULL) u_fclose(info);
 u_fclose(out);
 
 if (p->match_cache!=NULL) {
-	for (int i=0;i<p->tokens->size;i++) {
-		free_LocateCache(p->match_cache[i],locate_work_abstract_allocator);
-	}
-	free_cb(p->match_cache,locate_work_abstract_allocator);
+    for (int i=0;i<p->tokens->size;i++) {
+        free_LocateCache(p->match_cache[i],locate_work_abstract_allocator);
+    }
+    free_cb(p->match_cache,locate_work_abstract_allocator);
 }
 int free_abstract_allocator_item=(get_allocator_cb_flag(locate_abstract_allocator) & AllocatorGetFlagAutoFreePresent) ? 0 : 1;
 
@@ -573,15 +573,15 @@ morphlogical_content_buffer_recycle_abstract_allocator=NULL;
 /* We don't free 'parameters->tags' because it was just a link on 'parameters->fst2->tags' */
 free_alphabet(p->alphabet);
 if (p->korean!=NULL) {
-	delete p->korean;
+    delete p->korean;
 }
 if (p->jamo_tags!=NULL) {
-	/* jamo tags must be freed before tokens, because we need to know how
-	 * many jamo tags there are, and this number is the number of tokens */
-	for (int i=0;i<p->tokens->size;i++) {
-		free(p->jamo_tags[i]);
-	}
-	free(p->jamo_tags);
+    /* jamo tags must be freed before tokens, because we need to know how
+     * many jamo tags there are, and this number is the number of tokens */
+    for (int i=0;i<p->tokens->size;i++) {
+        free(p->jamo_tags[i]);
+    }
+    free(p->jamo_tags);
 }
 free_string_hash(p->tokens);
 free_lemma_node(root);
@@ -595,7 +595,7 @@ free_FilterSet(p->filters);
 free_FilterMatchIndex(p->filter_match_index);
 #endif
 for (int i=0;i<p->n_morpho_dics;i++) {
-	free_Dictionary(p->morpho_dic[i]);
+    free_Dictionary(p->morpho_dic[i]);
    /*free_abstract_INF(p->morpho_dic_inf[i],&(p->morpho_dic_inf_free[i]));
    free_abstract_BIN(p->morpho_dic_bin[i],&(p->morpho_dic_bin_free[i]));*/
 }
@@ -896,7 +896,7 @@ while (EOF!=readline(line,f)) {
    free_list_int(ptr_copy,load_dic_list_int_recycle_abstract_allocator);
    if (!is_a_simple_word(entry->inflected,parameters->tokenization_policy,alphabet)) {
       /* If the inflected form is a compound word */
-	  if (is_DIC_pattern || is_CDIC_pattern) {
+      if (is_DIC_pattern || is_CDIC_pattern) {
          /* If the .fst2 contains "<DIC>" and/or "<CDIC>", then we
           * must note that all compound words can be matched by them */
          add_compound_word_with_no_pattern(entry->inflected,alphabet,tokens,parameters->DLC_tree,parameters->tokenization_policy);

--- a/LocatePattern.h
+++ b/LocatePattern.h
@@ -70,23 +70,23 @@ struct locate_parameters ;
 
 struct locate_trace_info
 {
-	int size_struct_locate_trace_info;
-	int is_on_morphlogical;
+    int size_struct_locate_trace_info;
+    int is_on_morphlogical;
 
-	OptimizedFst2State current_state;
+    OptimizedFst2State current_state;
 
-	int current_state_index;
-	int pos_in_tokens;
-	int pos_in_chars;
+    int current_state_index;
+    int pos_in_tokens;
+    int pos_in_chars;
 
-	int n_matches;
-	struct parsing_info** matches; /* current match list. Irrelevant if graph_depth==0 */
-	struct list_context* ctx; /* information about the current context, if any */
-	struct locate_parameters* p; /* miscellaneous parameters needed by the function */
-	unichar* jamo;
-	int pos_in_jamo;
+    int n_matches;
+    struct parsing_info** matches; /* current match list. Irrelevant if graph_depth==0 */
+    struct list_context* ctx; /* information about the current context, if any */
+    struct locate_parameters* p; /* miscellaneous parameters needed by the function */
+    unichar* jamo;
+    int pos_in_jamo;
 
-	int step_number;
+    int step_number;
 } ;
 
 typedef int (ABSTRACT_CALLBACK_UNITEX* t_fnc_locate_trace_step)
@@ -126,7 +126,7 @@ struct locate_parameters {
    Variables* input_variables;
    OutputVariables* output_variables;
 
-   
+
    int graph_depth;
    int explore_depth;
 
@@ -214,7 +214,7 @@ struct locate_parameters {
 
    int is_in_cancel_state;
    int is_in_trace_state;
-	
+
    /* The token buffer used to parse the text. This is a pointer
     * that must be initialized after mapping the 'text.cod' file */
    int buffer_size;
@@ -362,7 +362,7 @@ struct locate_parameters {
 /* #define STACK_MAX 1000 The maximal size of recursive calls of the
                           function parcourir_opt =~ the maximal number
                           of tokens to be recognized in one match */
-   int stack_max;   
+   int stack_max;
 
 
 /* #define MAX_MATCHES_AT_TOKEN_POS 400 The maximal number of matches

--- a/LocateTfst.cpp
+++ b/LocateTfst.cpp
@@ -176,7 +176,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
              strcpy(alphabet,options.vars()->optarg);
              break;
    case 'K': is_korean=1;
-   	   	   	  match_word_boundaries=0;
+              match_word_boundaries=0;
               break;
    case 'l': search_limit=NO_MATCH_LIMIT; break;
    case 'g': if (options.vars()->optarg[0]=='\0') {
@@ -235,19 +235,19 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'v': {
-	   unichar* key=u_strdup(options.vars()->optarg);
-	   unichar* value=u_strchr(key,'=');
-	   if (value==NULL) {
-		   error("Invalid variable injection: %s\n",options.vars()->optarg);
+       unichar* key=u_strdup(options.vars()->optarg);
+       unichar* value=u_strchr(key,'=');
+       if (value==NULL) {
+           error("Invalid variable injection: %s\n",options.vars()->optarg);
        free_vector_ptr(injected);
        return USAGE_ERROR_CODE;
-	   }
-	   (*value)='\0';
-	   value++;
-	   value=u_strdup(value);
-	   vector_ptr_add(injected,key);
-	   vector_ptr_add(injected,value);
-	   break;
+       }
+       (*value)='\0';
+       value++;
+       value=u_strdup(value);
+       vector_ptr_add(injected,key);
+       vector_ptr_add(injected,value);
+       break;
    }
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_LocateTfst[index].name);

--- a/LocateTfst.cpp
+++ b/LocateTfst.cpp
@@ -192,14 +192,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
              if ((strcmp(options.vars()->optarg,"tilde")!=0) && (strcmp(options.vars()->optarg,"~")!=0)) {
                  error("You must specify a valid argument for negation operator\n");
                  free_vector_ptr(injected);
-                 return USAGE_ERROR_CODE;                 
+                 return USAGE_ERROR_CODE;
              }
              break;
    case 'n': if (1!=sscanf(options.vars()->optarg,"%d%c",&search_limit,&foo) || search_limit<=0) {
                 /* foo is used to check that the search limit is not like "45gjh" */
                 error("Invalid search limit argument: %s\n",options.vars()->optarg);
                 free_vector_ptr(injected);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'S': match_policy=SHORTEST_MATCHES; break;
@@ -215,7 +215,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
    case 'z': ambiguous_output_policy=IGNORE_AMBIGUOUS_OUTPUTS; break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 1: tagging=1; break;
    case 2: single_tags_only=1; break;
@@ -223,14 +223,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
                 free_vector_ptr(injected);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
    case 'q': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_encoding argument\n");
                 free_vector_ptr(injected);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
@@ -240,7 +240,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_LocateTfst,lopts_LocateT
 	   if (value==NULL) {
 		   error("Invalid variable injection: %s\n",options.vars()->optarg);
        free_vector_ptr(injected);
-       return USAGE_ERROR_CODE;       
+       return USAGE_ERROR_CODE;
 	   }
 	   (*value)='\0';
 	   value++;

--- a/LocateTfstMatches.cpp
+++ b/LocateTfstMatches.cpp
@@ -511,7 +511,7 @@ return 1;
 
 /**
  * Explores all the partial matches to produce outputs in MERGE or REPLACE mode.
- * 
+ *
  * If *var_starts!=NULL, it means that there are pending $var_start( tags
  * that wait for being taken into account when a text dependent tag is found.
  */
@@ -616,7 +616,7 @@ while (text_tags!=NULL) {
           set_output_variable_pending(infos->output_variables,fst2_tag->variable);
           goto restore_dic_variable;
       } else if (fst2_tag->type==BEGIN_VAR_TAG) {
-         /* If we have a variable start tag $a(, we add it to our 
+         /* If we have a variable start tag $a(, we add it to our
           * variable tag list */
          struct transduction_variable* v=get_transduction_variable(infos->input_variables,fst2_tag->variable);
          int old_value=v->start_in_tokens;
@@ -631,7 +631,7 @@ while (text_tags!=NULL) {
          free_list_pointer(*var_starts);
          (*var_starts)=NULL;
          v->start_in_tokens=old_value;
-         /* If we have a $a( tag, we know that we can only have just one text tag 
+         /* If we have a $a( tag, we know that we can only have just one text tag
           * with special value -1 */
          goto restore_dic_variable;
       } else if (fst2_tag->type==END_VAR_TAG) {
@@ -651,7 +651,7 @@ while (text_tags!=NULL) {
             goto restore_dic_variable;
          }
       } else if (fst2_tag->type==LEFT_CONTEXT_TAG) {
-         /* If we have found a $* tag, we must reset the stack string and the 
+         /* If we have found a $* tag, we must reset the stack string and the
           * start position, so we save them */
          unichar* old_stack=u_strdup(s->str);
          int old_pos_token=element->m.start_pos_in_token;
@@ -660,17 +660,17 @@ while (text_tags!=NULL) {
          /* We set the new values */
          empty(s);
          element->m.start_pos_in_token=LEFT_CONTEXT_PENDING;
-         /* We must reset last_tag to -1, because is not, we will have an 
+         /* We must reset last_tag to -1, because is not, we will have an
           * extra space on the left of the match */
          explore_match_for_MERGE_or_REPLACE_mode(infos,element,items,current_item+1,s,-1,var_starts);
-         
+
          /* And we restore previous values */
          element->m.start_pos_in_token=old_pos_token;
          element->m.start_pos_in_char=old_pos_char;
          element->m.start_pos_in_letter=old_pos_letter;
          u_strcpy(s,old_stack);
          free(old_stack);
-         /* If we have a $* tag, we know that we can only have just one text tag 
+         /* If we have a $* tag, we know that we can only have just one text tag
           * with special value -1 */
          goto restore_dic_variable;
       } else if (fst2_tag->type==BEGIN_POSITIVE_CONTEXT_TAG) {
@@ -681,7 +681,7 @@ while (text_tags!=NULL) {
       /* We update the last tag */
       last_tag=text_tags->n;
       /* If the current text tag is not a text independent one */
-      
+
       /* If there are some pending $a( tags, we set them to the current tag */
       if (var_starts!=NULL) {
          struct list_pointer* ptr=(*var_starts);
@@ -691,7 +691,7 @@ while (text_tags!=NULL) {
             ptr=ptr->next;
          }
       }
-      int previous_start_token,previous_start_char; 
+      int previous_start_token,previous_start_char;
       if (last_text_dependent_tfst_tag!=-1) {
          /* If the item is not the first, we must insert the original text that is
           * between the end of the previous merged text and the beginning of the
@@ -738,7 +738,7 @@ while (text_tags!=NULL) {
    free_list_pointer(ptr2);
    if (infos->ambiguous_output_policy==IGNORE_AMBIGUOUS_OUTPUTS) {
       /* If we don't want ambiguous outputs, then the first path is
-       * enough for our purpose */ 
+       * enough for our purpose */
       goto restore_dic_variable;
    }
    text_tags=text_tags->next;

--- a/LocateTfstMatches.cpp
+++ b/LocateTfstMatches.cpp
@@ -182,18 +182,18 @@ while (list!=NULL && list!=limit && list->pointed_by==0) {
  * of the tfst_match.
  */
 struct tfst_simple_match_list* new_tfst_simple_match_list(struct tfst_simple_match_list* e,
-		                                                  struct tfst_simple_match_list* next) {
+                                                          struct tfst_simple_match_list* next) {
 struct tfst_simple_match_list* m=(struct tfst_simple_match_list*)malloc(sizeof(struct tfst_simple_match_list));
 if (m==NULL) {
-	fatal_alloc_error("new_tfst_simple_match_list");
+    fatal_alloc_error("new_tfst_simple_match_list");
 }
 memcpy(m,e,sizeof(struct tfst_simple_match_list));
 if (m->output!=NULL) {
-	/* If there was an output, we have to clone it */
-	m->output=u_strdup(m->output);
+    /* If there was an output, we have to clone it */
+    m->output=u_strdup(m->output);
 }
 if (m->match!=NULL) {
-	(m->match->pointed_by)++;
+    (m->match->pointed_by)++;
 }
 m->next=next;
 return m;
@@ -206,10 +206,10 @@ return m;
  */
 void free_tfst_simple_match_list(struct tfst_simple_match_list* m) {
 if (m==NULL) {
-	return;
+    return;
 }
 if (m->match!=NULL) {
-	(m->match->pointed_by)--;
+    (m->match->pointed_by)--;
 }
 free(m->output);
 free(m);
@@ -282,16 +282,16 @@ struct list_int* tags=first_text_dependent_tag->text_tag_numbers;
 while (tags!=NULL) {
    if (tags->n!=-1) {
       /* We only consider tags that are not text independent */
-	   TfstTag* t=(TfstTag*)(infos->tfst->tags->tab[tags->n]);
-	   if (e->m.end_pos_in_token==-1 || e->m.end_pos_in_token<t->m.end_pos_in_token
-	       || e->m.end_pos_in_char<t->m.end_pos_in_char
-	       || e->m.end_pos_in_letter<t->m.end_pos_in_letter) {
-		   e->m.end_pos_in_token=t->m.end_pos_in_token;
-		   e->m.end_pos_in_char=t->m.end_pos_in_char;
-		   e->m.end_pos_in_letter=t->m.end_pos_in_letter;
-	   }
+       TfstTag* t=(TfstTag*)(infos->tfst->tags->tab[tags->n]);
+       if (e->m.end_pos_in_token==-1 || e->m.end_pos_in_token<t->m.end_pos_in_token
+           || e->m.end_pos_in_char<t->m.end_pos_in_char
+           || e->m.end_pos_in_letter<t->m.end_pos_in_letter) {
+           e->m.end_pos_in_token=t->m.end_pos_in_token;
+           e->m.end_pos_in_char=t->m.end_pos_in_char;
+           e->m.end_pos_in_letter=t->m.end_pos_in_letter;
+       }
    }
-	tags=tags->next;
+    tags=tags->next;
 }
 
 /* Then, we locate the last element in order to get information about the start offset */
@@ -303,11 +303,11 @@ if (last_text_dependent_tag==NULL) {
 }
 e->start=last_text_dependent_tag->source_state_text;
 if (infos->single_tags_only &&
-	(last_text_dependent_tag->source_state_text!=first_text_dependent_tag->source_state_text
-			|| last_text_dependent_tag->dest_state_text!=first_text_dependent_tag->dest_state_text)) {
-	/* In lemmatize mode, we only allow results that match one single text tag */
-	e->m.end_pos_in_token=-1;
-	return;
+    (last_text_dependent_tag->source_state_text!=first_text_dependent_tag->source_state_text
+            || last_text_dependent_tag->dest_state_text!=first_text_dependent_tag->dest_state_text)) {
+    /* In lemmatize mode, we only allow results that match one single text tag */
+    e->m.end_pos_in_token=-1;
+    return;
 }
 e->m.start_pos_in_token=-1;
 e->m.start_pos_in_char=-1;
@@ -316,16 +316,16 @@ tags=last_text_dependent_tag->text_tag_numbers;
 while (tags!=NULL) {
    if (tags->n!=-1) {
       /* We only consider tags that are not text independent */
-	   TfstTag* t=(TfstTag*)(infos->tfst->tags->tab[tags->n]);
-	   if (e->m.start_pos_in_token==-1 || e->m.start_pos_in_token>t->m.start_pos_in_token
-	       || e->m.start_pos_in_char>t->m.start_pos_in_char
-	       || e->m.start_pos_in_letter>t->m.start_pos_in_letter) {
-		   e->m.start_pos_in_token=t->m.start_pos_in_token;
-		   e->m.start_pos_in_char=t->m.start_pos_in_char;
-		   e->m.start_pos_in_letter=t->m.start_pos_in_letter;
-	   }
+       TfstTag* t=(TfstTag*)(infos->tfst->tags->tab[tags->n]);
+       if (e->m.start_pos_in_token==-1 || e->m.start_pos_in_token>t->m.start_pos_in_token
+           || e->m.start_pos_in_char>t->m.start_pos_in_char
+           || e->m.start_pos_in_letter>t->m.start_pos_in_letter) {
+           e->m.start_pos_in_token=t->m.start_pos_in_token;
+           e->m.start_pos_in_char=t->m.start_pos_in_char;
+           e->m.start_pos_in_letter=t->m.start_pos_in_letter;
+       }
    }
-	tags=tags->next;
+    tags=tags->next;
 }
 /* Finally, we adjust offsets with the base offset of the current sentence */
 e->m.start_pos_in_token+=infos->tfst->offset_in_tokens;
@@ -370,68 +370,68 @@ dest->output=u_strdup(src->output);
  */
 struct tfst_simple_match_list* add_element_to_list(struct locate_tfst_infos* p,struct tfst_simple_match_list* list,struct tfst_simple_match_list* e) {
 if (list==NULL) {
-	/* We can always add a match to the empty list */
-	return new_tfst_simple_match_list(e,NULL);
+    /* We can always add a match to the empty list */
+    return new_tfst_simple_match_list(e,NULL);
 }
 switch (compare_matches(&(list->m),&(e->m))) {
    case A_BEFORE_B:
    case A_BEFORE_B_OVERLAP: {
-	   /* If the candidate starts after the end of the current match, then we have to go on,
-	    * no matter the mode (shortest, longest or all matches) */
-	   list->next=add_element_to_list(p,list->next,e);
-	   return list;
+       /* If the candidate starts after the end of the current match, then we have to go on,
+        * no matter the mode (shortest, longest or all matches) */
+       list->next=add_element_to_list(p,list->next,e);
+       return list;
    }
 
    case A_INCLUDES_B: {
-	   if (p->match_policy==SHORTEST_MATCHES) {
-		   /* e must replace the current match in the list */
-		   replace_match(list,e);
-		   return list;
-	   } else if (p->match_policy==LONGEST_MATCHES) {
-		   /* Our match is shorter than a match in the list, we discard it */
-		   return list;
-	   } else {
-		   list->next=add_element_to_list(p,list->next,e);
-		   return list;
-	   }
+       if (p->match_policy==SHORTEST_MATCHES) {
+           /* e must replace the current match in the list */
+           replace_match(list,e);
+           return list;
+       } else if (p->match_policy==LONGEST_MATCHES) {
+           /* Our match is shorter than a match in the list, we discard it */
+           return list;
+       } else {
+           list->next=add_element_to_list(p,list->next,e);
+           return list;
+       }
    }
 
    case A_EQUALS_B: {
-	   /* In any mode we replace the existing match by the new one, except if we allow
-	    * ambiguous outputs */
-	   if (u_strcmp(list->output,e->output)) {
-		   if (p->ambiguous_output_policy==ALLOW_AMBIGUOUS_OUTPUTS) {
-			   list=new_tfst_simple_match_list(e,list);
-			   return list;
-		   } else {
-				/* If we don't allow ambiguous outputs, we have to print an error message */
-				error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",list->output,e->output);
-		   }
-	   }
-	   replace_match(list,e);
-	   return list;
+       /* In any mode we replace the existing match by the new one, except if we allow
+        * ambiguous outputs */
+       if (u_strcmp(list->output,e->output)) {
+           if (p->ambiguous_output_policy==ALLOW_AMBIGUOUS_OUTPUTS) {
+               list=new_tfst_simple_match_list(e,list);
+               return list;
+           } else {
+                /* If we don't allow ambiguous outputs, we have to print an error message */
+                error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",list->output,e->output);
+           }
+       }
+       replace_match(list,e);
+       return list;
    }
 
    case B_INCLUDES_A: {
-	   if (p->match_policy==SHORTEST_MATCHES) {
-		   /* Our match is longer than a match in the list, we discard it */
-		   return list;
-   	   } else if (p->match_policy==LONGEST_MATCHES) {
-   		   /* e must replace the current match in the list */
-   		   replace_match(list,e);
-   		   return list;
-   	   } else {
-   		   list->next=add_element_to_list(p,list->next,e);
-   		   return list;
-   	   }
+       if (p->match_policy==SHORTEST_MATCHES) {
+           /* Our match is longer than a match in the list, we discard it */
+           return list;
+       } else if (p->match_policy==LONGEST_MATCHES) {
+           /* e must replace the current match in the list */
+           replace_match(list,e);
+           return list;
+       } else {
+           list->next=add_element_to_list(p,list->next,e);
+           return list;
+       }
    }
 
    case A_AFTER_B:
    case A_AFTER_B_OVERLAP: {
-	   /* If the candidate ends before the start of the current match, then we have to insert it
-	    * no matter the mode (shortest, longest or all matches) */
-	   list=new_tfst_simple_match_list(e,list);
-	   return list;
+       /* If the candidate ends before the start of the current match, then we have to insert it
+        * no matter the mode (shortest, longest or all matches) */
+       list=new_tfst_simple_match_list(e,list);
+       return list;
    }
 }
 /* Should not arrive here */
@@ -460,7 +460,7 @@ int is_capture_variable(unichar* output,unichar* name) {
 if (output==NULL || output[0]!='$' || output[1]!=':') return 0;
 int i=2,j=0;
 while (is_variable_char(output[i])) {
-	name[j++]=output[i++];
+    name[j++]=output[i++];
 }
 if (output[i]!='$' || output[i+1]!='\0') return 0;
 name[j]='\0';
@@ -474,35 +474,35 @@ return 1;
  * policy is IGNORE_VARIABLE_ERROR.
  */
 int do_variable_capture(int tfst_tag_number, int fst2_tag_number,
-		struct locate_tfst_infos* infos, unichar* name) {
+        struct locate_tfst_infos* infos, unichar* name) {
 if (tfst_tag_number == -1) {
-	/* If we have a text independent match like <E>/$:X$, it's an error case */
-	switch (infos->variable_error_policy) {
-		case EXIT_ON_VARIABLE_ERRORS:
-			fatal_error(
-				"Should not have capture variable $:%S$ associated to text independent input %S\n",
-				name, infos->fst2->tags[fst2_tag_number]->input);
-		case IGNORE_VARIABLE_ERRORS: return 1;
-		case BACKTRACK_ON_VARIABLE_ERRORS: return 0;
-	}
+    /* If we have a text independent match like <E>/$:X$, it's an error case */
+    switch (infos->variable_error_policy) {
+        case EXIT_ON_VARIABLE_ERRORS:
+            fatal_error(
+                "Should not have capture variable $:%S$ associated to text independent input %S\n",
+                name, infos->fst2->tags[fst2_tag_number]->input);
+        case IGNORE_VARIABLE_ERRORS: return 1;
+        case BACKTRACK_ON_VARIABLE_ERRORS: return 0;
+    }
 }
 TfstTag* tag = (TfstTag*) (infos->tfst->tags->tab[tfst_tag_number]);
 if (tag->content[0] != '{' || tag->content[1] == '\0') {
-	/* If we have a non tagged token like "foo" */
-	switch (infos->variable_error_policy) {
-		case EXIT_ON_VARIABLE_ERRORS:
-			fatal_error(
-				"Should not have capture variable $:%S$ associated to a tag that may capture untagged tokens: %S\n",
-				name, infos->fst2->tags[fst2_tag_number]->input);
-		case IGNORE_VARIABLE_ERRORS: return 1;
-		case BACKTRACK_ON_VARIABLE_ERRORS: return 0;
-	}
+    /* If we have a non tagged token like "foo" */
+    switch (infos->variable_error_policy) {
+        case EXIT_ON_VARIABLE_ERRORS:
+            fatal_error(
+                "Should not have capture variable $:%S$ associated to a tag that may capture untagged tokens: %S\n",
+                name, infos->fst2->tags[fst2_tag_number]->input);
+        case IGNORE_VARIABLE_ERRORS: return 1;
+        case BACKTRACK_ON_VARIABLE_ERRORS: return 0;
+    }
 }
 /* We can capture the tag */
 struct dela_entry* e=tokenize_tag_token(tag->content,1);
 if (e==NULL) {
-	/* Should not happen */
-	fatal_error("Unexpected tag tokenization error in do_variable_capture for tag:\n%S\n",tag->content);
+    /* Should not happen */
+    fatal_error("Unexpected tag tokenization error in do_variable_capture for tag:\n%S\n",tag->content);
 }
 set_dic_variable(name,e,&(infos->dic_variables),0);
 return 1;
@@ -534,12 +534,12 @@ if (item==NULL) {
    fatal_error("Unexpected NULL item in explore_match_for_MERGE_mode\n");
 }
 if (item->debug_output!=NULL) {
-	/* If we have a debug output, we deal it */
-	u_strcat(s,item->debug_output);
-	explore_match_for_MERGE_or_REPLACE_mode(infos,element,items,current_item+1,s,last_text_dependent_tfst_tag,var_starts);
-	s->len=len;
-	s->str[len]='\0';
-	return;
+    /* If we have a debug output, we deal it */
+    u_strcat(s,item->debug_output);
+    explore_match_for_MERGE_or_REPLACE_mode(infos,element,items,current_item+1,s,last_text_dependent_tfst_tag,var_starts);
+    s->len=len;
+    s->str[len]='\0';
+    return;
 }
 
 
@@ -550,9 +550,9 @@ int capture;
 struct dela_entry* old_value_dela=NULL;
 capture=is_capture_variable(output,name);
 if (capture) {
-	/* If we have a capture variable $:X$, we must save the previous value
-	 * for this dictionary variable */
-	old_value_dela=clone_dela_entry(get_dic_variable(name,infos->dic_variables));
+    /* If we have a capture variable $:X$, we must save the previous value
+     * for this dictionary variable */
+    old_value_dela=clone_dela_entry(get_dic_variable(name,infos->dic_variables));
 }
 
 Match saved_element=element->m;
@@ -566,25 +566,25 @@ while (text_tags!=NULL) {
    captured_chars=0;
    /* We deal with the fst2 tag output, if any */
    if (item->first_time) {
-	   /* We only have to process the output only once,
-	    * since it will have the same effect on all tfst tags.
-	    *
-	    * Example: the fst2 tag "cybercrime/ZZ" may match the two tfst tags "cyber" and
-	    * "crime", but we must process the "ZZ" output only before the first tfst tag "cyber" */
-	   if (capture) {
-		   /* If we have a capture variable, then we have to check whether the tfst tag
-	   	    * is a tagged token or not */
-	   	   int tfst_tag_number=text_tags->n;
-	   	   int fst2_tag_number=item->fst2_transition->tag_number;
-	   	   if (!do_variable_capture(tfst_tag_number,fst2_tag_number,infos,name)) {
-	   		   goto restore_dic_variable;
-	   	   }
-	   } else if (!deal_with_output_tfst(s,output,infos,&captured_chars)) {
+       /* We only have to process the output only once,
+        * since it will have the same effect on all tfst tags.
+        *
+        * Example: the fst2 tag "cybercrime/ZZ" may match the two tfst tags "cyber" and
+        * "crime", but we must process the "ZZ" output only before the first tfst tag "cyber" */
+       if (capture) {
+           /* If we have a capture variable, then we have to check whether the tfst tag
+            * is a tagged token or not */
+           int tfst_tag_number=text_tags->n;
+           int fst2_tag_number=item->fst2_transition->tag_number;
+           if (!do_variable_capture(tfst_tag_number,fst2_tag_number,infos,name)) {
+               goto restore_dic_variable;
+           }
+       } else if (!deal_with_output_tfst(s,output,infos,&captured_chars)) {
          /* We do not take into account matches with variable errors if the
           * process_output_for_tfst_match function has decided that backtracking
           * was necessary, either because of a variable error of because of a
           * $a.SET$ or $a.UNSET$ test */
-		  goto restore_dic_variable;
+          goto restore_dic_variable;
       }
    }
    int last_tag=last_text_dependent_tfst_tag;
@@ -596,17 +596,17 @@ while (text_tags!=NULL) {
           /* If we an output variable start $|a( */
           int var_index=get_value_index(fst2_tag->variable,infos->output_variables->variable_index);
 
-		  Ustring* old_value = new_Ustring();
-		  swap_output_variable_content(infos->output_variables, var_index, old_value);
-		  // now old_value contain the backup
+          Ustring* old_value = new_Ustring();
+          swap_output_variable_content(infos->output_variables, var_index, old_value);
+          // now old_value contain the backup
 
           set_output_variable_pending(infos->output_variables,fst2_tag->variable);
           explore_match_for_MERGE_or_REPLACE_mode(infos,element,items,current_item+1,s,last_tag,var_starts);
           unset_output_variable_pending(infos->output_variables,fst2_tag->variable);
 
-		  // restore the good content from backup
-		  swap_output_variable_content(infos->output_variables, var_index, old_value);
-		  free_Ustring(old_value);
+          // restore the good content from backup
+          swap_output_variable_content(infos->output_variables, var_index, old_value);
+          free_Ustring(old_value);
 
           goto restore_dic_variable;
       } else if (fst2_tag->type==END_OUTPUT_VAR_TAG) {
@@ -674,7 +674,7 @@ while (text_tags!=NULL) {
           * with special value -1 */
          goto restore_dic_variable;
       } else if (fst2_tag->type==BEGIN_POSITIVE_CONTEXT_TAG) {
-    	  fatal_error("problem $[\n");
+          fatal_error("problem $[\n");
       }
    } else {
       current_tag=(TfstTag*)(infos->tfst->tags->tab[text_tags->n]);
@@ -718,7 +718,7 @@ while (text_tags!=NULL) {
       /* Here we have to insert the text that is between current_start and current_end,
        * and then, the ouput of the fst2 transition */
       if (infos->output_policy==MERGE_OUTPUTS) {
-    	  insert_text_interval_tfst(infos,s,previous_start_token,previous_start_char,
+          insert_text_interval_tfst(infos,s,previous_start_token,previous_start_char,
                  current_tag->m.end_pos_in_token,current_tag->m.end_pos_in_char);
       }
    }
@@ -752,9 +752,9 @@ restore_dic_variable:
 /* We redo this about output variables here, since we may have jumped here directly */
 remove_chars_from_output_variables(infos->output_variables,captured_chars);
 if (capture) {
-	/* If we have a capture variable $:X$, we must restore the previous value
-	 * for this dictionary variable */
-	set_dic_variable(name,old_value_dela,&(infos->dic_variables),0);
+    /* If we have a capture variable $:X$, we must restore the previous value
+     * for this dictionary variable */
+    set_dic_variable(name,old_value_dela,&(infos->dic_variables),0);
 }
 }
 
@@ -765,7 +765,7 @@ if (capture) {
  * The output(s) is(are) then used to add matches to the infos->matches list.
  */
 void explore_match_to_get_outputs(struct locate_tfst_infos* infos,struct tfst_match* m,
-		                          struct tfst_simple_match_list* element) {
+                                  struct tfst_simple_match_list* element) {
 /* As m is a reversed list, we first need to get its elements in the right order */
 vector_ptr* items=new_vector_ptr(16);
 fill_vector(items,m);
@@ -794,10 +794,10 @@ if (element.m.end_pos_in_token==-1) {
 //error("match from token %d.%d to %d.%d\n",element.m.start_pos_in_token,element.m.start_pos_in_char,
 //      element.m.end_pos_in_token,element.m.end_pos_in_char);
 if (infos->output_policy==IGNORE_OUTPUTS) {
-	/* The simplest case */
-	infos->matches=add_element_to_list(infos,infos->matches,&element);
+    /* The simplest case */
+    infos->matches=add_element_to_list(infos,infos->matches,&element);
 } else {
-	explore_match_to_get_outputs(infos,m,&element);
+    explore_match_to_get_outputs(infos,m,&element);
 }
 }
 
@@ -813,14 +813,14 @@ void save_tfst_matches(struct locate_tfst_infos* p) {
 struct tfst_simple_match_list* l=p->matches;
 struct tfst_simple_match_list* ptr;
 if (p->number_of_matches==p->search_limit) {
-	/* If we have reached the limit, then we must free all the remaining matches */
-	while (l!=NULL) {
-		ptr=l;
-		l=l->next;
-		free_tfst_simple_match_list(ptr);
-	}
-	p->matches=NULL;
-	return;
+    /* If we have reached the limit, then we must free all the remaining matches */
+    while (l!=NULL) {
+        ptr=l;
+        l=l->next;
+        free_tfst_simple_match_list(ptr);
+    }
+    p->matches=NULL;
+    return;
 }
 U_FILE* f=p->output;
 if (l==NULL) return;
@@ -828,17 +828,17 @@ u_fprintf(f,"%d.%d.%d %d.%d.%d",l->m.start_pos_in_token,l->m.start_pos_in_char,
       l->m.start_pos_in_letter,l->m.end_pos_in_token,
       l->m.end_pos_in_char,l->m.end_pos_in_letter);
 if (l->output!=NULL) {
-	/* If there is an output */
-	u_fprintf(f," ");
-	if (p->tagging) {
-		/* In tagging mode, we add the sentence number as well as
-		 * the start and end states in the .tfst of the match */
-		u_fprintf(f,"%d %d %d:",p->tfst->current_sentence,l->start,l->end);
-	}
-	if (p->debug) {
-		save_real_output_from_debug(f,p->output_policy,l->output);
-	}
-	u_fputs(l->output,f);
+    /* If there is an output */
+    u_fprintf(f," ");
+    if (p->tagging) {
+        /* In tagging mode, we add the sentence number as well as
+         * the start and end states in the .tfst of the match */
+        u_fprintf(f,"%d %d %d:",p->tfst->current_sentence,l->start,l->end);
+    }
+    if (p->debug) {
+        save_real_output_from_debug(f,p->output_policy,l->output);
+    }
+    u_fputs(l->output,f);
 }
 u_fprintf(f,"\n");
 if (p->ambiguous_output_policy==ALLOW_AMBIGUOUS_OUTPUTS) {
@@ -846,14 +846,14 @@ if (p->ambiguous_output_policy==ALLOW_AMBIGUOUS_OUTPUTS) {
    if (!(p->start_position_last_printed_match_token == l->m.start_pos_in_token
          && p->start_position_last_printed_match_char == l->m.start_pos_in_char
          && p->start_position_last_printed_match_letter == l->m.start_pos_in_letter
-	      && p->end_position_last_printed_match_token == l->m.end_pos_in_token
-	      && p->end_position_last_printed_match_char == l->m.end_pos_in_char
-	      && p->end_position_last_printed_match_letter == l->m.end_pos_in_letter)) {
-	   (p->number_of_matches)++;
+          && p->end_position_last_printed_match_token == l->m.end_pos_in_token
+          && p->end_position_last_printed_match_char == l->m.end_pos_in_char
+          && p->end_position_last_printed_match_letter == l->m.end_pos_in_letter)) {
+       (p->number_of_matches)++;
    }
 } else {
-	/* If we don't allow ambiguous outputs, we count the matches */
-	(p->number_of_matches)++;
+    /* If we don't allow ambiguous outputs, we count the matches */
+    (p->number_of_matches)++;
 }
 p->start_position_last_printed_match_token=l->m.start_pos_in_token;
 p->end_position_last_printed_match_token=l->m.end_pos_in_token;
@@ -862,15 +862,15 @@ p->end_position_last_printed_match_char=l->m.end_pos_in_char;
 p->start_position_last_printed_match_letter=l->m.start_pos_in_letter;
 p->end_position_last_printed_match_letter=l->m.end_pos_in_letter;
 if (p->number_of_matches==p->search_limit) {
-	/* If we have reached the search limitation, we free the remaining
-	 * matches and return */
-	while (l!=NULL) {
-		ptr=l;
-		l=l->next;
-		free_tfst_simple_match_list(ptr);
-	}
-	p->matches=NULL;
-	return;
+    /* If we have reached the search limitation, we free the remaining
+     * matches and return */
+    while (l!=NULL) {
+        ptr=l;
+        l=l->next;
+        free_tfst_simple_match_list(ptr);
+    }
+    p->matches=NULL;
+    return;
 }
 ptr=l->next;
 free_tfst_simple_match_list(l);

--- a/LocateTfstMatches.h
+++ b/LocateTfstMatches.h
@@ -44,20 +44,20 @@ namespace unitex {
  * how many times a tfst_match is referenced.
  */
 struct tfst_match {
-	/* If this field is non NULL, then all other fields other than 'next'
-	 * are not to be taken into account */
-	unichar* debug_output;
+    /* If this field is non NULL, then all other fields other than 'next'
+     * are not to be taken into account */
+    unichar* debug_output;
 
    int source_state_text;
    int dest_state_text;
    Transition* fst2_transition;
-   
+
    /* This field is used when 1) a fst2 tag is consumed by several TfstTag and 2) outputs
     * are used. In such a case, we don't want to consider the fst2 tag output more than
     * once, so we use this field to know if it's the first time we use this transition
     * or not */
    int first_time;
-   
+
    int pos_kr;
    int pointed_by;
    struct list_int* text_tag_numbers;
@@ -87,13 +87,13 @@ struct tfst_match_list {
  * in a similar way that 'struct match_list'.
  */
 struct tfst_simple_match_list {
-	struct tfst_match* match;
-	Match m;
-	/* start and end are the tfst states that bound the match */
-	int start;
-	int end;
-	unichar* output;
-	struct tfst_simple_match_list* next;
+    struct tfst_match* match;
+    Match m;
+    /* start and end are the tfst states that bound the match */
+    int start;
+    int end;
+    unichar* output;
+    struct tfst_simple_match_list* next;
 };
 
 

--- a/LocateTfst_lib.cpp
+++ b/LocateTfst_lib.cpp
@@ -36,7 +36,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1
@@ -304,7 +304,7 @@ if (!is_korean) {
 infos->korean=new Korean(infos->alphabet);
 infos->n_jamo_tfst_tags=0;
 infos->jamo_tfst_tags=NULL;
-/* We also initializes the Chinese -> Hangul table */ 
+/* We also initializes the Chinese -> Hangul table */
 infos->n_jamo_fst2_tags=infos->fst2->number_of_tags;
 infos->jamo_fst2_tags=(unichar**)malloc(sizeof(unichar*)*infos->n_jamo_fst2_tags);
 if (infos->jamo_fst2_tags==NULL) {
@@ -425,8 +425,8 @@ void explore_tfst(int* visits,Tfst* tfst,int current_state_in_tfst,
                 struct tfst_match_list* *LIST,
                 struct locate_tfst_infos* infos,
                 /* This is used for Korean only when a fst2 tag contains a token that
-                 * can match several boxes in the tfst. 'pos_kr_in_fst2_tag' represents 
-                 * the current position in the current fst2 tag, or -1 if unused. 
+                 * can match several boxes in the tfst. 'pos_kr_in_fst2_tag' represents
+                 * the current position in the current fst2 tag, or -1 if unused.
                  * 'current_kr_fst2_transition' is the current fst2 transition being explored if
                  * 'pos_kr_in_fst2_tag' is not -1; null otherwise. */
                 int pos_pending_in_fst2_tag,
@@ -539,7 +539,7 @@ if (current_pending_tfst_transition!=NULL) {
                grammar_transition,pos_pending_fst2,current_pending_tfst_transition->tag_number,1);
       }
       else if (result==TEXT_INDEPENDENT_MATCH || result==PARTIAL_MATCH_STATUS) {
-         /* If we have a match independent of the text automaton (i.e. <E>) 
+         /* If we have a match independent of the text automaton (i.e. <E>)
           * or that does not consume all the tfst tag, we go on */
          struct tfst_match* foo=insert_in_tfst_matches(NULL,current_state_in_tfst,current_state_in_tfst,
                                       grammar_transition,pos_pending_tfst,NO_TEXT_TOKEN_WAS_MATCHED,1);
@@ -556,7 +556,7 @@ if (current_pending_tfst_transition!=NULL) {
             foo->next=NULL;
             if (match_element_list!=NULL) {(match_element_list->pointed_by)--;}
             free_tfst_match(foo);
-         } 
+         }
       }
       grammar_transition=grammar_transition->next;
    }
@@ -600,7 +600,7 @@ if (is_final_state(current_state_in_grammar)) {
        * looking for a context, it's an error because every
        * opened context must be closed before the end of the graph. */
       fatal_error("ERROR: unclosed context\n");
-   }   
+   }
    if (graph_depth==0) {
       /* If we are in the main graph, we add a match to the main match list */
       if (match_element_list!=NULL) {
@@ -761,7 +761,7 @@ while (grammar_transition!=NULL) {
       while (text_transition!=NULL) {
          int pos_pending_fst2=-1;
          int pos_pending_tfst=-1;
-         
+
          int result=match_between_text_and_grammar_tags(tfst,(TfstTag*)(tfst->tags->tab[text_transition->tag_number]),
                                                  infos->fst2->tags[grammar_transition->tag_number],
                                                  text_transition->tag_number,
@@ -778,7 +778,7 @@ while (grammar_transition!=NULL) {
                  grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
          } else if (result==PARTIAL_MATCH_STATUS) {
             /* If the fst2 tag was entirely consumed, but not the tfst one,
-             * we must go on. At the opposite of a partial fst2 tag, we don't 
+             * we must go on. At the opposite of a partial fst2 tag, we don't
              * add a normal partial match to 'list', because this must only be done when
              * a tfst tag has matched, and this is not the case here. We add a
              * text independent match, just in order to use the output associated to
@@ -869,7 +869,7 @@ if (grammar_tag->type==BEGIN_VAR_TAG
    return TEXT_INDEPENDENT_MATCH;
 }
 
-/* Here we test the special case of the " " and # tags that are contextual matches, and 
+/* Here we test the special case of the " " and # tags that are contextual matches, and
  * for this reason, that cannot be cached */
 if (!u_strcmp(grammar_tag->input," ")) {
    if ((*pos_pending_tfst_tag)==-1 && is_space_on_the_left_in_tfst(tfst,text_tag)) {
@@ -910,10 +910,10 @@ return result;
 
 /**
  * This function tests if a text tag can be matched by a grammar tag.
- * 
+ *
  * WARNING: as we use a cache that is supposed to be context independent, no
  *          context dependent operation must be done here. Contextual
- *          operations like # or " " must be handled in 
+ *          operations like # or " " must be handled in
  *          'match_between_text_and_grammar_tags'
  */
 int real_match_between_text_and_grammar_tags(Tfst* tfst,TfstTag* text_tag,Fst2Tag grammar_tag,
@@ -983,7 +983,7 @@ if (/*infos->korean &&*/ (*pos_pending_fst2_tag!=-1 || (grammar_tag->input[0]!='
       return OK_MATCH_STATUS;
    }
    if (jamo_fst2[k]=='\0') {
-      /* If we are at the end of the fst2 tag but not at the end of the tfst tag, 
+      /* If we are at the end of the fst2 tag but not at the end of the tfst tag,
        * it's a partial match */
       (*pos_pending_fst2_tag)=-1;
       (*pos_pending_tfst_tag)=j;
@@ -1100,7 +1100,7 @@ if (grammar_tag->input[0]=='<' && grammar_tag->input[1]!='\0') {
       goto no_match;
    }
    if (!u_strcmp(grammar_tag->input,"<!MOT>") || !u_strcmp(grammar_tag->input,"<!WORD>")) {
-      /* <!MOT> matches the opposite of <MOT> 
+      /* <!MOT> matches the opposite of <MOT>
        <!WORD> matches the opposite of <WORD>*/
       if (!is_letter(text_tag->content[pos_in_tfst_input],infos->alphabet)
           && text_entry==NULL) {

--- a/LocateTfst_lib.cpp
+++ b/LocateTfst_lib.cpp
@@ -50,8 +50,8 @@ namespace unitex {
 
 
 void explore_tfst(int* visits,Tfst* tfst,int current_state_in_tfst,
-		          int current_state_in_fst2,int graph_depth,
-		          struct tfst_match* match_element_list,
+                  int current_state_in_fst2,int graph_depth,
+                  struct tfst_match* match_element_list,
                 struct tfst_match_list** LIST,
                 struct locate_tfst_infos* infos,
                 int pos_pending_in_fst2_tag,
@@ -83,23 +83,23 @@ int morphological_filter_is_ok(const unichar* content,Fst2Tag grammar_tag,const 
  */
 Ustring* get_debug_output_in_context(struct tfst_match* match_element_list,struct locate_tfst_infos* infos) {
 if (match_element_list==NULL) {
-	return new_Ustring();
+    return new_Ustring();
 }
 Ustring* s=get_debug_output_in_context(match_element_list->next,infos);
 Transition* t=match_element_list->fst2_transition;
 u_strcat(s,infos->fst2->tags[t->tag_number]->output);
 struct list_int* l=match_element_list->text_tag_numbers;
 if (l!=NULL) {
-	TfstTag* tag=(TfstTag*)(infos->tfst->tags->tab[l->n]);
-	if (tag->content[0]!='{' || tag->content[1]=='\0') {
-		/* Untagged token ? */
-		u_strcat(s,tag->content);
-	} else {
-		/* Real tag ? We only take the inflected form */
-		struct dela_entry* d=tokenize_tag_token(tag->content,1);
-		u_strcat(s,d->inflected);
-		free_dela_entry(d);
-	}
+    TfstTag* tag=(TfstTag*)(infos->tfst->tags->tab[l->n]);
+    if (tag->content[0]!='{' || tag->content[1]=='\0') {
+        /* Untagged token ? */
+        u_strcat(s,tag->content);
+    } else {
+        /* Real tag ? We only take the inflected form */
+        struct dela_entry* d=tokenize_tag_token(tag->content,1);
+        u_strcat(s,d->inflected);
+        free_dela_entry(d);
+    }
 }
 return s;
 }
@@ -112,20 +112,20 @@ return s;
 int locate_tfst(const char* text,const char* grammar,const char* alphabet,const char* output,
                 const VersatileEncodingConfig* vec,
                 MatchPolicy match_policy,
-		          OutputPolicy output_policy,AmbiguousOutputPolicy ambiguous_output_policy,
-		          VariableErrorPolicy variable_error_policy,int search_limit,int is_korean,
-		          int tilde_negation_operator,vector_ptr* injected_vars,int tagging,
-		          int single_tags_only,int match_word_boundaries) {
+                  OutputPolicy output_policy,AmbiguousOutputPolicy ambiguous_output_policy,
+                  VariableErrorPolicy variable_error_policy,int search_limit,int is_korean,
+                  int tilde_negation_operator,vector_ptr* injected_vars,int tagging,
+                  int single_tags_only,int match_word_boundaries) {
 Tfst* tfst=open_text_automaton(vec,text);
 if (tfst==NULL) {
-	return 0;
+    return 0;
 }
 struct FST2_free_info fst2_free;
 struct locate_tfst_infos infos;
 infos.fst2=load_abstract_fst2(vec,grammar,1,&fst2_free);
 if (infos.fst2==NULL) {
-	close_text_automaton(tfst);
-	return 0;
+    close_text_automaton(tfst);
+    return 0;
 }
 infos.tagging=tagging;
 infos.tfst=tfst;
@@ -138,57 +138,57 @@ if (alphabet!=NULL && alphabet[0]!='\0') {
     * in Alphabet.cpp) */
    infos.alphabet=load_alphabet(vec,alphabet,is_korean);
    if (infos.alphabet==NULL) {
-	   close_text_automaton(tfst);
-	   free_abstract_Fst2(infos.fst2,&fst2_free);
-	   error("Cannot load alphabet file: %s\n",alphabet);
-	   return 0;
+       close_text_automaton(tfst);
+       free_abstract_Fst2(infos.fst2,&fst2_free);
+       error("Cannot load alphabet file: %s\n",alphabet);
+       return 0;
    }
 }
 infos.output=u_fopen(vec,output,U_WRITE);
 if (infos.output==NULL) {
-	close_text_automaton(tfst);
-	free_abstract_Fst2(infos.fst2,&fst2_free);
-	free_alphabet(infos.alphabet);
-	error("Cannot open %s\n",output);
-	return 0;
+    close_text_automaton(tfst);
+    free_abstract_Fst2(infos.fst2,&fst2_free);
+    free_alphabet(infos.alphabet);
+    error("Cannot open %s\n",output);
+    return 0;
 }
 infos.real_output_policy=output_policy;
 infos.output_policy=output_policy;
 infos.debug=0;
 if (infos.fst2->debug) {
-	/* If LocateTfst uses a debug fst2, we force the output mode to MERGE,
-	 * we allow ambiguous outputs and we write graph names into the
-	 * concordance file */
-	if (tagging) {
-		fatal_error("--tagging option cannot be used with a debug-compiled .fst2\n");
-	}
-	infos.output_policy=MERGE_OUTPUTS;
-	infos.ambiguous_output_policy=ALLOW_AMBIGUOUS_OUTPUTS;
-	infos.debug=1;
-	u_fprintf(infos.output,"#D\n");
-	u_fprintf(infos.output,"%d\n",infos.fst2->number_of_graphs);
-	for (int i=0;i<infos.fst2->number_of_graphs;i++) {
-		u_fprintf(infos.output,"%S\n",infos.fst2->graph_names[i+1]);
-	}
+    /* If LocateTfst uses a debug fst2, we force the output mode to MERGE,
+     * we allow ambiguous outputs and we write graph names into the
+     * concordance file */
+    if (tagging) {
+        fatal_error("--tagging option cannot be used with a debug-compiled .fst2\n");
+    }
+    infos.output_policy=MERGE_OUTPUTS;
+    infos.ambiguous_output_policy=ALLOW_AMBIGUOUS_OUTPUTS;
+    infos.debug=1;
+    u_fprintf(infos.output,"#D\n");
+    u_fprintf(infos.output,"%d\n",infos.fst2->number_of_graphs);
+    for (int i=0;i<infos.fst2->number_of_graphs;i++) {
+        u_fprintf(infos.output,"%S\n",infos.fst2->graph_names[i+1]);
+    }
 }
 if (tagging) {
-	u_fprintf(infos.output,"#X\n");
+    u_fprintf(infos.output,"#X\n");
 } else {
-	switch (infos.real_output_policy) {
-	case IGNORE_OUTPUTS: u_fprintf(infos.output,"#I\n"); break;
-	case MERGE_OUTPUTS: u_fprintf(infos.output,"#M\n"); break;
-	case REPLACE_OUTPUTS: u_fprintf(infos.output,"#R\n"); break;
-	default: break;
+    switch (infos.real_output_policy) {
+    case IGNORE_OUTPUTS: u_fprintf(infos.output,"#I\n"); break;
+    case MERGE_OUTPUTS: u_fprintf(infos.output,"#M\n"); break;
+    case REPLACE_OUTPUTS: u_fprintf(infos.output,"#R\n"); break;
+    default: break;
 }
 }
 #ifdef REGEX_FACADE_ENGINE
 infos.filters=new_FilterSet(infos.fst2,infos.alphabet);
 infos.matches=NULL;
 if (infos.filters==NULL) {
-	close_text_automaton(tfst);
-	free_abstract_Fst2(infos.fst2,&fst2_free);
-	free_alphabet(infos.alphabet);
-	u_fclose(infos.output);
+    close_text_automaton(tfst);
+    free_abstract_Fst2(infos.fst2,&fst2_free);
+    free_alphabet(infos.alphabet);
+    u_fclose(infos.output);
     error("Cannot compile filter(s)\n");
    return 0;
 }
@@ -214,32 +214,32 @@ infos.contexts=compute_contexts(infos.fst2);
 /* We launch the matching for each sentence */
 for (int i=1;i<=tfst->N && infos.number_of_matches!=infos.search_limit;i++) {
    if (i%100==0) {
-		u_printf("\rSentence %d/%d...",i,tfst->N);
-	}
+        u_printf("\rSentence %d/%d...",i,tfst->N);
+    }
    load_sentence(tfst,i);
-	compute_token_contents(tfst);
-	if (infos.korean!=NULL) {
-	   compute_jamo_tfst_tags(&infos);
-	}
-	infos.matches=NULL;
-	prepare_cache_for_new_sentence(infos.cache,tfst->tags->nbelems);
+    compute_token_contents(tfst);
+    if (infos.korean!=NULL) {
+       compute_jamo_tfst_tags(&infos);
+    }
+    infos.matches=NULL;
+    prepare_cache_for_new_sentence(infos.cache,tfst->tags->nbelems);
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-	int* visits=(int*)malloc(sizeof(int)*(1+tfst->automaton->number_of_states));
+    int* visits=(int*)malloc(sizeof(int)*(1+tfst->automaton->number_of_states));
 #else
-	int visits[tfst->automaton->number_of_states];
+    int visits[tfst->automaton->number_of_states];
 #endif
-	/* Within a sentence graph, we try to match from any state */
-	for (int j=0;j<tfst->automaton->number_of_states;j++) {
-	   for (int k=0;k<tfst->automaton->number_of_states;k++) {
-	      visits[k]=0;
-	   }
-	   explore_tfst(visits,tfst,j,infos.fst2->initial_states[1],0,NULL,NULL,&infos,-1,-1,NULL,NULL,NULL,tilde_negation_operator);
-	}
+    /* Within a sentence graph, we try to match from any state */
+    for (int j=0;j<tfst->automaton->number_of_states;j++) {
+       for (int k=0;k<tfst->automaton->number_of_states;k++) {
+          visits[k]=0;
+       }
+       explore_tfst(visits,tfst,j,infos.fst2->initial_states[1],0,NULL,NULL,&infos,-1,-1,NULL,NULL,NULL,tilde_negation_operator);
+    }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-	free(visits);
+    free(visits);
 #endif
-	save_tfst_matches(&infos);
-	clear_dic_variable_list(&(infos.dic_variables));
+    save_tfst_matches(&infos);
+    clear_dic_variable_list(&(infos.dic_variables));
 }
 u_printf("\rDone.                                    \n");
 /* We save some infos */
@@ -248,16 +248,16 @@ get_path(output,concord_tfst_n);
 strcat(concord_tfst_n,"concord_tfst.n");
 U_FILE* f=u_fopen(vec,concord_tfst_n,U_WRITE);
 if (f==NULL) {
-	error("Cannot save information in %s\n",concord_tfst_n);
+    error("Cannot save information in %s\n",concord_tfst_n);
 } else {
-	u_fprintf(f,"%d match%s",infos.number_of_matches,(infos.number_of_matches<=1)?"":"es");
-	if ((infos.number_of_outputs != infos.number_of_matches)
-	       && (infos.number_of_outputs != 0))
-	     {
-	       u_fprintf(f,"(%d output%s)\n",infos.number_of_outputs,(infos.number_of_outputs<=1)?"":"s");
-	     }
-	u_fprintf(f,"\n");
-	u_fclose(f);
+    u_fprintf(f,"%d match%s",infos.number_of_matches,(infos.number_of_matches<=1)?"":"es");
+    if ((infos.number_of_outputs != infos.number_of_matches)
+           && (infos.number_of_outputs != 0))
+         {
+           u_fprintf(f,"(%d output%s)\n",infos.number_of_outputs,(infos.number_of_outputs<=1)?"":"s");
+         }
+    u_fprintf(f,"\n");
+    u_fclose(f);
 }
 u_printf("%d match%s",infos.number_of_matches,(infos.number_of_matches<=1)?"":"es");
 if ((infos.number_of_outputs != infos.number_of_matches)
@@ -420,8 +420,8 @@ for (int i=0;i<infos->n_jamo_tfst_tags;i++) {
  * Explores in parallel the tfst and the fst2.
  */
 void explore_tfst(int* visits,Tfst* tfst,int current_state_in_tfst,
-		          int current_state_in_fst2,int graph_depth,
-		          struct tfst_match* match_element_list,
+                  int current_state_in_fst2,int graph_depth,
+                  struct tfst_match* match_element_list,
                 struct tfst_match_list* *LIST,
                 struct locate_tfst_infos* infos,
                 /* This is used for Korean only when a fst2 tag contains a token that
@@ -447,9 +447,9 @@ if (current_pending_fst2_transition!=NULL && current_pending_tfst_transition!=NU
 
 /* CASE 1: if we have not finished to explore a fst2 tag in the grammar */
 if (current_pending_fst2_transition!=NULL) {
-	if (infos->match_word_boundaries) {
-		return;
-	}
+    if (infos->match_word_boundaries) {
+        return;
+    }
    struct tfst_match* list=NULL;
    Transition* text_transition=tfst->automaton->states[current_state_in_tfst]->outgoing_transitions;
    /* For a given tag in the grammar, we test all the transitions in the
@@ -514,9 +514,9 @@ if (current_pending_fst2_transition!=NULL) {
 
 /* CASE 2: if we have not finished to explore a tfst tag */
 if (current_pending_tfst_transition!=NULL) {
-	if (infos->match_word_boundaries) {
-		return;
-	}
+    if (infos->match_word_boundaries) {
+        return;
+    }
    Fst2State current_state_in_grammar=infos->fst2->states[current_state_in_fst2];
    Transition* grammar_transition=current_state_in_grammar->transitions;
    struct tfst_match* list=NULL;
@@ -604,13 +604,13 @@ if (is_final_state(current_state_in_grammar)) {
    if (graph_depth==0) {
       /* If we are in the main graph, we add a match to the main match list */
       if (match_element_list!=NULL) {
-    	  add_tfst_match(infos,match_element_list);
+          add_tfst_match(infos,match_element_list);
       }
    } else {
       /* If we are in a subgraph, we add a match to the current match list */
-	   if (match_element_list!=NULL) {
-		  (*LIST)=add_match_in_list((*LIST),match_element_list);
-	   }
+       if (match_element_list!=NULL) {
+          (*LIST)=add_match_in_list((*LIST),match_element_list);
+       }
    }
 }
 
@@ -633,15 +633,15 @@ while (grammar_transition!=NULL) {
           * we decrease its 'pointed_by' variable that was previously increased
           * in the 'add_match_in_list' function */
          if (list_for_subgraph->match!=NULL) {
-        	 (list_for_subgraph->match->pointed_by)--;
-        	 explore_tfst(visits,tfst,list_for_subgraph->match->dest_state_text,
+             (list_for_subgraph->match->pointed_by)--;
+             explore_tfst(visits,tfst,list_for_subgraph->match->dest_state_text,
                            grammar_transition->state_number,
                            graph_depth,list_for_subgraph->match,LIST,infos,-1,-1,NULL,NULL,ctx,tilde_negation_operator);
-        	 /* Finally, we remove, if necessary, the list of match element
-        	  * that was used for storing the subgraph match. This cleaning
-        	  * will only free elements that are not involved in others
-        	  * matches, that is to say element with pointed_by=0 */
-        	 clean_tfst_match_list(list_for_subgraph->match,match_element_list);
+             /* Finally, we remove, if necessary, the list of match element
+              * that was used for storing the subgraph match. This cleaning
+              * will only free elements that are not involved in others
+              * matches, that is to say element with pointed_by=0 */
+             clean_tfst_match_list(list_for_subgraph->match,match_element_list);
          }
          free(list_for_subgraph);
          list_for_subgraph=tmp;
@@ -667,7 +667,7 @@ while (grammar_transition!=NULL) {
             Transition* states=context->positive_mark[n_ctxt+1];
             struct tfst_match* debug_match_element=match_element_list;
             if (infos->debug && c->output!=NULL) {
-            	debug_match_element=new_debug_tfst_match(c->output,match_element_list);
+                debug_match_element=new_debug_tfst_match(c->output,match_element_list);
             }
             while (states!=NULL) {
                explore_tfst(visits,tfst,current_state_in_tfst,states->state_number,
@@ -675,7 +675,7 @@ while (grammar_transition!=NULL) {
                states=states->next;
             }
             if (debug_match_element!=match_element_list) {
-            	free_tfst_match(debug_match_element);
+                free_tfst_match(debug_match_element);
             }
          }
          free_list_context(c);
@@ -721,9 +721,9 @@ while (grammar_transition!=NULL) {
        * and we return */
       ctx->n=1;
       if (infos->debug && ctx->output==NULL) {
-    	  Ustring* output=get_debug_output_in_context(match_element_list,infos);
-    	  set_list_context_output(ctx,output->str);
-    	  free_Ustring(output);
+          Ustring* output=get_debug_output_in_context(match_element_list,infos);
+          set_list_context_output(ctx,output->str);
+          free_Ustring(output);
       }
       return;
       /* End of $] case */
@@ -731,31 +731,31 @@ while (grammar_transition!=NULL) {
       /* Normal case (not a subgraph call) */
       struct tfst_match* list=NULL;
       Transition* text_transition=tfst->automaton->states[current_state_in_tfst]->outgoing_transitions;
-	  if (text_transition==NULL) {
-    	  /* If there is no transition, it should mean that we are on the final state, but
-    	   * even here, some special transitions may match */
-    	  if (!u_strcmp(infos->fst2->tags[e]->input,"<E>")) {
-    		  list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
-    		              grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
-    	  }
-    	  else if (!u_strcmp(infos->fst2->tags[e]->input,"{$}")) {
-    		  /* {$} may match only if we are in the final state of the last sentence */
-    		  if (is_final_state(tfst->automaton->states[current_state_in_tfst])
-    				  && tfst->current_sentence==tfst->N) {
-    			  list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
-    			      		              grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
-    		  }
-    	  }
+      if (text_transition==NULL) {
+          /* If there is no transition, it should mean that we are on the final state, but
+           * even here, some special transitions may match */
+          if (!u_strcmp(infos->fst2->tags[e]->input,"<E>")) {
+              list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
+                          grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
+          }
+          else if (!u_strcmp(infos->fst2->tags[e]->input,"{$}")) {
+              /* {$} may match only if we are in the final state of the last sentence */
+              if (is_final_state(tfst->automaton->states[current_state_in_tfst])
+                      && tfst->current_sentence==tfst->N) {
+                  list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
+                                          grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
+              }
+          }
       }
       /* {^} can be tested without considering text transitions */
-	  if (!u_strcmp(infos->fst2->tags[e]->input,"{^}")) {
-		  /* {^} may match only if we are in the initial state of the first sentence */
-		  if (is_initial_state(tfst->automaton->states[current_state_in_tfst])
-				  && tfst->current_sentence==1) {
-			  list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
-			      		              grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
-		  }
-	  }
+      if (!u_strcmp(infos->fst2->tags[e]->input,"{^}")) {
+          /* {^} may match only if we are in the initial state of the first sentence */
+          if (is_initial_state(tfst->automaton->states[current_state_in_tfst])
+                  && tfst->current_sentence==1) {
+              list=insert_in_tfst_matches(list,current_state_in_tfst,current_state_in_tfst,
+                                      grammar_transition,-1,NO_TEXT_TOKEN_WAS_MATCHED,1);
+          }
+      }
       /* For a given tag in the grammar, we test all the transitions in the
        * text automaton, and we note all the states we can reach */
       while (text_transition!=NULL) {
@@ -814,7 +814,7 @@ while (grammar_transition!=NULL) {
          list->next=match_element_list;
          /* match_element_list is pointed by one more element */
          if (match_element_list!=NULL) {
-        	   (match_element_list->pointed_by)++;
+               (match_element_list->pointed_by)++;
          }
          Transition* tmp_trans=(list->pos_kr!=-1)?list->fst2_transition:NULL;
          int dest_state_in_fst2=(list->pos_kr!=-1)?-1:grammar_transition->state_number;
@@ -850,7 +850,7 @@ if (grammar_tag->type==BEGIN_POSITIVE_CONTEXT_TAG
    || grammar_tag->type==TEXT_START_TAG
    || grammar_tag->type==TEXT_END_TAG) {
    /* A context should not start or end within a text tag, so we fail here */
-	return NO_MATCH_STATUS;
+    return NO_MATCH_STATUS;
 }
 
 /* We start by looking at special fst2 tags */
@@ -938,20 +938,20 @@ if (/*infos->korean &&*/ (*pos_pending_fst2_tag!=-1 || (grammar_tag->input[0]!='
    unichar* jamo_fst2;
    struct dela_entry* my_entry=NULL;
    if (infos->korean) {
-	   jamo_tfst=infos->jamo_tfst_tags[tfst_tag_index];
-	   jamo_fst2=infos->jamo_fst2_tags[fst2_tag_index];
+       jamo_tfst=infos->jamo_tfst_tags[tfst_tag_index];
+       jamo_fst2=infos->jamo_fst2_tags[fst2_tag_index];
    } else {
-	   if (text_tag->content[0]=='{' && text_tag->content[1]!='\0') {
-	         /* text={toto,tutu.XXX} */
-		  my_entry=tokenize_tag_token(text_tag->content,1);
-	   	  if (my_entry==NULL) {
-	   		  fatal_error("NULL text_entry error in match_between_text_and_grammar_tags\n");
-	   	  }
-	   	  jamo_tfst=my_entry->inflected;
-	   } else {
-		   jamo_tfst=text_tag->content;
-	   }
-	   jamo_fst2=grammar_tag->input;
+       if (text_tag->content[0]=='{' && text_tag->content[1]!='\0') {
+             /* text={toto,tutu.XXX} */
+          my_entry=tokenize_tag_token(text_tag->content,1);
+          if (my_entry==NULL) {
+              fatal_error("NULL text_entry error in match_between_text_and_grammar_tags\n");
+          }
+          jamo_tfst=my_entry->inflected;
+       } else {
+           jamo_tfst=text_tag->content;
+       }
+       jamo_fst2=grammar_tag->input;
    }
    int k=(*pos_pending_fst2_tag);
    int j=(*pos_pending_tfst_tag!=-1)?(*pos_pending_tfst_tag):0;
@@ -966,10 +966,10 @@ if (/*infos->korean &&*/ (*pos_pending_fst2_tag!=-1 || (grammar_tag->input[0]!='
          continue;
       }
       if ((grammar_tag->control & RESPECT_CASE_TAG_BIT_MASK && jamo_fst2[k]!=jamo_tfst[j])
-    		  || !is_equal_or_uppercase(jamo_fst2[k],jamo_tfst[j],infos->alphabet)) {
+              || !is_equal_or_uppercase(jamo_fst2[k],jamo_tfst[j],infos->alphabet)) {
          /* If a character doesn't match */
          //error("match failed between tfst=%S and fst2=%S\n",jamo_tfst,jamo_fst2);
-    	 if (my_entry!=NULL) free_dela_entry(my_entry);
+         if (my_entry!=NULL) free_dela_entry(my_entry);
          return NO_MATCH_STATUS;
       }
       k++;
@@ -1006,10 +1006,10 @@ struct dela_entry* text_entry=NULL;
 
 int pos_in_tfst_input = (*pos_pending_tfst_tag)!=-1 ? (*pos_pending_tfst_tag) : 0;
 if (pos_in_tfst_input!=0 && text_tag->content[0]=='{') {
-	   /* pos_in_tfst_input contains a value that is relative to the whole tag like {toto,tutu.XXX},
-	    * so we have to substract 1 to start on the inflected form
-	    */
-	   pos_in_tfst_input--;
+       /* pos_in_tfst_input contains a value that is relative to the whole tag like {toto,tutu.XXX},
+        * so we have to substract 1 to start on the inflected form
+        */
+       pos_in_tfst_input--;
 }
 
 
@@ -1028,24 +1028,24 @@ if (is_letter(grammar_tag->input[0],infos->alphabet)) {
       }
    } else if (text_tag->content[0]=='{' && text_tag->content[1]!='\0') {
       /* text={toto,tutu.XXX} */
-	  text_entry=tokenize_tag_token(text_tag->content,1);
-	  if (text_entry==NULL) {
-		  fatal_error("NULL text_entry error in match_between_text_and_grammar_tags\n");
-	  }
-	  if (grammar_tag->control & RESPECT_CASE_TAG_BIT_MASK) {
+      text_entry=tokenize_tag_token(text_tag->content,1);
+      if (text_entry==NULL) {
+          fatal_error("NULL text_entry error in match_between_text_and_grammar_tags\n");
+      }
+      if (grammar_tag->control & RESPECT_CASE_TAG_BIT_MASK) {
          /* If we must respect case */
-		 if (!u_strcmp(grammar_tag->input,text_entry->inflected+pos_in_tfst_input)) {
-			 goto ok_match;
-		 } else {
-			 goto no_match;
-		 }
+         if (!u_strcmp(grammar_tag->input,text_entry->inflected+pos_in_tfst_input)) {
+             goto ok_match;
+         } else {
+             goto no_match;
+         }
       } else {
          /* If case does not matter */
-    	 if (is_equal_or_uppercase(grammar_tag->input,text_entry->inflected+pos_in_tfst_input,infos->alphabet)) {
-    		 goto ok_match;
-    	 } else {
-    		 goto no_match;
-    	 }
+         if (is_equal_or_uppercase(grammar_tag->input,text_entry->inflected+pos_in_tfst_input,infos->alphabet)) {
+             goto ok_match;
+         } else {
+             goto no_match;
+         }
       }
    }
    return NO_MATCH_STATUS;
@@ -1064,16 +1064,16 @@ if (grammar_tag->input[0]=='{' && u_strcmp(grammar_tag->input,"{S}")) {
       /* We allow case variations on the inflected form :
        * if there is "{tutu,toto.XXX}" in the grammar, we want it
        * to match "{Tutu,toto.XXX}" in the text automaton */
-	  goto no_match;
+      goto no_match;
    }
    if (u_strcmp(grammar_entry->lemma,text_entry->lemma)) {
       /* If lemmas are different,we don't match */
-	  goto no_match;
+      goto no_match;
    }
    if (!same_codes(grammar_entry,text_entry)) {
       /* If grammatical, semantical and inflectional informations
        * are different we don't match*/
-	  goto no_match;
+      goto no_match;
    }
    goto ok_match;
 }
@@ -1082,10 +1082,10 @@ if (grammar_tag->input[0]=='{' && u_strcmp(grammar_tag->input,"{S}")) {
  * We want to match something like "<....>". The
  * <E> case has already been handled in text independent matchings */
 if (grammar_tag->input[0]=='<' && grammar_tag->input[1]!='\0') {
-	/* We tokenize the text tag, if we have one */
-	if (text_tag->content[0]=='{' && text_tag->content[1]!='\0') {
-	   text_entry=tokenize_tag_token(text_tag->content,1);
-	}
+    /* We tokenize the text tag, if we have one */
+    if (text_tag->content[0]=='{' && text_tag->content[1]!='\0') {
+       text_entry=tokenize_tag_token(text_tag->content,1);
+    }
    if (!u_strcmp(grammar_tag->input,"<MOT>") || !u_strcmp(grammar_tag->input,"<WORD>")) {
       /* <MOT> matches a sequence of letters or a tag like {tutu,toto.XXX}, even
        * if 'tutu' is not made of characters,
@@ -1094,7 +1094,7 @@ if (grammar_tag->input[0]=='<' && grammar_tag->input[1]!='\0') {
        * {préciser,.V:W}
        * <WORD> can also be used instead of <MOT> */
       if ((is_letter(text_tag->content[pos_in_tfst_input],infos->alphabet) || text_entry!=NULL)
-    		  && !((*pos_pending_tfst_tag)>0)) {
+              && !((*pos_pending_tfst_tag)>0)) {
          goto ok_match;
       }
       goto no_match;
@@ -1104,7 +1104,7 @@ if (grammar_tag->input[0]=='<' && grammar_tag->input[1]!='\0') {
        <!WORD> matches the opposite of <WORD>*/
       if (!is_letter(text_tag->content[pos_in_tfst_input],infos->alphabet)
           && text_entry==NULL) {
-    	  goto ok_match;
+          goto ok_match;
       }
       goto no_match;
    }
@@ -1232,7 +1232,7 @@ if (grammar_tag->input[0]=='<' && grammar_tag->input[1]!='\0') {
    int ok=is_entry_compatible_with_pattern(text_entry,pattern);
    free_pattern(pattern);
    if ((ok && !negation) || (!ok && negation)) {
-	   goto ok_match;
+       goto ok_match;
    }
    goto no_match;
 }
@@ -1249,7 +1249,7 @@ return NO_MATCH_STATUS;
 ok_match:
 /* We test the morphological filter, if any */
 if (!morphological_filter_is_ok((text_entry!=NULL)?text_entry->inflected:text_tag->content,grammar_tag,infos)) {
-	goto no_match;
+    goto no_match;
 }
 ret_value=OK_MATCH_STATUS;
 goto clean;
@@ -1296,17 +1296,17 @@ return pattern;
  */
 int is_space_on_the_left_in_tfst(Tfst* tfst,TfstTag* tag) {
 if (tag->m.start_pos_in_char==0) {
-	/* The tag starts exactly at the beginning of a token, so we just
-	 * have to look if the previous token was ending with a space. By convention,
-	 * we say that the token #0 has no space on its left */
-	if (tag->m.start_pos_in_token==0) {
-		return 0;
-	}
-	int size_of_previous=tfst->token_sizes->tab[tag->m.start_pos_in_token-1];
-	return tfst->token_content[tag->m.start_pos_in_token-1][size_of_previous-1]==' ';
+    /* The tag starts exactly at the beginning of a token, so we just
+     * have to look if the previous token was ending with a space. By convention,
+     * we say that the token #0 has no space on its left */
+    if (tag->m.start_pos_in_token==0) {
+        return 0;
+    }
+    int size_of_previous=tfst->token_sizes->tab[tag->m.start_pos_in_token-1];
+    return tfst->token_content[tag->m.start_pos_in_token-1][size_of_previous-1]==' ';
 } else {
-	/* The tag is in the middle of a token */
-	return tfst->token_content[tag->m.start_pos_in_token][tag->m.start_pos_in_char-1]==' ';
+    /* The tag is in the middle of a token */
+    return tfst->token_content[tag->m.start_pos_in_token][tag->m.start_pos_in_char-1]==' ';
 }
 }
 
@@ -1317,7 +1317,7 @@ if (tag->m.start_pos_in_char==0) {
  */
 int morphological_filter_is_ok(const unichar* content,Fst2Tag grammar_tag,const struct locate_tfst_infos* infos) {
 if (grammar_tag->filter_number==-1) {
-	return 1;
+    return 1;
 }
 #ifdef REGEX_FACADE_ENGINE
 return string_match_filter(infos->filters,content,grammar_tag->filter_number);

--- a/LocateTfst_lib.h
+++ b/LocateTfst_lib.h
@@ -55,69 +55,69 @@ namespace unitex {
  * operation on a text automaton.
  */
 struct locate_tfst_infos {
-	U_FILE* output;
+    U_FILE* output;
 
-	Alphabet* alphabet;
-	
-	Fst2* fst2;
+    Alphabet* alphabet;
 
-	int number_of_matches;
+    Fst2* fst2;
+
+    int number_of_matches;
 
     /* Indicates the number of matches we want, or NO_MATCH_LIMIT (-1) if
      * there is no limit. */
     int search_limit;
 
-	Tfst* tfst;
+    Tfst* tfst;
 
-	#ifdef REGEX_FACADE_ENGINE
-	/* These field is used to manipulate morphological filters like:
-	 *
-	 * <<en$>>
-	 *
-	 * 'filters' is a structure used to store the filters.
-	 */
-	FilterSet* filters;
-	#endif
+    #ifdef REGEX_FACADE_ENGINE
+    /* These field is used to manipulate morphological filters like:
+     *
+     * <<en$>>
+     *
+     * 'filters' is a structure used to store the filters.
+     */
+    FilterSet* filters;
+    #endif
 
-	MatchPolicy match_policy;
-	OutputPolicy real_output_policy;
-	OutputPolicy output_policy;
-	AmbiguousOutputPolicy ambiguous_output_policy;
-	VariableErrorPolicy variable_error_policy;
-	
-	Variables* input_variables;
-	OutputVariables* output_variables;
-	struct dic_variable* dic_variables;
+    MatchPolicy match_policy;
+    OutputPolicy real_output_policy;
+    OutputPolicy output_policy;
+    AmbiguousOutputPolicy ambiguous_output_policy;
+    VariableErrorPolicy variable_error_policy;
 
-	/* The total number of outputs. It may be different from the number
-	 * of matches if ambiguous outputs are allowed. */
-	int number_of_outputs;
+    Variables* input_variables;
+    OutputVariables* output_variables;
+    struct dic_variable* dic_variables;
 
-	/* Position of the last printed match. It is used when ambiguous outputs
-	 * are used. */
-	int start_position_last_printed_match_token;
-	int end_position_last_printed_match_token;
-	int start_position_last_printed_match_char;
-	int end_position_last_printed_match_char;
-	int start_position_last_printed_match_letter;
-	int end_position_last_printed_match_letter;
-	
-	struct tfst_simple_match_list* matches;
-	
-	/* Stuffs for Korean */
-	Korean* korean;
-	int n_jamo_fst2_tags;
-	unichar** jamo_fst2_tags;
-	int n_jamo_tfst_tags;
-	unichar** jamo_tfst_tags;
-	
-	LocateTfstTagMatchingCache* cache;
-	struct opt_contexts** contexts;
+    /* The total number of outputs. It may be different from the number
+     * of matches if ambiguous outputs are allowed. */
+    int number_of_outputs;
 
-	int debug;
-	int tagging;
-	int single_tags_only;
-	int match_word_boundaries;
+    /* Position of the last printed match. It is used when ambiguous outputs
+     * are used. */
+    int start_position_last_printed_match_token;
+    int end_position_last_printed_match_token;
+    int start_position_last_printed_match_char;
+    int end_position_last_printed_match_char;
+    int start_position_last_printed_match_letter;
+    int end_position_last_printed_match_letter;
+
+    struct tfst_simple_match_list* matches;
+
+    /* Stuffs for Korean */
+    Korean* korean;
+    int n_jamo_fst2_tags;
+    unichar** jamo_fst2_tags;
+    int n_jamo_tfst_tags;
+    unichar** jamo_tfst_tags;
+
+    LocateTfstTagMatchingCache* cache;
+    struct opt_contexts** contexts;
+
+    int debug;
+    int tagging;
+    int single_tags_only;
+    int match_word_boundaries;
 };
 
 

--- a/LocateTrace.cpp
+++ b/LocateTrace.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -85,7 +85,7 @@ UNITEX_FUNC int UNITEX_CALL SetLocateTraceInfo(const t_locate_trace_func_array* 
 	memset(&cur_locate_trace_func_array,0,sizeof(t_locate_trace_func_array_ex));
 	size_t size_struct = sizeof(t_locate_trace_func_array_ex);
 	size_t size_struct_param = func_array->size_struct;
-	memcpy(&cur_locate_trace_func_array,func_array,(size_struct < size_struct_param) ? size_struct : size_struct_param);    
+	memcpy(&cur_locate_trace_func_array,func_array,(size_struct < size_struct_param) ? size_struct : size_struct_param);
     privatePtrGlobal = privatePtrGlobalSet;
     return 1;
 }

--- a/LocateTrace.cpp
+++ b/LocateTrace.cpp
@@ -57,12 +57,12 @@ void open_locate_trace(struct locate_parameters* p,t_fnc_locate_trace_step * p_f
 {
     if (is_locate_trace_installed != 0)
     {
-		if (cur_locate_trace_func_array.fnc_open_locate_trace != NULL) {
-			*p_private_param_locate_trace = (*(cur_locate_trace_func_array.fnc_open_locate_trace))(privatePtrGlobal,p);
-		}
-		else {
-			*p_private_param_locate_trace = (*(cur_locate_trace_func_array.fnc_open_locate_trace_ex))(privatePtrGlobal,p,params);
-		}
+        if (cur_locate_trace_func_array.fnc_open_locate_trace != NULL) {
+            *p_private_param_locate_trace = (*(cur_locate_trace_func_array.fnc_open_locate_trace))(privatePtrGlobal,p);
+        }
+        else {
+            *p_private_param_locate_trace = (*(cur_locate_trace_func_array.fnc_open_locate_trace_ex))(privatePtrGlobal,p,params);
+        }
         *p_fnc_locate_trace_step = cur_locate_trace_func_array.fnc_locate_trace_step;
     }
 }
@@ -82,10 +82,10 @@ void close_locate_trace(struct locate_parameters* p,t_fnc_locate_trace_step /*fn
 UNITEX_FUNC int UNITEX_CALL SetLocateTraceInfo(const t_locate_trace_func_array* func_array,void* privatePtrGlobalSet)
 {
     is_locate_trace_installed = 1;
-	memset(&cur_locate_trace_func_array,0,sizeof(t_locate_trace_func_array_ex));
-	size_t size_struct = sizeof(t_locate_trace_func_array_ex);
-	size_t size_struct_param = func_array->size_struct;
-	memcpy(&cur_locate_trace_func_array,func_array,(size_struct < size_struct_param) ? size_struct : size_struct_param);
+    memset(&cur_locate_trace_func_array,0,sizeof(t_locate_trace_func_array_ex));
+    size_t size_struct = sizeof(t_locate_trace_func_array_ex);
+    size_t size_struct_param = func_array->size_struct;
+    memcpy(&cur_locate_trace_func_array,func_array,(size_struct < size_struct_param) ? size_struct : size_struct_param);
     privatePtrGlobal = privatePtrGlobalSet;
     return 1;
 }

--- a/LocateTrace.h
+++ b/LocateTrace.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/LocateTracePlugCallback.h
+++ b/LocateTracePlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/MF_DLC_inflect.cpp
+++ b/MF_DLC_inflect.cpp
@@ -51,77 +51,77 @@ l_class_T* DLC_class_para(unichar* para, d_class_equiv_T* D_CLASS_EQUIV);
 int DLC_print_entry(U_FILE* f,struct l_morpho_t* pL_MORPHO,DLC_entry_T* entry);
 int DLC_print_unit(U_FILE* f,struct l_morpho_t* pL_MORPHO,SU_id_T* unit);
 int DLC_format_form(struct l_morpho_t* pL_MORPHO,unichar* entry, int max, MU_f_T f, DLC_entry_T* dlc_entry,
-		d_class_equiv_T* D_CLASS_EQUIV);
+        d_class_equiv_T* D_CLASS_EQUIV);
 void DLC_delete_entry(DLC_entry_T* entry);
 
 /////////////////////////////////////////////////////////////////////////////////
 // Inflect a DELAS/DELAC into a DELAF/DELACF.
 // On error returns 1, 0 otherwise.
 int inflect(char* DLC, char* DLCF,
-		    MultiFlex_ctx* p_multiFlex_ctx, Alphabet* alph,
-		    int error_check_status) {
-	U_FILE *dlc, *dlcf; //DELAS/DELAC and DELAF/DELACF files
-	unichar output_line[DIC_LINE_SIZE]; //current DELAF/DELACF line
-	int l; //length of the line scanned
-	DLC_entry_T* dlc_entry;
-	MU_forms_T MU_forms; //inflected forms of the MWU
-	int err;
+            MultiFlex_ctx* p_multiFlex_ctx, Alphabet* alph,
+            int error_check_status) {
+    U_FILE *dlc, *dlcf; //DELAS/DELAC and DELAF/DELACF files
+    unichar output_line[DIC_LINE_SIZE]; //current DELAF/DELACF line
+    int l; //length of the line scanned
+    DLC_entry_T* dlc_entry;
+    MU_forms_T MU_forms; //inflected forms of the MWU
+    int err;
 
-	//Open DELAS/DELAC
-	dlc = u_fopen(p_multiFlex_ctx->vec, DLC, U_READ);
-	if (!dlc) {
-		return 1;
-	}
-	//Open DELAF/DELACF
-	dlcf = u_fopen(p_multiFlex_ctx->vec, DLCF, U_WRITE);
-	if (!dlcf) {
-		error("Unable to open file: '%s' !\n", DLCF);
-		return 1;
-	}
-	//Inflect one entry at a time
-	Ustring* input_line=new_Ustring(DIC_LINE_SIZE);
-	l = readline(input_line,dlc);
-	//Omit the final newline
-	int flag = 0;
-	//If a line is empty the file is not necessarily finished.
-	//If the last entry has no newline, we should not skip this entry
-	struct dela_entry* DELAS_entry;
-	int semitic = 0;
-	int current_line=0;
-	while (l != EOF) {
-	    current_line++;
-		DELAS_entry = is_strict_DELAS_line(input_line->str, alph);
-		if (DELAS_entry != NULL) {
-			/* If we have a strict DELAS line, that is to say, one with
-			 * a simple word */
-			if (error_check_status==ONLY_COMPOUND_WORDS) {
-				error("Unexpected simple word forbidden by -c:\n%S\n",input_line);
-				free_dela_entry(DELAS_entry);
-				goto next_line;
-			}
-			SU_forms_T forms;
-			SU_init_forms(&forms); //Allocate the space for forms and initialize it to null values
-			char inflection_code[1024];
-			unichar code_gramm[1024];
-			/* We take the first grammatical code, and we extract from it the name
-			 * of the inflection transducer to use */
-			get_inflection_code(DELAS_entry->semantic_codes[0],
-					inflection_code, code_gramm, &semitic);
-			/* And we inflect the word */
-			// Fix bug#8 - "Inflection with Semitic Mode is not working anymore"
-			p_multiFlex_ctx->semitic  = semitic;
-			//   err=SU_inflect(DELAS_entry->lemma,inflection_code,&forms,semitic);
-			if (DELAS_entry->n_filter_codes != 0) {
+    //Open DELAS/DELAC
+    dlc = u_fopen(p_multiFlex_ctx->vec, DLC, U_READ);
+    if (!dlc) {
+        return 1;
+    }
+    //Open DELAF/DELACF
+    dlcf = u_fopen(p_multiFlex_ctx->vec, DLCF, U_WRITE);
+    if (!dlcf) {
+        error("Unable to open file: '%s' !\n", DLCF);
+        return 1;
+    }
+    //Inflect one entry at a time
+    Ustring* input_line=new_Ustring(DIC_LINE_SIZE);
+    l = readline(input_line,dlc);
+    //Omit the final newline
+    int flag = 0;
+    //If a line is empty the file is not necessarily finished.
+    //If the last entry has no newline, we should not skip this entry
+    struct dela_entry* DELAS_entry;
+    int semitic = 0;
+    int current_line=0;
+    while (l != EOF) {
+        current_line++;
+        DELAS_entry = is_strict_DELAS_line(input_line->str, alph);
+        if (DELAS_entry != NULL) {
+            /* If we have a strict DELAS line, that is to say, one with
+             * a simple word */
+            if (error_check_status==ONLY_COMPOUND_WORDS) {
+                error("Unexpected simple word forbidden by -c:\n%S\n",input_line);
+                free_dela_entry(DELAS_entry);
+                goto next_line;
+            }
+            SU_forms_T forms;
+            SU_init_forms(&forms); //Allocate the space for forms and initialize it to null values
+            char inflection_code[1024];
+            unichar code_gramm[1024];
+            /* We take the first grammatical code, and we extract from it the name
+             * of the inflection transducer to use */
+            get_inflection_code(DELAS_entry->semantic_codes[0],
+                    inflection_code, code_gramm, &semitic);
+            /* And we inflect the word */
+            // Fix bug#8 - "Inflection with Semitic Mode is not working anymore"
+            p_multiFlex_ctx->semitic  = semitic;
+            //   err=SU_inflect(DELAS_entry->lemma,inflection_code,&forms,semitic);
+            if (DELAS_entry->n_filter_codes != 0) {
 
-				p_multiFlex_ctx->n_filter_codes = DELAS_entry->n_filter_codes;
-				p_multiFlex_ctx->filter_polarity = DELAS_entry->filter_polarity;
-				p_multiFlex_ctx->filter_codes = DELAS_entry->filter_codes;
+                p_multiFlex_ctx->n_filter_codes = DELAS_entry->n_filter_codes;
+                p_multiFlex_ctx->filter_polarity = DELAS_entry->filter_polarity;
+                p_multiFlex_ctx->filter_codes = DELAS_entry->filter_codes;
 
-				err = SU_inflect(p_multiFlex_ctx,DELAS_entry->lemma, inflection_code,&forms);
+                err = SU_inflect(p_multiFlex_ctx,DELAS_entry->lemma, inflection_code,&forms);
 
-				p_multiFlex_ctx->n_filter_codes=0;
-			}
-			else err = SU_inflect(p_multiFlex_ctx,DELAS_entry->lemma, inflection_code,&forms);
+                p_multiFlex_ctx->n_filter_codes=0;
+            }
+            else err = SU_inflect(p_multiFlex_ctx,DELAS_entry->lemma, inflection_code,&forms);
 
 
 #ifdef REMINDER_WARNING
@@ -133,102 +133,102 @@ int inflect(char* DLC, char* DLCF,
 #endif
 
 
-			/* Then, we print its inflected forms to the output */
-			for (int i = 0; i < forms.no_forms; i++) {
-			   unichar foo[1024];
-			   if (p_multiFlex_ctx->korean!=NULL) {
+            /* Then, we print its inflected forms to the output */
+            for (int i = 0; i < forms.no_forms; i++) {
+               unichar foo[1024];
+               if (p_multiFlex_ctx->korean!=NULL) {
 
-			      Hanguls_to_Jamos(forms.forms[i].form,foo,p_multiFlex_ctx->korean,1);
-			   } else {
-			      u_strcpy(foo,forms.forms[i].form);
-			   }
+                  Hanguls_to_Jamos(forms.forms[i].form,foo,p_multiFlex_ctx->korean,1);
+               } else {
+                  u_strcpy(foo,forms.forms[i].form);
+               }
 
-			   u_fprintf(dlcf, "%S,%S.%S", foo/*forms.forms[i].form*/,
-						DELAS_entry->lemma, code_gramm);
-				/* We add the semantic codes, if any */
-				for (int j = 1; j < DELAS_entry->n_semantic_codes; j++) {
-					u_fprintf(dlcf, "+%S", DELAS_entry->semantic_codes[j]);
-				}
-				if (forms.forms[i].local_semantic_code != NULL) {
-					u_fprintf(dlcf, "%S", forms.forms[i].local_semantic_code);
-				}
-				if (forms.forms[i].raw_features != NULL
-						&& forms.forms[i].raw_features[0] != '\0') {
-					u_fprintf(dlcf, ":%S", forms.forms[i].raw_features);
-				}
-				u_fprintf(dlcf, "\n");
-			}
-			SU_delete_inflection(&forms);
-			free_dela_entry(DELAS_entry);
-			/* End of simple word case */
-		} else {
-			/* If we have not a simple word DELAS line, we try to analyse it
-			 * as a compound word DELAC line */
-			if (error_check_status==ONLY_SIMPLE_WORDS) {
-				error("Unexpected compound word forbidden by -s:\n%S\n",input_line);
-				goto next_line;
-			}
-			if (p_multiFlex_ctx->config_files_status != CONFIG_FILES_ERROR) {
-				/* If this is a compound word, we process it if and only if the
-				 * configuration files have been correctly loaded */
-				dlc_entry = (DLC_entry_T*) malloc(sizeof(DLC_entry_T));
-				if (!dlc_entry) {
-					fatal_alloc_error("inflect");
-				}
-				/* Convert a DELAC entry into the internal multi-word format */
-				err = DLC_line2entry(alph,p_multiFlex_ctx->pL_MORPHO,input_line->str, dlc_entry, &(p_multiFlex_ctx->D_CLASS_EQUIV));
-				if (!err) {
-					//Inflect the entry
-					MU_init_forms(&MU_forms);
-					err = MU_inflect(p_multiFlex_ctx,dlc_entry->lemma,&MU_forms);
-					if (!err) {
-						int f; //index of the current inflected form
-						//Inform the user if no form generated
-						if (MU_forms.no_forms == 0) {
-							error("No inflected form could be generated for ");
-							DLC_print_entry(U_STDERR,p_multiFlex_ctx->pL_MORPHO,dlc_entry);
-						}
-						//Print inflected forms
-						for (f = 0; f < MU_forms.no_forms; f++) {
-							//Format the inflected form to the DELACF format
-							err = DLC_format_form(p_multiFlex_ctx->pL_MORPHO,output_line, DIC_LINE_SIZE
-									- 1, MU_forms.forms[f], dlc_entry,
-									&(p_multiFlex_ctx->D_CLASS_EQUIV));
-							if (!err) {
-								//Print one inflected form at a time to the DELACF file
-								u_fprintf(dlcf, "%S\n", output_line);
-							}
-						}
-					}
-					MU_delete_inflection(&MU_forms);
-					DLC_delete_entry(dlc_entry);
-				}
-			} else {
-				/* We try to inflect a compound word whereas the "Morphology.txt" and/or
-				 * "Equivalences.txt" file(s) has/have not been loaded */
-				if (!flag) {
-					/* We use a flag to print the error message only once */
-					error(
-							"WARNING: Compound words won't be inflected because configuration files\n");
-					error("         have not been correctly loaded.\n");
-					flag = 1;
-				}
-			}
-		}
-		next_line:
-		//Get next entry
-		l = readline(input_line,dlc);
-		if (l!=EOF) {
-			if (input_line->str[0]=='\0') {
-				/* If we find an empty line, then we go on */
-				goto next_line;
-			}
-		}
-	}
-	free_Ustring(input_line);
-	u_fclose(dlc);
-	u_fclose(dlcf);
-	return 0;
+               u_fprintf(dlcf, "%S,%S.%S", foo/*forms.forms[i].form*/,
+                        DELAS_entry->lemma, code_gramm);
+                /* We add the semantic codes, if any */
+                for (int j = 1; j < DELAS_entry->n_semantic_codes; j++) {
+                    u_fprintf(dlcf, "+%S", DELAS_entry->semantic_codes[j]);
+                }
+                if (forms.forms[i].local_semantic_code != NULL) {
+                    u_fprintf(dlcf, "%S", forms.forms[i].local_semantic_code);
+                }
+                if (forms.forms[i].raw_features != NULL
+                        && forms.forms[i].raw_features[0] != '\0') {
+                    u_fprintf(dlcf, ":%S", forms.forms[i].raw_features);
+                }
+                u_fprintf(dlcf, "\n");
+            }
+            SU_delete_inflection(&forms);
+            free_dela_entry(DELAS_entry);
+            /* End of simple word case */
+        } else {
+            /* If we have not a simple word DELAS line, we try to analyse it
+             * as a compound word DELAC line */
+            if (error_check_status==ONLY_SIMPLE_WORDS) {
+                error("Unexpected compound word forbidden by -s:\n%S\n",input_line);
+                goto next_line;
+            }
+            if (p_multiFlex_ctx->config_files_status != CONFIG_FILES_ERROR) {
+                /* If this is a compound word, we process it if and only if the
+                 * configuration files have been correctly loaded */
+                dlc_entry = (DLC_entry_T*) malloc(sizeof(DLC_entry_T));
+                if (!dlc_entry) {
+                    fatal_alloc_error("inflect");
+                }
+                /* Convert a DELAC entry into the internal multi-word format */
+                err = DLC_line2entry(alph,p_multiFlex_ctx->pL_MORPHO,input_line->str, dlc_entry, &(p_multiFlex_ctx->D_CLASS_EQUIV));
+                if (!err) {
+                    //Inflect the entry
+                    MU_init_forms(&MU_forms);
+                    err = MU_inflect(p_multiFlex_ctx,dlc_entry->lemma,&MU_forms);
+                    if (!err) {
+                        int f; //index of the current inflected form
+                        //Inform the user if no form generated
+                        if (MU_forms.no_forms == 0) {
+                            error("No inflected form could be generated for ");
+                            DLC_print_entry(U_STDERR,p_multiFlex_ctx->pL_MORPHO,dlc_entry);
+                        }
+                        //Print inflected forms
+                        for (f = 0; f < MU_forms.no_forms; f++) {
+                            //Format the inflected form to the DELACF format
+                            err = DLC_format_form(p_multiFlex_ctx->pL_MORPHO,output_line, DIC_LINE_SIZE
+                                    - 1, MU_forms.forms[f], dlc_entry,
+                                    &(p_multiFlex_ctx->D_CLASS_EQUIV));
+                            if (!err) {
+                                //Print one inflected form at a time to the DELACF file
+                                u_fprintf(dlcf, "%S\n", output_line);
+                            }
+                        }
+                    }
+                    MU_delete_inflection(&MU_forms);
+                    DLC_delete_entry(dlc_entry);
+                }
+            } else {
+                /* We try to inflect a compound word whereas the "Morphology.txt" and/or
+                 * "Equivalences.txt" file(s) has/have not been loaded */
+                if (!flag) {
+                    /* We use a flag to print the error message only once */
+                    error(
+                            "WARNING: Compound words won't be inflected because configuration files\n");
+                    error("         have not been correctly loaded.\n");
+                    flag = 1;
+                }
+            }
+        }
+        next_line:
+        //Get next entry
+        l = readline(input_line,dlc);
+        if (l!=EOF) {
+            if (input_line->str[0]=='\0') {
+                /* If we find an empty line, then we go on */
+                goto next_line;
+            }
+        }
+    }
+    free_Ustring(input_line);
+    u_fclose(dlc);
+    u_fclose(dlcf);
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -237,98 +237,98 @@ int inflect(char* DLC, char* DLCF,
 // Initially, entry has its space allocated but is empty.
 // Returns 1 if 'line' is empty, 2 if its format is incorrect, -1 if memory allocation problems, 0 otherwise.
 int DLC_line2entry(Alphabet* alph,struct l_morpho_t* pL_MORPHO,unichar* line, DLC_entry_T* entry,
-		d_class_equiv_T* D_CLASS_EQUIV) {
-	int l; //length of the scanned sequence
-	int pos; //index of the next character to be read
-	SU_id_T* unit;
+        d_class_equiv_T* D_CLASS_EQUIV) {
+    int l; //length of the scanned sequence
+    int pos; //index of the next character to be read
+    SU_id_T* unit;
 
-	pos = 0;
-	if (!line[pos]) //Empty line
-		return 1;
+    pos = 0;
+    if (!line[pos]) //Empty line
+        return 1;
 
-	//Initalize the lemma
-	entry->lemma = (MU_lemma_T*) malloc(sizeof(MU_lemma_T));
-	if (!entry->lemma) {
-		fatal_alloc_error("DLC_line2entry");
-	}
-	entry->lemma->no_units = 0;
+    //Initalize the lemma
+    entry->lemma = (MU_lemma_T*) malloc(sizeof(MU_lemma_T));
+    if (!entry->lemma) {
+        fatal_alloc_error("DLC_line2entry");
+    }
+    entry->lemma->no_units = 0;
 
-	//Scan the single units
-	while (line[pos] && line[pos] != (unichar) ',') { //Each DELAC line must contain a comma
-		unit = (SU_id_T*) malloc(sizeof(SU_id_T));
-		if (!unit) {
-			fatal_alloc_error("DLC_line2entry");
-		}
-		l = DLC_scan_unit(alph,pL_MORPHO,unit, &(line[pos]), D_CLASS_EQUIV);
-		if (l <= 0) {
-			free(unit);
-			MU_delete_lemma(entry->lemma);
-			return 2;
-		}
-		entry->lemma->units[entry->lemma->no_units] = unit;
-		entry->lemma->no_units++;
-		pos += l;
-	}
+    //Scan the single units
+    while (line[pos] && line[pos] != (unichar) ',') { //Each DELAC line must contain a comma
+        unit = (SU_id_T*) malloc(sizeof(SU_id_T));
+        if (!unit) {
+            fatal_alloc_error("DLC_line2entry");
+        }
+        l = DLC_scan_unit(alph,pL_MORPHO,unit, &(line[pos]), D_CLASS_EQUIV);
+        if (l <= 0) {
+            free(unit);
+            MU_delete_lemma(entry->lemma);
+            return 2;
+        }
+        entry->lemma->units[entry->lemma->no_units] = unit;
+        entry->lemma->no_units++;
+        pos += l;
+    }
 
-	if (line[pos] != (unichar) ',') {
-		error("Comma missing in DELAC line:\n%S\n", line);
-		MU_delete_lemma(entry->lemma);
-		return 2;
-	}
+    if (line[pos] != (unichar) ',') {
+        error("Comma missing in DELAC line:\n%S\n", line);
+        MU_delete_lemma(entry->lemma);
+        return 2;
+    }
 
-	//Scan the inflection paradigm
-	unichar tmp[DIC_LINE_SIZE];
-	pos++; //Omit the comma
-	l = u_scan_until_char(tmp, &(line[pos]), DIC_LINE_SIZE - 1, "+:)\\/", 1);
-	pos += l;
-	if (!l) {
-		error("Inflection paradigm inexistent in line:\n%S\n", line);
-		MU_delete_lemma(entry->lemma);
-		return 2;
-	}
-	entry->lemma->paradigm = (char*) malloc((u_strlen(tmp) + 1) * sizeof(char));
-	if (!entry->lemma->paradigm) {
-		fatal_alloc_error("DLC_line2entry");
-	}
-	for (unsigned int c = 0; c <= u_strlen(tmp); c++) //Convert to char and copy
-		entry->lemma->paradigm[c] = (char) tmp[c];
+    //Scan the inflection paradigm
+    unichar tmp[DIC_LINE_SIZE];
+    pos++; //Omit the comma
+    l = u_scan_until_char(tmp, &(line[pos]), DIC_LINE_SIZE - 1, "+:)\\/", 1);
+    pos += l;
+    if (!l) {
+        error("Inflection paradigm inexistent in line:\n%S\n", line);
+        MU_delete_lemma(entry->lemma);
+        return 2;
+    }
+    entry->lemma->paradigm = (char*) malloc((u_strlen(tmp) + 1) * sizeof(char));
+    if (!entry->lemma->paradigm) {
+        fatal_alloc_error("DLC_line2entry");
+    }
+    for (unsigned int c = 0; c <= u_strlen(tmp); c++) //Convert to char and copy
+        entry->lemma->paradigm[c] = (char) tmp[c];
 
-	//Determine the class (e.g. noun)
-	l_class_T* cl;
-	cl = DLC_class_para(tmp, D_CLASS_EQUIV);
-	if (!cl) {
-		error(
-				"Impossible to deduce the compound's inflection class (noun, adj, etc.):\n%S\n",
-				line);
-		MU_delete_lemma(entry->lemma);
-		return 2;
-	}
-	entry->lemma->cl = cl;
+    //Determine the class (e.g. noun)
+    l_class_T* cl;
+    cl = DLC_class_para(tmp, D_CLASS_EQUIV);
+    if (!cl) {
+        error(
+                "Impossible to deduce the compound's inflection class (noun, adj, etc.):\n%S\n",
+                line);
+        MU_delete_lemma(entry->lemma);
+        return 2;
+    }
+    entry->lemma->cl = cl;
 
-	//Scan the semantic codes
-	l = DLC_scan_codes(entry->codes, &(line[pos]));
-	if (l < 0) {
-		error("Bad format in DELAC line:\n%S\n", line);
-		MU_delete_lemma(entry->lemma); //delete lemma
-		for (int c = 0; entry->codes[c]; c++) //delete codes
-			free(entry->codes[c]);
-		return 2;
+    //Scan the semantic codes
+    l = DLC_scan_codes(entry->codes, &(line[pos]));
+    if (l < 0) {
+        error("Bad format in DELAC line:\n%S\n", line);
+        MU_delete_lemma(entry->lemma); //delete lemma
+        for (int c = 0; entry->codes[c]; c++) //delete codes
+            free(entry->codes[c]);
+        return 2;
   }
-	pos += l;
+    pos += l;
 
-	//Scan the comment
-	l = DLC_scan_comment(&(entry->comment), &(line[pos]));
-	pos += l;
+    //Scan the comment
+    l = DLC_scan_comment(&(entry->comment), &(line[pos]));
+    pos += l;
 
-	if (line[pos]) {
-		error("Bad format in DELAC line:\n%S\n", line);
-		MU_delete_lemma(entry->lemma); //delete lemma
-		for (int c = 0; entry->codes[c]; c++) //delete codes
-			free(entry->codes[c]);
-		free(entry->comment); //delete comment
-		return 2;
-	}
-	return 0;
+    if (line[pos]) {
+        error("Bad format in DELAC line:\n%S\n", line);
+        MU_delete_lemma(entry->lemma); //delete lemma
+        for (int c = 0; entry->codes[c]; c++) //delete codes
+            free(entry->codes[c]);
+        free(entry->comment); //delete comment
+        return 2;
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -336,117 +336,117 @@ int DLC_line2entry(Alphabet* alph,struct l_morpho_t* pL_MORPHO,unichar* line, DL
 // Initially, 'u' has its space allocated but is empty.
 // Returns the length of the scanned sequence, -1 if a format error occurred, -2 if a memory allocation problem occured.
 int DLC_scan_unit(Alphabet* alph,struct l_morpho_t* pL_MORPHO,SU_id_T* u, unichar* line, d_class_equiv_T* D_CLASS_EQUIV) {
-	int l; //length of the scanned sequence
-	int pos; //index of the next caracter to be scanned
-	unichar tmp[DIC_LINE_SIZE];
+    int l; //length of the scanned sequence
+    int pos; //index of the next caracter to be scanned
+    unichar tmp[DIC_LINE_SIZE];
 
-	pos = 0;
-	//Scan a unit
-	l = SU_get_unit(tmp, line, DIC_LINE_SIZE - 1, alph, 0); //The single word module determines what is a word and what is a separator, etc.
-	if (l <= 0) {
-		return -1;
-	}
-	u->form = u_strdup(tmp);
-	pos += l;
+    pos = 0;
+    //Scan a unit
+    l = SU_get_unit(tmp, line, DIC_LINE_SIZE - 1, alph, 0); //The single word module determines what is a word and what is a separator, etc.
+    if (l <= 0) {
+        return -1;
+    }
+    u->form = u_strdup(tmp);
+    pos += l;
 
-	//If no lemma indication
-	if (line[pos] != (unichar) '(') {
-		u->lemma = NULL;
-		u->feat = NULL;
-	}
+    //If no lemma indication
+    if (line[pos] != (unichar) '(') {
+        u->lemma = NULL;
+        u->feat = NULL;
+    }
 
-	//Scan the unit's description contained between '(' and ')'
-	else {
-		pos++; //Omit the '('
-		//Scan the lemma if any
-		u->lemma = (SU_lemma_T*) malloc(sizeof(SU_lemma_T));
-		if (!u->lemma) {
-			fatal_alloc_error("DLC_scan_unit");
-		}
-		l = SU_get_unit(tmp, &(line[pos]), DIC_LINE_SIZE - 1, alph, 0); //The single word module determines what is a word and what is a separator, etc.
-		if (l < 0) {
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return l;
-		}
-		u->lemma->unit = u_strdup(tmp);
-		pos += l;
+    //Scan the unit's description contained between '(' and ')'
+    else {
+        pos++; //Omit the '('
+        //Scan the lemma if any
+        u->lemma = (SU_lemma_T*) malloc(sizeof(SU_lemma_T));
+        if (!u->lemma) {
+            fatal_alloc_error("DLC_scan_unit");
+        }
+        l = SU_get_unit(tmp, &(line[pos]), DIC_LINE_SIZE - 1, alph, 0); //The single word module determines what is a word and what is a separator, etc.
+        if (l < 0) {
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return l;
+        }
+        u->lemma->unit = u_strdup(tmp);
+        pos += l;
 
-		//Scan the lemma's inflection paradigm
-		if (line[pos] != (unichar) '.') {
-			error("Dot missing after a unit's lemma:\n%S\n", line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		pos++; //Omit the dot
-		unichar u_para[DIC_LINE_SIZE];
-		l = u_scan_until_char(u_para, &(line[pos]), DIC_LINE_SIZE - 1, "+:\\",
-				1);
-		if (!l) {
-			error(
-					"Unit's inflection paradigm non existent in DELAC line:\n%S\n",
-					line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		u->lemma->paradigm = (char*) malloc((u_strlen(u_para) + 1)
-				* sizeof(char));
-		if (!u->lemma->paradigm) {
-			fatal_alloc_error("DLC_scan_unit");
-		}
-		for (unsigned int c = 0; c <= u_strlen(u_para); c++)
-			u->lemma->paradigm[c] = (char) u_para[c];
+        //Scan the lemma's inflection paradigm
+        if (line[pos] != (unichar) '.') {
+            error("Dot missing after a unit's lemma:\n%S\n", line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        pos++; //Omit the dot
+        unichar u_para[DIC_LINE_SIZE];
+        l = u_scan_until_char(u_para, &(line[pos]), DIC_LINE_SIZE - 1, "+:\\",
+                1);
+        if (!l) {
+            error(
+                    "Unit's inflection paradigm non existent in DELAC line:\n%S\n",
+                    line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        u->lemma->paradigm = (char*) malloc((u_strlen(u_para) + 1)
+                * sizeof(char));
+        if (!u->lemma->paradigm) {
+            fatal_alloc_error("DLC_scan_unit");
+        }
+        for (unsigned int c = 0; c <= u_strlen(u_para); c++)
+            u->lemma->paradigm[c] = (char) u_para[c];
 
-		//Determine the lemma's inflection class (noun, adj, etc.)
-		l_class_T* cl;
-		cl = DLC_class_para(u_para, D_CLASS_EQUIV);
-		if (!cl) {
-			error(
-					"Impossible to deduce the unit's inflection class (noun, adj, etc.):\n%S\n",
-					line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		u->lemma->cl = cl;
-		pos += l;
+        //Determine the lemma's inflection class (noun, adj, etc.)
+        l_class_T* cl;
+        cl = DLC_class_para(u_para, D_CLASS_EQUIV);
+        if (!cl) {
+            error(
+                    "Impossible to deduce the unit's inflection class (noun, adj, etc.):\n%S\n",
+                    line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        u->lemma->cl = cl;
+        pos += l;
 
-		//Scan the unit's inflection features
-		unichar tmp_scan[DIC_LINE_SIZE];
-		if (line[pos] != (unichar) ':') {
-			error("Colon missing after a unit's lemma:\n%S\n", line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		pos++; //Omit the colon
-		l = u_scan_until_char(tmp_scan, &(line[pos]), DIC_LINE_SIZE - 1, ")", 1);
-		if (l <= 0) {
-			error("Inflection features missing after ':' for a unit:\n%S\n",
-					line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		pos += l;
-		if (line[pos] != (unichar) ')') {
-			error("')' missing after a unit's inflection features:\n%S\n", line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-		pos++; //Omit the ')'
-		u->feat = d_get_feat_str(pL_MORPHO,tmp_scan);
-		if (!u->feat) {
-			error("Incorrect inflection features in a unit:\n%S\n", line);
-			free(u->form);
-			SU_delete_lemma(u->lemma);
-			return -1;
-		}
-	}
-	return pos;
+        //Scan the unit's inflection features
+        unichar tmp_scan[DIC_LINE_SIZE];
+        if (line[pos] != (unichar) ':') {
+            error("Colon missing after a unit's lemma:\n%S\n", line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        pos++; //Omit the colon
+        l = u_scan_until_char(tmp_scan, &(line[pos]), DIC_LINE_SIZE - 1, ")", 1);
+        if (l <= 0) {
+            error("Inflection features missing after ':' for a unit:\n%S\n",
+                    line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        pos += l;
+        if (line[pos] != (unichar) ')') {
+            error("')' missing after a unit's inflection features:\n%S\n", line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+        pos++; //Omit the ')'
+        u->feat = d_get_feat_str(pL_MORPHO,tmp_scan);
+        if (!u->feat) {
+            error("Incorrect inflection features in a unit:\n%S\n", line);
+            free(u->form);
+            SU_delete_lemma(u->lemma);
+            return -1;
+        }
+    }
+    return pos;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -454,38 +454,38 @@ int DLC_scan_unit(Alphabet* alph,struct l_morpho_t* pL_MORPHO,SU_id_T* u, unicha
 // The function allocates space for codes scanned. It must be liberated by the calling function.
 // Returns the length of the scanned sequence, -1 if a format error occured, -2 if a memory allocation problem occured.
 int DLC_scan_codes(unichar* codes[MAX_CODES], unichar* line) {
-	int l; //length of the scanned sequence
-	int pos; //position of the current character in line
-	int c; //number of codes
-	unichar tmp[DIC_LINE_SIZE];
+    int l; //length of the scanned sequence
+    int pos; //position of the current character in line
+    int c; //number of codes
+    unichar tmp[DIC_LINE_SIZE];
 
-	pos = 0;
-	c = 0;
-	while (line[pos] == (unichar) '+') {
-		pos++; //Omit the '+'
-		l = u_scan_until_char(tmp, &(line[pos]), DIC_LINE_SIZE - 1, ":/\\+/", 1);
-		if (l) {
-			if (c == MAX_CODES - 1) {
-				// c[MAX_CODES - 1] -> last usable position to store NULL
-				error("Number of semantic codes exceeded, max = %d\n", MAX_CODES - 2);
-				codes[c] = NULL;
-				return -2;
-			}
+    pos = 0;
+    c = 0;
+    while (line[pos] == (unichar) '+') {
+        pos++; //Omit the '+'
+        l = u_scan_until_char(tmp, &(line[pos]), DIC_LINE_SIZE - 1, ":/\\+/", 1);
+        if (l) {
+            if (c == MAX_CODES - 1) {
+                // c[MAX_CODES - 1] -> last usable position to store NULL
+                error("Number of semantic codes exceeded, max = %d\n", MAX_CODES - 2);
+                codes[c] = NULL;
+                return -2;
+            }
 
-			for (int prev_code_index = 0; prev_code_index < c; ++prev_code_index) {
-				if (u_strcmp(codes[prev_code_index], tmp) == 0) {
-					error("Duplicate semantic code: %S\n", tmp);
-					codes[c] = NULL;
-					return -1;
-				}
-			}
+            for (int prev_code_index = 0; prev_code_index < c; ++prev_code_index) {
+                if (u_strcmp(codes[prev_code_index], tmp) == 0) {
+                    error("Duplicate semantic code: %S\n", tmp);
+                    codes[c] = NULL;
+                    return -1;
+                }
+            }
 
-			codes[c++] = u_strdup(tmp);
-			pos += l;
-		}
-	}
-	codes[c] = NULL;
-	return pos-1;
+            codes[c++] = u_strdup(tmp);
+            pos += l;
+        }
+    }
+    codes[c] = NULL;
+    return pos-1;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -493,83 +493,83 @@ int DLC_scan_codes(unichar* codes[MAX_CODES], unichar* line) {
 // The function allocates space for comment scanned. It must be liberated by the calling function.
 // Returns the length of the scanned sequence, -1 if a format error occured, -2 if a memory allocation problem occured.
 int DLC_scan_comment(unichar** comment, unichar* line) {
-	int l; //length of the scanned sequence
-	unichar tmp[DIC_LINE_SIZE];
+    int l; //length of the scanned sequence
+    unichar tmp[DIC_LINE_SIZE];
 
-	l = 0;
-	if (line[0] == '/') {
-		line++; //Omit the '/'
-		l = u_scan_until_char(tmp, line, DIC_LINE_SIZE - 1, "", 1);
-		if (l) {
-			*comment = u_strdup(tmp);
-		}
-	} else
-		*comment = NULL;
-	return l + 1; //Length od the comment plus '/'
+    l = 0;
+    if (line[0] == '/') {
+        line++; //Omit the '/'
+        l = u_scan_until_char(tmp, line, DIC_LINE_SIZE - 1, "", 1);
+        if (l) {
+            *comment = u_strdup(tmp);
+        }
+    } else
+        *comment = NULL;
+    return l + 1; //Length od the comment plus '/'
 }
 /**************************************************************************************/
 /* Deduces the morphological class (e.g. noun) from the inflection paradigm (e.g. "N41").*/
 /* If the string beginning the inflection paradigm is not in the list of class        */
 /* equivalences, returns NULL.                                                        */
 l_class_T* DLC_class_para(unichar* para, d_class_equiv_T* D_CLASS_EQUIV) {
-	unichar cl[MAX_DIC_CLASS_NAME]; //buffer for the class string
-	int l; //length of a scanned sequence
-	l = u_scan_until_char(cl, para, MAX_DIC_CLASS_NAME - 1, "0123456789 _;-:/\\+",
-			1);
-	if (l)
-		return d_get_class_str(cl, D_CLASS_EQUIV);
-	else
-		return NULL;
+    unichar cl[MAX_DIC_CLASS_NAME]; //buffer for the class string
+    int l; //length of a scanned sequence
+    l = u_scan_until_char(cl, para, MAX_DIC_CLASS_NAME - 1, "0123456789 _;-:/\\+",
+            1);
+    if (l)
+        return d_get_class_str(cl, D_CLASS_EQUIV);
+    else
+        return NULL;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 // Prints a DELAC entry into a DELAC file..
 // If entry void or entry's lemma void returns 1, 0 otherwise.
 int DLC_print_entry(U_FILE* f,struct l_morpho_t* pL_MORPHO,DLC_entry_T* entry) {
-	if (!entry || !entry->lemma)
-		return 1;
+    if (!entry || !entry->lemma)
+        return 1;
 
-	//Print  units
-	for (int u = 0; u < entry->lemma->no_units; u++) {
-		DLC_print_unit(f,pL_MORPHO,entry->lemma->units[u]);
-	}
+    //Print  units
+    for (int u = 0; u < entry->lemma->no_units; u++) {
+        DLC_print_unit(f,pL_MORPHO,entry->lemma->units[u]);
+    }
 
-	//Print paradigm
-	u_fprintf(f,",%s", entry->lemma->paradigm);
+    //Print paradigm
+    u_fprintf(f,",%s", entry->lemma->paradigm);
 
-	//Concat codes
-	for (int c = 0; entry->codes[c]; c++) {
-		u_fprintf(f,"+%S", entry->codes[c]);
-	}
+    //Concat codes
+    for (int c = 0; entry->codes[c]; c++) {
+        u_fprintf(f,"+%S", entry->codes[c]);
+    }
 
-	//Concat comment
-	if (entry->comment) {
-		u_fprintf(f,"/%S", entry->comment);
-	}
-	u_fprintf(f,"\n");
-	return 0;
+    //Concat comment
+    if (entry->comment) {
+        u_fprintf(f,"/%S", entry->comment);
+    }
+    u_fprintf(f,"\n");
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 // Prints single unit into a DELAC file.
 // If 'unit' void returns 1, if memory allocation problem returns -1, 0 otherwise.
 int DLC_print_unit(U_FILE* f,struct l_morpho_t* pL_MORPHO,SU_id_T* unit) {
-	if (unit == NULL)
-		return 1;
-	u_fprintf(f,"%S", unit->form);
-	if (unit->lemma) {
-		u_fprintf(f,"(%S.%s", unit->lemma->unit, unit->lemma->paradigm);
-		if (unit->feat) {
-			unichar* tmp;
-			tmp = d_get_str_feat(pL_MORPHO,unit->feat);
-			if (tmp == NULL)
-				return -1;
-			u_fprintf(f,":%S", tmp);
-			free(tmp);
-		}
-		u_fprintf(f,")");
-	}
-	return 0;
+    if (unit == NULL)
+        return 1;
+    u_fprintf(f,"%S", unit->form);
+    if (unit->lemma) {
+        u_fprintf(f,"(%S.%s", unit->lemma->unit, unit->lemma->paradigm);
+        if (unit->feat) {
+            unichar* tmp;
+            tmp = d_get_str_feat(pL_MORPHO,unit->feat);
+            if (tmp == NULL)
+                return -1;
+            u_fprintf(f,":%S", tmp);
+            free(tmp);
+        }
+        u_fprintf(f,")");
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -578,91 +578,91 @@ int DLC_print_unit(U_FILE* f,struct l_morpho_t* pL_MORPHO,SU_id_T* unit) {
 // 'entry' almready has its space allocated.
 // Returns 1 on error, 0 otherwise.
 int DLC_format_form(struct l_morpho_t* pL_MORPHO,unichar* entry, int max, MU_f_T f, DLC_entry_T* dlc_entry,
-		d_class_equiv_T* D_CLASS_EQUIV) {
-	int l; //length of the entry
+        d_class_equiv_T* D_CLASS_EQUIV) {
+    int l; //length of the entry
 
-	//Inflected form
-	l = u_strlen(f.form);
-	if (l >= max)
-		return 1;
-	u_strcpy(entry, f.form);
+    //Inflected form
+    l = u_strlen(f.form);
+    if (l >= max)
+        return 1;
+    u_strcpy(entry, f.form);
 
-	//Comma
-	l++;
-	if (l >= max)
-		return 1;
-	u_strcat(entry, ",");
+    //Comma
+    l++;
+    if (l >= max)
+        return 1;
+    u_strcat(entry, ",");
 
-	//Lemma
-	int u; //index of the current unit in the lemma of the MW form
-	for (u = 0; u < dlc_entry->lemma->no_units; u++)
-		l = l + u_strlen(dlc_entry->lemma->units[u]->form);
-	if (l >= max)
-		return 1;
-	for (u = 0; u < dlc_entry->lemma->no_units; u++)
-		u_strcat(entry, dlc_entry->lemma->units[u]->form);
+    //Lemma
+    int u; //index of the current unit in the lemma of the MW form
+    for (u = 0; u < dlc_entry->lemma->no_units; u++)
+        l = l + u_strlen(dlc_entry->lemma->units[u]->form);
+    if (l >= max)
+        return 1;
+    for (u = 0; u < dlc_entry->lemma->no_units; u++)
+        u_strcat(entry, dlc_entry->lemma->units[u]->form);
 
-	//Full stop
-	l++;
-	if (l >= max)
-		return 1;
-	u_strcat(entry, ".");
+    //Full stop
+    l++;
+    if (l >= max)
+        return 1;
+    u_strcat(entry, ".");
 
-	//Inflection paradigm
-	//l = l + strlen(dlc_entry->lemma->paradigm);
-	//if (l >= max) return 1;
-	//u_strcat(entry,dlc_entry->lemma->paradigm);
+    //Inflection paradigm
+    //l = l + strlen(dlc_entry->lemma->paradigm);
+    //if (l >= max) return 1;
+    //u_strcat(entry,dlc_entry->lemma->paradigm);
 
-	//Inflection class
-	l = l + u_strlen(d_get_str_class(dlc_entry->lemma->cl, D_CLASS_EQUIV));
-	if (l >= max)
-		return 1;
-	u_strcat(entry, d_get_str_class(dlc_entry->lemma->cl, D_CLASS_EQUIV));
+    //Inflection class
+    l = l + u_strlen(d_get_str_class(dlc_entry->lemma->cl, D_CLASS_EQUIV));
+    if (l >= max)
+        return 1;
+    u_strcat(entry, d_get_str_class(dlc_entry->lemma->cl, D_CLASS_EQUIV));
 
-	//Semantic codes
-	int c; //index of the current semantic code
-	for (c = 0; dlc_entry->codes[c]; c++)
-		l = l + u_strlen(dlc_entry->codes[c]) + 1;
-	if (l >= max)
-		return 1;
-	for (c = 0; dlc_entry->codes[c]; c++) {
-		u_strcat(entry, "+");
-		u_strcat(entry, dlc_entry->codes[c]);
-	}
+    //Semantic codes
+    int c; //index of the current semantic code
+    for (c = 0; dlc_entry->codes[c]; c++)
+        l = l + u_strlen(dlc_entry->codes[c]) + 1;
+    if (l >= max)
+        return 1;
+    for (c = 0; dlc_entry->codes[c]; c++) {
+        u_strcat(entry, "+");
+        u_strcat(entry, dlc_entry->codes[c]);
+    }
 
-	//Inflection features
-	unichar* feat; //sequence of single-letter inflection features, e.g. 'sIf'
-	if (f.features && f.features->no_cats > 0) {
-		feat = d_get_str_feat(pL_MORPHO,f.features);
-		l = l + u_strlen(feat) + 1; //Place for a ':' and all features
-		if (l >= max)
-			return 1;
-		u_strcat(entry, ":");
-		u_strcat(entry, feat);
-		free(feat);
-	}
+    //Inflection features
+    unichar* feat; //sequence of single-letter inflection features, e.g. 'sIf'
+    if (f.features && f.features->no_cats > 0) {
+        feat = d_get_str_feat(pL_MORPHO,f.features);
+        l = l + u_strlen(feat) + 1; //Place for a ':' and all features
+        if (l >= max)
+            return 1;
+        u_strcat(entry, ":");
+        u_strcat(entry, feat);
+        free(feat);
+    }
 
-	//Comment
-	if (dlc_entry->comment && u_strlen(dlc_entry->comment)) {
-		l = l + u_strlen(dlc_entry->comment);//Place for a '/' and the comment
-		if (l >= max)
-			return 1;
-		u_strcat(entry, "/");
-		u_strcat(entry, dlc_entry->comment);
-	}
-	return 0;
+    //Comment
+    if (dlc_entry->comment && u_strlen(dlc_entry->comment)) {
+        l = l + u_strlen(dlc_entry->comment);//Place for a '/' and the comment
+        if (l >= max)
+            return 1;
+        u_strcat(entry, "/");
+        u_strcat(entry, dlc_entry->comment);
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 // Liberates the memory allocated for a DELAC entry.
 void DLC_delete_entry(DLC_entry_T* entry) {
-	if (!entry)
-		return;
-	MU_delete_lemma(entry->lemma);
-	for (int c = 0; entry->codes[c]; c++) //delete codes
-		free(entry->codes[c]);
-	free(entry->comment); //delete comment
-	free(entry);
+    if (!entry)
+        return;
+    MU_delete_lemma(entry->lemma);
+    for (int c = 0; entry->codes[c]; c++) //delete codes
+        free(entry->codes[c]);
+    free(entry->comment); //delete comment
+    free(entry);
 }
 
 } // namespace unitex

--- a/MF_DicoMorpho.cpp
+++ b/MF_DicoMorpho.cpp
@@ -106,9 +106,9 @@ int d_init_morpho_equiv(const VersatileEncodingConfig* vec,struct l_morpho_t* pL
   while (EOF!=readline(line,ef)) {
     line_no++;
     if (line->str[0]!='\0' && d_read_line(pL_MORPHO,line->str,line_no)) {
-    	u_fclose(ef);
-    	free_Ustring(line);
-    	return 1;
+        u_fclose(ef);
+        free_Ustring(line);
+        return 1;
     }
   }
   free_Ustring(line);
@@ -265,8 +265,8 @@ f_morpho_T* d_get_feat_str(struct l_morpho_t* pL_MORPHO,unichar* feat_str) {
     found = 0;
     for (e=0; e<pL_MORPHO->D_MORPHO_EQUIV.no_equiv && !found; e++)
       if (pL_MORPHO->D_MORPHO_EQUIV.equiv[e].dico_feat == feat_str[f]) {
-	f_add_morpho(feat, pL_MORPHO->D_MORPHO_EQUIV.equiv[e].cat.cat, pL_MORPHO->D_MORPHO_EQUIV.equiv[e].cat.val);
-	found = 1;
+    f_add_morpho(feat, pL_MORPHO->D_MORPHO_EQUIV.equiv[e].cat.cat, pL_MORPHO->D_MORPHO_EQUIV.equiv[e].cat.val);
+    found = 1;
       }
     if (!found)
       return NULL;
@@ -300,9 +300,9 @@ unichar* d_get_str_feat(struct l_morpho_t* pL_MORPHO,f_morpho_T* feat) {
     found = 0;
     for (ef=0; ef<pL_MORPHO->D_MORPHO_EQUIV.no_equiv && !found; ef++) {
       if ((feat->cats[f].cat == pL_MORPHO->D_MORPHO_EQUIV.equiv[ef].cat.cat) && (feat->cats[f].val == pL_MORPHO->D_MORPHO_EQUIV.equiv[ef].cat.val) ) {
-	tmp[c] = pL_MORPHO->D_MORPHO_EQUIV.equiv[ef].dico_feat;
-	c++;
-	found = 1;
+    tmp[c] = pL_MORPHO->D_MORPHO_EQUIV.equiv[ef].dico_feat;
+    c++;
+    found = 1;
       }
     }
     //If a feature was not found in equivalences and it is not empty

--- a/MF_FormMorpho.cpp
+++ b/MF_FormMorpho.cpp
@@ -69,8 +69,8 @@ int f_change_morpho(struct l_morpho_t* pL_MORPHO,f_morpho_T *old_feat, f_morpho_
     found = 0;
     for (c_old=0; c_old<old_feat->no_cats && !found; c_old++)
       if (old_feat->cats[c_old].cat == new_feat->cats[c_new].cat) {
-	old_feat->cats[c_old].val = new_feat->cats[c_new].val;
-	found = 1;
+    old_feat->cats[c_old].val = new_feat->cats[c_new].val;
+    found = 1;
       }
     //If a category was not found in 'old_feat' but is admits and empty value
     //then it is added to 'old_feat' with the current value
@@ -105,7 +105,7 @@ int f_morpho_cmp(f_morpho_T* m1, f_morpho_T* m2) {
     c2=0;
     while (c2<m2->no_cats && !found) {
       if ((m1->cats[c1].cat == m2->cats[c2].cat) && (m1->cats[c1].val == m2->cats[c2].val))
-	  found = 1;
+      found = 1;
       c2++;
     }
     //If the current category-value pair in m1 does not exist in m2 then m1 and m2 are not identical
@@ -175,8 +175,8 @@ int f_del_one_morpho(f_morpho_T *feat, l_category_T* cat) {
   for (c=0; c<feat->no_cats; c++)
     if (feat->cats[c].cat == cat) {   //Category 'cat' found in 'feat'.
       while (c < feat->no_cats - 1) {  //Shift the remaining cat-val pairs to the left.
-	feat->cats[c] = feat->cats[c+1];
-	c++;
+    feat->cats[c] = feat->cats[c+1];
+    c++;
       }
       feat->no_cats--;
       return 0;

--- a/MF_FormMorpho.cpp
+++ b/MF_FormMorpho.cpp
@@ -60,7 +60,7 @@ void f_delete_morpho(f_morpho_T *feat) {
 // this category may admit an empty value. In this case the category is added to 'old_feat'.
 // e.g. if 'old_feat'={Gen=fem, Nb=sing} and 'new_feat'={Nb=pl, Gr=D} and Gr:<E>,D,A then
 // 'old_feat' becomes {Gen=fem, Nb=pl, Gr=D}. But if Gr:B,D,A than an error appears.
-// Returns 0 on success, 1 otherwise  
+// Returns 0 on success, 1 otherwise
 int f_change_morpho(struct l_morpho_t* pL_MORPHO,f_morpho_T *old_feat, f_morpho_T *new_feat) {
   int c_old, c_new;  //category indices in old_feat and in new_feat
   int found;
@@ -82,10 +82,10 @@ int f_change_morpho(struct l_morpho_t* pL_MORPHO,f_morpho_T *old_feat, f_morpho_
     if (!found)   //Error if the category to be changed does not appear in 'old_feat'
       return 1;
     */
-    
+
   }
   return 0;
-} 
+}
 
 ////////////////////////////////////////////
 // Compare two morphological descriptions
@@ -102,7 +102,7 @@ int f_morpho_cmp(f_morpho_T* m1, f_morpho_T* m2) {
   int found;  //Boolean saying if the current category-value in m1 has been found in m2
   for (c1=0; c1<m1->no_cats; c1++) {
     found = 0;
-    c2=0; 
+    c2=0;
     while (c2<m2->no_cats && !found) {
       if ((m1->cats[c1].cat == m2->cats[c2].cat) && (m1->cats[c1].val == m2->cats[c2].val))
 	  found = 1;
@@ -124,8 +124,8 @@ int f_morpho_cmp(f_morpho_T* m1, f_morpho_T* m2) {
 int f_add_morpho(f_morpho_T *feat, l_category_T *cat, int val) {
   int c;  //category index in feat
 
-  for (c=0; c<feat->no_cats; c++) 
-      if (feat->cats[c].cat == cat) 
+  for (c=0; c<feat->no_cats; c++)
+      if (feat->cats[c].cat == cat)
         return 1;      //Error if the category to be added already appears in old_cat
 
   //Check if there is enough space for a new category
@@ -211,7 +211,7 @@ for (c=0; c<feat->no_cats; c++) {
    i=feat->cats[c].val;
    u_printf("%S",feat->cats[c].cat->values[i]);    //Print the value
    if (c<feat->no_cats-1)  {
-      u_printf(";");    
+      u_printf(";");
    }
 }
 u_printf("}\n");
@@ -225,7 +225,7 @@ return 0;
 // Returns 0 on success, -1 on error
 int f_copy_morpho(f_morpho_T *feat1, f_morpho_T *feat2) {
   int c;  //category index in feat1 and feat2
-  
+
   if (!feat1) {
     feat1 = (f_morpho_T*) malloc(sizeof(f_morpho_T));
     if (!feat1)
@@ -235,7 +235,7 @@ int f_copy_morpho(f_morpho_T *feat1, f_morpho_T *feat2) {
   if (!feat2)
     return -1;
 
-  for (c=0; c<feat2->no_cats; c++)  
+  for (c=0; c<feat2->no_cats; c++)
     feat1->cats[c] = feat2->cats[c];  //Add new category-value pair
 
   feat1->no_cats = feat2->no_cats;

--- a/MF_FormMorpho.h
+++ b/MF_FormMorpho.h
@@ -111,7 +111,7 @@ int f_print_morpho(f_morpho_T *feat);
 // If feat1 does not have its space allocated it is allocated first and then filled with a copy feat2
 // Returns 0 on success, -1 on error
 int f_copy_morpho(f_morpho_T *feat1, f_morpho_T *feat2);
-  
+
 } // namespace unitex
 
 #endif

--- a/MF_Global.cpp
+++ b/MF_Global.cpp
@@ -49,10 +49,10 @@ int get_node(MultiFlex_ctx* p_multiFlex_ctx,char* flex,int pos,struct node* n);
 
 
 MultiFlex_ctx* new_MultiFlex_ctx(const char* inflection_dir,const char* morphologyTxt,
-								const char* equivalencesTxt,
-								VersatileEncodingConfig* vec,Korean* korean,
-								const char* pkgdir,const char* named_repositories,
-								GraphRecompilationPolicy graph_recompilation_policy) {
+                                const char* equivalencesTxt,
+                                VersatileEncodingConfig* vec,Korean* korean,
+                                const char* pkgdir,const char* named_repositories,
+                                GraphRecompilationPolicy graph_recompilation_policy) {
 MultiFlex_ctx* ctx = (MultiFlex_ctx*)malloc(sizeof(MultiFlex_ctx));
 if (ctx==NULL) {
    fatal_alloc_error("new_MultiFlex_ctx");
@@ -68,35 +68,35 @@ if (ctx->pL_MORPHO == NULL) {
 }
 ctx->vec=vec;
 if (morphologyTxt!=NULL && morphologyTxt[0]!='\0'
-		&& 0!=read_language_morpho(vec,ctx->pL_MORPHO,morphologyTxt)) {
+        && 0!=read_language_morpho(vec,ctx->pL_MORPHO,morphologyTxt)) {
    error("read_language_morpho error\n");
    ctx->config_files_status=CONFIG_FILES_ERROR;
 }
 if (ctx->config_files_status!=CONFIG_FILES_ERROR
-		&& equivalencesTxt!=NULL && equivalencesTxt[0]!='\0'
-		&& 0!=d_init_morpho_equiv(vec,ctx->pL_MORPHO,equivalencesTxt)) {
-	   error("d_init_morpho_equiv error\n");
-	   ctx->config_files_status=CONFIG_FILES_ERROR;
+        && equivalencesTxt!=NULL && equivalencesTxt[0]!='\0'
+        && 0!=d_init_morpho_equiv(vec,ctx->pL_MORPHO,equivalencesTxt)) {
+       error("d_init_morpho_equiv error\n");
+       ctx->config_files_status=CONFIG_FILES_ERROR;
 }
 ctx->graph_recompilation_policy = graph_recompilation_policy;
 ctx->semitic=0;
 ctx->pkgdir=NULL;
 if (pkgdir!=NULL) {
-	ctx->pkgdir=strdup(pkgdir);
-	if (ctx->pkgdir==NULL) {
-		fatal_alloc_error("new_MultiFlex_ctx");
-	}
+    ctx->pkgdir=strdup(pkgdir);
+    if (ctx->pkgdir==NULL) {
+        fatal_alloc_error("new_MultiFlex_ctx");
+    }
 }
 ctx->named_repositories=NULL;
 if (named_repositories!=NULL) {
-	ctx->named_repositories=strdup(named_repositories);
-	if (ctx->named_repositories==NULL) {
-	   fatal_alloc_error("new_MultiFlex_ctx");
-	}
+    ctx->named_repositories=strdup(named_repositories);
+    if (ctx->named_repositories==NULL) {
+       fatal_alloc_error("new_MultiFlex_ctx");
+    }
 }
 ctx->korean=korean;
 if (ctx->config_files_status!=CONFIG_FILES_ERROR) {
-	d_init_class_equiv(ctx->pL_MORPHO,&(ctx->D_CLASS_EQUIV));
+    d_init_class_equiv(ctx->pL_MORPHO,&(ctx->D_CLASS_EQUIV));
 }
 ctx->n_filter_codes=0;
 ctx->filter_codes=NULL;
@@ -275,7 +275,7 @@ if (flex[pos]=='\0') {
            /* Following the GraphRecompilationPolicy, if there is no .fst2 file,
             * of a one than is older than the corresponding .grf, we try to compile it */
            pseudo_main_Grf2Fst2(p_multiFlex_ctx->vec,grf,1,NULL,1,0,p_multiFlex_ctx->pkgdir,
-        		   p_multiFlex_ctx->named_repositories,0);
+                   p_multiFlex_ctx->named_repositories,0);
         }
         p_multiFlex_ctx->fst2[p_multiFlex_ctx->n_fst2]=load_abstract_fst2(p_multiFlex_ctx->vec,s,1,&(p_multiFlex_ctx->fst2_free[p_multiFlex_ctx->n_fst2]));
         n->final=p_multiFlex_ctx->n_fst2;

--- a/MF_Global.cpp
+++ b/MF_Global.cpp
@@ -51,7 +51,7 @@ int get_node(MultiFlex_ctx* p_multiFlex_ctx,char* flex,int pos,struct node* n);
 MultiFlex_ctx* new_MultiFlex_ctx(const char* inflection_dir,const char* morphologyTxt,
 								const char* equivalencesTxt,
 								VersatileEncodingConfig* vec,Korean* korean,
-								const char* pkgdir,const char* named_repositories, 
+								const char* pkgdir,const char* named_repositories,
 								GraphRecompilationPolicy graph_recompilation_policy) {
 MultiFlex_ctx* ctx = (MultiFlex_ctx*)malloc(sizeof(MultiFlex_ctx));
 if (ctx==NULL) {
@@ -204,25 +204,25 @@ return tmp;
 
 
 /**
- * Returns 0 if  
+ * Returns 0 if
  *  -  The .grf or the .fst2 uses an installed abstract filespace; or
- *  -  The .grf file does not exists; or    
+ *  -  The .grf file does not exists; or
  *  -  GraphRecompilationPolicy is NEVER_RECOMPILE
- * Returns 1 if 
+ * Returns 1 if
  *  - fst2 file does not exists; or
  *  - GraphRecompilationPolicy is :
  *      ALWAYS_RECOMPILE or
- *      ONLY_OUT_OF_DATE and the .grf exists and is more recent than the .fst2    
+ *      ONLY_OUT_OF_DATE and the .grf exists and is more recent than the .fst2
  */
 int must_compile_grf(char* grf,char* fst2, GraphRecompilationPolicy graph_recompilation_policy) {
-  // if the fst2 or the grf uses an installed abstract filespace, 
+  // if the fst2 or the grf uses an installed abstract filespace,
   // there is nothing to compile
-  if ((is_filename_in_abstract_file_space(fst2) != 0) || 
+  if ((is_filename_in_abstract_file_space(fst2) != 0) ||
       (is_filename_in_abstract_file_space(grf)  != 0)) {
       /* abstract ? no compare, no recompile*/
       return 0;
   }
-  
+
   // if .grf does not exits, there is nothing to compile
   if (!fexists(grf)) {
      /* No .grf? We fail */
@@ -243,8 +243,8 @@ int must_compile_grf(char* grf,char* fst2, GraphRecompilationPolicy graph_recomp
     case ONLY_OUT_OF_DATE : recompilation_status = (get_file_date(grf) >= get_file_date(fst2)); break;
     //   NEVER_RECOMPILE
     default               : break;
-  }  
-  
+  }
+
   // return 0 otherwise
   return recompilation_status;
 }
@@ -272,7 +272,7 @@ if (flex[pos]=='\0') {
         new_file(p_multiFlex_ctx->inflection_directory,flex,grf);
         strcat(grf,".grf");
         if (must_compile_grf(grf,s,p_multiFlex_ctx->graph_recompilation_policy)) {
-           /* Following the GraphRecompilationPolicy, if there is no .fst2 file, 
+           /* Following the GraphRecompilationPolicy, if there is no .fst2 file,
             * of a one than is older than the corresponding .grf, we try to compile it */
            pseudo_main_Grf2Fst2(p_multiFlex_ctx->vec,grf,1,NULL,1,0,p_multiFlex_ctx->pkgdir,
         		   p_multiFlex_ctx->named_repositories,0);

--- a/MF_Global.h
+++ b/MF_Global.h
@@ -64,7 +64,7 @@ struct transition {
 // To configure the graph recompilation policy (fst already exists)
 typedef enum {
   // Recompile only if the fst is out of date
-  ONLY_OUT_OF_DATE, 
+  ONLY_OUT_OF_DATE,
   // Force .grf recompilation even if fst exists
   ALWAYS_RECOMPILE,
   // Never recompile .grf files
@@ -130,10 +130,10 @@ unichar** filter_codes;
 
 
 MultiFlex_ctx* new_MultiFlex_ctx(const char* inflection_dir,const char* morphologyTxt,
-								const char* equivalencesTxt,
-								VersatileEncodingConfig* vec,Korean* koran,
-								const char* pkgdir,const char* named_repositories,
-								GraphRecompilationPolicy graph_recompilation_policy);
+                                const char* equivalencesTxt,
+                                VersatileEncodingConfig* vec,Korean* koran,
+                                const char* pkgdir,const char* named_repositories,
+                                GraphRecompilationPolicy graph_recompilation_policy);
 void free_MultiFlex_ctx(MultiFlex_ctx* ctx);
 
 int get_transducer(MultiFlex_ctx* p_multiFlex_ctx,char* flex);

--- a/MF_LangMorpho.cpp
+++ b/MF_LangMorpho.cpp
@@ -58,18 +58,18 @@ l_category_T* get_cat(struct l_morpho_t*,const unichar* val);
 /* (e.g. sing, pl, masc, etc.).                                                       */
 /* <E> is a special character meaning that the feature may have an empty value, e.g.  */
 /* the base form in gradation                                                         */
-/* E.g. for Polish:								      */
-/* 			Polish							      */
+/* E.g. for Polish:                                   */
+/*          Polish                                */
 /*                      <CATEGORIES>                                                  */
-/* 			Nb:sing,pl		                 		      */
-/* 			Case:Nom,Gen,Dat,Acc,Inst,Loc,Voc			      */
-/* 			Gen:masc_pers,masc_anim,masc_inanim,fem,neu                   */
+/*          Nb:sing,pl                                    */
+/*          Case:Nom,Gen,Dat,Acc,Inst,Loc,Voc                 */
+/*          Gen:masc_pers,masc_anim,masc_inanim,fem,neu                   */
 /*                      Gr:<E>,aug,sup                                                */
 /*                      <CLASSES>                                                     */
 /*                      noun: (Nb,<var>),(Case,<var>),(Gen,<fixed>)                   */
 /*                      adj: (Nb,<var>),(Case,<var>),(Gen,<var>),(Gr,<var>)           */
 /*                      adv: (Gr,<var>)                                               */
-/* Fills out pL_MORPHO->L_CLASSES and pL_MORPHO->L_CATS.						      */
+/* Fills out pL_MORPHO->L_CLASSES and pL_MORPHO->L_CATS.                              */
 /* Returns 0 if success, 1 otherwise                                                  */
 int read_language_morpho(const VersatileEncodingConfig* vec,struct l_morpho_t* pL_MORPHO, const char *file) {
   //Initialise the symbol representing an empty morphological value
@@ -268,14 +268,14 @@ int read_class_line(struct l_morpho_t* pL_MORPHO,int class_no) {
       line_pos = line_pos + u_scan_while_char(tmp_void, line_pos, MAX_MORPHO_NAME-1," \t");  //Omit void characters
       //Check if tmp contains an existing category
       for (c=0, found=0; c<pL_MORPHO->L_CATS.no_cats && !found; c++)
-	if (! u_strcmp(pL_MORPHO->L_CATS.cats[c].name,tmp))
-	  found = 1;
+    if (! u_strcmp(pL_MORPHO->L_CATS.cats[c].name,tmp))
+      found = 1;
       if (!found) {
-	      error("Undefined category in language morphology file: pL_MORPHO->line %d!\n", pL_MORPHO->line_no);
-	      return 1;
+          error("Undefined category in language morphology file: pL_MORPHO->line %d!\n", pL_MORPHO->line_no);
+          return 1;
       }
       else
-	pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].cat = &(pL_MORPHO->L_CATS.cats[c-1]);
+    pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].cat = &(pL_MORPHO->L_CATS.cats[c-1]);
 
       //Read the fixedness
       line_pos = line_pos + u_scan_while_char(tmp_void, line_pos, MAX_MORPHO_NAME-1," \t");  //Omit void characters
@@ -287,13 +287,13 @@ int read_class_line(struct l_morpho_t* pL_MORPHO,int class_no) {
       line_pos = line_pos + l;
       line_pos = line_pos + u_scan_while_char(tmp_void, line_pos, MAX_MORPHO_NAME-1," \t");  //Omit void characters
       if (!u_strcmp(tmp,"fixed"))
-	pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].fixed = 1;
+    pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].fixed = 1;
       else
-	if (!u_strcmp(tmp,"var"))
-	  pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].fixed = 0;
-	else {
-	  error("Undefined fixedness symbol in language morphology file: pL_MORPHO->line %d!\n", pL_MORPHO->line_no);
-	  return 1;
+    if (!u_strcmp(tmp,"var"))
+      pL_MORPHO->L_CLASSES.classes[class_no].cats[c_cnt].fixed = 0;
+    else {
+      error("Undefined fixedness symbol in language morphology file: pL_MORPHO->line %d!\n", pL_MORPHO->line_no);
+      return 1;
       }
       c_cnt++;
       line_pos++; //Omit the '>'
@@ -301,9 +301,9 @@ int read_class_line(struct l_morpho_t* pL_MORPHO,int class_no) {
       line_pos++; //Omit the ')'
       line_pos = line_pos + u_scan_while_char(tmp_void, line_pos, MAX_MORPHO_NAME-1," \t");  //Omit void characters
       if (*line_pos == (char) '\n')
-	done = 1;
+    done = 1;
       else
-	line_pos++;  //Omit the ','
+    line_pos++;  //Omit the ','
     } while (!done);
   }
   pL_MORPHO->L_CLASSES.classes[class_no].no_cats = c_cnt;
@@ -312,7 +312,7 @@ int read_class_line(struct l_morpho_t* pL_MORPHO,int class_no) {
 
 /**************************************************************************************/
 /* Prints to the standard output the morphological system of the language             */
-/* as defined by pL_MORPHO->L_CLASSES.       		    			              */
+/* as defined by pL_MORPHO->L_CLASSES.                                            */
 /* Returns 0 on success, 1 otherwise.                                                 */
 int print_language_morpho(struct l_morpho_t* pL_MORPHO) {
 int c,v, cl;
@@ -458,7 +458,7 @@ l_category_T* get_cat(struct l_morpho_t* pL_MORPHO,const unichar* val) {
   for (c=0; c<pL_MORPHO->L_CATS.no_cats; c++)
     for (v=0; v<pL_MORPHO->L_CATS.cats[c].no_values; v++)
       if (!u_strcmp(val,pL_MORPHO->L_CATS.cats[c].values[v]))
-	return &(pL_MORPHO->L_CATS.cats[c]);
+    return &(pL_MORPHO->L_CATS.cats[c]);
   return NULL;
 }
 

--- a/MF_LangMorpho.h
+++ b/MF_LangMorpho.h
@@ -36,10 +36,10 @@
 namespace unitex {
 
 /**
- * 
- * This library is used to parse the "Morphology" file that is 
+ *
+ * This library is used to parse the "Morphology" file that is
  * supposed to be in the same directory than the inflection graphs.
- * 
+ *
  */
 
 
@@ -78,24 +78,24 @@ struct l_morpho_t* init_langage_morph();
 /* (e.g. sing, pl, masc, etc.).                                                       */
 /* <E> is a special character meaning that the feature may have an empty value, e.g.  */
 /* the base form in gradation                                                         */
-/* E.g. for Polish:								      */
-/* 			Polish							      */
+/* E.g. for Polish:                                   */
+/*          Polish                                */
 /*                      <CATEGORIES>                                                  */
-/* 			Nb:sing,pl		                 		      */
-/* 			Case:Nom,Gen,Dat,Acc,Inst,Loc,Voc			      */
-/* 			Gen:masc_pers,masc_anim,masc_inanim,fem,neu                   */
+/*          Nb:sing,pl                                    */
+/*          Case:Nom,Gen,Dat,Acc,Inst,Loc,Voc                 */
+/*          Gen:masc_pers,masc_anim,masc_inanim,fem,neu                   */
 /*                      Gr:<E>,aug,sup                                                */
 /*                      <CLASSES>                                                     */
 /*                      noun: (Nb,<var>),(Case,<var>),(Gen,<fixed>)                   */
 /*                      adj: (Nb,<var>),(Case,<var>),(Gen,<var>),(Gr,<var>)           */
 /*                      adv: (Gr,<var>)                                               */
-/* Fills out L_CLASSES and L_CATS.						      */
+/* Fills out L_CLASSES and L_CATS.                            */
 /* Returns 0 if success, 1 otherwise                                                  */
 int read_language_morpho(const VersatileEncodingConfig*,struct l_morpho_t*, const char *file);
 
 /**************************************************************************************/
 /* Prints to the standard output the morphological system of the language             */
-/* as defined by L_CLASSES.       		    			              */
+/* as defined by L_CLASSES.                                           */
 /* Returns 0 on success, 1 otherwise.                                                 */
 int print_language_morpho(struct l_morpho_t*);
 

--- a/MF_LangMorphoBase.h
+++ b/MF_LangMorphoBase.h
@@ -36,10 +36,10 @@
 namespace unitex {
 
 /**
- * 
- * This library is used to parse the "Morphology" file that is 
+ *
+ * This library is used to parse the "Morphology" file that is
  * supposed to be in the same directory than the inflection graphs.
- * 
+ *
  */
 
 
@@ -59,9 +59,9 @@ namespace unitex {
 #define MAX_MORPHO_NAME 20
 
 //Structure for an inflection category (cf Inflection/Morphology file)
-//e.g. for English 
+//e.g. for English
 //          name = "Nb"  (number inflection)
-//          no_values = 2 
+//          no_values = 2
 //          values = ["sing","pl"] (singular, plural)
 typedef struct {
   unichar* name;
@@ -76,13 +76,13 @@ typedef struct {
 } l_cats_T;
 
 //Structure for an inflection class (cf Inflection/Morphology file)
-//e.g. for Polish 
+//e.g. for Polish
 //          name = "noun"
-//          no_cats = 3 
+//          no_cats = 3
 //          cats = ((Nb,0),(Case,0),(Gen,1))  // a Polish noun HAS a gender and INFLECTS IN number and case
 typedef struct {
-  unichar* name;   
-  int no_cats; 
+  unichar* name;
+  int no_cats;
   struct {
     l_category_T* cat;
     int fixed;

--- a/MF_MU_graph.cpp
+++ b/MF_MU_graph.cpp
@@ -40,52 +40,52 @@ namespace unitex {
 Fst2State MU_graph_get_initial(MultiFlex_ctx* p_multiFlex_ctx,char* graph_name);
 int MU_graph_explore_state(MultiFlex_ctx* p_multiFlex_ctx, Fst2State q,MU_forms_T* forms);
 int MU_graph_explore_label(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_label_T* l, Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_label_T* l, Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_scan_label(MultiFlex_ctx* p_multiFlex_ctx, unichar* label_in,
-		unichar* label_out, MU_graph_label_T* MU_label);
+        unichar* label_out, MU_graph_label_T* MU_label);
 int MU_graph_explore_label_in_var(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
-		MU_graph_morpho_T* l_in_morpho, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_morpho_T* l_in_morpho, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_in_var_rec(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
-		MU_graph_morpho_T* l_in_morpho, int i_morpho, f_morpho_T* feat,
-		MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_morpho_T* l_in_morpho, int i_morpho, f_morpho_T* feat,
+        MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_get_unit_forms(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
-		f_morpho_T* feat, SU_forms_T* SU_forms);
+        f_morpho_T* feat, SU_forms_T* SU_forms);
 int MU_graph_explore_label_in_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_in_morph_inher(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_in_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_out(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_out_rec(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
-		Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
+        Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_out_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, MU_graph_morpho_T* l_out_morpho, int i_morpho,
-		f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_category_T* c, MU_graph_morpho_T* l_out_morpho, int i_morpho,
+        f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_explore_label_out_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, MU_graph_morpho_T* l_out_morpho, int i_morpho,
-		f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms);
+        MU_graph_category_T* c, MU_graph_morpho_T* l_out_morpho, int i_morpho,
+        f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms);
 int MU_graph_scan_label(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label_in, unichar* label_out,
-		MU_graph_label_T* MU_label);
+        unichar* label_in, unichar* label_out,
+        MU_graph_label_T* MU_label);
 int MU_graph_scan_label_in(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_in_T* MU_label_in);
+        unichar* label,
+        MU_graph_in_T* MU_label_in);
 int MU_graph_scan_label_out(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_out_T* MU_label_out);
+        unichar* label,
+        MU_graph_out_T* MU_label_out);
 int MU_graph_scan_graph_morpho(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_morpho_T* MU_graph_morpho);
+        unichar* label,
+        MU_graph_morpho_T* MU_graph_morpho);
 void MU_graph_print_label(MU_graph_label_T* MU_label);
 void MU_graph_print_morpho(MU_graph_morpho_T* MU_morpho);
 void MU_graph_free_label(MU_graph_label_T* MU_label);
@@ -97,43 +97,43 @@ void MU_graph_free_morpho(MU_graph_morpho_T* MU_morpho);
 // Initially, 'forms' has its space allocated but is empty.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_explore_graph(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_lemma_T* MU_l, MU_forms_T* forms) {
-	int res;
+        MU_lemma_T* MU_l, MU_forms_T* forms) {
+    int res;
 
-	//Initialize the current multi-word unit
-	p_multiFlex_ctx->MU_lemma = MU_l;
+    //Initialize the current multi-word unit
+    p_multiFlex_ctx->MU_lemma = MU_l;
 
-	//Initialize the structure for graph unification variables
-	unif_init_vars(&(p_multiFlex_ctx->UNIF_VARS));
+    //Initialize the structure for graph unification variables
+    unif_init_vars(&(p_multiFlex_ctx->UNIF_VARS));
 
-	//Get the initial state of the inflection tranducer
-	Fst2State initial;
-	initial = MU_graph_get_initial(p_multiFlex_ctx,p_multiFlex_ctx->MU_lemma->paradigm);
+    //Get the initial state of the inflection tranducer
+    Fst2State initial;
+    initial = MU_graph_get_initial(p_multiFlex_ctx,p_multiFlex_ctx->MU_lemma->paradigm);
 
-	if (!initial)
-		return 1;
+    if (!initial)
+        return 1;
 
-	//Explore the inflection transducer starting from its initial state
-	res = MU_graph_explore_state(p_multiFlex_ctx,initial,forms);
+    //Explore the inflection transducer starting from its initial state
+    res = MU_graph_explore_state(p_multiFlex_ctx,initial,forms);
 
-	unif_free_vars(&(p_multiFlex_ctx->UNIF_VARS));
-	return res;
+    unif_free_vars(&(p_multiFlex_ctx->UNIF_VARS));
+    return res;
 }
 
 /////////////////////////////////////////////////
 // In the graph not yet loaded loads it otherwise searches for it in the structure.
 // On success returns the graph's initial state, otherwise returns NULL.
 Fst2State MU_graph_get_initial(MultiFlex_ctx* p_multiFlex_ctx,char* graph_name) {
-	//Get the index of the tranducer in the transducer table
-	p_multiFlex_ctx->T = get_transducer(p_multiFlex_ctx, graph_name);
-	if (p_multiFlex_ctx->fst2[p_multiFlex_ctx->T] == NULL) {
-		// if the automaton has not been loaded
-		return NULL;
-	}
-	//Get the initial state
-	Fst2* a = p_multiFlex_ctx->fst2[p_multiFlex_ctx->T];
-	Fst2State q = a->states[0];
-	return q;
+    //Get the index of the tranducer in the transducer table
+    p_multiFlex_ctx->T = get_transducer(p_multiFlex_ctx, graph_name);
+    if (p_multiFlex_ctx->fst2[p_multiFlex_ctx->T] == NULL) {
+        // if the automaton has not been loaded
+        return NULL;
+    }
+    //Get the initial state
+    Fst2* a = p_multiFlex_ctx->fst2[p_multiFlex_ctx->T];
+    Fst2State q = a->states[0];
+    return q;
 }
 
 ////////////////////////////////////////////
@@ -145,58 +145,58 @@ Fst2State MU_graph_get_initial(MultiFlex_ctx* p_multiFlex_ctx,char* graph_name) 
 // Initially, 'forms' has its space allocated but is empty.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_state(MultiFlex_ctx* p_multiFlex_ctx,Fst2State q, MU_forms_T* forms) {
-	int err;
-	MU_graph_label_T* lab;
-	Fst2State q_bis;
+    int err;
+    MU_graph_label_T* lab;
+    Fst2State q_bis;
 
-	//If we are in a final state, then the empty word is recognized, we add it to 'forms' and we continue to explore
-	if (q->control & 1)
-		MU_add_empty_form(forms);
+    //If we are in a final state, then the empty word is recognized, we add it to 'forms' and we continue to explore
+    if (q->control & 1)
+        MU_add_empty_form(forms);
 
-	//Explore each outgoing transition
-	Transition* t;
-	MU_forms_T forms_bis; //Suffixes obtained by the exploration of one outgoing transition
+    //Explore each outgoing transition
+    Transition* t;
+    MU_forms_T forms_bis; //Suffixes obtained by the exploration of one outgoing transition
 
-	t = q->transitions;
-	while (t) {
-		lab = (MU_graph_label_T*) malloc(sizeof(MU_graph_label_T));
-		if (!lab) {
-			fatal_alloc_error("MU_graph_explore_state");
-		}
-		q_bis
-				= p_multiFlex_ctx->fst2[p_multiFlex_ctx->T]->states[t->state_number]; //get the arrival state
-		Fst2Tag e =
-				p_multiFlex_ctx->fst2[p_multiFlex_ctx->T]->tags[t->tag_number]; //get the transition's label
-		err = MU_graph_scan_label(p_multiFlex_ctx, e->input,
-				e->output, lab); //transform the label into a MU_graph_label
-		if (err) {
-			MU_graph_free_label(lab);
-			free(lab);
-			return err;
-		}
-		//Initialize the set of inflected forms
-		MU_init_forms(&forms_bis);
-		err = MU_graph_explore_label(p_multiFlex_ctx, lab, q_bis, &forms_bis);
-		if (err) {
-			MU_graph_free_label(lab);
-			free(lab);
-			MU_delete_inflection(&forms_bis);
-			return err;
-		}
+    t = q->transitions;
+    while (t) {
+        lab = (MU_graph_label_T*) malloc(sizeof(MU_graph_label_T));
+        if (!lab) {
+            fatal_alloc_error("MU_graph_explore_state");
+        }
+        q_bis
+                = p_multiFlex_ctx->fst2[p_multiFlex_ctx->T]->states[t->state_number]; //get the arrival state
+        Fst2Tag e =
+                p_multiFlex_ctx->fst2[p_multiFlex_ctx->T]->tags[t->tag_number]; //get the transition's label
+        err = MU_graph_scan_label(p_multiFlex_ctx, e->input,
+                e->output, lab); //transform the label into a MU_graph_label
+        if (err) {
+            MU_graph_free_label(lab);
+            free(lab);
+            return err;
+        }
+        //Initialize the set of inflected forms
+        MU_init_forms(&forms_bis);
+        err = MU_graph_explore_label(p_multiFlex_ctx, lab, q_bis, &forms_bis);
+        if (err) {
+            MU_graph_free_label(lab);
+            free(lab);
+            MU_delete_inflection(&forms_bis);
+            return err;
+        }
 
-		//Add each new form to the one generated previously, if it does not exist already
-		MU_merge_forms(forms, &forms_bis);
+        //Add each new form to the one generated previously, if it does not exist already
+        MU_merge_forms(forms, &forms_bis);
 
-		MU_delete_inflection(&forms_bis);
+        MU_delete_inflection(&forms_bis);
 
-		//Free the current label
-		MU_graph_free_label(lab);
-		free(lab);
+        //Free the current label
+        MU_graph_free_label(lab);
+        free(lab);
 
-		//Go to the next transition
-		t = t->next;
-	}
-	return 0;
+        //Go to the next transition
+        t = t->next;
+    }
+    return 0;
 }
 
 ////////////////////////////////////////////
@@ -209,60 +209,60 @@ int MU_graph_explore_state(MultiFlex_ctx* p_multiFlex_ctx,Fst2State q, MU_forms_
 // Initially, '*forms' has its space allocated but is empty.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_label_T* l, Fst2State q_bis, MU_forms_T* forms) {
-	int err;
-	//If the current unit is a reference to a lemma's unit (e.g. <$2>)
-	if (l->in && l->in->unit.type != cst) {
-		SU_id_T* u; //Referenced lemma's unit
-		int u_no; //Number of the referenced unit
-		u_no = l->in->unit.u.num - 1;
-		u = p_multiFlex_ctx->MU_lemma->units[u_no]; //Get the referenced lemma's unit
-		//explore the current unit according to its morphology, then the label's output and the rest of the automaton
-		err = MU_graph_explore_label_in_var(p_multiFlex_ctx, u,
-				l->in->morpho, l->out, q_bis, forms);
-		if (err)
-			return err;
-	}
+        MU_graph_label_T* l, Fst2State q_bis, MU_forms_T* forms) {
+    int err;
+    //If the current unit is a reference to a lemma's unit (e.g. <$2>)
+    if (l->in && l->in->unit.type != cst) {
+        SU_id_T* u; //Referenced lemma's unit
+        int u_no; //Number of the referenced unit
+        u_no = l->in->unit.u.num - 1;
+        u = p_multiFlex_ctx->MU_lemma->units[u_no]; //Get the referenced lemma's unit
+        //explore the current unit according to its morphology, then the label's output and the rest of the automaton
+        err = MU_graph_explore_label_in_var(p_multiFlex_ctx, u,
+                l->in->morpho, l->out, q_bis, forms);
+        if (err)
+            return err;
+    }
 
-	else { //If the current unit is fixed (empty or a fixed word, e.g. "of")
+    else { //If the current unit is fixed (empty or a fixed word, e.g. "of")
 
-		//////////////////////////////////
-		//Get the forms of the current unit
-		SU_forms_T SU_forms;
-		SU_init_forms(&SU_forms);
+        //////////////////////////////////
+        //Get the forms of the current unit
+        SU_forms_T SU_forms;
+        SU_init_forms(&SU_forms);
 
-		///If the current unit's input is empty (it is an epsilon input <E>)
-		if (!l->in)
-			//The current form is empty
-			SU_init_invariable_form_char(&SU_forms, "");
+        ///If the current unit's input is empty (it is an epsilon input <E>)
+        if (!l->in)
+            //The current form is empty
+            SU_init_invariable_form_char(&SU_forms, "");
 
-		//If the current unit is a constant (e.g. "of")
-		else
-			//Get the form appearing in the node's input
-			SU_init_invariable_form(&SU_forms, l->in->unit.u.seq);
+        //If the current unit is a constant (e.g. "of")
+        else
+            //Get the form appearing in the node's input
+            SU_init_invariable_form(&SU_forms, l->in->unit.u.seq);
 
-		///////////////////////////////////
-		//Get the suffixes of the MWU forms
-		MU_forms_T suffix_forms;
-		MU_init_forms(&suffix_forms);
-		err = MU_graph_explore_label_out(p_multiFlex_ctx,
-				l->out, q_bis, &suffix_forms); //Explore the rest of the automaton
-		if (err) {
-			SU_delete_inflection(&SU_forms);
-			MU_delete_inflection(&suffix_forms);
-			return err;
-		}
+        ///////////////////////////////////
+        //Get the suffixes of the MWU forms
+        MU_forms_T suffix_forms;
+        MU_init_forms(&suffix_forms);
+        err = MU_graph_explore_label_out(p_multiFlex_ctx,
+                l->out, q_bis, &suffix_forms); //Explore the rest of the automaton
+        if (err) {
+            SU_delete_inflection(&SU_forms);
+            MU_delete_inflection(&suffix_forms);
+            return err;
+        }
 
-		/////////////////////////////////////////////////////////////////////////////////////////
-		//Concatenate each inflected form of the current unit in front of each multi-unit form
-		//resulting from the exploration of the rest of the automaton
-		MU_concat_forms(&SU_forms, &suffix_forms, forms);
+        /////////////////////////////////////////////////////////////////////////////////////////
+        //Concatenate each inflected form of the current unit in front of each multi-unit form
+        //resulting from the exploration of the rest of the automaton
+        MU_concat_forms(&SU_forms, &suffix_forms, forms);
 
-		//Delete the intermediate simple et compound forms
-		SU_delete_inflection(&SU_forms);
-		MU_delete_inflection(&suffix_forms);
-	}
-	return 0;
+        //Delete the intermediate simple et compound forms
+        SU_delete_inflection(&SU_forms);
+        MU_delete_inflection(&suffix_forms);
+    }
+    return 0;
 }
 
 /*For testing
@@ -287,14 +287,14 @@ int MU_graph_explore_label(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_in_var(MultiFlex_ctx* p_multiFlex_ctx,SU_id_T* u,
-		MU_graph_morpho_T* l_in_morpho, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err;
-	f_morpho_T feat; //A set of the already treated morphological features contained in the label's input
-	feat.no_cats = 0;
-	err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u,
-			l_in_morpho, 0, &feat, l_out_morpho, q_bis, forms);
-	return err;
+        MU_graph_morpho_T* l_in_morpho, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err;
+    f_morpho_T feat; //A set of the already treated morphological features contained in the label's input
+    feat.no_cats = 0;
+    err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u,
+            l_in_morpho, 0, &feat, l_out_morpho, q_bis, forms);
+    return err;
 }
 
 ////////////////////////////////////////////
@@ -312,81 +312,81 @@ int MU_graph_explore_label_in_var(MultiFlex_ctx* p_multiFlex_ctx,SU_id_T* u,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_in_var_rec(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
-		MU_graph_morpho_T* l_in_morpho, int i_morpho, f_morpho_T* feat,
-		MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms) {
-	int err = 0;
+        MU_graph_morpho_T* l_in_morpho, int i_morpho, f_morpho_T* feat,
+        MU_graph_morpho_T* l_out_morpho, Fst2State q_bis, MU_forms_T* forms) {
+    int err = 0;
 
-	/////////////////////////////////////////////////////////////////
-	//If the whole label's input not yet treated continue treating it
-	if (l_in_morpho && i_morpho != l_in_morpho->no_cats) {
-		MU_graph_category_T* c; // a single graph category-value pair, e.g. Case==$n1
-		c = &(l_in_morpho->cats[i_morpho]);
-		switch (c->type) {
-		case cnst: //e.g. Nb=pl
-			err = MU_graph_explore_label_in_morph_const(p_multiFlex_ctx,
-					c, u, l_in_morpho, i_morpho + 1, feat,
-					l_out_morpho, q_bis, forms);
-			break;
-		case inherit_var: //e.g. Gen==$g
-			err = MU_graph_explore_label_in_morph_inher(p_multiFlex_ctx,
-					c, u, l_in_morpho, i_morpho + 1, feat,
-					l_out_morpho, q_bis, forms);
-			break;
-		case unif_var: //e.g. Case=$c1
-			err = MU_graph_explore_label_in_morph_unif(p_multiFlex_ctx,
-					c, u, l_in_morpho, i_morpho + 1, feat,
-					l_out_morpho, q_bis, forms);
-			break;
-		}
-		if (err)
-			return err;
-	}
+    /////////////////////////////////////////////////////////////////
+    //If the whole label's input not yet treated continue treating it
+    if (l_in_morpho && i_morpho != l_in_morpho->no_cats) {
+        MU_graph_category_T* c; // a single graph category-value pair, e.g. Case==$n1
+        c = &(l_in_morpho->cats[i_morpho]);
+        switch (c->type) {
+        case cnst: //e.g. Nb=pl
+            err = MU_graph_explore_label_in_morph_const(p_multiFlex_ctx,
+                    c, u, l_in_morpho, i_morpho + 1, feat,
+                    l_out_morpho, q_bis, forms);
+            break;
+        case inherit_var: //e.g. Gen==$g
+            err = MU_graph_explore_label_in_morph_inher(p_multiFlex_ctx,
+                    c, u, l_in_morpho, i_morpho + 1, feat,
+                    l_out_morpho, q_bis, forms);
+            break;
+        case unif_var: //e.g. Case=$c1
+            err = MU_graph_explore_label_in_morph_unif(p_multiFlex_ctx,
+                    c, u, l_in_morpho, i_morpho + 1, feat,
+                    l_out_morpho, q_bis, forms);
+            break;
+        }
+        if (err)
+            return err;
+    }
 
-	////////////////////////////////////////////////////////////////////////////////
-	//If the whole label's input treated get the inflected forms of the current unit
-	else {
+    ////////////////////////////////////////////////////////////////////////////////
+    //If the whole label's input treated get the inflected forms of the current unit
+    else {
 
-		//Get the inflected forms of the current unit
-		SU_forms_T SU_forms;
-		SU_init_forms(&SU_forms);
+        //Get the inflected forms of the current unit
+        SU_forms_T SU_forms;
+        SU_init_forms(&SU_forms);
 
-		//If no morphology in the input label, take the unit as it appears in the MWU's lemma
-		if (!l_in_morpho)
-			//Get the inflected form from the current unit (this form is not to be modified since there is no morphology in the input label)
-			SU_init_invariable_form(&SU_forms, u->form);
+        //If no morphology in the input label, take the unit as it appears in the MWU's lemma
+        if (!l_in_morpho)
+            //Get the inflected form from the current unit (this form is not to be modified since there is no morphology in the input label)
+            SU_init_invariable_form(&SU_forms, u->form);
 
-		//If all morphological category-value equations in the input label treated
-		else {
-			//Inflect the unit concerned according to desired features
-			err = MU_graph_get_unit_forms(p_multiFlex_ctx, u,feat, &SU_forms);
-			if (err) {
-				SU_delete_inflection(&SU_forms);
-				return err;
-			}
-		}
+        //If all morphological category-value equations in the input label treated
+        else {
+            //Inflect the unit concerned according to desired features
+            err = MU_graph_get_unit_forms(p_multiFlex_ctx, u,feat, &SU_forms);
+            if (err) {
+                SU_delete_inflection(&SU_forms);
+                return err;
+            }
+        }
 
-		///////////////////////////////////
-		//Get the suffixes of the MWU forms
-		MU_forms_T suffix_forms;
-		MU_init_forms(&suffix_forms);
-		err = MU_graph_explore_label_out(p_multiFlex_ctx,
-				l_out_morpho, q_bis, &suffix_forms); //Explore the rest of the automaton
-		if (err) {
-			SU_delete_inflection(&SU_forms);
-			MU_delete_inflection(&suffix_forms);
-			return err;
-		}
+        ///////////////////////////////////
+        //Get the suffixes of the MWU forms
+        MU_forms_T suffix_forms;
+        MU_init_forms(&suffix_forms);
+        err = MU_graph_explore_label_out(p_multiFlex_ctx,
+                l_out_morpho, q_bis, &suffix_forms); //Explore the rest of the automaton
+        if (err) {
+            SU_delete_inflection(&SU_forms);
+            MU_delete_inflection(&suffix_forms);
+            return err;
+        }
 
-		/////////////////////////////////////////////////////////////////////////////////////////
-		//Concatenante each inflected form of the current unit in front of each multi-unit form
-		//resulting from the exploration of the rest of the automaton
-		MU_concat_forms(&SU_forms, &suffix_forms, forms);
+        /////////////////////////////////////////////////////////////////////////////////////////
+        //Concatenante each inflected form of the current unit in front of each multi-unit form
+        //resulting from the exploration of the rest of the automaton
+        MU_concat_forms(&SU_forms, &suffix_forms, forms);
 
-		//Delete the intermediate simple et compound forms
-		SU_delete_inflection(&SU_forms);
-		MU_delete_inflection(&suffix_forms);
-	}
-	return 0;
+        //Delete the intermediate simple et compound forms
+        SU_delete_inflection(&SU_forms);
+        MU_delete_inflection(&suffix_forms);
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////
@@ -397,24 +397,24 @@ int MU_graph_explore_label_in_var_rec(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u
 // Initially, 'SU_forms' has its space allocated but is empty.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_get_unit_forms(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
-		f_morpho_T* feat, SU_forms_T* SU_forms) {
-	int err;
-	f_morpho_T old_feat; //Features that the current unit has in the lemma of the MWU
+        f_morpho_T* feat, SU_forms_T* SU_forms) {
+    int err;
+    f_morpho_T old_feat; //Features that the current unit has in the lemma of the MWU
 
-	//Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem> for "vif" in "memoire vive"
-	//SU_cpy_features(&old_feat,u);
-	err = f_copy_morpho(&old_feat, u->feat);
-	if (err)
-		return err;
+    //Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem> for "vif" in "memoire vive"
+    //SU_cpy_features(&old_feat,u);
+    err = f_copy_morpho(&old_feat, u->feat);
+    if (err)
+        return err;
 
-	//Change the features to adapt them to the desired features, e.g. if 'feat'=<Nb=pl> then old_feat<-<Nb=pl; Gen=fem>
-	err = f_change_morpho(p_multiFlex_ctx->pL_MORPHO, &old_feat, feat);
-	if (err)
-		return err;
+    //Change the features to adapt them to the desired features, e.g. if 'feat'=<Nb=pl> then old_feat<-<Nb=pl; Gen=fem>
+    err = f_change_morpho(p_multiFlex_ctx->pL_MORPHO, &old_feat, feat);
+    if (err)
+        return err;
 
-	//Generate the desired inflected forms of the single unit
-	err = SU_inflect(p_multiFlex_ctx, u, &old_feat, SU_forms);
-	return err;
+    //Generate the desired inflected forms of the single unit
+    err = SU_inflect(p_multiFlex_ctx, u, &old_feat, SU_forms);
+    return err;
 }
 
 ////////////////////////////////////////////
@@ -433,21 +433,21 @@ int MU_graph_get_unit_forms(MultiFlex_ctx* p_multiFlex_ctx, SU_id_T* u,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_in_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err;
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err;
 
-	//Add the current label's category-value pair to the features of the single unit to be generated
-	err = f_add_morpho(feat, c->cat, c->val.value);
-	if (err == -1) {
-		MU_delete_inflection(forms);
-		return 1;
-	}
+    //Add the current label's category-value pair to the features of the single unit to be generated
+    err = f_add_morpho(feat, c->cat, c->val.value);
+    if (err == -1) {
+        MU_delete_inflection(forms);
+        return 1;
+    }
 
-	//Explore recursively the rest of the label
-	return MU_graph_explore_label_in_var_rec(p_multiFlex_ctx,
-			u, l_in_morpho, i_morpho, feat, l_out_morpho, q_bis, forms);
+    //Explore recursively the rest of the label
+    return MU_graph_explore_label_in_var_rec(p_multiFlex_ctx,
+            u, l_in_morpho, i_morpho, feat, l_out_morpho, q_bis, forms);
 }
 
 ////////////////////////////////////////////
@@ -466,60 +466,60 @@ int MU_graph_explore_label_in_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_in_morph_inher(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err;
-	int new_instant = 0; //Controls if an instantiation occured in the current instance of the function
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err;
+    int new_instant = 0; //Controls if an instantiation occured in the current instance of the function
 
-	//Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem; Case=Nom>
-	f_morpho_T old_feat; //Features that the current unit has in the lemma of the MWU
-	//err = SU_cpy_features(&old_feat,u);    //e.g. <Nb=sing; Case=$c1; Gen==$g>
-	err = f_copy_morpho(&old_feat, u->feat);
-	if (err)
-		return err;
+    //Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem; Case=Nom>
+    f_morpho_T old_feat; //Features that the current unit has in the lemma of the MWU
+    //err = SU_cpy_features(&old_feat,u);    //e.g. <Nb=sing; Case=$c1; Gen==$g>
+    err = f_copy_morpho(&old_feat, u->feat);
+    if (err)
+        return err;
 
-	//Get the value of the current category (determined by 'c') of the unit as it appears in the lemma of the MWU
-	int val; //Value of the current category (index that this value has in the domain os the category)
-	val = f_get_value(p_multiFlex_ctx->pL_MORPHO, &old_feat, c->cat); //e.g. val: fem
+    //Get the value of the current category (determined by 'c') of the unit as it appears in the lemma of the MWU
+    int val; //Value of the current category (index that this value has in the domain os the category)
+    val = f_get_value(p_multiFlex_ctx->pL_MORPHO, &old_feat, c->cat); //e.g. val: fem
 
-	if (val == -1)
-		return -1;
+    if (val == -1)
+        return -1;
 
-	//Instantiate the variable if necessary
-	unichar* var;
-	var = c->val.inherit_var; //get the identifier of the variable, e.g. g1
-	if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
-		//If the same variable already instantiated to a DIFFERENT value then cut off the exploration path
-		//The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
-		if ((unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
-				|| (unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS), var) != val))
-			return 0;
-		//If variable already instantiated to the same value, no further instantiation needed
-	} else { //Variable not yet instantiated
-		err = unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
-		if (err)
-			return err;
-		new_instant = 1;
-	}
+    //Instantiate the variable if necessary
+    unichar* var;
+    var = c->val.inherit_var; //get the identifier of the variable, e.g. g1
+    if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
+        //If the same variable already instantiated to a DIFFERENT value then cut off the exploration path
+        //The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
+        if ((unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
+                || (unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS), var) != val))
+            return 0;
+        //If variable already instantiated to the same value, no further instantiation needed
+    } else { //Variable not yet instantiated
+        err = unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
+        if (err)
+            return err;
+        new_instant = 1;
+    }
 
-	//Add the the instantiated category-value pair to the features of the single unit to be generated
-	err = f_add_morpho(feat, c->cat, val);
-	if (err)
-		return err;
+    //Add the the instantiated category-value pair to the features of the single unit to be generated
+    err = f_add_morpho(feat, c->cat, val);
+    if (err)
+        return err;
 
-	//Explore recursively the rest of the label
-	err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u,
-			l_in_morpho, i_morpho, feat, l_out_morpho, q_bis, forms);
-	if (err)
-		return err;
+    //Explore recursively the rest of the label
+    err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u,
+            l_in_morpho, i_morpho, feat, l_out_morpho, q_bis, forms);
+    if (err)
+        return err;
 
-	//Desinstantiate the variable only if it has been instantiated by the current category-value pair 'c'
-	if (new_instant)
-		unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
+    //Desinstantiate the variable only if it has been instantiated by the current category-value pair 'c'
+    if (new_instant)
+        unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
 
-	err = f_del_one_morpho(feat, c->cat);
-	return err;
+    err = f_del_one_morpho(feat, c->cat);
+    return err;
 }
 
 ////////////////////////////////////////////
@@ -538,91 +538,91 @@ int MU_graph_explore_label_in_morph_inher(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_in_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
-		int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err; //Result of a function called
+        MU_graph_category_T* c, SU_id_T* u, MU_graph_morpho_T* l_in_morpho,
+        int i_morpho, f_morpho_T* feat, MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err; //Result of a function called
 
-	unichar* var; //Unification variable's identifier
-	var = c->val.unif_var;
+    unichar* var; //Unification variable's identifier
+    var = c->val.unif_var;
 
-	//Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem; Case=Nom>
-	//  f_morpho_T old_feat;  //Features that the current unit has in the lemma of the MWU
-	//  err = SU_cpy_features(&old_feat,u);    //e.g. <Nb=sing; Case=$c1; Gen==$g>
-	//  if (err)
-	//    return err;
+    //Get the features that the unit has in the lemma of the MWU, e.g. <Nb=sing; Gen=fem; Case=Nom>
+    //  f_morpho_T old_feat;  //Features that the current unit has in the lemma of the MWU
+    //  err = SU_cpy_features(&old_feat,u);    //e.g. <Nb=sing; Case=$c1; Gen==$g>
+    //  if (err)
+    //    return err;
 
-	if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
-		//If the same variable already instantiated for a DIFFERENT category then cut off the exploration path
-		//The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
-		if (unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
-			return 0;
+    if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
+        //If the same variable already instantiated for a DIFFERENT category then cut off the exploration path
+        //The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
+        if (unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
+            return 0;
 
-		//If the same variable already instantiated for the same category, only this instantiation is taken into account
-		//Add the instantiated category-value pair to the features of the single unit to be generated
-		err = f_add_morpho(feat, c->cat, unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS),
-				var));
-		if (err == -1) {
-			MU_delete_inflection(forms);
-			return 1;
-		}
+        //If the same variable already instantiated for the same category, only this instantiation is taken into account
+        //Add the instantiated category-value pair to the features of the single unit to be generated
+        err = f_add_morpho(feat, c->cat, unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS),
+                var));
+        if (err == -1) {
+            MU_delete_inflection(forms);
+            return 1;
+        }
 
-		//Return MU_graph_explore_label_in_var_rec(u,l_in_morpho,i_morpho,feat,l_out_morpho,q_bis,forms);
-		err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx,
-				u, l_in_morpho, i_morpho, feat, l_out_morpho, q_bis,forms);
-		if (err == -1) {
-			MU_delete_inflection(forms);
-			return 1;
-		}
-		err = f_del_one_morpho(feat, c->cat);
-		return err;
-	}
+        //Return MU_graph_explore_label_in_var_rec(u,l_in_morpho,i_morpho,feat,l_out_morpho,q_bis,forms);
+        err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx,
+                u, l_in_morpho, i_morpho, feat, l_out_morpho, q_bis,forms);
+        if (err == -1) {
+            MU_delete_inflection(forms);
+            return 1;
+        }
+        err = f_del_one_morpho(feat, c->cat);
+        return err;
+    }
 
-	else {//If the variable not yet instantiated
-		int val; //Index of different values in the domain of the current category
-		MU_forms_T suffix_forms; //Suffixes generated in one run of the for-loop
-		for (val = 0; val < c->cat->no_values; val++) {
+    else {//If the variable not yet instantiated
+        int val; //Index of different values in the domain of the current category
+        MU_forms_T suffix_forms; //Suffixes generated in one run of the for-loop
+        for (val = 0; val < c->cat->no_values; val++) {
 
-			//Instantiated to the current value
-			unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
+            //Instantiated to the current value
+            unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
 
-			//Add the the instantiated category-value pair to the features of the single unit to be generated
-			err = f_add_morpho(feat, c->cat, val);
-			if (err) {
-				MU_delete_inflection(&suffix_forms);
-				return err;
-			}
+            //Add the the instantiated category-value pair to the features of the single unit to be generated
+            err = f_add_morpho(feat, c->cat, val);
+            if (err) {
+                MU_delete_inflection(&suffix_forms);
+                return err;
+            }
 
-			//Explore the rest of the label and the rest of the automaton
-			MU_init_forms(&suffix_forms);
-			err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u, l_in_morpho,
-					i_morpho, feat, l_out_morpho, q_bis, &suffix_forms);
-			if (err) {
-				//Delete the intermediate simple et compound forms
-				MU_delete_inflection(&suffix_forms);
-				return err;
-			}
+            //Explore the rest of the label and the rest of the automaton
+            MU_init_forms(&suffix_forms);
+            err = MU_graph_explore_label_in_var_rec(p_multiFlex_ctx, u, l_in_morpho,
+                    i_morpho, feat, l_out_morpho, q_bis, &suffix_forms);
+            if (err) {
+                //Delete the intermediate simple et compound forms
+                MU_delete_inflection(&suffix_forms);
+                return err;
+            }
 
-			//Add each suffix obtained to the list of previously obtained suffixes
-			MU_merge_forms(forms, &suffix_forms);
+            //Add each suffix obtained to the list of previously obtained suffixes
+            MU_merge_forms(forms, &suffix_forms);
 
-			//Delete the current category-value pair
-			//feat->no_cats--;
-			err = f_del_one_morpho(feat, c->cat);
-			if (err) {
-				//Delete the intermediate simple et compound forms
-				MU_delete_inflection(&suffix_forms);
-				return err;
-			}
+            //Delete the current category-value pair
+            //feat->no_cats--;
+            err = f_del_one_morpho(feat, c->cat);
+            if (err) {
+                //Delete the intermediate simple et compound forms
+                MU_delete_inflection(&suffix_forms);
+                return err;
+            }
 
-			//Delete the current instantiation
-			unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
+            //Delete the current instantiation
+            unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
 
-			//Delete the intermediate simple et compound forms
-			MU_delete_inflection(&suffix_forms);
-		}
-	}
-	return 0;
+            //Delete the intermediate simple et compound forms
+            MU_delete_inflection(&suffix_forms);
+        }
+    }
+    return 0;
 }
 
 ////////////////////////////////////////////
@@ -635,15 +635,15 @@ int MU_graph_explore_label_in_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
 // Initially, '*forms' has its space allocated but is empty.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_out(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_morpho_T* l_out_morpho,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err;
-	f_morpho_T feat; //A set of the already treated morphological features contained in the label's input
-	f_init_morpho(&feat);
-	//feat.no_cats = 0;
-	err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
-			l_out_morpho, 0, &feat, q_bis, forms);
-	return (err);
+        MU_graph_morpho_T* l_out_morpho,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err;
+    f_morpho_T feat; //A set of the already treated morphological features contained in the label's input
+    f_init_morpho(&feat);
+    //feat.no_cats = 0;
+    err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
+            l_out_morpho, 0, &feat, q_bis, forms);
+    return (err);
 }
 
 ////////////////////////////////////////////
@@ -658,61 +658,61 @@ int MU_graph_explore_label_out(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_out_rec(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_morpho_T* l_out_morpho,
-		int i_morpho, f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms) {
-	int err = 0;
+        MU_graph_morpho_T* l_out_morpho,
+        int i_morpho, f_morpho_T* feat, Fst2State q_bis, MU_forms_T* forms) {
+    int err = 0;
 
-	//If no morphology in the output label, then go to the next state
-	if (!l_out_morpho) {
-		//Explore the arrival state
-		err = MU_graph_explore_state(p_multiFlex_ctx,q_bis, forms);
-		if (err)
-			return err;
-	} else //Label's input not empty
+    //If no morphology in the output label, then go to the next state
+    if (!l_out_morpho) {
+        //Explore the arrival state
+        err = MU_graph_explore_state(p_multiFlex_ctx,q_bis, forms);
+        if (err)
+            return err;
+    } else //Label's input not empty
 
-	//If the whole output morphology has been treated
-	if (i_morpho == l_out_morpho->no_cats) {
+    //If the whole output morphology has been treated
+    if (i_morpho == l_out_morpho->no_cats) {
 
-		//Explore the arrival state
-		err = MU_graph_explore_state(p_multiFlex_ctx, q_bis, forms);
-		if (err)
-			return err;
+        //Explore the arrival state
+        err = MU_graph_explore_state(p_multiFlex_ctx, q_bis, forms);
+        if (err)
+            return err;
 
-		//Add the current features to the features of the suffixes
-		int f; //Index of the current suffix
-		int c; //Index of the current category-value pair in 'feat'
-		for (f = 0; f < forms->no_forms; f++)
-			for (c = 0; c < feat->no_cats; c++) {
-				//If the ouput morphology in a graph is ambiguous, the final MWU's morphology is undefined
-				err = f_add_morpho(forms->forms[f].features, feat->cats[c].cat,
-						feat->cats[c].val);
-				if (err == -1) {
-					MU_delete_inflection(forms);
-					return 1;
-				}
-			}
-	}
+        //Add the current features to the features of the suffixes
+        int f; //Index of the current suffix
+        int c; //Index of the current category-value pair in 'feat'
+        for (f = 0; f < forms->no_forms; f++)
+            for (c = 0; c < feat->no_cats; c++) {
+                //If the ouput morphology in a graph is ambiguous, the final MWU's morphology is undefined
+                err = f_add_morpho(forms->forms[f].features, feat->cats[c].cat,
+                        feat->cats[c].val);
+                if (err == -1) {
+                    MU_delete_inflection(forms);
+                    return 1;
+                }
+            }
+    }
 
-	//If the whole label's output not yet treated
-	else {
-		MU_graph_category_T* c; // a single graph category-value pair, e.g. Case==$n1
-		c = &(l_out_morpho->cats[i_morpho]);
-		switch (c->type) {
-		case cnst: //e.g. Nb=pl
-			err = MU_graph_explore_label_out_morph_const(p_multiFlex_ctx,
-					c, l_out_morpho,i_morpho + 1, feat, q_bis, forms);
-			break;
-		case unif_var: //e.g. Case=$c1
-			err = MU_graph_explore_label_out_morph_unif(p_multiFlex_ctx,
-					c, l_out_morpho,i_morpho + 1, feat, q_bis, forms);
-			break;
-		default:
-			;
-		}
-		if (err)
-			return err;
-	}
-	return 0;
+    //If the whole label's output not yet treated
+    else {
+        MU_graph_category_T* c; // a single graph category-value pair, e.g. Case==$n1
+        c = &(l_out_morpho->cats[i_morpho]);
+        switch (c->type) {
+        case cnst: //e.g. Nb=pl
+            err = MU_graph_explore_label_out_morph_const(p_multiFlex_ctx,
+                    c, l_out_morpho,i_morpho + 1, feat, q_bis, forms);
+            break;
+        case unif_var: //e.g. Case=$c1
+            err = MU_graph_explore_label_out_morph_unif(p_multiFlex_ctx,
+                    c, l_out_morpho,i_morpho + 1, feat, q_bis, forms);
+            break;
+        default:
+            ;
+        }
+        if (err)
+            return err;
+    }
+    return 0;
 }
 
 ////////////////////////////////////////////
@@ -728,19 +728,19 @@ int MU_graph_explore_label_out_rec(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_out_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c,
-		MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err;
-	//Add the current label's category-value pair to the features of the single unit to be generated
-	err = f_add_morpho(feat, c->cat, c->val.value);
-	if (err == -1) {
-		MU_delete_inflection(forms);
-		return 1;
-	}
-	//Explore recursively the rest of the label
-	return MU_graph_explore_label_out_rec(p_multiFlex_ctx,
-			l_out_morpho, i_morpho, feat, q_bis, forms);
+        MU_graph_category_T* c,
+        MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err;
+    //Add the current label's category-value pair to the features of the single unit to be generated
+    err = f_add_morpho(feat, c->cat, c->val.value);
+    if (err == -1) {
+        MU_delete_inflection(forms);
+        return 1;
+    }
+    //Explore recursively the rest of the label
+    return MU_graph_explore_label_out_rec(p_multiFlex_ctx,
+            l_out_morpho, i_morpho, feat, q_bis, forms);
 }
 
 ////////////////////////////////////////////
@@ -756,74 +756,74 @@ int MU_graph_explore_label_out_morph_const(MultiFlex_ctx* p_multiFlex_ctx,
 // In case of error put an empty list into 'forms'.
 // Return a number !=0 in case of errors, 0 otherwise.
 int MU_graph_explore_label_out_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_graph_category_T* c,
-		MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
-		Fst2State q_bis, MU_forms_T* forms) {
-	int err; //Result of a function called
+        MU_graph_category_T* c,
+        MU_graph_morpho_T* l_out_morpho, int i_morpho, f_morpho_T* feat,
+        Fst2State q_bis, MU_forms_T* forms) {
+    int err; //Result of a function called
 
-	unichar* var; //Unification variable's identifier
-	var = c->val.unif_var;
+    unichar* var; //Unification variable's identifier
+    var = c->val.unif_var;
 
-	if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
-		//If the same variable already instantiated for a DIFFERENT category then cut off the exploration path
-		//The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
-		if (unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
-			return 0;
+    if (unif_instantiated(&(p_multiFlex_ctx->UNIF_VARS), var)) {
+        //If the same variable already instantiated for a DIFFERENT category then cut off the exploration path
+        //The 'forms' remain empty list as they were (which is not equivalent to a list containing (epsilon,empty_set)
+        if (unif_get_cat(&(p_multiFlex_ctx->UNIF_VARS), var) != c->cat)
+            return 0;
 
-		//If the same variable already instantiated for the same category, only this instantiation is taken into account
-		//Add the the instantiated category-value pair to the features of the single unit to be generated
-		err = f_add_morpho(feat, c->cat, unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS),
-				var));
-		if (err == -1) {
-			MU_delete_inflection(forms);
-			return 1;
-		}
-		err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
-				l_out_morpho, i_morpho, feat, q_bis, forms);
+        //If the same variable already instantiated for the same category, only this instantiation is taken into account
+        //Add the the instantiated category-value pair to the features of the single unit to be generated
+        err = f_add_morpho(feat, c->cat, unif_get_val_index(&(p_multiFlex_ctx->UNIF_VARS),
+                var));
+        if (err == -1) {
+            MU_delete_inflection(forms);
+            return 1;
+        }
+        err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
+                l_out_morpho, i_morpho, feat, q_bis, forms);
 
-		//Delete the current category-value pair
-		f_del_one_morpho(feat, c->cat);
-		//feat->no_cats--;
+        //Delete the current category-value pair
+        f_del_one_morpho(feat, c->cat);
+        //feat->no_cats--;
 
-		//Pass on the error
-		return err;
+        //Pass on the error
+        return err;
 
-	}
+    }
 
-	else {//If the variable not yet instantiated
-		int val; //Index of different values in the domain of the current category
-		MU_forms_T suffix_forms; //Suffixes generated in one run of the for-loop
-		for (val = 0; val < c->cat->no_values; val++) {
+    else {//If the variable not yet instantiated
+        int val; //Index of different values in the domain of the current category
+        MU_forms_T suffix_forms; //Suffixes generated in one run of the for-loop
+        for (val = 0; val < c->cat->no_values; val++) {
 
-			//Instantiated to the current value
-			unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
+            //Instantiated to the current value
+            unif_instantiate_index(&(p_multiFlex_ctx->UNIF_VARS), var, c->cat, val);
 
-			//Add the the instantiated category-value pair to the features of the single unit to be generated
-			err = f_add_morpho(feat, c->cat, val); //e.g. 'feat' devient <Nb=pl; Case=Nom; Gen=fem>
-			if (err == -1) {
-				MU_delete_inflection(forms);
-				return 1;
-			}
+            //Add the the instantiated category-value pair to the features of the single unit to be generated
+            err = f_add_morpho(feat, c->cat, val); //e.g. 'feat' devient <Nb=pl; Case=Nom; Gen=fem>
+            if (err == -1) {
+                MU_delete_inflection(forms);
+                return 1;
+            }
 
-			//Explore the rest of the label and the rest of the automaton
-			MU_init_forms(&suffix_forms);
-			err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
-					l_out_morpho, i_morpho, feat, q_bis, &suffix_forms);
-			if (err) {
-				MU_delete_inflection(&suffix_forms);
-				return err;
-			}
-			//If any suffix found, add it to the list of those generated previously
-			MU_merge_forms(forms, &suffix_forms);
+            //Explore the rest of the label and the rest of the automaton
+            MU_init_forms(&suffix_forms);
+            err = MU_graph_explore_label_out_rec(p_multiFlex_ctx,
+                    l_out_morpho, i_morpho, feat, q_bis, &suffix_forms);
+            if (err) {
+                MU_delete_inflection(&suffix_forms);
+                return err;
+            }
+            //If any suffix found, add it to the list of those generated previously
+            MU_merge_forms(forms, &suffix_forms);
 
-			//Delete the current category-value pair
-			f_del_one_morpho(feat, c->cat);
+            //Delete the current category-value pair
+            f_del_one_morpho(feat, c->cat);
 
-			//Delete the current instantiation
-			unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
-		}
-	}
-	return 0;
+            //Delete the current instantiation
+            unif_desinstantiate(&(p_multiFlex_ctx->UNIF_VARS), var);
+        }
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////
@@ -831,45 +831,45 @@ int MU_graph_explore_label_out_morph_unif(MultiFlex_ctx* p_multiFlex_ctx,
 // We suppose that MU_label already has its memory allocated.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_scan_label(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label_in, unichar* label_out,
-		MU_graph_label_T* MU_label) {
-	int err1, err2;
-	err1 = err2 = 0;
+        unichar* label_in, unichar* label_out,
+        MU_graph_label_T* MU_label) {
+    int err1, err2;
+    err1 = err2 = 0;
 
-	//Input label
-	/*
-	 printf("label_in = ");  //debug
-	 u_prints(label_in);//debug
-	 printf("\n");//debug
-	 */
-	if (!u_strcmp(label_in, "<E>")) //Epsilon case
-		MU_label->in = NULL;
-	else {
-		MU_label->in = (MU_graph_in_T*) malloc(sizeof(MU_graph_in_T));
-		if (MU_label->in == NULL) {
-			fatal_alloc_error("MU_graph_scan_label");
-		}
-		err1 = MU_graph_scan_label_in(p_multiFlex_ctx, label_in,
-				MU_label->in);
-	}
-	//Output label
-	/*
-	 printf("label_out = ");  //debug
-	 u_prints(label_out);//debug
-	 printf("\n");//debug
-	 */
-	if (label_out == NULL || (!u_strcmp(label_out, "<E>")) || (!u_strlen(
-			label_out))) //Case of epsilon or void output
-		MU_label->out = NULL;
-	else {
-		MU_label->out = (MU_graph_out_T*) malloc(sizeof(MU_graph_out_T));
-		if (MU_label->out == NULL) {
-			fatal_alloc_error("MU_graph_scan_label");
-		}
-		err2 = MU_graph_scan_label_out(p_multiFlex_ctx,label_out,
-				MU_label->out);
-	}
-	return (err1 || err2);
+    //Input label
+    /*
+     printf("label_in = ");  //debug
+     u_prints(label_in);//debug
+     printf("\n");//debug
+     */
+    if (!u_strcmp(label_in, "<E>")) //Epsilon case
+        MU_label->in = NULL;
+    else {
+        MU_label->in = (MU_graph_in_T*) malloc(sizeof(MU_graph_in_T));
+        if (MU_label->in == NULL) {
+            fatal_alloc_error("MU_graph_scan_label");
+        }
+        err1 = MU_graph_scan_label_in(p_multiFlex_ctx, label_in,
+                MU_label->in);
+    }
+    //Output label
+    /*
+     printf("label_out = ");  //debug
+     u_prints(label_out);//debug
+     printf("\n");//debug
+     */
+    if (label_out == NULL || (!u_strcmp(label_out, "<E>")) || (!u_strlen(
+            label_out))) //Case of epsilon or void output
+        MU_label->out = NULL;
+    else {
+        MU_label->out = (MU_graph_out_T*) malloc(sizeof(MU_graph_out_T));
+        if (MU_label->out == NULL) {
+            fatal_alloc_error("MU_graph_scan_label");
+        }
+        err2 = MU_graph_scan_label_out(p_multiFlex_ctx,label_out,
+                MU_label->out);
+    }
+    return (err1 || err2);
 }
 
 /////////////////////////////////////////////////
@@ -877,99 +877,99 @@ int MU_graph_scan_label(MultiFlex_ctx* p_multiFlex_ctx,
 // We suppose that MU_label_in already has its memory allocated.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_scan_label_in(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_in_T* MU_label_in) {
-	int l; //length of a scanned sequence
-	unichar* pos; //current position in label
-	unichar tmp[MAX_GRAPH_NODE];
-	int err = 0;
+        unichar* label,
+        MU_graph_in_T* MU_label_in) {
+    int l; //length of a scanned sequence
+    unichar* pos; //current position in label
+    unichar tmp[MAX_GRAPH_NODE];
+    int err = 0;
 
-	pos = label;
+    pos = label;
 
-	//Omit void characters
-	pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+    //Omit void characters
+    pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-	//Constant unit, e.g. "of"
-	if (*pos != (unichar) '<') {
-		l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, "", 1);
-		MU_label_in->unit.type = cst;
-		MU_label_in->unit.u.seq = u_strdup(tmp);
-		MU_label_in->morpho = NULL;
-		pos = pos + l;
-	} else { //Variable unit, e.g. <$2:Gen==$g>
-		pos++; //Omit the '<'
-		MU_label_in->unit.type = var;
-		if (*pos != (unichar) '$') {
-			error("In graph %s label format incorrect in %S",
-					p_multiFlex_ctx->MU_lemma->paradigm, label);
-			error(" (at position %d): ", (int) (pos - label));
-			error(" a '$' missing after '<'.\n");
-			return 1;
-		}
-		pos++; //Omit the '$'
-		l = u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, "0123456789");
-		if (!l) {
-			error("In graph %s label format incorrect in %S",
-					p_multiFlex_ctx->MU_lemma->paradigm, label);
-			error(" (at position %d): ", (int) (pos - label));
-			error(" unit number missing after \'$\'.\n");
-			return 1;
-		}
-		char tmp_char[MAX_GRAPH_NODE];
-		u_to_char(tmp_char, tmp);
-		MU_label_in->unit.u.num = atoi(tmp_char);
-		pos = pos + l;
+    //Constant unit, e.g. "of"
+    if (*pos != (unichar) '<') {
+        l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, "", 1);
+        MU_label_in->unit.type = cst;
+        MU_label_in->unit.u.seq = u_strdup(tmp);
+        MU_label_in->morpho = NULL;
+        pos = pos + l;
+    } else { //Variable unit, e.g. <$2:Gen==$g>
+        pos++; //Omit the '<'
+        MU_label_in->unit.type = var;
+        if (*pos != (unichar) '$') {
+            error("In graph %s label format incorrect in %S",
+                    p_multiFlex_ctx->MU_lemma->paradigm, label);
+            error(" (at position %d): ", (int) (pos - label));
+            error(" a '$' missing after '<'.\n");
+            return 1;
+        }
+        pos++; //Omit the '$'
+        l = u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, "0123456789");
+        if (!l) {
+            error("In graph %s label format incorrect in %S",
+                    p_multiFlex_ctx->MU_lemma->paradigm, label);
+            error(" (at position %d): ", (int) (pos - label));
+            error(" unit number missing after \'$\'.\n");
+            return 1;
+        }
+        char tmp_char[MAX_GRAPH_NODE];
+        u_to_char(tmp_char, tmp);
+        MU_label_in->unit.u.num = atoi(tmp_char);
+        pos = pos + l;
 
-		//Omit void characters
-		pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+        //Omit void characters
+        pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-		//A ':' or a '>' must follow
-		if ((*pos != (unichar) ':') && (*pos != (unichar) '>')) {
-			error("In graph %s label format incorrect in ",
-					p_multiFlex_ctx->MU_lemma->paradigm);
-			error("Graph label format incorrect in %S", label);
-			error(" (at position %d): ", (int) (pos - label));
-			error("':' or '>' missing.\n");
-			return 1;
-		}
+        //A ':' or a '>' must follow
+        if ((*pos != (unichar) ':') && (*pos != (unichar) '>')) {
+            error("In graph %s label format incorrect in ",
+                    p_multiFlex_ctx->MU_lemma->paradigm);
+            error("Graph label format incorrect in %S", label);
+            error(" (at position %d): ", (int) (pos - label));
+            error("':' or '>' missing.\n");
+            return 1;
+        }
 
-		//Check if morphology follows
-		if (*pos == (unichar) ':') {
-			pos++;
-			MU_label_in->morpho = (MU_graph_morpho_T*) malloc(
-					sizeof(MU_graph_morpho_T));
-			if (MU_label_in->morpho == NULL) {
-				fatal_alloc_error("MU_graph_scan_label_in");
-			}
-			unichar tmp1[MAX_GRAPH_NODE];
-			l = u_scan_until_char(tmp1, pos, MAX_GRAPH_NODE - 1, ">", 1);
-			err = MU_graph_scan_graph_morpho(p_multiFlex_ctx,tmp1,
-					MU_label_in->morpho);
-			pos = pos + l;
-		} else
-			MU_label_in->morpho = NULL;
-		//Closing '>'
-		if (*pos != (unichar) '>') {
-			error("In graph %s label format incorrect in %S",
-					p_multiFlex_ctx->MU_lemma->paradigm, label);
-			error(" (at position %d): ", (int) (pos - label));
-			error("'>' missing.\n");
-			return 1;
-		}
-		pos++;
-	}
+        //Check if morphology follows
+        if (*pos == (unichar) ':') {
+            pos++;
+            MU_label_in->morpho = (MU_graph_morpho_T*) malloc(
+                    sizeof(MU_graph_morpho_T));
+            if (MU_label_in->morpho == NULL) {
+                fatal_alloc_error("MU_graph_scan_label_in");
+            }
+            unichar tmp1[MAX_GRAPH_NODE];
+            l = u_scan_until_char(tmp1, pos, MAX_GRAPH_NODE - 1, ">", 1);
+            err = MU_graph_scan_graph_morpho(p_multiFlex_ctx,tmp1,
+                    MU_label_in->morpho);
+            pos = pos + l;
+        } else
+            MU_label_in->morpho = NULL;
+        //Closing '>'
+        if (*pos != (unichar) '>') {
+            error("In graph %s label format incorrect in %S",
+                    p_multiFlex_ctx->MU_lemma->paradigm, label);
+            error(" (at position %d): ", (int) (pos - label));
+            error("'>' missing.\n");
+            return 1;
+        }
+        pos++;
+    }
 
-	//Omit void characters
-	pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+    //Omit void characters
+    pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-	if (*pos != 0) {
-		error("In graph %s label format incorrect in %S",
-				p_multiFlex_ctx->MU_lemma->paradigm, label);
-		error(" (at position %d): ", (int) (pos - label));
-		error(" end of label expected.\n");
-		return 1;
-	}
-	return err;
+    if (*pos != 0) {
+        error("In graph %s label format incorrect in %S",
+                p_multiFlex_ctx->MU_lemma->paradigm, label);
+        error(" (at position %d): ", (int) (pos - label));
+        error(" end of label expected.\n");
+        return 1;
+    }
+    return err;
 }
 
 /////////////////////////////////////////////////
@@ -977,47 +977,47 @@ int MU_graph_scan_label_in(MultiFlex_ctx* p_multiFlex_ctx,
 // We suppose that MU_label_out already has its memory allocated.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_scan_label_out(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_out_T* MU_label_out) {
-	int cv; //number of the current category-value pair
-	int err;
-	int l; //length of a scanned sequence
-	unichar* pos; //current position in label
+        unichar* label,
+        MU_graph_out_T* MU_label_out) {
+    int cv; //number of the current category-value pair
+    int err;
+    int l; //length of a scanned sequence
+    unichar* pos; //current position in label
 
-	pos = label;
+    pos = label;
 
-	//Opening '<'
-	if (*pos != (unichar) '<') {
-		error("In graph %s label format incorrect in %S",
-				p_multiFlex_ctx->MU_lemma->paradigm, label);
-		error(" (at position %d): ", (int) (pos - label));
-		error(" '<'  expected.\n");
-		return 1;
-	}
-	pos++;
-	unichar tmp[MAX_GRAPH_NODE];
-	l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, ">", 1);
-	err = MU_graph_scan_graph_morpho(p_multiFlex_ctx,tmp,
-			MU_label_out);
-	pos = pos + l;
-	if (!err)
-		for (cv = 0; cv < MU_label_out->no_cats; cv++)
-			if (MU_label_out->cats[cv].type == inherit_var) {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(
-						": an output label may not contain a double assignment \'==\'.\n");
-				return 1;
-			}
-	//Closing '>'
-	if (*pos != (unichar) '>') {
-		error("In graph %s label format incorrect in %S",
-				p_multiFlex_ctx->MU_lemma->paradigm, label);
-		error(" (at position %d): ", (int) (pos - label));
-		error(" '>'  expected.\n");
-		return 1;
-	}
-	return 0;
+    //Opening '<'
+    if (*pos != (unichar) '<') {
+        error("In graph %s label format incorrect in %S",
+                p_multiFlex_ctx->MU_lemma->paradigm, label);
+        error(" (at position %d): ", (int) (pos - label));
+        error(" '<'  expected.\n");
+        return 1;
+    }
+    pos++;
+    unichar tmp[MAX_GRAPH_NODE];
+    l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, ">", 1);
+    err = MU_graph_scan_graph_morpho(p_multiFlex_ctx,tmp,
+            MU_label_out);
+    pos = pos + l;
+    if (!err)
+        for (cv = 0; cv < MU_label_out->no_cats; cv++)
+            if (MU_label_out->cats[cv].type == inherit_var) {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(
+                        ": an output label may not contain a double assignment \'==\'.\n");
+                return 1;
+            }
+    //Closing '>'
+    if (*pos != (unichar) '>') {
+        error("In graph %s label format incorrect in %S",
+                p_multiFlex_ctx->MU_lemma->paradigm, label);
+        error(" (at position %d): ", (int) (pos - label));
+        error(" '>'  expected.\n");
+        return 1;
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////
@@ -1025,228 +1025,228 @@ int MU_graph_scan_label_out(MultiFlex_ctx* p_multiFlex_ctx,
 // We suppose that MU_graph_morpho already has its memory allocated.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_scan_graph_morpho(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* label,
-		MU_graph_morpho_T* MU_graph_morpho) {
-	int l; //length of a scanned sequence
-	unichar* pos; //current position in label
-	unichar tmp[MAX_GRAPH_NODE];
-	int cv; //number of the current category-value pair
-	l_category_T* cat;
-	int val; //Index of a value in the domain of a category.
-	int dbl_eq; //Checks if a double equal sign has appeared
+        unichar* label,
+        MU_graph_morpho_T* MU_graph_morpho) {
+    int l; //length of a scanned sequence
+    unichar* pos; //current position in label
+    unichar tmp[MAX_GRAPH_NODE];
+    int cv; //number of the current category-value pair
+    l_category_T* cat;
+    int val; //Index of a value in the domain of a category.
+    int dbl_eq; //Checks if a double equal sign has appeared
 
-	pos = label;
+    pos = label;
 
-	//Omit void characters
-	pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+    //Omit void characters
+    pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-	//Category-value pairs
-	int done = 0;
-	cv = 0;
-	while (!done) {
-		//Omit void characters
-		pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+    //Category-value pairs
+    int done = 0;
+    cv = 0;
+    while (!done) {
+        //Omit void characters
+        pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-		//Category, e.g. Nb
-		l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t=", 1);
-		cat = is_valid_cat(p_multiFlex_ctx->pL_MORPHO, tmp);
-		if (!cat) {
-			error("In graph %s label format incorrect in %S",
-					p_multiFlex_ctx->MU_lemma->paradigm, label);
-			error(" (at position %d): %S", (int) (pos - label), tmp);
-			error(" is not a valid category\n");
-			return 1;
-		}
-		MU_graph_morpho->cats[cv].cat = cat;
-		pos = pos + l;
+        //Category, e.g. Nb
+        l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t=", 1);
+        cat = is_valid_cat(p_multiFlex_ctx->pL_MORPHO, tmp);
+        if (!cat) {
+            error("In graph %s label format incorrect in %S",
+                    p_multiFlex_ctx->MU_lemma->paradigm, label);
+            error(" (at position %d): %S", (int) (pos - label), tmp);
+            error(" is not a valid category\n");
+            return 1;
+        }
+        MU_graph_morpho->cats[cv].cat = cat;
+        pos = pos + l;
 
-		//Omit void characters
-		pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+        //Omit void characters
+        pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-		//The '=' character
-		if (*pos != (unichar) '=') {
-			error("In graph %s label format incorrect in %S",
-					p_multiFlex_ctx->MU_lemma->paradigm, label);
-			error(" (at position %d): ", (int) (pos - label));
-			error("\'=\' missing.\n");
-			return 1;
-		}
-		pos++;
+        //The '=' character
+        if (*pos != (unichar) '=') {
+            error("In graph %s label format incorrect in %S",
+                    p_multiFlex_ctx->MU_lemma->paradigm, label);
+            error(" (at position %d): ", (int) (pos - label));
+            error("\'=\' missing.\n");
+            return 1;
+        }
+        pos++;
 
-		//The double '==' if any
-		if (*pos == (unichar) '=') {
-			dbl_eq = 1;
-			pos++;
-		} else
-			dbl_eq = 0;
+        //The double '==' if any
+        if (*pos == (unichar) '=') {
+            dbl_eq = 1;
+            pos++;
+        } else
+            dbl_eq = 0;
 
-		//Omit void characters
-		pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+        //Omit void characters
+        pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-		//Value e.g. gen, $n1
-		//Variable
-		if (*pos == (unichar) '$') {
-			if (dbl_eq)
-				MU_graph_morpho->cats[cv].type = inherit_var;
-			else
-				MU_graph_morpho->cats[cv].type = unif_var;
-			pos++; //omit the '$'
-			l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t;>", 1);
-			if (!l) {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(" (at position %d): ", (int) (pos - label));
-				error("a variable missing after \'$\'.\n");
-				return 1;
-			}
-			MU_graph_morpho->cats[cv].val.unif_var = u_strdup(tmp);
-		} else { //constant value, e.g. fem
-			if (dbl_eq) {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(" (at position %d): ", (int) (pos - label));
-				error("a variable missing after \'==\'.\n");
-				return 1;
-			}
-			MU_graph_morpho->cats[cv].type = cnst;
-			l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t;>", 1);
-			if (!l) {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(" (at position %d): %S", (int) (pos - label), tmp);
-				error("a value missing after \'=\'.\n");
-				return 1;
-			}
-			val = is_valid_val(cat, tmp);
-			if (val == -1) {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(" (at position %d): %S", (int) (pos - label), tmp);
-				error(" is not a valid value in the domain of %S\n", cat->name);
-				return 1;
-			}
-			MU_graph_morpho->cats[cv].val.value = val;
-		}
-		pos = pos + l; //go to the end of the current value
+        //Value e.g. gen, $n1
+        //Variable
+        if (*pos == (unichar) '$') {
+            if (dbl_eq)
+                MU_graph_morpho->cats[cv].type = inherit_var;
+            else
+                MU_graph_morpho->cats[cv].type = unif_var;
+            pos++; //omit the '$'
+            l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t;>", 1);
+            if (!l) {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(" (at position %d): ", (int) (pos - label));
+                error("a variable missing after \'$\'.\n");
+                return 1;
+            }
+            MU_graph_morpho->cats[cv].val.unif_var = u_strdup(tmp);
+        } else { //constant value, e.g. fem
+            if (dbl_eq) {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(" (at position %d): ", (int) (pos - label));
+                error("a variable missing after \'==\'.\n");
+                return 1;
+            }
+            MU_graph_morpho->cats[cv].type = cnst;
+            l = u_scan_until_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t;>", 1);
+            if (!l) {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(" (at position %d): %S", (int) (pos - label), tmp);
+                error("a value missing after \'=\'.\n");
+                return 1;
+            }
+            val = is_valid_val(cat, tmp);
+            if (val == -1) {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(" (at position %d): %S", (int) (pos - label), tmp);
+                error(" is not a valid value in the domain of %S\n", cat->name);
+                return 1;
+            }
+            MU_graph_morpho->cats[cv].val.value = val;
+        }
+        pos = pos + l; //go to the end of the current value
 
-		//New category-value pair read in
-		cv++;
+        //New category-value pair read in
+        cv++;
 
-		//Omit void characters
-		pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+        //Omit void characters
+        pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-		//See if end of category-value pairs
-		if ((*pos == (unichar) '>') || (*pos == (unichar) '\0'))
-			done = 1;
-		else {
-			if (*pos != (unichar) ';') {
-				error("In graph %s label format incorrect in %S",
-						p_multiFlex_ctx->MU_lemma->paradigm, label);
-				error(" (at position %d): %S", (int) (pos - label), tmp);
-				error(" ';' missing\n");
-				return 1;
-			}
-			pos++; //Omit the ';'
-		}
-	}
-	MU_graph_morpho->no_cats = cv;
+        //See if end of category-value pairs
+        if ((*pos == (unichar) '>') || (*pos == (unichar) '\0'))
+            done = 1;
+        else {
+            if (*pos != (unichar) ';') {
+                error("In graph %s label format incorrect in %S",
+                        p_multiFlex_ctx->MU_lemma->paradigm, label);
+                error(" (at position %d): %S", (int) (pos - label), tmp);
+                error(" ';' missing\n");
+                return 1;
+            }
+            pos++; //Omit the ';'
+        }
+    }
+    MU_graph_morpho->no_cats = cv;
 
-	//Omit void characters
-	pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
+    //Omit void characters
+    pos = pos + u_scan_while_char(tmp, pos, MAX_GRAPH_NODE - 1, " \t");
 
-	return 0;
+    return 0;
 }
 
 /////////////////////////////////////////////////
 // Prints a MU_graph label.
 void MU_graph_print_label(MU_graph_label_T* MU_label) {
-	//Label's input
-	if (!MU_label->in) { //Epsilon case
-		u_printf("<E>");
-	} else {
-		if (MU_label->in->unit.type == cst)
-			u_printf("%S", MU_label->in->unit.u.seq);
-		else {
-			u_printf("<$%d", MU_label->in->unit.u.num);
-			if (MU_label->in->morpho) {
-				//Opening ':'
-				u_printf(":");
-				MU_graph_print_morpho(MU_label->in->morpho);
-			}
-			u_printf(">");
-		}
-	}
-	//Separating '/'
-	u_printf("/");
-	//Label's output
-	if (!MU_label->out) { //Epsilon case
-		u_printf("<E>");
-	} else {
-		u_printf("<");
-		MU_graph_print_morpho(MU_label->out);
-		u_printf(">");
-	}
-	//Newline
-	u_printf("\n");
+    //Label's input
+    if (!MU_label->in) { //Epsilon case
+        u_printf("<E>");
+    } else {
+        if (MU_label->in->unit.type == cst)
+            u_printf("%S", MU_label->in->unit.u.seq);
+        else {
+            u_printf("<$%d", MU_label->in->unit.u.num);
+            if (MU_label->in->morpho) {
+                //Opening ':'
+                u_printf(":");
+                MU_graph_print_morpho(MU_label->in->morpho);
+            }
+            u_printf(">");
+        }
+    }
+    //Separating '/'
+    u_printf("/");
+    //Label's output
+    if (!MU_label->out) { //Epsilon case
+        u_printf("<E>");
+    } else {
+        u_printf("<");
+        MU_graph_print_morpho(MU_label->out);
+        u_printf(">");
+    }
+    //Newline
+    u_printf("\n");
 }
 
 /////////////////////////////////////////////////
 // Prints a MU_graph morpho.
 void MU_graph_print_morpho(MU_graph_morpho_T* MU_morpho) {
-	int cv; //number of the current category-value pair
-	//Category-value features
-	for (cv = 0; cv < MU_morpho->no_cats; cv++) {
-		//Category
-		u_printf("%S", MU_morpho->cats[cv].cat->name);
-		//Equality
-		u_printf("=");
-		if (MU_morpho->cats[cv].type == inherit_var) {
-			u_printf("="); //Double '=='
-		}
-		//Value
-		if (MU_morpho->cats[cv].type == inherit_var) { //inherit_var
-			u_printf("$%S", MU_morpho->cats[cv].val.inherit_var);
-		} else if (MU_morpho->cats[cv].type == unif_var) { //unif_var
-			u_printf("$%S", MU_morpho->cats[cv].val.unif_var);
-		} else { //constant
-			int val = MU_morpho->cats[cv].val.value;
-			u_printf("%S", MU_morpho->cats[cv].cat->values[val]);
-		}
-		//Semi-colon
-		if (cv < MU_morpho->no_cats - 1) {
-			u_printf(";");
-		}
-	}
+    int cv; //number of the current category-value pair
+    //Category-value features
+    for (cv = 0; cv < MU_morpho->no_cats; cv++) {
+        //Category
+        u_printf("%S", MU_morpho->cats[cv].cat->name);
+        //Equality
+        u_printf("=");
+        if (MU_morpho->cats[cv].type == inherit_var) {
+            u_printf("="); //Double '=='
+        }
+        //Value
+        if (MU_morpho->cats[cv].type == inherit_var) { //inherit_var
+            u_printf("$%S", MU_morpho->cats[cv].val.inherit_var);
+        } else if (MU_morpho->cats[cv].type == unif_var) { //unif_var
+            u_printf("$%S", MU_morpho->cats[cv].val.unif_var);
+        } else { //constant
+            int val = MU_morpho->cats[cv].val.value;
+            u_printf("%S", MU_morpho->cats[cv].cat->values[val]);
+        }
+        //Semi-colon
+        if (cv < MU_morpho->no_cats - 1) {
+            u_printf(";");
+        }
+    }
 }
 /////////////////////////////////////////////////
 // Frees the memory allocated for a MU_graph label.
 void MU_graph_free_label(MU_graph_label_T* MU_label) {
-	//Free the label's input
-	if (MU_label->in) {
-		if (MU_label->in->unit.type == cst)
-			free(MU_label->in->unit.u.seq);
-		if (MU_label->in->morpho) {
-			MU_graph_free_morpho(MU_label->in->morpho);
-			free(MU_label->in->morpho);
-		}
-		free(MU_label->in);
-	}
-	//Free the label's output
-	if (MU_label->out) {
-		MU_graph_free_morpho(MU_label->out);
-		free(MU_label->out);
-	}
+    //Free the label's input
+    if (MU_label->in) {
+        if (MU_label->in->unit.type == cst)
+            free(MU_label->in->unit.u.seq);
+        if (MU_label->in->morpho) {
+            MU_graph_free_morpho(MU_label->in->morpho);
+            free(MU_label->in->morpho);
+        }
+        free(MU_label->in);
+    }
+    //Free the label's output
+    if (MU_label->out) {
+        MU_graph_free_morpho(MU_label->out);
+        free(MU_label->out);
+    }
 }
 
 /////////////////////////////////////////////////
 // Liberates the memory allocated for a MU_graph morpho.
 void MU_graph_free_morpho(MU_graph_morpho_T* MU_morpho) {
-	int cv; //number of the current category-value pair
-	for (cv = 0; cv < MU_morpho->no_cats; cv++)
-		if (MU_morpho->cats[cv].type == unif_var)
-			free(MU_morpho->cats[cv].val.unif_var);
-		else if (MU_morpho->cats[cv].type == inherit_var)
-			free(MU_morpho->cats[cv].val.inherit_var);
+    int cv; //number of the current category-value pair
+    for (cv = 0; cv < MU_morpho->no_cats; cv++)
+        if (MU_morpho->cats[cv].type == unif_var)
+            free(MU_morpho->cats[cv].val.unif_var);
+        else if (MU_morpho->cats[cv].type == inherit_var)
+            free(MU_morpho->cats[cv].val.inherit_var);
 }
 
 } // namespace unitex

--- a/MF_MU_graph.h
+++ b/MF_MU_graph.h
@@ -45,7 +45,7 @@ namespace unitex {
 
 /////////////////////////////////////////////////
 // Possible types for a value description
-// e.g. Gen=fem is a constant description, 
+// e.g. Gen=fem is a constant description,
 //      Gen=$g1 is a description containing a unification variable
 //      Gen==$g1 is a description containing an inheritance variable
 typedef enum {cnst, unif_var, inherit_var} MU_graph_value_T;
@@ -59,7 +59,7 @@ typedef struct {
     int value;             //category's value (e.g. fem): index of val in the domain of 'cat'
     unichar* unif_var;     //e.g. g1
     unichar* inherit_var;  //e.g. g1
-  } val;  
+  } val;
 } MU_graph_category_T;
 
 /////////////////////////////////////////////////
@@ -71,7 +71,7 @@ typedef struct {
 
 /////////////////////////////////////////////////
 // Possible types for a graphical unit reference in a node
-// e.g. "of" is a reference to a constant unit, 
+// e.g. "of" is a reference to a constant unit,
 //      $2 is a reference to a variable (here representing the 2nd constituent of the MWU's lemma)
 typedef enum {cst,var} MU_graph_u_T;
 
@@ -107,25 +107,25 @@ typedef struct {
 /////////////////////////////////////////////////
 
 /////////////////////////////////////////////////
-// Explores the inflection transducer of the MU-lemma 'MU_lemma' 
+// Explores the inflection transducer of the MU-lemma 'MU_lemma'
 // in order to generate all its inflected forms. The generated forms are put to 'forms'
 // (initially, 'forms' does not have its space allocated).
-//Returns 0 on success, 1 otherwise. 
+//Returns 0 on success, 1 otherwise.
 int MU_graph_explore_graph(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_lemma_T* MU_lemma, MU_forms_T* forms);
+        MU_lemma_T* MU_lemma, MU_forms_T* forms);
 
 /////////////////////////////////////////////////
-// Creates a MU_graph label from two strings.    
+// Creates a MU_graph label from two strings.
 // We suppose that MU_label already has its memory allocated.
 // Returns 0 on success, 1 otherwise.
 int MU_graph_scan_label(MultiFlex_ctx* p_multiFlex_ctx,unichar* label_in, unichar* label_out, MU_graph_label_T* MU_label);
 
 /////////////////////////////////////////////////
-// Prints a MU_graph label.    
+// Prints a MU_graph label.
 void MU_graph_print_label(MU_graph_label_T* MU_label);
 
 /////////////////////////////////////////////////
-// Liberates the memory allocated for a MU_graph label.    
+// Liberates the memory allocated for a MU_graph label.
 void MU_graph_free_label(MU_graph_label_T* MU_label);
 
 } // namespace unitex

--- a/MF_MU_morpho.cpp
+++ b/MF_MU_morpho.cpp
@@ -44,29 +44,29 @@ namespace unitex {
 // Initially, 'forms' has its space allocated but is empty.
 // Returns 0 on success, 1 otherwise.
 int MU_inflect(MultiFlex_ctx* p_multiFlex_ctx,MU_lemma_T* lemma,MU_forms_T* forms) {
-	int err;
+    int err;
 
-	//Explore the inflection tranducer and produce the inflected forms
-	err = MU_graph_explore_graph(p_multiFlex_ctx,lemma,forms);
-	if (err)
-		return 1;
-	else
-		return 0;
+    //Explore the inflection tranducer and produce the inflected forms
+    err = MU_graph_explore_graph(p_multiFlex_ctx,lemma,forms);
+    if (err)
+        return 1;
+    else
+        return 0;
 }
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a set of forms
 void MU_delete_inflection(MU_forms_T* forms) {
-	int f;
-	if (!forms)
-		return;
-	for (f = 0; f < forms->no_forms; f++) {
-		if (forms->forms[f].form)
-			free(forms->forms[f].form);
-		if (forms->forms[f].features)
-			f_delete_morpho(forms->forms[f].features);
-	}
-	free(forms->forms);
+    int f;
+    if (!forms)
+        return;
+    for (f = 0; f < forms->no_forms; f++) {
+        if (forms->forms[f].form)
+            free(forms->forms[f].form);
+        if (forms->forms[f].features)
+            f_delete_morpho(forms->forms[f].features);
+    }
+    free(forms->forms);
 }
 
 /*
@@ -84,56 +84,56 @@ void MU_delete_inflection(MU_forms_T* forms) {
 ////////////////////////////////////////////
 // Liberates the memory allocated for a form's id.
 void MU_delete_id(MU_id_T* id) {
-	if (id) {
-		free(id->form);
-		MU_delete_lemma(id->MU_lemma);
-		f_delete_morpho(id->feat);
-	}
-	free(id);
+    if (id) {
+        free(id->form);
+        MU_delete_lemma(id->MU_lemma);
+        f_delete_morpho(id->feat);
+    }
+    free(id);
 }
 
 ////////////////////////////////////////////
 // Compare two multi-unit forms
 // Return 0 if they are identical, 1 otherwise.
 int MU_form_cmp(MU_f_T f1, MU_f_T f2) {
-	if (u_strcmp(f1.form, f2.form))
-		return 1;
-	return f_morpho_cmp(f1.features, f2.features);
+    if (u_strcmp(f1.form, f2.form))
+        return 1;
+    return f_morpho_cmp(f1.features, f2.features);
 }
 
 ////////////////////////////////////////////
 // Initialize the multi-unit 'forms' with null values
 // We suppose that 'forms' has its space allocated
 void MU_init_forms(MU_forms_T* forms) {
-	forms->no_forms = 0;
-	forms->forms = NULL;
+    forms->no_forms = 0;
+    forms->forms = NULL;
 }
 
 ////////////////////////////////////////////
 // Add an empty form with empty features 'feat' to the initially empty set of forms 'forms'
 void MU_add_empty_form(MU_forms_T* forms) {
-	//Allocate space for a couple (epsilon,empty_set)
-	if (forms->forms!=NULL) {
-		fatal_error("Unexpected non NULL forms in MU_add_empty_form");
-	}
-	forms->forms = (MU_f_T*) malloc(sizeof(MU_f_T));
-	if (!forms->forms) {
-		fatal_alloc_error("MU_add_empty_form");
-	}
-	MU_f_T* f;
-	f = &(forms->forms[0]);
-	f->form = (unichar*) malloc(sizeof(unichar));
-	if (f->form == NULL) {
-		fatal_alloc_error("MU_add_empty_form");
-	}
-	f->form[0] = (unichar) '\0';
-	f->features = (f_morpho_T*) malloc(sizeof(f_morpho_T));
-	if (f->features == NULL) {
-		fatal_alloc_error("MU_add_empty_form");
-	}
-	f->features->no_cats = 0;
+    //Allocate space for a couple (epsilon,empty_set)
+    if (forms->forms!=NULL) {
+        fatal_error("Unexpected non NULL forms in MU_add_empty_form");
+    }
+    forms->forms = (MU_f_T*) malloc(sizeof(MU_f_T));
+    if (!forms->forms) {
+        fatal_alloc_error("MU_add_empty_form");
+    }
+    MU_f_T* f;
+    f = &(forms->forms[0]);
+    f->form = (unichar*) malloc(sizeof(unichar));
+    if (f->form == NULL) {
+        fatal_alloc_error("MU_add_empty_form");
+    }
+    f->form[0] = (unichar) '\0';
+    f->features = (f_morpho_T*) malloc(sizeof(f_morpho_T));
+    if (f->features == NULL) {
+        fatal_alloc_error("MU_add_empty_form");
+    }
+    f->features->no_cats = 0;
 
-	forms->no_forms++;
+    forms->no_forms++;
 }
 
 ////////////////////////////////////////////
@@ -150,46 +150,46 @@ void MU_add_empty_form(MU_forms_T* forms) {
 // Initially, 'forms' has its space allocated, it may be empty or non empty.
 // If it is non empty, the existing forms must not be lost
 void MU_concat_forms(SU_forms_T* SU_forms, MU_forms_T* MU_forms,
-		MU_forms_T* forms) {
-	int sf; //Index of a simple form in SU_forms
-	int mf; //Index of a multi-word form in MU_form
-	int f; //Index of a concatenated form
+        MU_forms_T* forms) {
+    int sf; //Index of a simple form in SU_forms
+    int mf; //Index of a multi-word form in MU_form
+    int f; //Index of a concatenated form
 
-	if (MU_forms->no_forms && SU_forms->no_forms) { //Check if there is anything to concatenante
-		forms->forms = (MU_f_T*) realloc(forms->forms, (forms->no_forms
-				+ MU_forms->no_forms * SU_forms->no_forms) * sizeof(MU_f_T));
-		if (!forms->forms) {
-			fatal_alloc_error("MU_concat_forms");
-		}
-		f = forms->no_forms;
-		for (sf = 0; sf < SU_forms->no_forms; sf++)
-			for (mf = 0; mf < MU_forms->no_forms; mf++) {
-				forms->forms[f].form = (unichar*) malloc((u_strlen(
-						MU_forms->forms[mf].form) + u_strlen(
-						SU_forms->forms[sf].form) + 1) * sizeof(unichar));
-				if (!forms->forms[f].form) {
-					fatal_alloc_error("MU_concat_forms");
-				}
-				//Concatenate the forms
-				u_strcpy(forms->forms[f].form, SU_forms->forms[sf].form);
-				u_strcat(forms->forms[f].form, MU_forms->forms[mf].form);
-				//Copy the features
-				forms->forms[f].features = (f_morpho_T*) malloc(
-						sizeof(f_morpho_T));
-				if (!forms->forms[f].features) {
-					fatal_alloc_error("MU_concat_forms");
-				}
-				forms->forms[f].features->no_cats
-						= MU_forms->forms[mf].features->no_cats;
-				for (int c = 0; c < MU_forms->forms[mf].features->no_cats; c++)
-					forms->forms[f].features->cats[c]
-							= MU_forms->forms[mf].features->cats[c];
-				f++;
-			}
-		forms->no_forms = f;
-	} else
-		//If there is nothing to concatenate
-		forms = NULL;
+    if (MU_forms->no_forms && SU_forms->no_forms) { //Check if there is anything to concatenante
+        forms->forms = (MU_f_T*) realloc(forms->forms, (forms->no_forms
+                + MU_forms->no_forms * SU_forms->no_forms) * sizeof(MU_f_T));
+        if (!forms->forms) {
+            fatal_alloc_error("MU_concat_forms");
+        }
+        f = forms->no_forms;
+        for (sf = 0; sf < SU_forms->no_forms; sf++)
+            for (mf = 0; mf < MU_forms->no_forms; mf++) {
+                forms->forms[f].form = (unichar*) malloc((u_strlen(
+                        MU_forms->forms[mf].form) + u_strlen(
+                        SU_forms->forms[sf].form) + 1) * sizeof(unichar));
+                if (!forms->forms[f].form) {
+                    fatal_alloc_error("MU_concat_forms");
+                }
+                //Concatenate the forms
+                u_strcpy(forms->forms[f].form, SU_forms->forms[sf].form);
+                u_strcat(forms->forms[f].form, MU_forms->forms[mf].form);
+                //Copy the features
+                forms->forms[f].features = (f_morpho_T*) malloc(
+                        sizeof(f_morpho_T));
+                if (!forms->forms[f].features) {
+                    fatal_alloc_error("MU_concat_forms");
+                }
+                forms->forms[f].features->no_cats
+                        = MU_forms->forms[mf].features->no_cats;
+                for (int c = 0; c < MU_forms->forms[mf].features->no_cats; c++)
+                    forms->forms[f].features->cats[c]
+                            = MU_forms->forms[mf].features->cats[c];
+                f++;
+            }
+        forms->no_forms = f;
+    } else
+        //If there is nothing to concatenate
+        forms = NULL;
 }
 
 ////////////////////////////////////////////
@@ -199,115 +199,115 @@ void MU_concat_forms(SU_forms_T* SU_forms, MU_forms_T* MU_forms,
 // liberated while 'new_forms' are liberated.
 // Exit in case of errors.
 void MU_merge_forms(MU_forms_T* forms, MU_forms_T* new_forms) {
-	int nb_mf; //Number of forms to be added to 'forms'
-	int mf; //index of a sigle MU form in 'forms'
-	int nmf; //index of a sigle MU form in 'new_forms
-	int found; //Boolean showing if a search form has been found
+    int nb_mf; //Number of forms to be added to 'forms'
+    int mf; //index of a sigle MU form in 'forms'
+    int nmf; //index of a sigle MU form in 'new_forms
+    int found; //Boolean showing if a search form has been found
 
-	//Check how many forms are to be added to 'forms'
-	nb_mf = 0;
-	for (nmf = 0; nmf < new_forms->no_forms; nmf++) {
-		mf = 0;
-		found = 0;
-		while (mf < forms->no_forms && !found) {
-			if (!MU_form_cmp(forms->forms[mf], new_forms->forms[nmf])) //If forms are identical
-				found = 1;
-			mf++;
-		}
-		if (!found)
-			nb_mf++;
-	}
+    //Check how many forms are to be added to 'forms'
+    nb_mf = 0;
+    for (nmf = 0; nmf < new_forms->no_forms; nmf++) {
+        mf = 0;
+        found = 0;
+        while (mf < forms->no_forms && !found) {
+            if (!MU_form_cmp(forms->forms[mf], new_forms->forms[nmf])) //If forms are identical
+                found = 1;
+            mf++;
+        }
+        if (!found)
+            nb_mf++;
+    }
 
-	//Add the new forms
-	if (nb_mf) { //If any forms are to be added
-		//Reallocate the memory for new forms
-		forms->forms = (MU_f_T*) realloc(forms->forms, sizeof(MU_f_T)
-				* (forms->no_forms + nb_mf));
-		if (!forms->forms) {
-			fatal_alloc_error("MU_merge_forms");
-		}
-		//Treat each new form
-		for (nmf = 0; nmf < new_forms->no_forms; nmf++) {
-			//Check if the new form exists already in 'forms'
-			mf = 0;
-			found = 0;
-			while (mf < forms->no_forms && !found) {
-				if (!MU_form_cmp(forms->forms[mf], new_forms->forms[nmf])) //If forms are identical
-					found = 1;
-				mf++;
-			}
-			//If the new form does not exist in 'forms', add it
-			if (!found) {
-				forms->forms[forms->no_forms] = new_forms->forms[nmf];
-				//If a form has been added to a different list, it shouldn't be accessible from the old one (otherwise memory liberation problems).
-				new_forms->forms[nmf].form = NULL;
-				new_forms->forms[nmf].features = NULL;
-				forms->no_forms++;
-			}
-			//Otherwise free the space allocated for the form
-			else {
-				free(new_forms->forms[nmf].form);
-				f_delete_morpho(new_forms->forms[nmf].features);
-				new_forms->forms[nmf].form = NULL;
-				new_forms->forms[nmf].features = NULL;
-			}
-		}
-	}
+    //Add the new forms
+    if (nb_mf) { //If any forms are to be added
+        //Reallocate the memory for new forms
+        forms->forms = (MU_f_T*) realloc(forms->forms, sizeof(MU_f_T)
+                * (forms->no_forms + nb_mf));
+        if (!forms->forms) {
+            fatal_alloc_error("MU_merge_forms");
+        }
+        //Treat each new form
+        for (nmf = 0; nmf < new_forms->no_forms; nmf++) {
+            //Check if the new form exists already in 'forms'
+            mf = 0;
+            found = 0;
+            while (mf < forms->no_forms && !found) {
+                if (!MU_form_cmp(forms->forms[mf], new_forms->forms[nmf])) //If forms are identical
+                    found = 1;
+                mf++;
+            }
+            //If the new form does not exist in 'forms', add it
+            if (!found) {
+                forms->forms[forms->no_forms] = new_forms->forms[nmf];
+                //If a form has been added to a different list, it shouldn't be accessible from the old one (otherwise memory liberation problems).
+                new_forms->forms[nmf].form = NULL;
+                new_forms->forms[nmf].features = NULL;
+                forms->no_forms++;
+            }
+            //Otherwise free the space allocated for the form
+            else {
+                free(new_forms->forms[nmf].form);
+                f_delete_morpho(new_forms->forms[nmf].features);
+                new_forms->forms[nmf].form = NULL;
+                new_forms->forms[nmf].features = NULL;
+            }
+        }
+    }
 }
 
 ////////////////////////////////////////////
 // Prints a form and its inflection features.
 int MU_print_f(MU_f_T* f) {
-	u_printf("%S : ", f->form);
-	f_print_morpho(f->features);
-	return 0;
+    u_printf("%S : ", f->form);
+    f_print_morpho(f->features);
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Prints a set of forms and their inflection features.
 int MU_print_forms(MU_forms_T* F) {
-	int f;
-	for (f = 0; f < F->no_forms; f++)
-		MU_print_f(&(F->forms[f]));
-	return 0;
+    int f;
+    for (f = 0; f < F->no_forms; f++)
+        MU_print_f(&(F->forms[f]));
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Prints a lemma and its info.
 int MU_print_lemma(MU_lemma_T* l) {
-	u_printf("-----------------\n");
-	u_printf("MULTI-WORD LEMMA:\n");
-	u_printf("Units:\n");
-	int u;
-	for (u = 0; u < l->no_units; u++) {
-		u_printf("%S", l->units[u]->form);
-		if (l->units[u]->lemma) {
-			u_printf(":");
-			SU_print_lemma(l->units[u]->lemma);
-		} else {
-			u_printf("\n");
-		}
-	}
-	u_printf("Class: %S\n", l->cl->name);
-	u_printf("Paradigm: %s\n", l->paradigm);
-	u_printf("-----------------\n");
-	return 0;
+    u_printf("-----------------\n");
+    u_printf("MULTI-WORD LEMMA:\n");
+    u_printf("Units:\n");
+    int u;
+    for (u = 0; u < l->no_units; u++) {
+        u_printf("%S", l->units[u]->form);
+        if (l->units[u]->lemma) {
+            u_printf(":");
+            SU_print_lemma(l->units[u]->lemma);
+        } else {
+            u_printf("\n");
+        }
+    }
+    u_printf("Class: %S\n", l->cl->name);
+    u_printf("Paradigm: %s\n", l->paradigm);
+    u_printf("-----------------\n");
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Delete sample lemma stucture for tests.
 void MU_delete_lemma(MU_lemma_T* l) {
-	int u;
-	if (!l)
-		return;
-	//Delete the single units
-	for (u = 0; u < l->no_units; u++)
-		SU_delete_id(l->units[u]);
-	//Don't delete the class because it is a global variable usefull all through the treatment
-	//Delete the paradigm
-	free(l->paradigm);
-	//Delete the lemma
-	free(l);
+    int u;
+    if (!l)
+        return;
+    //Delete the single units
+    for (u = 0; u < l->no_units; u++)
+        SU_delete_id(l->units[u]);
+    //Don't delete the class because it is a global variable usefull all through the treatment
+    //Delete the paradigm
+    free(l->paradigm);
+    //Delete the lemma
+    free(l);
 }
 
 } // namespace unitex

--- a/MF_MU_morpho.h
+++ b/MF_MU_morpho.h
@@ -42,9 +42,9 @@ namespace unitex {
 ////////////////////////////////////////////
 // For a given multi-word unit, generates all the inflected forms,
 // e.g. {["mémoire vive",{Gen=fem,Nb=sing}],["mémoires vives",{Gen=fem,Nb=pl}]}
-// Returns 0 on success, 1 otherwise.   
+// Returns 0 on success, 1 otherwise.
 int MU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
-		MU_lemma_T* lemma, MU_forms_T* forms);
+        MU_lemma_T* lemma, MU_forms_T* forms);
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a set of forms
@@ -54,7 +54,7 @@ void MU_delete_inflection(MU_forms_T* forms);
 ////////////////////////////////////////////
 // Returns the word form's identifier on the basis of the form, its lemma, its inflection paradigm, and its inflection features.
 // MU_form : form and its inflection features, e.g. ["mémoires vives",{Gen=fem,Nb=pl]
-// MU_lemma : lemma and its inflection paradigm, 
+// MU_lemma : lemma and its inflection paradigm,
 //                e.g. [[[word,"mémoires",->[mémoire],2],[sep," "],[word,"vives",->[vif],4]],noun,NC76,{"Conc"},"computing"]
 // Returns the pointer to the forms identifier on success (e.g. ->([mémoire vive,noun,NC76,{"Conc"},"computing"],2)), NULL otherwise.
 MU_id_T*  MU_get_id(MU_f_T* MU_form, MU_lemma_T* MU_lemma);

--- a/MF_MU_morphoBase.h
+++ b/MF_MU_morphoBase.h
@@ -62,9 +62,9 @@ typedef struct  {
 //Structure for the lemma of a MWU
 typedef struct {
   int no_units;
-  SU_id_T* units[MAX_UNITS];	//e.g. pointer to "vive" in the paadigm of "vif"
-  l_class_T *cl;	        //e_.g. adj
-  char *paradigm;		//e.g. N41
+  SU_id_T* units[MAX_UNITS];    //e.g. pointer to "vive" in the paadigm of "vif"
+  l_class_T *cl;            //e_.g. adj
+  char *paradigm;       //e.g. N41
 } MU_lemma_T;
 
 /////////////////////////////////////////////////
@@ -74,7 +74,7 @@ typedef struct {
   unichar* form;         // the textual form, e.g. "pommes de terre"
   MU_lemma_T *MU_lemma; //lemma and its info
   f_morpho_T* feat;   //the form's morphology, e.g. {Gen=fem; Nb=pl; Case=I}
-  //  int form_nr;   	//ordinal number of the form in the list of all inflected forms of the lemma
+  //  int form_nr;      //ordinal number of the form in the list of all inflected forms of the lemma
 } MU_id_T;
 
 } // namespace unitex

--- a/MF_Operators_Util.cpp
+++ b/MF_Operators_Util.cpp
@@ -47,7 +47,7 @@ int i,res;
         i++;
     }
 
-    if (p_multiFlex_ctx->filter_polarity) 
+    if (p_multiFlex_ctx->filter_polarity)
       return res;
 
     return (1-res);

--- a/MF_Operators_Util.cpp
+++ b/MF_Operators_Util.cpp
@@ -259,12 +259,12 @@ unsigned int mode=0;
        //if (VERBOSE) error("***DEBUT***\n");
       if (get_var_op(var_name,etiq,&pos_pattern)) {
     //if (VERBOSE) error("GET Variable name  : %S\n",var_name);
-	 if (is_var_op(etiq,pos_pattern-1) || etiq[pos_pattern-1] == '<') {
+     if (is_var_op(etiq,pos_pattern-1) || etiq[pos_pattern-1] == '<') {
          // si <$  ou <$1$  ou (POUND?) $ ....on capte le contenu de la variable
              (*pos)--;
              var_end = *pos;
              if (var_name[0] == '$' ) {pos_match = var_end-1;}
-	     else { pos_match = -1; *pos = 0;}
+         else { pos_match = -1; *pos = 0;}
      // if (VERBOSE) error("pos_match = %d var_end = %d \n",pos_match,var_end);
              init_var(var_name,Variables,pile,pos_match + 1,var_end);
              ind = get_indice_var_op(var_name);
@@ -273,7 +273,7 @@ unsigned int mode=0;
             if (*pos == -1) *pos = 0;
             retour = 1;
           }
-	 else {var_precede = 1;}
+     else {var_precede = 1;}
 
       pos_pattern--;
       }
@@ -292,7 +292,7 @@ unsigned int mode=0;
          var_end = *pos;
          retour = get_pos_factor(pile,pos,facteur,match_type,&pos_match);
          if (mode == PROTEGE)  (*pos) = tmp_pos;
-	 if (retour == 0) { *pos = init_pos; return retour;}
+     if (retour == 0) { *pos = init_pos; return retour;}
      //if (VERBOSE) error("RETOUR %d pos:%d match_type:%d facteur:%s pos_match %d\n",retour,*pos,match_type,facteur,pos_match);
          if (var_precede) {
             init_var(var_name,Variables,pile,pos_match + 1,var_end);

--- a/MF_SU_morpho.cpp
+++ b/MF_SU_morpho.cpp
@@ -548,11 +548,11 @@ int old_local_semantic_code_length=u_strlen(local_semantic_codes);
 		   // <LEMMA> tag copies the whole lemma into the inflection stack
 	     for (int e=0;lemma[e]!='\0';e++) {
 		         p_SU_buf->stack[pos_inflected++] = lemma[e];
-		   }  
-	   } // In the semitic mode, deal with tags as <n> or <n.LEMMA>  
-	     else if (p_multiFlex_ctx->semitic && 
-	              2==u_sscanf(p_SU_buf->tag,"<%d%CLEMMA>%C", 
-	                          &val, &tag_symbol ,&foo)   && 
+		   }
+	   } // In the semitic mode, deal with tags as <n> or <n.LEMMA>
+	     else if (p_multiFlex_ctx->semitic &&
+	              2==u_sscanf(p_SU_buf->tag,"<%d%CLEMMA>%C",
+	                          &val, &tag_symbol ,&foo)   &&
 	             (tag_symbol == '>' || tag_symbol == '.')) {
          /* If we are in semitic mode, we must handle tags like <12> like references
           * to letters in the lemma. We must deal this way with values >9, because
@@ -569,7 +569,7 @@ int old_local_semantic_code_length=u_strlen(local_semantic_codes);
 	      } else {                 // tag_symbol == '.', tag == <n.LEMMA>
           for (int e = val; lemma[e] != '\0'; e++) {
             p_SU_buf->stack[pos_inflected++] = lemma[e];
-          }	        
+          }
 	      }
 	   }
 	   /* Otherwise, we deal with the tag in the normal way */

--- a/MF_SU_morpho.cpp
+++ b/MF_SU_morpho.cpp
@@ -57,32 +57,32 @@ namespace unitex {
  * to get up information from a subgraph exploration.
  */
 struct inflect_infos {
-	unichar* inflected;
-	int pos_inflected;
-	unichar* local_semantic_code;
-	unichar* output;
-	struct inflect_infos* next;
+    unichar* inflected;
+    int pos_inflected;
+    unichar* local_semantic_code;
+    unichar* output;
+    struct inflect_infos* next;
 };
 
 //////////////////////////////
 int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,SU_id_T* SU_id, f_morpho_T* desired_features,
-				SU_forms_T* forms);
+                SU_forms_T* forms);
 int SU_explore_state(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* flechi, int pos_inflected,
-		unichar* canonique, unichar* sortie,
-		Fst2* a, int etat_courant, f_morpho_T* desired_features,
-		SU_forms_T* forms, int, unichar* var_name, unsigned int,
-		unichar *);
+        unichar* flechi, int pos_inflected,
+        unichar* canonique, unichar* sortie,
+        Fst2* a, int etat_courant, f_morpho_T* desired_features,
+        SU_forms_T* forms, int, unichar* var_name, unsigned int,
+        unichar *);
 int SU_explore_state_recursion(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* flechi, int pos_inflected, unichar* canonique,
-		unichar* sortie, Fst2* a, int etat_courant, struct inflect_infos** L,
-		f_morpho_T* desired_features, SU_forms_T* forms, int, unichar* var_name,
-		unsigned int,unichar *);
+        unichar* flechi, int pos_inflected, unichar* canonique,
+        unichar* sortie, Fst2* a, int etat_courant, struct inflect_infos** L,
+        f_morpho_T* desired_features, SU_forms_T* forms, int, unichar* var_name,
+        unsigned int,unichar *);
 int SU_explore_tag(MultiFlex_ctx* p_multiFlex_ctx,Transition* T,
-		unichar* flechi, int pos_inflected, unichar* canonique,
-		unichar* sortie, Fst2* a, struct inflect_infos** LISTE,
-		f_morpho_T* desired_features, SU_forms_T* forms, int, unichar* var_name,
-		unsigned int, unichar*);
+        unichar* flechi, int pos_inflected, unichar* canonique,
+        unichar* sortie, Fst2* a, struct inflect_infos** LISTE,
+        f_morpho_T* desired_features, SU_forms_T* forms, int, unichar* var_name,
+        unsigned int, unichar*);
 void shift_stack(unichar* stack, int pos, int shift);
 void shift_stack(unichar* stack, int pos);
 void shift_stack_left(unichar* stack, int pos);
@@ -129,25 +129,25 @@ int SU_delete_lemma(SU_lemma_T* l);
 // Returns 0 on success, 1 otherwise.
 int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
                SU_id_T* SU_id, f_morpho_T* desired_features, SU_forms_T* forms) {
-	int err;
-	unichar inflected[MAX_CHARS_IN_STACK];
-	unichar inflection_codes[MAX_CHARS_IN_STACK];
-	unichar local_sem_code[MAX_CHARS_IN_STACK];
-	inflection_codes[0] = '\0';
-	int T = get_transducer(p_multiFlex_ctx,SU_id->lemma->paradigm);
-	if (p_multiFlex_ctx->fst2[T] == NULL) {
-		// if the automaton has not been loaded
-		return 1;
-	}
-	u_strcpy(inflected, p_multiFlex_ctx->semitic ? U_EMPTY : SU_id->lemma->unit);
-	local_sem_code[0] = '\0';
+    int err;
+    unichar inflected[MAX_CHARS_IN_STACK];
+    unichar inflection_codes[MAX_CHARS_IN_STACK];
+    unichar local_sem_code[MAX_CHARS_IN_STACK];
+    inflection_codes[0] = '\0';
+    int T = get_transducer(p_multiFlex_ctx,SU_id->lemma->paradigm);
+    if (p_multiFlex_ctx->fst2[T] == NULL) {
+        // if the automaton has not been loaded
+        return 1;
+    }
+    u_strcpy(inflected, p_multiFlex_ctx->semitic ? U_EMPTY : SU_id->lemma->unit);
+    local_sem_code[0] = '\0';
     unichar var_name[100];
-	err = SU_explore_state(p_multiFlex_ctx,inflected,
-			u_strlen(inflected),
-			SU_id->lemma->unit, inflection_codes,
-			p_multiFlex_ctx->fst2[T], 0, desired_features, forms, 0, var_name,
-			0, local_sem_code);
-	return err;
+    err = SU_explore_state(p_multiFlex_ctx,inflected,
+            u_strlen(inflected),
+            SU_id->lemma->unit, inflection_codes,
+            p_multiFlex_ctx->fst2[T], 0, desired_features, forms, 0, var_name,
+            0, local_sem_code);
+    return err;
 }
 
 /**
@@ -160,68 +160,68 @@ int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
 int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
                unichar* lemma, char* inflection_code,
                SU_forms_T* forms) {
-	int err;
-	unichar inflected[MAX_CHARS_IN_STACK];
-	unichar inflection_codes[MAX_CHARS_IN_STACK];
-	unichar local_semantic_code[MAX_CHARS_IN_STACK];
+    int err;
+    unichar inflected[MAX_CHARS_IN_STACK];
+    unichar inflection_codes[MAX_CHARS_IN_STACK];
+    unichar local_semantic_code[MAX_CHARS_IN_STACK];
 
-	inflection_codes[0] = '\0';
-	int T = get_transducer(p_multiFlex_ctx,inflection_code);
-	if (T==-1 || p_multiFlex_ctx->fst2[T] == NULL) {
-		// if the automaton has not been loaded
-		return 1;
-	}
-	u_strcpy(inflected, p_multiFlex_ctx->semitic ? U_EMPTY : lemma);
-	local_semantic_code[0] = '\0';
+    inflection_codes[0] = '\0';
+    int T = get_transducer(p_multiFlex_ctx,inflection_code);
+    if (T==-1 || p_multiFlex_ctx->fst2[T] == NULL) {
+        // if the automaton has not been loaded
+        return 1;
+    }
+    u_strcpy(inflected, p_multiFlex_ctx->semitic ? U_EMPTY : lemma);
+    local_semantic_code[0] = '\0';
     unichar var_name[100];
-	err = SU_explore_state(p_multiFlex_ctx,inflected, u_strlen(inflected),
-			lemma, inflection_codes, p_multiFlex_ctx->fst2[T], 0,
-			NULL, forms, 0, var_name, 0, local_semantic_code);
-	return err;
+    err = SU_explore_state(p_multiFlex_ctx,inflected, u_strlen(inflected),
+            lemma, inflection_codes, p_multiFlex_ctx->fst2[T], 0,
+            NULL, forms, 0, var_name, 0, local_semantic_code);
+    return err;
 }
 
 Transition* explore_trans(Transition** T, Transition** debut, Fst2* a) {
-	Transition empty, *ptr, *defaut;
-	empty.next = *T;
-	ptr = &empty;
-	defaut = NULL;
+    Transition empty, *ptr, *defaut;
+    empty.next = *T;
+    ptr = &empty;
+    defaut = NULL;
 
-	while (ptr != NULL && ptr->next != NULL) {
-		if (ptr->next->tag_number >= 0) {
-			Fst2Tag e = a->tags[ptr->next->tag_number];// A VERIFIER
+    while (ptr != NULL && ptr->next != NULL) {
+        if (ptr->next->tag_number >= 0) {
+            Fst2Tag e = a->tags[ptr->next->tag_number];// A VERIFIER
 
-			if (!u_strcmp(e->input, "<!>")) {
-				defaut = ptr->next;
-				ptr->next = ptr->next->next;
-				defaut->next = empty.next;
-				empty.next = defaut;
-				//error("PASS0  def==%x\n",defaut);
-				*T = empty.next;
-				*debut = empty.next->next;
-				return defaut;
-			}
-		}
-		ptr = ptr->next;
-	}
-	*T = empty.next;
-	*debut = *T;
-	//error("PASS1\n");
-	return defaut;
+            if (!u_strcmp(e->input, "<!>")) {
+                defaut = ptr->next;
+                ptr->next = ptr->next->next;
+                defaut->next = empty.next;
+                empty.next = defaut;
+                //error("PASS0  def==%x\n",defaut);
+                *T = empty.next;
+                *debut = empty.next->next;
+                return defaut;
+            }
+        }
+        ptr = ptr->next;
+    }
+    *T = empty.next;
+    *debut = *T;
+    //error("PASS1\n");
+    return defaut;
 }
 
 void aff_trans(Transition* T, Fst2* a) {
-	Transition *t;
-	t = T;
+    Transition *t;
+    t = T;
 
-	while (t != NULL) {
-		if (t->tag_number >= 0) {
-			Fst2Tag e = a->tags[t->tag_number];
-			error("AFF %S,", e->input);
-		}
-		t = t->next;
-	}
+    while (t != NULL) {
+        if (t->tag_number >= 0) {
+            Fst2Tag e = a->tags[t->tag_number];
+            error("AFF %S,", e->input);
+        }
+        t = t->next;
+    }
 
-	error("\n");
+    error("\n");
 }
 
 ////////////////////////////////////////////
@@ -236,145 +236,145 @@ void aff_trans(Transition* T, Fst2* a) {
 //        or   (1,{["-",{}]})
 // Returns 0 on success, 1 otherwise.
 int SU_explore_state(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* flechi,int pos_inflected,
-		unichar* canonique, unichar* sortie,
-		Fst2* a, int etat_courant, f_morpho_T* desired_features,
-		SU_forms_T* forms, int flag_var, unichar* var_name,
-		unsigned int var_in_use,
-		unichar *local_semantic_codes) {
-	int err;
-	Fst2State e = a->states[etat_courant];
-	if (e->control & 1) { //If final state
-		if (desired_features != NULL) {
-			/* If we want to select only some inflected forms */
-			f_morpho_T** feat; //Table of sets of inflection features; necessary in case of factorisation of entries, e.g. :ms:fs
-			err = SU_convert_features(p_multiFlex_ctx->pL_MORPHO,&feat, sortie);
-			if (err) {
-				return (err);
-			}
-			int f; //Index of the current morphological features in the current node
-			f = 0;
-			while (feat[f]) {
-				//If the form's morphology agrees with the desired features
-				if (SU_feature_agreement(p_multiFlex_ctx->pL_MORPHO,feat[f], desired_features)) {
-					//Put the form into 'forms'
-					forms->forms = (SU_f_T*) realloc(forms->forms,
-							(forms->no_forms + 1) * sizeof(SU_f_T));
-					if (!forms->forms) {
-						fatal_alloc_error("SU_explore_state");
-					}
-					forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
-					forms->forms[forms->no_forms].local_semantic_code = u_strdup(local_semantic_codes);
-					forms->forms[forms->no_forms].features = feat[f];
-					forms->no_forms++;
-				} else { // If undesired form delete 'feat'
-					f_delete_morpho(feat[f]);
-				}
-				f++;
-			}
-			free(feat);
-		} else {
-			/* If we want all the inflected forms */
-			if (p_multiFlex_ctx->n_filter_codes != 0 ) {
-//				u_fprintf(U_STDERR,"PASS 1\n",sortie);
-//				u_fprintf(U_STDERR,"sortie1:%S\n",sortie);
-				filtrer(sortie, p_multiFlex_ctx);
-//				u_fprintf(U_STDERR,"sortie2:%S\n",sortie);
-			}
-			if (sortie[0] == '\0' && p_multiFlex_ctx->n_filter_codes == 0 ) {
-//				u_fprintf(U_STDERR,"***PASS sortie:%S\n",sortie);
-				/* If we have an empty output, for instance in the case of an ADV grammar */
-				//Put the form into 'forms'
-				forms->forms = (SU_f_T*) realloc(forms->forms,
-						(forms->no_forms + 1) * sizeof(SU_f_T));
-				if (!forms->forms) {
-					fatal_alloc_error("SU_explore_state");
-				}
-				forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
-				forms->forms[forms->no_forms].local_semantic_code
-						= u_strdup(local_semantic_codes);
-				forms->forms[forms->no_forms].raw_features=u_strdup("");
-				forms->no_forms++;
-			} else {				//u_fprintf(U_STDERR,"***sortie1:%S\n",sortie);
+        unichar* flechi,int pos_inflected,
+        unichar* canonique, unichar* sortie,
+        Fst2* a, int etat_courant, f_morpho_T* desired_features,
+        SU_forms_T* forms, int flag_var, unichar* var_name,
+        unsigned int var_in_use,
+        unichar *local_semantic_codes) {
+    int err;
+    Fst2State e = a->states[etat_courant];
+    if (e->control & 1) { //If final state
+        if (desired_features != NULL) {
+            /* If we want to select only some inflected forms */
+            f_morpho_T** feat; //Table of sets of inflection features; necessary in case of factorisation of entries, e.g. :ms:fs
+            err = SU_convert_features(p_multiFlex_ctx->pL_MORPHO,&feat, sortie);
+            if (err) {
+                return (err);
+            }
+            int f; //Index of the current morphological features in the current node
+            f = 0;
+            while (feat[f]) {
+                //If the form's morphology agrees with the desired features
+                if (SU_feature_agreement(p_multiFlex_ctx->pL_MORPHO,feat[f], desired_features)) {
+                    //Put the form into 'forms'
+                    forms->forms = (SU_f_T*) realloc(forms->forms,
+                            (forms->no_forms + 1) * sizeof(SU_f_T));
+                    if (!forms->forms) {
+                        fatal_alloc_error("SU_explore_state");
+                    }
+                    forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
+                    forms->forms[forms->no_forms].local_semantic_code = u_strdup(local_semantic_codes);
+                    forms->forms[forms->no_forms].features = feat[f];
+                    forms->no_forms++;
+                } else { // If undesired form delete 'feat'
+                    f_delete_morpho(feat[f]);
+                }
+                f++;
+            }
+            free(feat);
+        } else {
+            /* If we want all the inflected forms */
+            if (p_multiFlex_ctx->n_filter_codes != 0 ) {
+//              u_fprintf(U_STDERR,"PASS 1\n",sortie);
+//              u_fprintf(U_STDERR,"sortie1:%S\n",sortie);
+                filtrer(sortie, p_multiFlex_ctx);
+//              u_fprintf(U_STDERR,"sortie2:%S\n",sortie);
+            }
+            if (sortie[0] == '\0' && p_multiFlex_ctx->n_filter_codes == 0 ) {
+//              u_fprintf(U_STDERR,"***PASS sortie:%S\n",sortie);
+                /* If we have an empty output, for instance in the case of an ADV grammar */
+                //Put the form into 'forms'
+                forms->forms = (SU_f_T*) realloc(forms->forms,
+                        (forms->no_forms + 1) * sizeof(SU_f_T));
+                if (!forms->forms) {
+                    fatal_alloc_error("SU_explore_state");
+                }
+                forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
+                forms->forms[forms->no_forms].local_semantic_code
+                        = u_strdup(local_semantic_codes);
+                forms->forms[forms->no_forms].raw_features=u_strdup("");
+                forms->no_forms++;
+            } else {                //u_fprintf(U_STDERR,"***sortie1:%S\n",sortie);
 
-				struct list_ustring* features = SU_split_raw_features(sortie);
-				while (features != NULL) {
-					//Put the form into 'forms'
-					forms->forms = (SU_f_T*) realloc(forms->forms,
-							(forms->no_forms + 1) * sizeof(SU_f_T));
-					if (!forms->forms) {
-						fatal_alloc_error("SU_explore_state");
-					}
-					forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
-					forms->forms[forms->no_forms].local_semantic_code
-							= u_strdup(local_semantic_codes);
+                struct list_ustring* features = SU_split_raw_features(sortie);
+                while (features != NULL) {
+                    //Put the form into 'forms'
+                    forms->forms = (SU_f_T*) realloc(forms->forms,
+                            (forms->no_forms + 1) * sizeof(SU_f_T));
+                    if (!forms->forms) {
+                        fatal_alloc_error("SU_explore_state");
+                    }
+                    forms->forms[forms->no_forms].form = u_strndup(flechi,pos_inflected);
+                    forms->forms[forms->no_forms].local_semantic_code
+                            = u_strdup(local_semantic_codes);
 
-					forms->forms[forms->no_forms].raw_features
-							= features->string;
-					forms->no_forms++;
-					struct list_ustring* tmp = features->next;
-					/* WARNING: here we must not call free_list_ustring, since the associated
-					 * string would also be freed */
-					free(features);
-					features = tmp;
-				}
-			}
-		}
-	}
-	int retour_all_tags = 0;
-	int retour_tag;
-	Transition* t = e->transitions, *default_trans = NULL;
+                    forms->forms[forms->no_forms].raw_features
+                            = features->string;
+                    forms->no_forms++;
+                    struct list_ustring* tmp = features->next;
+                    /* WARNING: here we must not call free_list_ustring, since the associated
+                     * string would also be freed */
+                    free(features);
+                    features = tmp;
+                }
+            }
+        }
+    }
+    int retour_all_tags = 0;
+    int retour_tag;
+    Transition* t = e->transitions, *default_trans = NULL;
 
-	default_trans = explore_trans(&(e->transitions), &t, a);
+    default_trans = explore_trans(&(e->transitions), &t, a);
 
-	while (t != NULL) {//error("Explore 1\n");
-		retour_tag = SU_explore_tag(p_multiFlex_ctx,t, flechi,
-				pos_inflected, canonique, sortie, a, NULL,
-				desired_features, forms, flag_var, var_name, var_in_use,
-				local_semantic_codes);
-		retour_all_tags += retour_tag;
-		t = t->next;
-	}
-	if (default_trans != NULL) {//error("PASS02\n");retour_tag = SU_explore_tag(default_trans,flechi,canonique,sortie,a,NULL,desired_features,forms,semitic,flag_var,var_name, var_in_use,filters);
-		//default_trans->next=e2->transitions->next;e2->transitions=default_trans;e=e2;
-	}
+    while (t != NULL) {//error("Explore 1\n");
+        retour_tag = SU_explore_tag(p_multiFlex_ctx,t, flechi,
+                pos_inflected, canonique, sortie, a, NULL,
+                desired_features, forms, flag_var, var_name, var_in_use,
+                local_semantic_codes);
+        retour_all_tags += retour_tag;
+        t = t->next;
+    }
+    if (default_trans != NULL) {//error("PASS02\n");retour_tag = SU_explore_tag(default_trans,flechi,canonique,sortie,a,NULL,desired_features,forms,semitic,flag_var,var_name, var_in_use,filters);
+        //default_trans->next=e2->transitions->next;e2->transitions=default_trans;e=e2;
+    }
 
-	//if ((retour_all_tags+retour_tag)) return 0; else return 1;
-	//Modif Agata
-	// return 1;
-	return 0;
+    //if ((retour_all_tags+retour_tag)) return 0; else return 1;
+    //Modif Agata
+    // return 1;
+    return 0;
 }
 
 /**
  * Allocates, initializes and returns a new inflect_infos structue.
  */
 struct inflect_infos* new_inflect_infos() {
-	struct inflect_infos* i = (struct inflect_infos*) malloc(
-			sizeof(struct inflect_infos));
-	if (i == NULL) {
-		fatal_alloc_error("new_inflect_infos");
-	}
-	i->inflected = NULL;
-	i->pos_inflected=-1;
-	i->output = NULL;
-	i->local_semantic_code = NULL;
-	i->next = NULL;
-	return i;
+    struct inflect_infos* i = (struct inflect_infos*) malloc(
+            sizeof(struct inflect_infos));
+    if (i == NULL) {
+        fatal_alloc_error("new_inflect_infos");
+    }
+    i->inflected = NULL;
+    i->pos_inflected=-1;
+    i->output = NULL;
+    i->local_semantic_code = NULL;
+    i->next = NULL;
+    return i;
 }
 
 /**
  * Frees the given single list cell.
  */
 void free_inflect_infos(struct inflect_infos* i) {
-	if (i == NULL)
-		return;
-	if (i->inflected != NULL)
-		free(i->inflected);
-	if (i->output != NULL)
-		free(i->output);
-	if (i->local_semantic_code != NULL)
-		free(i->local_semantic_code);
-	free(i);
+    if (i == NULL)
+        return;
+    if (i->inflected != NULL)
+        free(i->inflected);
+    if (i->output != NULL)
+        free(i->output);
+    if (i->local_semantic_code != NULL)
+        free(i->local_semantic_code);
+    free(i);
 }
 
 ////////////////////////////////////////////
@@ -386,65 +386,65 @@ void free_inflect_infos(struct inflect_infos* i) {
 //        or   (1,{["-",{}]})
 // Returns 0 on success, 1 otherwise.
 int SU_explore_state_recursion(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* inflected, int pos_inflected, unichar* lemma,
-		unichar* output, Fst2* a, int current_state, struct inflect_infos** L,
-		f_morpho_T* desired_features, SU_forms_T* forms,
-		int flag_var, unichar* var_name, unsigned int var_in_use,
-		unichar *local_semantic_codes) {
-	Fst2State e = a->states[current_state];
-	if (e->control & 1) {
-		// if we are in a final state, we save the computed things
-		struct inflect_infos* res = new_inflect_infos();
-		res->inflected = u_strdup(inflected);
-		res->inflected[pos_inflected]='\0';
-		res->pos_inflected=pos_inflected;
+        unichar* inflected, int pos_inflected, unichar* lemma,
+        unichar* output, Fst2* a, int current_state, struct inflect_infos** L,
+        f_morpho_T* desired_features, SU_forms_T* forms,
+        int flag_var, unichar* var_name, unsigned int var_in_use,
+        unichar *local_semantic_codes) {
+    Fst2State e = a->states[current_state];
+    if (e->control & 1) {
+        // if we are in a final state, we save the computed things
+        struct inflect_infos* res = new_inflect_infos();
+        res->inflected = u_strdup(inflected);
+        res->inflected[pos_inflected]='\0';
+        res->pos_inflected=pos_inflected;
 
-		res->local_semantic_code = u_strdup(local_semantic_codes);
+        res->local_semantic_code = u_strdup(local_semantic_codes);
 
-		if (p_multiFlex_ctx->n_filter_codes != 0 ){
-//			u_fprintf(U_STDERR,"sortie1:%S\n",output);
-			filtrer(output, p_multiFlex_ctx);
-//			u_fprintf(U_STDERR,"sortie2:%S\n",output);
-	}
-		res->output = u_strdup(output);
-		res->next = (*L);
-		(*L) = res;
-	}
-	//Transition* t=e->transitions,*default_trans;
-	// default_trans = explore_trans(&t,a);
-	Transition* t = e->transitions, *default_trans = NULL;
+        if (p_multiFlex_ctx->n_filter_codes != 0 ){
+//          u_fprintf(U_STDERR,"sortie1:%S\n",output);
+            filtrer(output, p_multiFlex_ctx);
+//          u_fprintf(U_STDERR,"sortie2:%S\n",output);
+    }
+        res->output = u_strdup(output);
+        res->next = (*L);
+        (*L) = res;
+    }
+    //Transition* t=e->transitions,*default_trans;
+    // default_trans = explore_trans(&t,a);
+    Transition* t = e->transitions, *default_trans = NULL;
 
-	default_trans = explore_trans(&(e->transitions), &t, a);
-	//default_trans=NULL;
-	//Transition* t=e->transitions;
-	//static Transition *default_trans=explore_trans(&t,a);
-	int retour_all_tags = 0;
-	int retour_tag;
-	while (t != NULL) {//error("Explore 2\n");local_
-		retour_tag = SU_explore_tag(p_multiFlex_ctx,t, inflected,
-				pos_inflected, lemma, output, a, L,
-				desired_features, forms, flag_var, var_name, var_in_use,
-				local_semantic_codes);
-		retour_all_tags += retour_tag;
-		t = t->next;
-	}
-	if (default_trans != NULL) { //error("PASS2\n");
-		SU_explore_tag(p_multiFlex_ctx,default_trans, inflected,
-				pos_inflected, lemma, output, a, L,
-				desired_features, forms, flag_var, var_name, var_in_use,
-				local_semantic_codes);
-	}
+    default_trans = explore_trans(&(e->transitions), &t, a);
+    //default_trans=NULL;
+    //Transition* t=e->transitions;
+    //static Transition *default_trans=explore_trans(&t,a);
+    int retour_all_tags = 0;
+    int retour_tag;
+    while (t != NULL) {//error("Explore 2\n");local_
+        retour_tag = SU_explore_tag(p_multiFlex_ctx,t, inflected,
+                pos_inflected, lemma, output, a, L,
+                desired_features, forms, flag_var, var_name, var_in_use,
+                local_semantic_codes);
+        retour_all_tags += retour_tag;
+        t = t->next;
+    }
+    if (default_trans != NULL) { //error("PASS2\n");
+        SU_explore_tag(p_multiFlex_ctx,default_trans, inflected,
+                pos_inflected, lemma, output, a, L,
+                desired_features, forms, flag_var, var_name, var_in_use,
+                local_semantic_codes);
+    }
 
-	//if ((retour_all_tags+retour_tag)) return 0; else return 1;
-	return 1;
+    //if ((retour_all_tags+retour_tag)) return 0; else return 1;
+    return 1;
 }
 
 
 struct SU_explore_tag_buffers
 {
-	unichar out[MAX_CHARS_IN_STACK];
-	unichar stack[MAX_CHARS_IN_STACK];
-	unichar tag[MAX_CHARS_IN_STACK];
+    unichar out[MAX_CHARS_IN_STACK];
+    unichar stack[MAX_CHARS_IN_STACK];
+    unichar tag[MAX_CHARS_IN_STACK];
 } ;
 ////////////////////////////////////////////
 // Explores the tag of the transition T
@@ -455,253 +455,253 @@ struct SU_explore_tag_buffers
 //        or   (1,{["-",{}]})
 // Returns 0 on success, 1 otherwise.
 int SU_explore_tag(MultiFlex_ctx* p_multiFlex_ctx,Transition* T,
-		unichar* inflected, int pos_inflected, unichar* lemma,
-		unichar* output, Fst2* a, struct inflect_infos** LIST,
-		f_morpho_T* desired_features, SU_forms_T* forms,
-		int flag_var, unichar* var_name, unsigned int var_in_use,
-		unichar *local_semantic_codes) {
+        unichar* inflected, int pos_inflected, unichar* lemma,
+        unichar* output, Fst2* a, struct inflect_infos** LIST,
+        f_morpho_T* desired_features, SU_forms_T* forms,
+        int flag_var, unichar* var_name, unsigned int var_in_use,
+        unichar *local_semantic_codes) {
 int old_local_semantic_code_length=u_strlen(local_semantic_codes);
-	if (T->tag_number < 0) {
-		/* If we are in the case of a call to a sub-graph */
-		struct inflect_infos* L = NULL;
-		struct inflect_infos* temp;
-		int retour_state = 0;
-		int retour_all_states = 1;
-		SU_explore_state_recursion(p_multiFlex_ctx,inflected,
-				pos_inflected, lemma, output, a,
-				a->initial_states[-(T->tag_number)], &L, desired_features,
-				forms, flag_var, var_name, var_in_use,
-				local_semantic_codes);
-		while (L != NULL) {
-			if (LIST == NULL) {//error("Explore state 1\n");
-				retour_state = SU_explore_state(p_multiFlex_ctx,L->inflected,
-						L->pos_inflected,
-						lemma, L->output,
-						a, T->state_number, desired_features, forms,
-						flag_var, var_name, var_in_use,
-						L->local_semantic_code);
-				retour_all_states += (retour_state + 1);
-			} else {//error("Explore state recursion 1\n");
-				retour_state = SU_explore_state_recursion(p_multiFlex_ctx,
-						L->inflected, L->pos_inflected, lemma,
-						L->output, a, T->state_number, LIST, desired_features,
-						forms, flag_var, var_name, var_in_use,
-						L->local_semantic_code);
-				retour_all_states += (1 - retour_state);
-			}
-			temp = L;
-			L = L->next;
-			free_inflect_infos(temp);
-		}
-		//  return retour_all_states;
-		local_semantic_codes[old_local_semantic_code_length]='\0';
-		return 0;
-	}
-	Fst2Tag t = a->tags[T->tag_number];
+    if (T->tag_number < 0) {
+        /* If we are in the case of a call to a sub-graph */
+        struct inflect_infos* L = NULL;
+        struct inflect_infos* temp;
+        int retour_state = 0;
+        int retour_all_states = 1;
+        SU_explore_state_recursion(p_multiFlex_ctx,inflected,
+                pos_inflected, lemma, output, a,
+                a->initial_states[-(T->tag_number)], &L, desired_features,
+                forms, flag_var, var_name, var_in_use,
+                local_semantic_codes);
+        while (L != NULL) {
+            if (LIST == NULL) {//error("Explore state 1\n");
+                retour_state = SU_explore_state(p_multiFlex_ctx,L->inflected,
+                        L->pos_inflected,
+                        lemma, L->output,
+                        a, T->state_number, desired_features, forms,
+                        flag_var, var_name, var_in_use,
+                        L->local_semantic_code);
+                retour_all_states += (retour_state + 1);
+            } else {//error("Explore state recursion 1\n");
+                retour_state = SU_explore_state_recursion(p_multiFlex_ctx,
+                        L->inflected, L->pos_inflected, lemma,
+                        L->output, a, T->state_number, LIST, desired_features,
+                        forms, flag_var, var_name, var_in_use,
+                        L->local_semantic_code);
+                retour_all_states += (1 - retour_state);
+            }
+            temp = L;
+            L = L->next;
+            free_inflect_infos(temp);
+        }
+        //  return retour_all_states;
+        local_semantic_codes[old_local_semantic_code_length]='\0';
+        return 0;
+    }
+    Fst2Tag t = a->tags[T->tag_number];
     /*
-	unichar out[MAX_CHARS_IN_STACK];
-	unichar stack[MAX_CHARS_IN_STACK];
-	unichar tag[MAX_CHARS_IN_STACK];
+    unichar out[MAX_CHARS_IN_STACK];
+    unichar stack[MAX_CHARS_IN_STACK];
+    unichar tag[MAX_CHARS_IN_STACK];
     */
-	/* NOTE: very important to use calloc here in order to ensure zeros
-	 * in all fields */
+    /* NOTE: very important to use calloc here in order to ensure zeros
+     * in all fields */
     struct SU_explore_tag_buffers* p_SU_buf =
-    		(struct SU_explore_tag_buffers*)calloc(1,sizeof(struct SU_explore_tag_buffers));
+            (struct SU_explore_tag_buffers*)calloc(1,sizeof(struct SU_explore_tag_buffers));
     if (p_SU_buf == NULL) {
         fatal_alloc_error("SU_explore_tag");
     }
 
 
-	int i, ln, ind, retour;
-	//static unichar var_name[100];
-	retour = 1;
+    int i, ln, ind, retour;
+    //static unichar var_name[100];
+    retour = 1;
 
-	u_strcpy(p_SU_buf->out, output);
-	int pos_out = u_strlen(p_SU_buf->out);
-	u_strcpy(p_SU_buf->stack, inflected);
-	u_strcpy(p_SU_buf->tag, t->input);
-	if (u_strcmp(p_SU_buf->tag, "<E>")) {
-		/* If the tag is not <E>, we process it */
-	   unichar foo        = '\0';
-	   unichar tag_symbol = '\0';
-	   int val;
+    u_strcpy(p_SU_buf->out, output);
+    int pos_out = u_strlen(p_SU_buf->out);
+    u_strcpy(p_SU_buf->stack, inflected);
+    u_strcpy(p_SU_buf->tag, t->input);
+    if (u_strcmp(p_SU_buf->tag, "<E>")) {
+        /* If the tag is not <E>, we process it */
+       unichar foo        = '\0';
+       unichar tag_symbol = '\0';
+       int val;
 
-	   if (u_starts_with(p_SU_buf->tag,"<R=")) {
-		   /* Replacement of the first letter, useful for Malagasy */
-		   if (p_SU_buf->tag[4]!='>' || p_SU_buf->tag[5]!='\0') {
-			   fatal_error("Invalid <R=?> tag\n");
-		   }
-		   p_SU_buf->stack[0]=p_SU_buf->tag[3];
-	   } else if (u_starts_with(p_SU_buf->tag,"<I=")) {
-		   /* Insertion of an initial letter, useful for Malagasy */
-		   if (p_SU_buf->tag[4]!='>' || p_SU_buf->tag[5]!='\0') {
-			   fatal_error("Invalid <I=?> tag\n");
-		   }
-		   shift_stack(p_SU_buf->stack,1);
-		   pos_inflected++;
-		   p_SU_buf->stack[0]=p_SU_buf->tag[3];
-	   } else if (1==u_sscanf(p_SU_buf->tag,"<X=%d>%C",&val,&foo)) {
-		   /* Removal of the first val letters */
-		   shift_stack_left2(p_SU_buf->stack,val);
-		   pos_inflected=pos_inflected-val;
-	   } else if (/*semitic &&*/ !u_strcmp(p_SU_buf->tag,"<LEMMA>")) {
-		   // <LEMMA> tag copies the whole lemma into the inflection stack
-	     for (int e=0;lemma[e]!='\0';e++) {
-		         p_SU_buf->stack[pos_inflected++] = lemma[e];
-		   }
-	   } // In the semitic mode, deal with tags as <n> or <n.LEMMA>
-	     else if (p_multiFlex_ctx->semitic &&
-	              2==u_sscanf(p_SU_buf->tag,"<%d%CLEMMA>%C",
-	                          &val, &tag_symbol ,&foo)   &&
-	             (tag_symbol == '>' || tag_symbol == '.')) {
+       if (u_starts_with(p_SU_buf->tag,"<R=")) {
+           /* Replacement of the first letter, useful for Malagasy */
+           if (p_SU_buf->tag[4]!='>' || p_SU_buf->tag[5]!='\0') {
+               fatal_error("Invalid <R=?> tag\n");
+           }
+           p_SU_buf->stack[0]=p_SU_buf->tag[3];
+       } else if (u_starts_with(p_SU_buf->tag,"<I=")) {
+           /* Insertion of an initial letter, useful for Malagasy */
+           if (p_SU_buf->tag[4]!='>' || p_SU_buf->tag[5]!='\0') {
+               fatal_error("Invalid <I=?> tag\n");
+           }
+           shift_stack(p_SU_buf->stack,1);
+           pos_inflected++;
+           p_SU_buf->stack[0]=p_SU_buf->tag[3];
+       } else if (1==u_sscanf(p_SU_buf->tag,"<X=%d>%C",&val,&foo)) {
+           /* Removal of the first val letters */
+           shift_stack_left2(p_SU_buf->stack,val);
+           pos_inflected=pos_inflected-val;
+       } else if (/*semitic &&*/ !u_strcmp(p_SU_buf->tag,"<LEMMA>")) {
+           // <LEMMA> tag copies the whole lemma into the inflection stack
+         for (int e=0;lemma[e]!='\0';e++) {
+                 p_SU_buf->stack[pos_inflected++] = lemma[e];
+           }
+       } // In the semitic mode, deal with tags as <n> or <n.LEMMA>
+         else if (p_multiFlex_ctx->semitic &&
+                  2==u_sscanf(p_SU_buf->tag,"<%d%CLEMMA>%C",
+                              &val, &tag_symbol ,&foo)   &&
+                 (tag_symbol == '>' || tag_symbol == '.')) {
          /* If we are in semitic mode, we must handle tags like <12> like references
           * to letters in the lemma. We must deal this way with values >9, because
           * the graph compiler would split "12" in "1" and "2" */
-	      val--;
-	      if (val<0 || val>=((int)u_strlen(lemma))) {
-	         error("Invalid reference in %S.fst2 to consonant #%d for skeleton \"%S\"\n",
+          val--;
+          if (val<0 || val>=((int)u_strlen(lemma))) {
+             error("Invalid reference in %S.fst2 to consonant #%d for skeleton \"%S\"\n",
                   a->graph_names[1], val+1, lemma);
             free(p_SU_buf);
             return 0;
          }
-	      if (tag_symbol == '>') { // tag == <n>
-	        p_SU_buf->stack[pos_inflected++] = lemma[val];
-	      } else {                 // tag_symbol == '.', tag == <n.LEMMA>
+          if (tag_symbol == '>') { // tag == <n>
+            p_SU_buf->stack[pos_inflected++] = lemma[val];
+          } else {                 // tag_symbol == '.', tag == <n.LEMMA>
           for (int e = val; lemma[e] != '\0'; e++) {
             p_SU_buf->stack[pos_inflected++] = lemma[e];
           }
-	      }
-	   }
-	   /* Otherwise, we deal with the tag in the normal way */
-	   else for (int pos_tag = 0; p_SU_buf->tag[pos_tag] != '\0';) {
-		   if (t->control & RESPECT_CASE_TAG_BIT_MASK
-				   ||
-				   (p_multiFlex_ctx->semitic && is_arabic_letter(p_SU_buf->tag[pos_tag])
-				   )
-				) {
-			   /* If the transition was a "..." one, we don't try to interpret its content.
-			    * This is useful when one needs to produce a symbol that is an inflection
-			    * operator */
-			   p_SU_buf->stack[pos_inflected++]=p_SU_buf->tag[pos_tag++];
-		   } else switch (p_SU_buf->tag[pos_tag]) {
-			case '<':
-				retour = flex_op_with_var(p_multiFlex_ctx->Variables_op, p_SU_buf->stack, p_SU_buf->tag, &pos_inflected,
-						&pos_tag, &var_in_use);
+          }
+       }
+       /* Otherwise, we deal with the tag in the normal way */
+       else for (int pos_tag = 0; p_SU_buf->tag[pos_tag] != '\0';) {
+           if (t->control & RESPECT_CASE_TAG_BIT_MASK
+                   ||
+                   (p_multiFlex_ctx->semitic && is_arabic_letter(p_SU_buf->tag[pos_tag])
+                   )
+                ) {
+               /* If the transition was a "..." one, we don't try to interpret its content.
+                * This is useful when one needs to produce a symbol that is an inflection
+                * operator */
+               p_SU_buf->stack[pos_inflected++]=p_SU_buf->tag[pos_tag++];
+           } else switch (p_SU_buf->tag[pos_tag]) {
+            case '<':
+                retour = flex_op_with_var(p_multiFlex_ctx->Variables_op, p_SU_buf->stack, p_SU_buf->tag, &pos_inflected,
+                        &pos_tag, &var_in_use);
 
-				break;
-			case '$':
-			case (unichar) POUND: {
-				var_name[0] = p_SU_buf->tag[pos_tag];
-				var_name[1] = '\0';
-				p_multiFlex_ctx->save_pos = pos_inflected;
-				ind = get_indice_var_op(var_name);
-				if (get_flag_var(ind, var_in_use)) {
-					ln = u_strlen(p_multiFlex_ctx->Variables_op[ind]);
-					for (i = 0; i < ln; i++, pos_inflected++)
-						p_SU_buf->stack[pos_inflected] = p_multiFlex_ctx->Variables_op[ind][i];
-				}
-				//if (VERBOSE) error("COPIE VAR \n");
-				flag_var = 1;
-				pos_tag++;
-			}
-				;
-				break;
-				/* Left move operator */
-			case 'L': {
-				if (pos_inflected != 0) {
-					/* If the stack is not empty, we decrease the stack pointer */
-					pos_inflected--;
-				}
-				pos_tag++;
-				break;
-			}
+                break;
+            case '$':
+            case (unichar) POUND: {
+                var_name[0] = p_SU_buf->tag[pos_tag];
+                var_name[1] = '\0';
+                p_multiFlex_ctx->save_pos = pos_inflected;
+                ind = get_indice_var_op(var_name);
+                if (get_flag_var(ind, var_in_use)) {
+                    ln = u_strlen(p_multiFlex_ctx->Variables_op[ind]);
+                    for (i = 0; i < ln; i++, pos_inflected++)
+                        p_SU_buf->stack[pos_inflected] = p_multiFlex_ctx->Variables_op[ind][i];
+                }
+                //if (VERBOSE) error("COPIE VAR \n");
+                flag_var = 1;
+                pos_tag++;
+            }
+                ;
+                break;
+                /* Left move operator */
+            case 'L': {
+                if (pos_inflected != 0) {
+                    /* If the stack is not empty, we decrease the stack pointer */
+                    pos_inflected--;
+                }
+                pos_tag++;
+                break;
+            }
 
-				/* Right move operator */
-			case 'R': {
-				pos_inflected++;
-				pos_tag++;
-				break;
-			}
+                /* Right move operator */
+            case 'R': {
+                pos_inflected++;
+                pos_tag++;
+                break;
+            }
 
-				/* Unaccent operator */
-			case 'U': {
-				p_SU_buf->stack[pos_inflected] = u_deaccentuate(p_SU_buf->stack[pos_inflected]);
-				pos_inflected++;
-				pos_tag++;
-				break;
-			}
+                /* Unaccent operator */
+            case 'U': {
+                p_SU_buf->stack[pos_inflected] = u_deaccentuate(p_SU_buf->stack[pos_inflected]);
+                pos_inflected++;
+                pos_tag++;
+                break;
+            }
 
-				/* Lowercase operator */
-			case 'W': {
-				p_SU_buf->stack[0] = u_tolower(p_SU_buf->stack[0]);
-				pos_tag++;
-				break;
-			}
+                /* Lowercase operator */
+            case 'W': {
+                p_SU_buf->stack[0] = u_tolower(p_SU_buf->stack[0]);
+                pos_tag++;
+                break;
+            }
 
-				/* Uppercase operator */
-			case 'P': {
-				p_SU_buf->stack[0] = u_toupper(p_SU_buf->stack[0]);
-				pos_tag++;
-				break;
-			}
+                /* Uppercase operator */
+            case 'P': {
+                p_SU_buf->stack[0] = u_toupper(p_SU_buf->stack[0]);
+                pos_tag++;
+                break;
+            }
 
-			/* Korean Jamo left operator */
-			case 'J': {
-				pos_tag++;
-				if (p_multiFlex_ctx->korean==NULL) {
-					fatal_error("NULL jamo error: cannot apply operator J if no jamo table is defined\n");
-				}
-				if (pos_inflected==0) {
-					fatal_error("Cannot apply operator J to empty stack\n");
-				}
-				if (!u_is_Hangul(p_SU_buf->stack[pos_inflected-1]) && !u_is_Hangul_Jamo(p_SU_buf->stack[pos_inflected-1])) {
-					fatal_error("Cannot apply J operator to a non Hangul or Jamo character '%C' (%04X)\n",p_SU_buf->stack[pos_inflected-1],p_SU_buf->stack[pos_inflected-1]);
-				}
-				if (u_is_Hangul(p_SU_buf->stack[pos_inflected-1])) {
-					/* If we have a Hangul syllable, we first turn it into a Jamo
-					 * character sequence */
-					unichar tmp[10];
-					unichar src[2];
-					src[0]=p_SU_buf->stack[pos_inflected-1];
-					src[1]='\0';
-					Hanguls_to_Jamos(src,tmp,p_multiFlex_ctx->korean,0);
-					int len=u_strlen(tmp);
-					/* Now, we copy the jamo sequence
-					 * in place of the hangul syllable. We use l-1 because we take into
-					 * account the hangul syllable */
-					pos_inflected--;
-					for (int il=0;il<len;il++) {
-						p_SU_buf->stack[pos_inflected++]=tmp[il];
-					}
-				}
-				if (u_is_Hangul_Jamo_consonant(p_SU_buf->stack[pos_inflected-1])) {
-					while (u_is_Hangul_Jamo_consonant(p_SU_buf->stack[pos_inflected-1])) {
-						pos_inflected--;
-					}
-					p_SU_buf->stack[pos_inflected]='\0';
-				}
-				else if (u_is_Hangul_Jamo_medial_vowel(p_SU_buf->stack[pos_inflected-1])){
-					while (u_is_Hangul_Jamo_medial_vowel(p_SU_buf->stack[pos_inflected-1])) {
-						pos_inflected--;
-					}
-					p_SU_buf->stack[pos_inflected]='\0';
-				} else {
-					fatal_error("Operator J: unexpected character '%C' (%04X)\n",p_SU_buf->stack[pos_inflected-1],p_SU_buf->stack[pos_inflected-1]);
-				}
-				break;
-			}
+            /* Korean Jamo left operator */
+            case 'J': {
+                pos_tag++;
+                if (p_multiFlex_ctx->korean==NULL) {
+                    fatal_error("NULL jamo error: cannot apply operator J if no jamo table is defined\n");
+                }
+                if (pos_inflected==0) {
+                    fatal_error("Cannot apply operator J to empty stack\n");
+                }
+                if (!u_is_Hangul(p_SU_buf->stack[pos_inflected-1]) && !u_is_Hangul_Jamo(p_SU_buf->stack[pos_inflected-1])) {
+                    fatal_error("Cannot apply J operator to a non Hangul or Jamo character '%C' (%04X)\n",p_SU_buf->stack[pos_inflected-1],p_SU_buf->stack[pos_inflected-1]);
+                }
+                if (u_is_Hangul(p_SU_buf->stack[pos_inflected-1])) {
+                    /* If we have a Hangul syllable, we first turn it into a Jamo
+                     * character sequence */
+                    unichar tmp[10];
+                    unichar src[2];
+                    src[0]=p_SU_buf->stack[pos_inflected-1];
+                    src[1]='\0';
+                    Hanguls_to_Jamos(src,tmp,p_multiFlex_ctx->korean,0);
+                    int len=u_strlen(tmp);
+                    /* Now, we copy the jamo sequence
+                     * in place of the hangul syllable. We use l-1 because we take into
+                     * account the hangul syllable */
+                    pos_inflected--;
+                    for (int il=0;il<len;il++) {
+                        p_SU_buf->stack[pos_inflected++]=tmp[il];
+                    }
+                }
+                if (u_is_Hangul_Jamo_consonant(p_SU_buf->stack[pos_inflected-1])) {
+                    while (u_is_Hangul_Jamo_consonant(p_SU_buf->stack[pos_inflected-1])) {
+                        pos_inflected--;
+                    }
+                    p_SU_buf->stack[pos_inflected]='\0';
+                }
+                else if (u_is_Hangul_Jamo_medial_vowel(p_SU_buf->stack[pos_inflected-1])){
+                    while (u_is_Hangul_Jamo_medial_vowel(p_SU_buf->stack[pos_inflected-1])) {
+                        pos_inflected--;
+                    }
+                    p_SU_buf->stack[pos_inflected]='\0';
+                } else {
+                    fatal_error("Operator J: unexpected character '%C' (%04X)\n",p_SU_buf->stack[pos_inflected-1],p_SU_buf->stack[pos_inflected-1]);
+                }
+                break;
+            }
 
-			/* Korean syllable delimiter operator */
-			case '.': {
-				if (pos_inflected>0 && u_is_Hangul_Jamo(p_SU_buf->stack[pos_inflected-1])) {
-					/* If the last char is a jamo, then we want to recombine all previous jamo
-					 * with the first syllable found on the left */
+            /* Korean syllable delimiter operator */
+            case '.': {
+                if (pos_inflected>0 && u_is_Hangul_Jamo(p_SU_buf->stack[pos_inflected-1])) {
+                    /* If the last char is a jamo, then we want to recombine all previous jamo
+                     * with the first syllable found on the left */
                    int z=pos_inflected-1;
                    while (z>0 && (u_is_Hangul_Jamo(p_SU_buf->stack[z]) || p_SU_buf->stack[z]==KR_SYLLABLE_BOUND)) {
-                	   z--;
+                       z--;
                    }
                    if (z<0 || !u_is_Hangul(p_SU_buf->stack[z])) {
-                	   fatal_error("Operator . unexpected if no hangul before jamos\n");
+                       fatal_error("Operator . unexpected if no hangul before jamos\n");
                    }
                    unichar hangul[2];
                    hangul[0]=p_SU_buf->stack[z];
@@ -711,148 +711,148 @@ int old_local_semantic_code_length=u_strlen(local_semantic_codes);
                    int len2=u_strlen(tmp);
                    int ip;
                    for (ip=z+1;ip<pos_inflected;ip++) {
-                	  if (p_SU_buf->stack[ip]!=KR_SYLLABLE_BOUND) {
-                		  /* The syllable bound must be ignored when we have to recombine
-                		   * jamos with an hangul */
-                		  tmp[len2++]=p_SU_buf->stack[ip];
-                	  }
+                      if (p_SU_buf->stack[ip]!=KR_SYLLABLE_BOUND) {
+                          /* The syllable bound must be ignored when we have to recombine
+                           * jamos with an hangul */
+                          tmp[len2++]=p_SU_buf->stack[ip];
+                      }
                    }
                    tmp[len2]='\0';
                    unichar tmp2[32];
                    convert_jamo_to_hangul(tmp,tmp2,p_multiFlex_ctx->korean);
                    u_strcpy(p_SU_buf->stack+z,tmp2);
                    pos_inflected=z+u_strlen(tmp2);
-				}
-				p_SU_buf->stack[pos_inflected++] = KR_SYLLABLE_BOUND;
-				pos_tag++;
-				break;
-			}
+                }
+                p_SU_buf->stack[pos_inflected++] = KR_SYLLABLE_BOUND;
+                pos_tag++;
+                break;
+            }
 
-				/* Right copy operator */
-			case 'C': {
-				shift_stack(p_SU_buf->stack, pos_inflected);
-				pos_inflected++;
-				pos_tag++;
-				break;
-			}
+                /* Right copy operator */
+            case 'C': {
+                shift_stack(p_SU_buf->stack, pos_inflected);
+                pos_inflected++;
+                pos_tag++;
+                break;
+            }
 
-				/* Left copy operator */
-			case 'D': {
-				shift_stack_left(p_SU_buf->stack, pos_inflected);
-				pos_inflected--;
-				pos_tag++;
-				break;
-			}
+                /* Left copy operator */
+            case 'D': {
+                shift_stack_left(p_SU_buf->stack, pos_inflected);
+                pos_inflected--;
+                pos_tag++;
+                break;
+            }
 
-				/* If we have a digit between 1 and 9, we consider it as a reference to a root
-				 * consonant, but only if we are in semitic mode */
+                /* If we have a digit between 1 and 9, we consider it as a reference to a root
+                 * consonant, but only if we are in semitic mode */
 
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-				if (flag_var) {
-					var_name[1] = p_SU_buf->tag[pos_tag];
-					var_name[2] = '\0';
-					flag_var = 0;
-					pos_inflected = p_multiFlex_ctx->save_pos;
-					ind = get_indice_var_op(var_name);
-					if (get_flag_var(ind, var_in_use)) {
-						ln = u_strlen(p_multiFlex_ctx->Variables_op[ind]);
-						for (i = 0; i < ln; i++, pos_inflected++)
-							p_SU_buf->stack[pos_inflected] = p_multiFlex_ctx->Variables_op[ind][i];
-					}
-					pos_tag++;
-				} else if (p_multiFlex_ctx->semitic) {
-				   int pos_letter=p_SU_buf->tag[pos_tag++]-'0';
-					int ip = pos_letter-1; /* Numbering from 0, always... */
-					if (ip >= ((int)u_strlen(lemma))) {
-						error(
-								"Invalid reference in %S.fst2 to consonant #%C for skeleton \"%S\"\n",
-								a->graph_names[1], p_SU_buf->tag[pos_tag - 1], lemma);
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                if (flag_var) {
+                    var_name[1] = p_SU_buf->tag[pos_tag];
+                    var_name[2] = '\0';
+                    flag_var = 0;
+                    pos_inflected = p_multiFlex_ctx->save_pos;
+                    ind = get_indice_var_op(var_name);
+                    if (get_flag_var(ind, var_in_use)) {
+                        ln = u_strlen(p_multiFlex_ctx->Variables_op[ind]);
+                        for (i = 0; i < ln; i++, pos_inflected++)
+                            p_SU_buf->stack[pos_inflected] = p_multiFlex_ctx->Variables_op[ind][i];
+                    }
+                    pos_tag++;
+                } else if (p_multiFlex_ctx->semitic) {
+                   int pos_letter=p_SU_buf->tag[pos_tag++]-'0';
+                    int ip = pos_letter-1; /* Numbering from 0, always... */
+                    if (ip >= ((int)u_strlen(lemma))) {
+                        error(
+                                "Invalid reference in %S.fst2 to consonant #%C for skeleton \"%S\"\n",
+                                a->graph_names[1], p_SU_buf->tag[pos_tag - 1], lemma);
                         free(p_SU_buf);
-						return 0;
-					}
-					p_SU_buf->stack[pos_inflected++] = lemma[ip];
-				} else {
-					/* Someone wants to print a digit */
-					p_SU_buf->stack[pos_inflected++]=p_SU_buf->tag[pos_tag++];
-				}
-				break;
+                        return 0;
+                    }
+                    p_SU_buf->stack[pos_inflected++] = lemma[ip];
+                } else {
+                    /* Someone wants to print a digit */
+                    p_SU_buf->stack[pos_inflected++]=p_SU_buf->tag[pos_tag++];
+                }
+                break;
 
-				/* Default push operator */
-			default: {
-				unichar tmp[32];
-				single_HGJ_to_Jamos(p_SU_buf->tag[pos_tag],tmp,p_multiFlex_ctx->korean);
-				int len3=u_strlen(tmp);
-				u_strncpy(p_SU_buf->stack+pos_inflected,tmp,len3);
-				pos_inflected=pos_inflected+len3;
-				//old version before Korean: stack[pos++] = tag[pos_tag];
-				pos_tag++;
-				break;
-			}
-			}
-		}
-	}
-	p_SU_buf->out[pos_out] = '\0';
-	/* We process the output, if any and not NULL */
-	if (t->output != NULL && u_strcmp(t->output, "<E>")) {
-		/* If we are in normal mode, we just append the tag's output to the global one */
-		if (t->output[0] == '+') {
-			//error("SEMANTIC:%S\n",local_semantic_codes);
-			//error("SEM:%S\n",t->output);
-			int sem = 0;
-			int x=old_local_semantic_code_length;
-			while (t->output[sem] != ':' && t->output[sem] != '\0') {
-				local_semantic_codes[x++] = t->output[sem];
-				sem++;
-			}
-			local_semantic_codes[x] = '\0';
-			u_strcat(p_SU_buf->out, t->output+sem);
-		} else {
-		    u_strcat(p_SU_buf->out, t->output);
-		}
-	}
-	/* Then, we go the next state */
+                /* Default push operator */
+            default: {
+                unichar tmp[32];
+                single_HGJ_to_Jamos(p_SU_buf->tag[pos_tag],tmp,p_multiFlex_ctx->korean);
+                int len3=u_strlen(tmp);
+                u_strncpy(p_SU_buf->stack+pos_inflected,tmp,len3);
+                pos_inflected=pos_inflected+len3;
+                //old version before Korean: stack[pos++] = tag[pos_tag];
+                pos_tag++;
+                break;
+            }
+            }
+        }
+    }
+    p_SU_buf->out[pos_out] = '\0';
+    /* We process the output, if any and not NULL */
+    if (t->output != NULL && u_strcmp(t->output, "<E>")) {
+        /* If we are in normal mode, we just append the tag's output to the global one */
+        if (t->output[0] == '+') {
+            //error("SEMANTIC:%S\n",local_semantic_codes);
+            //error("SEM:%S\n",t->output);
+            int sem = 0;
+            int x=old_local_semantic_code_length;
+            while (t->output[sem] != ':' && t->output[sem] != '\0') {
+                local_semantic_codes[x++] = t->output[sem];
+                sem++;
+            }
+            local_semantic_codes[x] = '\0';
+            u_strcat(p_SU_buf->out, t->output+sem);
+        } else {
+            u_strcat(p_SU_buf->out, t->output);
+        }
+    }
+    /* Then, we go the next state */
 
-	//int retour_state = 1;
-	if (retour) {
-		if (LIST == NULL) {//error("Explore state 2\n");
-			/*retour_state = */SU_explore_state(p_multiFlex_ctx,p_SU_buf->stack,
-					pos_inflected, lemma, p_SU_buf->out, a,
-					T->state_number, desired_features, forms,
-					flag_var, var_name, var_in_use,
-					local_semantic_codes);
-		} else {//error("Explore state recursion 2\n");
-			/*retour_state = */SU_explore_state_recursion(p_multiFlex_ctx,p_SU_buf->stack,
-					pos_inflected, lemma, p_SU_buf->out, a,
-					T->state_number, LIST, desired_features, forms,
-					flag_var, var_name, var_in_use,
-					local_semantic_codes);
-		}
-	}
-	local_semantic_codes[old_local_semantic_code_length]='\0';
-	//return (retour * (1-retour_state));
+    //int retour_state = 1;
+    if (retour) {
+        if (LIST == NULL) {//error("Explore state 2\n");
+            /*retour_state = */SU_explore_state(p_multiFlex_ctx,p_SU_buf->stack,
+                    pos_inflected, lemma, p_SU_buf->out, a,
+                    T->state_number, desired_features, forms,
+                    flag_var, var_name, var_in_use,
+                    local_semantic_codes);
+        } else {//error("Explore state recursion 2\n");
+            /*retour_state = */SU_explore_state_recursion(p_multiFlex_ctx,p_SU_buf->stack,
+                    pos_inflected, lemma, p_SU_buf->out, a,
+                    T->state_number, LIST, desired_features, forms,
+                    flag_var, var_name, var_in_use,
+                    local_semantic_codes);
+        }
+    }
+    local_semantic_codes[old_local_semantic_code_length]='\0';
+    //return (retour * (1-retour_state));
     free(p_SU_buf);
-	return retour;
+    return retour;
 }
 
 ////////////////////////////////////////////
 // Shifts right all the stack from the position pos
 // 'shift' is the length of the move in chars
 void shift_stack(unichar* stack, int pos,int shift) {
-	if (pos == 0) {
-		// this case should never happen
-		return;
-	}
-	for (int i = (MAX_CHARS_IN_STACK - shift); i >= pos; i--) {
-		stack[i] = stack[i - shift];
-	}
+    if (pos == 0) {
+        // this case should never happen
+        return;
+    }
+    for (int i = (MAX_CHARS_IN_STACK - shift); i >= pos; i--) {
+        stack[i] = stack[i - shift];
+    }
 }
 
 
@@ -867,26 +867,26 @@ shift_stack(stack,pos,1);
 // Shifts all the stack to the left from the position pos
 //
 void shift_stack_left(unichar* stack, int pos) {
-	if (pos == 0) {
-		// this case should never happen
-		return;
-	}
-	for (int i = pos - 1; i < MAX_CHARS_IN_STACK-1; i++) {
-		stack[i] = stack[i + 1];
-	}
+    if (pos == 0) {
+        // this case should never happen
+        return;
+    }
+    for (int i = pos - 1; i < MAX_CHARS_IN_STACK-1; i++) {
+        stack[i] = stack[i + 1];
+    }
 }
 
 //
 // Shifts all the stack to the left from the position pos
 //
 void shift_stack_left2(unichar* stack,int shift) {
-	if (shift == 0) {
-		// this case should never happen
-		return;
-	}
-	for (int i=0;i<MAX_CHARS_IN_STACK-shift;i++) {
-		stack[i]=stack[i+shift];
-	}
+    if (shift == 0) {
+        // this case should never happen
+        return;
+    }
+    for (int i=0;i<MAX_CHARS_IN_STACK-shift;i++) {
+        stack[i]=stack[i+shift];
+    }
 }
 
 
@@ -896,43 +896,43 @@ void shift_stack_left2(unichar* stack,int shift) {
 // Initially 'feat' does not have its space allocated
 // Returns 1 on error, 0 otherwise.
 int SU_convert_features(struct l_morpho_t* pL_MORPHO,f_morpho_T*** feat, unichar* feat_str) {
-	unichar tmp[MAX_CATS]; //buffer for a single set of features, e.g. Ipf
-	f_morpho_T* f; //current feature structure
-	int l; //length of a scanned sequence
-	int no_f; //number of feature sets scanned
+    unichar tmp[MAX_CATS]; //buffer for a single set of features, e.g. Ipf
+    f_morpho_T* f; //current feature structure
+    int l; //length of a scanned sequence
+    int no_f; //number of feature sets scanned
 
-	(*feat) = (f_morpho_T**) malloc(sizeof(f_morpho_T*));
-	if ((*feat) == NULL) {
-		fatal_alloc_error("SU_convert_features");
-	}
-	no_f = 0;
+    (*feat) = (f_morpho_T**) malloc(sizeof(f_morpho_T*));
+    if ((*feat) == NULL) {
+        fatal_alloc_error("SU_convert_features");
+    }
+    no_f = 0;
 
-	while (*feat_str) {
-		//Delete the leading ':' if any
-		if (feat_str[0] == (unichar) ':')
-			feat_str++;
-		//Get next feature structures, e.g. Ipf, out of a sequence, e.g. :Ipf:Ipm
-		l = u_scan_until_char(tmp, feat_str, MAX_CATS - 1, ":", 1);
-		feat_str = feat_str + l;
-		//Convert the set of features, e.g. Ipm, into a feature structure, e.g. <Case=I; Nb=p; Gen=m>
-		f = d_get_feat_str(pL_MORPHO,tmp);
-		if (!f) {
-			for (int i = 0; i < no_f; i++)
-				//delete the previously constracted feature structures
-				free((*feat)[i]);
-			free(*feat);
-			return 1;
-		}
-		no_f++;
-		(*feat) = (f_morpho_T**) realloc((*feat), (no_f + 1)
-				* sizeof(f_morpho_T*));
-		if (!(*feat)) {
-			fatal_alloc_error("SU_convert_features");
-		}
-		(*feat)[no_f - 1] = f;
-	}
-	(*feat)[no_f] = NULL;
-	return 0;
+    while (*feat_str) {
+        //Delete the leading ':' if any
+        if (feat_str[0] == (unichar) ':')
+            feat_str++;
+        //Get next feature structures, e.g. Ipf, out of a sequence, e.g. :Ipf:Ipm
+        l = u_scan_until_char(tmp, feat_str, MAX_CATS - 1, ":", 1);
+        feat_str = feat_str + l;
+        //Convert the set of features, e.g. Ipm, into a feature structure, e.g. <Case=I; Nb=p; Gen=m>
+        f = d_get_feat_str(pL_MORPHO,tmp);
+        if (!f) {
+            for (int i = 0; i < no_f; i++)
+                //delete the previously constracted feature structures
+                free((*feat)[i]);
+            free(*feat);
+            return 1;
+        }
+        no_f++;
+        (*feat) = (f_morpho_T**) realloc((*feat), (no_f + 1)
+                * sizeof(f_morpho_T*));
+        if (!(*feat)) {
+            fatal_alloc_error("SU_convert_features");
+        }
+        (*feat)[no_f - 1] = f;
+    }
+    (*feat)[no_f] = NULL;
+    return 0;
 }
 
 ////////////////////////////////////////////
@@ -940,22 +940,22 @@ int SU_convert_features(struct l_morpho_t* pL_MORPHO,f_morpho_T*** feat, unichar
 // into a list of strings "Ipf", "Ipm"
 // Returns the list; NULL if an error occurs.
 struct list_ustring* SU_split_raw_features(unichar* features) {
-	struct list_ustring* result = NULL;
-	if (features == NULL || features[0] == '\0') {
-		return NULL;
-	}
-	int pos = 0;
-	if (features[0] == ':') {
-		pos++;
-	}
-	unichar feature[1024];
-	while (P_OK == parse_string(features, &pos, feature, P_COLON)) {
-		result = new_list_ustring(feature, result);
-		if (features[pos] == ':') {
-			pos++;
-		}
-	}
-	return result;
+    struct list_ustring* result = NULL;
+    if (features == NULL || features[0] == '\0') {
+        return NULL;
+    }
+    int pos = 0;
+    if (features[0] == ':') {
+        pos++;
+    }
+    unichar feature[1024];
+    while (P_OK == parse_string(features, &pos, feature, P_COLON)) {
+        result = new_list_ustring(feature, result);
+        if (features[pos] == ':') {
+            pos++;
+        }
+    }
+    return result;
 }
 
 ////////////////////////////////////////////
@@ -974,71 +974,71 @@ struct list_ustring* SU_split_raw_features(unichar* features) {
 // that 'feat2'=NULL means that all the inflected forms are
 // to keep.
 int SU_feature_agreement(struct l_morpho_t* pL_MORPHO,f_morpho_T* feat1, f_morpho_T* feat2) {
-	if (feat2 == NULL)
-		return 1;
+    if (feat2 == NULL)
+        return 1;
 
-	if (feat1 == NULL)
-		return 0;
+    if (feat1 == NULL)
+        return 0;
 
-	int f1; //Index of the current feature in 'feat1'
-	int f2; //Index of the current feature in 'feat2'
-	int found; //Has the current feature's category been found in 'feat2'
+    int f1; //Index of the current feature in 'feat1'
+    int f2; //Index of the current feature in 'feat2'
+    int found; //Has the current feature's category been found in 'feat2'
 
-	//Each category-value pair of the 'feat2' has to be present in 'feat1'
-	//except empty features (<E>)
-	for (f2 = 0; f2 < feat2->no_cats; f2++) {
-		found = 0;
-		f1 = 0;
-		while ((!found) && (f1 < feat1->no_cats)) {
-			if (feat2->cats[f2].cat == feat1->cats[f1].cat) {
-				found = 1;
-				//If the same category then the value has to be the same
-				if (feat2->cats[f2].val != feat1->cats[f1].val)
-					return 0;
-			}
-			f1++;
-		}
-		//If a desired category has a non empty value, and it does not appear in 'feat'
-		//then both feature sets do not agree
-		if (!found && !is_empty_val(pL_MORPHO,feat2->cats[f2].cat, feat2->cats[f2].val))
-			return 0;
-	}
+    //Each category-value pair of the 'feat2' has to be present in 'feat1'
+    //except empty features (<E>)
+    for (f2 = 0; f2 < feat2->no_cats; f2++) {
+        found = 0;
+        f1 = 0;
+        while ((!found) && (f1 < feat1->no_cats)) {
+            if (feat2->cats[f2].cat == feat1->cats[f1].cat) {
+                found = 1;
+                //If the same category then the value has to be the same
+                if (feat2->cats[f2].val != feat1->cats[f1].val)
+                    return 0;
+            }
+            f1++;
+        }
+        //If a desired category has a non empty value, and it does not appear in 'feat'
+        //then both feature sets do not agree
+        if (!found && !is_empty_val(pL_MORPHO,feat2->cats[f2].cat, feat2->cats[f2].val))
+            return 0;
+    }
 
-	//Each category-value pair of the 'feat' has to be present in 'feat2'
-	//except empty features (<E>)
-	for (f1 = 0; f1 < feat1->no_cats; f1++) {
-		found = 0;
-		f2 = 0;
-		while ((!found) && (f2 < feat2->no_cats)) {
-			if (feat1->cats[f1].cat == feat2->cats[f2].cat) {
-				found = 1;
-				//If the same category then the value has to be the same
-				if (feat1->cats[f1].val != feat2->cats[f2].val)
-					return 0;
-			}
-			f2++;
-		}
-		//If a desired category has a non empty value, and it does not appear in 'feat'
-		//then both feature sets do not agree
-		if (!found && !is_empty_val(pL_MORPHO,feat1->cats[f1].cat, feat1->cats[f1].val))
-			return 0;
-	}
-	return 1;
+    //Each category-value pair of the 'feat' has to be present in 'feat2'
+    //except empty features (<E>)
+    for (f1 = 0; f1 < feat1->no_cats; f1++) {
+        found = 0;
+        f2 = 0;
+        while ((!found) && (f2 < feat2->no_cats)) {
+            if (feat1->cats[f1].cat == feat2->cats[f2].cat) {
+                found = 1;
+                //If the same category then the value has to be the same
+                if (feat1->cats[f1].val != feat2->cats[f2].val)
+                    return 0;
+            }
+            f2++;
+        }
+        //If a desired category has a non empty value, and it does not appear in 'feat'
+        //then both feature sets do not agree
+        if (!found && !is_empty_val(pL_MORPHO,feat1->cats[f1].cat, feat1->cats[f1].val))
+            return 0;
+    }
+    return 1;
 }
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a set of forms
 void SU_delete_inflection(SU_forms_T* forms) {
-	int f;
-	if (!forms)
-		return;
-	for (f = 0; f < forms->no_forms; f++) {
-		free(forms->forms[f].form);
-		free(forms->forms[f].features);
+    int f;
+    if (!forms)
+        return;
+    for (f = 0; f < forms->no_forms; f++) {
+        free(forms->forms[f].form);
+        free(forms->forms[f].features);
         if (forms->forms[f].local_semantic_code != NULL) {
-		   free(forms->forms[f].local_semantic_code);
+           free(forms->forms[f].local_semantic_code);
         }
-	}
+    }
     free(forms->forms);
 }
 
@@ -1047,22 +1047,22 @@ void SU_delete_inflection(SU_forms_T* forms) {
 // Initially 'feat' has its space allocated but is empty.
 // Returns 1 on error, 0 otherwise.
 int SU_cpy_features(f_morpho_T* feat, SU_id_T* SU_id) {
-	int c;
+    int c;
 
-	if (!SU_id || !SU_id->feat)
-		return 1;
+    if (!SU_id || !SU_id->feat)
+        return 1;
 
-	for (c = 0; c < SU_id->feat->no_cats; c++)
-		feat->cats[c] = SU_id->feat->cats[c];
+    for (c = 0; c < SU_id->feat->no_cats; c++)
+        feat->cats[c] = SU_id->feat->cats[c];
 
-	feat->no_cats = SU_id->feat->no_cats;
-	return 0;
+    feat->no_cats = SU_id->feat->no_cats;
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a form's morphology.
 void SU_delete_features(f_morpho_T* f) {
-	free(f);
+    free(f);
 }
 
 ////////////////////////////////////////////
@@ -1073,45 +1073,45 @@ void SU_delete_features(f_morpho_T* f) {
 // (e.g. ->("reka",word,[reka,noun,N56,{"Conc"},"body"],{Gen=fem; Nb=sing; Case=I})), NULL otherwise.
 // The identifier is allocated in this function. The liberation must be done by the calling function.
 SU_id_T* SU_get_id(unichar* form, f_morpho_T* feat, SU_lemma_T* SU_lemma) {
-	SU_id_T* SU_id;
-	SU_id = (SU_id_T*) malloc(sizeof(SU_id_T));
-	if (SU_id == NULL) {
-		fatal_alloc_error("SU_get_id");
-	}
+    SU_id_T* SU_id;
+    SU_id = (SU_id_T*) malloc(sizeof(SU_id_T));
+    if (SU_id == NULL) {
+        fatal_alloc_error("SU_get_id");
+    }
 
-	//Form
-	SU_id->form = u_strdup(form);
+    //Form
+    SU_id->form = u_strdup(form);
 
-	if (SU_lemma) { //if not a separator
+    if (SU_lemma) { //if not a separator
 
-		//Lemma
-		SU_id->lemma = (SU_lemma_T*) malloc(sizeof(SU_lemma_T));
-		if (!SU_id->lemma) {
-			fatal_alloc_error("SU_get_id");
-		}
-		//Lemma form
-		SU_id->lemma->unit = u_strdup(SU_lemma->unit);
-		//Class
-		SU_id->lemma->cl = SU_lemma->cl;
-		//Paradigm
-		SU_id->lemma->paradigm = strdup(SU_lemma->paradigm);
-		if (SU_id->lemma->paradigm == NULL) {
-			fatal_alloc_error("SU_get_id");
-		}
-		//Features
-		f_morpho_T* fea;
-		fea = (f_morpho_T*) malloc(sizeof(f_morpho_T));
-		if (!fea) {
-			fatal_alloc_error("SU_get_id");
-		}
-		f_init_morpho(fea);
-		int f; //index of the current category-value pair in 'feat'
-		for (f = 0; f < feat->no_cats; f++) {
-			f_add_morpho(fea, feat->cats[f].cat, feat->cats[f].val);
-		}
+        //Lemma
+        SU_id->lemma = (SU_lemma_T*) malloc(sizeof(SU_lemma_T));
+        if (!SU_id->lemma) {
+            fatal_alloc_error("SU_get_id");
+        }
+        //Lemma form
+        SU_id->lemma->unit = u_strdup(SU_lemma->unit);
+        //Class
+        SU_id->lemma->cl = SU_lemma->cl;
+        //Paradigm
+        SU_id->lemma->paradigm = strdup(SU_lemma->paradigm);
+        if (SU_id->lemma->paradigm == NULL) {
+            fatal_alloc_error("SU_get_id");
+        }
+        //Features
+        f_morpho_T* fea;
+        fea = (f_morpho_T*) malloc(sizeof(f_morpho_T));
+        if (!fea) {
+            fatal_alloc_error("SU_get_id");
+        }
+        f_init_morpho(fea);
+        int f; //index of the current category-value pair in 'feat'
+        for (f = 0; f < feat->no_cats; f++) {
+            f_add_morpho(fea, feat->cats[f].cat, feat->cats[f].val);
+        }
 
-	}
-	return SU_id;
+    }
+    return SU_id;
 }
 
 ////////////////////////////////////////////
@@ -1125,93 +1125,93 @@ SU_id_T* SU_get_id(unichar* form, f_morpho_T* feat, SU_lemma_T* SU_lemma) {
 // Returns the length of the scanned sequence.
 // Returns -2 on memory allocation problem.
 int SU_get_unit(unichar* unit, unichar* line, int max, Alphabet* alph,
-		int eliminate_bcksl) {
-	int l = 0; //length of the scanned sequence
-	int u = 0; //index of the next element in 'unit'
-	int end = 0;
-	int no_elim_bcksl = 0; //number of eliminated backslashes
-	int bcksl_precedes = 0; //1 if the preceding character was a '\', 0 otherwise
-	if (!line)
-		return 0;
+        int eliminate_bcksl) {
+    int l = 0; //length of the scanned sequence
+    int u = 0; //index of the next element in 'unit'
+    int end = 0;
+    int no_elim_bcksl = 0; //number of eliminated backslashes
+    int bcksl_precedes = 0; //1 if the preceding character was a '\', 0 otherwise
+    if (!line)
+        return 0;
 
-	//Separator
-	if (line[0] == (unichar) '\\' && line[1] && !is_letter(line[1], alph))
-		if (eliminate_bcksl) {
-			unit[0] = line[1];
-			unit[1] = '\0';
-			return 2;
-		} else {
-			unit[0] = line[0];
-			unit[1] = line[1];
-			unit[2] = '\0';
-			return 2;
-		}
-	else if (line[0] != (unichar) '\\' && line[0] && !is_letter(line[0], alph)) {
-		unit[0] = line[0];
-		unit[1] = '\0';
-		return 1;
-	}
+    //Separator
+    if (line[0] == (unichar) '\\' && line[1] && !is_letter(line[1], alph))
+        if (eliminate_bcksl) {
+            unit[0] = line[1];
+            unit[1] = '\0';
+            return 2;
+        } else {
+            unit[0] = line[0];
+            unit[1] = line[1];
+            unit[2] = '\0';
+            return 2;
+        }
+    else if (line[0] != (unichar) '\\' && line[0] && !is_letter(line[0], alph)) {
+        unit[0] = line[0];
+        unit[1] = '\0';
+        return 1;
+    }
 
-	//Word
-	else {
-		l = 0;
-		u = 0;
-		end = 0;
-		no_elim_bcksl = 0;
-		bcksl_precedes = 0;
-		while (!end && u < max && line[l] != (unichar) '\0')
-			if (line[l] == (unichar) '\\') //current character is a '\'
-				if (!bcksl_precedes) { //not preceded by '\'
-					bcksl_precedes = 1;
-					l++;
-				} else //preceded by '\'
-				if (!is_letter(line[l], alph)) //'\' is no letter
-					end = 1;
-				else { //\ '\' is a letter
-					if (!eliminate_bcksl)
-						unit[u++] = (unichar) '\\';
-					else
-						no_elim_bcksl++;
-					unit[u++] = line[l++];
-					bcksl_precedes = 0;
-				}
-			else {//Current character is not a '\'
-				if (!is_letter(line[l], alph)) //'\' is no letter
-					end = 1;
-				else { //\ '\' is a letter
-					if (bcksl_precedes) {
-						if (!eliminate_bcksl)
-							unit[u++] = (unichar) '\\';
-						else
-							no_elim_bcksl++;
-					}
-					unit[u++] = line[l++];
-					bcksl_precedes = 0;
-				}
-			}
-	}
-	unit[u] = (unichar) '\0';
-	return u + no_elim_bcksl;
+    //Word
+    else {
+        l = 0;
+        u = 0;
+        end = 0;
+        no_elim_bcksl = 0;
+        bcksl_precedes = 0;
+        while (!end && u < max && line[l] != (unichar) '\0')
+            if (line[l] == (unichar) '\\') //current character is a '\'
+                if (!bcksl_precedes) { //not preceded by '\'
+                    bcksl_precedes = 1;
+                    l++;
+                } else //preceded by '\'
+                if (!is_letter(line[l], alph)) //'\' is no letter
+                    end = 1;
+                else { //\ '\' is a letter
+                    if (!eliminate_bcksl)
+                        unit[u++] = (unichar) '\\';
+                    else
+                        no_elim_bcksl++;
+                    unit[u++] = line[l++];
+                    bcksl_precedes = 0;
+                }
+            else {//Current character is not a '\'
+                if (!is_letter(line[l], alph)) //'\' is no letter
+                    end = 1;
+                else { //\ '\' is a letter
+                    if (bcksl_precedes) {
+                        if (!eliminate_bcksl)
+                            unit[u++] = (unichar) '\\';
+                        else
+                            no_elim_bcksl++;
+                    }
+                    unit[u++] = line[l++];
+                    bcksl_precedes = 0;
+                }
+            }
+    }
+    unit[u] = (unichar) '\0';
+    return u + no_elim_bcksl;
 }
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a form's id.
 int SU_delete_id(SU_id_T* id) {
-	free(id->form);
-	if (id->lemma)
-		SU_delete_lemma(id->lemma);
+    free(id->form);
+    if (id->lemma)
+        SU_delete_lemma(id->lemma);
     if (id->feat)
         f_delete_morpho(id->feat);
-	free(id);
-	return 0;
+    free(id);
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Initialize the single-unit 'forms' with null values
 // We suppose that 'forms' has its space allocated
 void SU_init_forms(SU_forms_T* forms) {
-	forms->no_forms = 0;
-	forms->forms = NULL;
+    forms->no_forms = 0;
+    forms->forms = NULL;
 }
 
 ////////////////////////////////////////////
@@ -1219,104 +1219,104 @@ void SU_init_forms(SU_forms_T* forms) {
 // the unique form "form"
 // E.g. if form = "rekami" then forms becomes (1,{("rekami",NULL)}
 void SU_init_invariable_form(SU_forms_T* forms, const unichar* form) {
-	forms->no_forms = 1;
-	forms->forms = (SU_f_T*) malloc(sizeof(SU_f_T));
-	if (!forms->forms) {
-		fatal_alloc_error("SU_init_invariable_form");
-	}
-	forms->forms[0].form = u_strdup(form);
-	forms->forms[0].local_semantic_code=NULL;
-	forms->forms[0].features = NULL;
+    forms->no_forms = 1;
+    forms->forms = (SU_f_T*) malloc(sizeof(SU_f_T));
+    if (!forms->forms) {
+        fatal_alloc_error("SU_init_invariable_form");
+    }
+    forms->forms[0].form = u_strdup(form);
+    forms->forms[0].local_semantic_code=NULL;
+    forms->forms[0].features = NULL;
 }
 
 /////////////////////////////////////////////////////////////////////
 // Same as SU_init_invariable_form but the second parameter is a char*
 void SU_init_invariable_form_char(SU_forms_T* forms, const char* form) {
-	forms->no_forms = 1;
-	forms->forms = (SU_f_T*) malloc(sizeof(SU_f_T));
-	if (!forms->forms) {
-		fatal_alloc_error("SU_init_invariable_form_char");
-	}
-	forms->forms[0].form = u_strdup(form);
-	forms->forms[0].local_semantic_code=NULL;
-	forms->forms[0].features = NULL;
+    forms->no_forms = 1;
+    forms->forms = (SU_f_T*) malloc(sizeof(SU_f_T));
+    if (!forms->forms) {
+        fatal_alloc_error("SU_init_invariable_form_char");
+    }
+    forms->forms[0].form = u_strdup(form);
+    forms->forms[0].local_semantic_code=NULL;
+    forms->forms[0].features = NULL;
 }
 
 ////////////////////////////////////////////
 // Prints a form and its inflection features.
 int SU_print_f(SU_f_T* f) {
-	u_printf("%S : ", f->form);
-	f_print_morpho(f->features);
-	return 0;
+    u_printf("%S : ", f->form);
+    f_print_morpho(f->features);
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Prints a set of forms and their inflection features.
 int SU_print_forms(SU_forms_T* F) {
-	int f;
-	for (f = 0; f < F->no_forms; f++)
-		SU_print_f(&(F->forms[f]));
-	return 0;
+    int f;
+    for (f = 0; f < F->no_forms; f++)
+        SU_print_f(&(F->forms[f]));
+    return 0;
 }
 
 ////////////////////////////////////////////
 // Prints a lemma and its info.
 int SU_print_lemma(SU_lemma_T* l) {
-	u_printf("%S:", l->unit); //lemma
-	u_printf("%S:", l->cl->name); //class
-	u_printf("%s", l->paradigm); //inflection paradigm
-	return 0;
+    u_printf("%S:", l->unit); //lemma
+    u_printf("%S:", l->cl->name); //class
+    u_printf("%s", l->paradigm); //inflection paradigm
+    return 0;
 }
 
 ////////////////////////////////////////////
 // For testing purposes
 // Initialise a sample lemma structure for tests.
 int SU_init_lemma(struct l_morpho_t* pL_MORPHO,SU_lemma_T* l, char* word, char* cl, char* para) {
-	//lemma
-	l->unit = u_strdup(word);
-	//class
-	if (!strcmp(cl, "noun"))
-		l->cl = &(pL_MORPHO->L_CLASSES.classes[0]);
-	else if (!strcmp(cl, "adj"))
-		l->cl = &(pL_MORPHO->L_CLASSES.classes[1]);
-	else if (!strcmp(cl, "adv"))
-		l->cl = &(pL_MORPHO->L_CLASSES.classes[2]);
-	else
-		l->cl = NULL;
-	//paradigm
-	l->paradigm = strdup(para);
-	if (l->paradigm == NULL) {
-		fatal_alloc_error("SU_init_lemma");
-	}
-	return 0;
+    //lemma
+    l->unit = u_strdup(word);
+    //class
+    if (!strcmp(cl, "noun"))
+        l->cl = &(pL_MORPHO->L_CLASSES.classes[0]);
+    else if (!strcmp(cl, "adj"))
+        l->cl = &(pL_MORPHO->L_CLASSES.classes[1]);
+    else if (!strcmp(cl, "adv"))
+        l->cl = &(pL_MORPHO->L_CLASSES.classes[2]);
+    else
+        l->cl = NULL;
+    //paradigm
+    l->paradigm = strdup(para);
+    if (l->paradigm == NULL) {
+        fatal_alloc_error("SU_init_lemma");
+    }
+    return 0;
 }
 
 ////////////////////////////////////////////
 // For testing purposes
 // Delete sample lemma stucture for tests.
 int SU_delete_lemma(SU_lemma_T* l) {
-	free(l->unit);
-	free(l->paradigm);
-	free(l);
-	return 0;
+    free(l->unit);
+    free(l->paradigm);
+    free(l);
+    return 0;
 }
 
 ////////////////////////////////////////////
 // *COMMENT CONCERNING THE UNIQUE IDENTIFICATION OF SINGLE WORD FORMS
 //
 // In order to uniquely identify a word form four elements are necessary:
-//	- the form  (e.g. "rekami")
-//	- its lemma (e.g. "reka")
-//	- its inflection paradigm (e.g. N56)
-//	- its inflection features (e.g. {Gen=fem,Nb=pl,Case=Inst}
+//  - the form  (e.g. "rekami")
+//  - its lemma (e.g. "reka")
+//  - its inflection paradigm (e.g. N56)
+//  - its inflection features (e.g. {Gen=fem,Nb=pl,Case=Inst}
 // Note that omitting one of these elements may introduce ambiguities from the morphological point of view.
 // Examples :
-//	1) If the form itself is missing, an ambiguity may exist between variants corresponding to the same inflection features
-//	   e.g. given only the lemma "reka", the paradigm N56, and the features {Gen=fem,Nb=pl,Case=Inst}), we may not distinguish
-// 	   between "rekami" and "rekoma"
-//	2) If the lemma is missing we may not lemmatize the form (unless the paradigm allows to do that on the basis of the 3 elements)
-//	3) If the inflection paradigm is missing we may not produce other inflected forms.
-//	4) If the inflection deatures are missing the may be an ambiguity in case of homographs e.g. "rece" may be both
-//	   {Gen=fem,Nb=pl,Case=Nom} and {Gen=fem,Nb=pl,Case=Acc}
+//  1) If the form itself is missing, an ambiguity may exist between variants corresponding to the same inflection features
+//     e.g. given only the lemma "reka", the paradigm N56, and the features {Gen=fem,Nb=pl,Case=Inst}), we may not distinguish
+//     between "rekami" and "rekoma"
+//  2) If the lemma is missing we may not lemmatize the form (unless the paradigm allows to do that on the basis of the 3 elements)
+//  3) If the inflection paradigm is missing we may not produce other inflected forms.
+//  4) If the inflection deatures are missing the may be an ambiguity in case of homographs e.g. "rece" may be both
+//     {Gen=fem,Nb=pl,Case=Nom} and {Gen=fem,Nb=pl,Case=Acc}
 
 } // namespace unitex

--- a/MF_SU_morpho.h
+++ b/MF_SU_morpho.h
@@ -47,13 +47,13 @@ namespace unitex {
 //        or   (1,{["-",{}]})
 // Returns 0 on success, 1 otherwise.
 int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
-		SU_id_T* SU_id,f_morpho_T* feat,
-		SU_forms_T* forms);
+        SU_id_T* SU_id,f_morpho_T* feat,
+        SU_forms_T* forms);
 
 /* This prototype has been added in order to deal with simple words */
 int SU_inflect(MultiFlex_ctx* p_multiFlex_ctx,
-		unichar* lemma,
-		char* inflection_code,SU_forms_T* forms);
+        unichar* lemma,
+        char* inflection_code,SU_forms_T* forms);
 
 ////////////////////////////////////////////
 // Liberates the memory allocated for a set of forms
@@ -133,20 +133,20 @@ int SU_delete_lemma(SU_lemma_T* l);
 // COMMENT CONCERNING THE UNIQUE IDENTIFICATION OF SINGLE WORD FORMS
 //
 // In order to uniquely identify a word form four elements are necessary:
-//	- the form  (e.g. "rekami")
-//	- its lemma (e.g. "reka")
-//	- its inflection paradigm (e.g. N56)
-//	- its inflection features (e.g. {Gen=fem,Nb=pl,Case=Inst}
+//  - the form  (e.g. "rekami")
+//  - its lemma (e.g. "reka")
+//  - its inflection paradigm (e.g. N56)
+//  - its inflection features (e.g. {Gen=fem,Nb=pl,Case=Inst}
 // Note that omitting one of these elements may introduce ambiguities from the morphological point of view.
 // Examples :
-//	1) If the form itself is missing, an ambiguity may exist between variants corresponding to the same inflection features
-//	   e.g. given only the lemma "reka", the paradigm N56, and the features {Gen=fem,Nb=pl,Case=Inst}), we may not distinguish
-// 	   between "rekami" and "rekoma"
-//	2) If the lemma is missing we may not lemmatize the form (unless the paradigm allows to do that on the basis of the 3 elements).
+//  1) If the form itself is missing, an ambiguity may exist between variants corresponding to the same inflection features
+//     e.g. given only the lemma "reka", the paradigm N56, and the features {Gen=fem,Nb=pl,Case=Inst}), we may not distinguish
+//     between "rekami" and "rekoma"
+//  2) If the lemma is missing we may not lemmatize the form (unless the paradigm allows to do that on the basis of the 3 elements).
 //         A certain form may be identical for two different lemmas.
-//	3) If the inflection paradigm is missing we may not produce other inflected forms.
-//	4) If the inflection features are missing there may be an ambiguity in case of homographs e.g. "rece" may be both
-//	   {Gen=fem,Nb=pl,Case=Nom} and {Gen=fem,Nb=pl,Case=Acc}
+//  3) If the inflection paradigm is missing we may not produce other inflected forms.
+//  4) If the inflection features are missing there may be an ambiguity in case of homographs e.g. "rece" may be both
+//     {Gen=fem,Nb=pl,Case=Nom} and {Gen=fem,Nb=pl,Case=Acc}
 //
 // A UNIQUE identification of a form in the set of all inflected forms
 

--- a/MF_SU_morphoBase.h
+++ b/MF_SU_morphoBase.h
@@ -59,9 +59,9 @@ typedef struct  {
 /////////////////////////////////////////////////
 //Structure for the lemma of a single word
 typedef struct {
-  unichar* unit;		//e.g. "vif"
-  l_class_T *cl;	        //e.g. adj
-  char *paradigm;		//e.g. A41
+  unichar* unit;        //e.g. "vif"
+  l_class_T *cl;            //e.g. adj
+  char *paradigm;       //e.g. A41
 } SU_lemma_T;
 
 /////////////////////////////////////////////////
@@ -83,7 +83,7 @@ typedef struct {
   //  SU_unit_T type;        //word or sep
   SU_lemma_T *lemma;     //lemma and its info; empty for a separator
   f_morpho_T* feat;    //the form's morphology, e.g. {Gen=fem; Nb=sing; Case=I}
-  //  int form_nr;   	 //identifier of the form in the list of all inflected forms of the lemma; irrelevant for a separator
+  //  int form_nr;       //identifier of the form in the list of all inflected forms of the lemma; irrelevant for a separator
 } SU_id_T;
 
 } // namespace unitex

--- a/MF_Unif.cpp
+++ b/MF_Unif.cpp
@@ -50,14 +50,14 @@ namespace unitex {
 ///unif_vars_T UNIF_VARS;
 
 ////////////////////////////////////////////
-// Initializes the set of instantiations. 
+// Initializes the set of instantiations.
 int unif_init_vars(unif_vars_T* UNIF_VARS) {
   UNIF_VARS->no_vars = 0;
   return 0;
 }
 
 ////////////////////////////////////////////
-// Prints the set of instantiations. 
+// Prints the set of instantiations.
 int unif_print_vars(unif_vars_T* UNIF_VARS) {
 int v;
 int i;
@@ -72,7 +72,7 @@ return 0;
 
 //////////////////////////////////////////////////////////////////////////////////
 // If variable "var" already instantiated, returns -1. Otherwise,
-// instantiates the unification variable "var" to category "cat" and value "val". 
+// instantiates the unification variable "var" to category "cat" and value "val".
 // Returns 1 or -1 in case of error, 0 otherwise.
 int unif_instantiate(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, unichar* val) {
   int i;
@@ -80,7 +80,7 @@ int unif_instantiate(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, uni
   //Check if not yet instantiated.
   if (unif_instantiated(UNIF_VARS,var))
       return -1;
- 
+
   i = UNIF_VARS->no_vars;
 
   //Category
@@ -90,7 +90,7 @@ int unif_instantiate(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, uni
   v = is_valid_val(cat,val);
   if (v == -1) {
     error("Instantiation impossible: %S is an invalid value in category %S.\n",val,cat->name);
-    return 1;    
+    return 1;
   }
   UNIF_VARS->vars[i].val = v;
 
@@ -103,17 +103,17 @@ int unif_instantiate(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, uni
 
 //////////////////////////////////////////////////////////////////////////////////
 // If variable "var" already instantiated, returns -1. Otherwise,
-// instantiates the unification variable "var" to category "cat" and value whole index in the domain of "cat" is "val". 
+// instantiates the unification variable "var" to category "cat" and value whole index in the domain of "cat" is "val".
 // Returns 1 or -1 in case of error, 0 otherwise.
 int unif_instantiate_index(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, int val) {
   //Check if not yet instantiated.
   if (unif_instantiated(UNIF_VARS,var))
       return -1;
-  
+
   //Check if the value is in the domain of "cat"
   if (cat->no_values <= val)
     return -1;
- 
+
   int i = UNIF_VARS->no_vars;
   //Category
   UNIF_VARS->vars[i].cat = cat;
@@ -128,7 +128,7 @@ int unif_instantiate_index(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* ca
 }
 
 //////////////////////////////////////////////////////////////////////////////////
-// Desinstantiates the unification variable "var". 
+// Desinstantiates the unification variable "var".
 int unif_desinstantiate(unif_vars_T* UNIF_VARS,unichar* var) {
   int v, w, found;
 
@@ -159,7 +159,7 @@ int unif_instantiated(unif_vars_T* UNIF_VARS,unichar* var) {
   }
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its index 
+// If the unification variable "var" is instantiated returns its index
 // in the domain of its category otherwise returns -1.
 int unif_get_val_index(unif_vars_T* UNIF_VARS,unichar* var) {
   int v;
@@ -170,7 +170,7 @@ int unif_get_val_index(unif_vars_T* UNIF_VARS,unichar* var) {
   }
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its value, 
+// If the unification variable "var" is instantiated returns its value,
 // otherwise returns NULL.
 unichar* unif_get_val(unif_vars_T* UNIF_VARS,unichar* var) {
   int v,i;
@@ -183,7 +183,7 @@ unichar* unif_get_val(unif_vars_T* UNIF_VARS,unichar* var) {
   }
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its category, 
+// If the unification variable "var" is instantiated returns its category,
 // otherwise returns NULL.
 l_category_T* unif_get_cat(unif_vars_T* UNIF_VARS,unichar* var) {
   int v;
@@ -194,7 +194,7 @@ l_category_T* unif_get_cat(unif_vars_T* UNIF_VARS,unichar* var) {
   }
 
 //////////////////////////////////////////////////////////////
-// Liberates the space allocated for the set of instantiations. 
+// Liberates the space allocated for the set of instantiations.
 int unif_free_vars(unif_vars_T* UNIF_VARS) {
   int v;
   for (v=0; v<UNIF_VARS->no_vars; v++)

--- a/MF_Unif.cpp
+++ b/MF_Unif.cpp
@@ -142,7 +142,7 @@ int unif_desinstantiate(unif_vars_T* UNIF_VARS,unichar* var) {
   if (found) {
     free(UNIF_VARS->vars[v].id);
     for (w=v+1; w<UNIF_VARS->no_vars;w++)
-    	UNIF_VARS->vars[w-1] = UNIF_VARS->vars[w];
+        UNIF_VARS->vars[w-1] = UNIF_VARS->vars[w];
     UNIF_VARS->no_vars--;
   }
   return 0;

--- a/MF_Unif.h
+++ b/MF_Unif.h
@@ -41,29 +41,29 @@
 namespace unitex {
 
 ////////////////////////////////////////////
-// Initializes the set of instantiations. 
+// Initializes the set of instantiations.
 int unif_init_vars(unif_vars_T* UNIF_VARS);
 
 ////////////////////////////////////////////
-// Prints the set of instantiations. 
+// Prints the set of instantiations.
 int unif_print_vars(unif_vars_T* UNIF_VARS);
 
 //////////////////////////////////////////////////////////////
-// Liberates the space allocated for the set of instantiations. 
+// Liberates the space allocated for the set of instantiations.
 int unif_free_vars(unif_vars_T* UNIF_VARS);
 
 //////////////////////////////////////////////////////////////////////////////////
-// Instantiates the unification variable "var" to category "cat" and value "val". 
+// Instantiates the unification variable "var" to category "cat" and value "val".
 int unif_instantiate(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, unichar* val);
 
 //////////////////////////////////////////////////////////////////////////////////
 // If variable "var" already instantiated, returns -1. Otherwise,
-// instantiates the unification variable "var" to category "cat" and value whole index in the domain of "cat" is "val". 
+// instantiates the unification variable "var" to category "cat" and value whole index in the domain of "cat" is "val".
 // Returns 1 or -1 in case of error, 0 otherwise.
 int unif_instantiate_index(unif_vars_T* UNIF_VARS,unichar* var, l_category_T* cat, int val);
 
 //////////////////////////////////////////////////////////////////////////////////
-// Desinstantiates the unification variable "var". 
+// Desinstantiates the unification variable "var".
 int unif_desinstantiate(unif_vars_T* UNIF_VARS,unichar* var);
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -71,22 +71,22 @@ int unif_desinstantiate(unif_vars_T* UNIF_VARS,unichar* var);
 int unif_instantiated(unif_vars_T* UNIF_VARS,unichar* var);
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its value, 
+// If the unification variable "var" is instantiated returns its value,
 // otherwise returns NULL.
 unichar* unif_get_val(unif_vars_T* UNIF_VARS,unichar* var);
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its index 
+// If the unification variable "var" is instantiated returns its index
 // in the domain of its category otherwise returns -1.
 int unif_get_val_index(unif_vars_T* UNIF_VARS,unichar* var);
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its index 
+// If the unification variable "var" is instantiated returns its index
 // in the domain of its category otherwise returns -1.
 int unif_get_val_index(unif_vars_T* UNIF_VARS,unichar* var);
 
 //////////////////////////////////////////////////////////////////////////////////
-// If the unification variable "var" is instantiated returns its category, 
+// If the unification variable "var" is instantiated returns its category,
 // otherwisz returns NULL..
 l_category_T* unif_get_cat(unif_vars_T* UNIF_VARS,unichar* var);
 

--- a/MF_Util.cpp
+++ b/MF_Util.cpp
@@ -316,7 +316,7 @@ void u_tri_a(void *T, int *cnt, int len) {
 
 //////////////////////////////////////////////////////////
 // Add a new unichar string to the dynamic unichar table
-// while reallocating memory space and updating the 
+// while reallocating memory space and updating the
 // cardinality. Space for the new form must be allocated.
 // Returns 0 on success, 1 otherwise.
 int u_add_unitab_elem(unichar* form, unitab_t* tab) {

--- a/MF_Util.cpp
+++ b/MF_Util.cpp
@@ -23,7 +23,7 @@
  */
 
 /****************************************************************/
-/* Operations sur des chaines de caracteres			*/
+/* Operations sur des chaines de caracteres         */
 /****************************************************************/
 
 #include <stdio.h>
@@ -41,9 +41,9 @@
 namespace unitex {
 
 /****************************************************************/
-/* Verifier si le caractere c a un correspondant parmi les 	*/
-/* elements de la chaine qui ne sont pas encore marqu�s dans 	*/
-/* "where". Si oui, inscrire 1 dans "where" a la position du	*/
+/* Verifier si le caractere c a un correspondant parmi les  */
+/* elements de la chaine qui ne sont pas encore marqu�s dans  */
+/* "where". Si oui, inscrire 1 dans "where" a la position du    */
 /* correspondant et returner cette position. Sinon retourner -1.*/
 int u_member(unichar c, const unichar *str, int *where) {
 
@@ -62,7 +62,7 @@ int u_member(unichar c, const unichar *str, int *where) {
 /****************************************************************/
 
 /****************************************************************/
-/* Retourner 1 si str1 contient str2, sinon 0.			*/
+/* Retourner 1 si str1 contient str2, sinon 0.          */
 int u_contient(const unichar *str1, const unichar *str2) {
 
    unsigned int len, i;
@@ -73,7 +73,7 @@ int u_contient(const unichar *str1, const unichar *str2) {
       return (0);
 
    /*Initialiser le tableau d'elements de str1, qui ont des*/
-   /*correspondants dans str2				*/
+   /*correspondants dans str2               */
    for (i=0; i<u_strlen(str1); i++)
       where[i] = 0;
    for (i=u_strlen(str1); i<MAX_STR_LEN; i++)
@@ -93,7 +93,7 @@ int u_contient(const unichar *str1, const unichar *str2) {
 /****************************************************************/
 
 /****************************************************************/
-/* Retourner 1 si str1 est une permutation de str2, sinon 0.  	*/
+/* Retourner 1 si str1 est une permutation de str2, sinon 0.    */
 int u_is_permut(const unichar *str1, const unichar *str2) {
 
    /*Si longeurs differentes - ce ne sont pas des permutations*/
@@ -107,7 +107,7 @@ int u_is_permut(const unichar *str1, const unichar *str2) {
 /****************************************************************/
 
 /****************************************************************/
-/* Verifier si la chaine unicode str contient le caractere c.	*/
+/* Verifier si la chaine unicode str contient le caractere c.   */
 int u_is_in(unichar c, const unichar *str) {
 
    while (*str != 0) {
@@ -120,7 +120,7 @@ int u_is_in(unichar c, const unichar *str) {
 /****************************************************************/
 
 /****************************************************************/
-/* Verifier si la chaine char str contient le caractere c.	*/
+/* Verifier si la chaine char str contient le caractere c.  */
 int u_is_in_char(unichar c, const char *str) {
 
    while (*str != 0) {
@@ -275,7 +275,7 @@ int u_scan_while_char(unichar *dest, const unichar *source, int max,
 /****************************************************************/
 
 /****************************************************************/
-/* Trier un tableau de chaines de charact�res et enlever les	*/
+/* Trier un tableau de chaines de charact�res et enlever les  */
 /* doublons (bubble sort). len = longeur d'un �l�ment du tableau*/
 void u_tri_a(void *T, int *cnt, int len) {
    int i, j;

--- a/MF_Util.h
+++ b/MF_Util.h
@@ -23,7 +23,7 @@
  */
 
 /****************************************************************/
-/* Operations sur des strings unicode			        */
+/* Operations sur des strings unicode                   */
 /****************************************************************/
 
 #ifndef UtilH
@@ -44,24 +44,24 @@ namespace unitex {
 #define MAX_STR_LEN 2000  //Maximum length of strings treated by this library
 
 /****************************************************************/
-/* Retourner 1 si str1 contient str2, sinon 0.			*/
+/* Retourner 1 si str1 contient str2, sinon 0.          */
 int u_contient(const unichar *str1,const unichar *str2);
 
 /****************************************************************/
-/* Retourne 1 si str1 est une permutation de str2, sinon 0.  	*/
+/* Retourne 1 si str1 est une permutation de str2, sinon 0.     */
 int u_is_permut(const unichar *str1,const unichar *str2);
 
 /****************************************************************/
-/* Verifier si la chaine unicode str contient le caractere c.	*/
+/* Verifier si la chaine unicode str contient le caractere c.   */
 int u_is_in(unichar c,const unichar *str);
 
 /****************************************************************/
-/* Verifier si la chaine char str contient le caractere c.	*/
+/* Verifier si la chaine char str contient le caractere c.  */
 int u_is_in_char(unichar c,const char *str);
 
 /********************************************************************************/
 /* Scan the prefix of "source" string until the first non protected             */
-/* deliminator belonging to "delim" or the end of "source".                     */        
+/* deliminator belonging to "delim" or the end of "source".                     */
 /* The scanned sequence is copied to "dest" which must have its space allocated */
 /* (at least max+1 unichars).                                                   */
 /* The length of the copied sequence is no higner than "max" unicode characters.*/
@@ -98,7 +98,7 @@ int u_scan_while_char(unichar *dest,const unichar *source, int max,const char *a
 
 
 /****************************************************************/
-/* Trier un tableau de chaines de charact�res et enlever les	*/
+/* Trier un tableau de chaines de charact�res et enlever les  */
 /* doublons (bubble sort). len = longeur d'un �l�ment du tableau*/
 void u_tri_a(void *TAB, int *cnt, int len);
 
@@ -106,12 +106,12 @@ void u_tri_a(void *TAB, int *cnt, int len);
 //Table of unicode strings with its cardinality
 typedef struct {
   unichar** t;
-  int n;       
+  int n;
 } unitab_t;
 
 //////////////////////////////////////////////////////////
 // Add a new unichar string to the dynamic unichar table
-// while reallocating memory space and updating the 
+// while reallocating memory space and updating the
 // cardinality. Space for the new form must be allocated.
 // Returns 0 on success, 1 otherwise.
 int u_add_unitab_elem(unichar* form,unitab_t* tab);

--- a/Main_Fst2Check.cpp
+++ b/Main_Fst2Check.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Main_MzRepairUlp.cpp
+++ b/Main_MzRepairUlp.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Main_MzRepairUlp.cpp
+++ b/Main_MzRepairUlp.cpp
@@ -38,7 +38,7 @@
 using namespace unitex;
 
 #ifdef HAS_LOGGER_NAMESPACE
-	using namespace ::unitex::logger;
+    using namespace ::unitex::logger;
 #endif
 
 int main(int argc,char* argv[]) {

--- a/Main_Test.cpp
+++ b/Main_Test.cpp
@@ -52,31 +52,31 @@ int main(int argc,char* argv[]) {
 setBufferMode();
 
 if (argc!=4) {
-	fatal_error("Usage: cmd <txt> start end\n");
+    fatal_error("Usage: cmd <txt> start end\n");
 }
 U_FILE* f=u_fopen(UTF16_LE,argv[1],U_READ);
 if (f==NULL) return 1;
 int a,b;
 if (1!=sscanf(argv[2],"%d",&a) || a <0) {
-	fatal_error("Invalid start position %d\n",a);
+    fatal_error("Invalid start position %d\n",a);
 }
 if (1!=sscanf(argv[3],"%d",&b) || b <a) {
-	fatal_error("Invalid end position %d\n",b);
+    fatal_error("Invalid end position %d\n",b);
 }
 int i;
 for (i=0;i<a-40;i++) u_fgetc_raw(f);
 int c;
 for (;i<a;i++) {
-	c=u_fgetc_raw(f);
-	u_printf("%C",c);
+    c=u_fgetc_raw(f);
+    u_printf("%C",c);
 }
 u_printf("<$");
 for (;i<b;i++) u_printf("%C",u_fgetc_raw(f));
 u_printf("$>");
 for (i=0;i<40;i++) {
-	c=u_fgetc_raw(f);
-	if (c==EOF) break;
-	u_printf("%C",c);
+    c=u_fgetc_raw(f);
+    if (c==EOF) break;
+    u_printf("%C",c);
 }
 u_printf("\n");
 
@@ -90,9 +90,9 @@ return 0;
 /*
  * benchmark A1: aucune optimisation
  *
-real	0m34.424s
-user	0m33.070s
-sys		0m1.264s
+real    0m34.424s
+user    0m33.070s
+sys     0m1.264s
 */
 
 /*
@@ -109,17 +109,17 @@ load_persistent_fst2("/home/paumier/unitex/French/Dela/fogg-r.fst2");
 load_persistent_fst2("/home/paumier/Unitex3.0beta/French/Dela/Suffixes+.fst2");
 load_persistent_fst2("/home/paumier/unitex/French/Graphs/essai_poids.fst2");
 
-real	0m31.826s
-user	0m30.938s
-sys		0m0.804s
+real    0m31.826s
+user    0m30.938s
+sys     0m0.804s
 */
 
 /*
  * benchmark A3: avec virtualisation
 
-real	0m29.476s
-user	0m29.446s
-sys		0m0.024s
+real    0m29.476s
+user    0m29.446s
+sys     0m0.024s
 */
 
 
@@ -127,19 +127,19 @@ sys		0m0.024s
 
 
 B1:
-real	0m6.341s
-user	0m5.852s
-sys			0m0.428s
+real    0m6.341s
+user    0m5.852s
+sys         0m0.428s
 
 B2:
-real	0m4.557s
-user	0m4.084s
-sys		0m0.092s
+real    0m4.557s
+user    0m4.084s
+sys     0m0.092s
 
 B3:
-real	0m3.914s
-user	0m3.896s
-sys		0m0.016s
+real    0m3.914s
+user    0m3.896s
+sys     0m0.016s
 
  */
 
@@ -148,19 +148,19 @@ sys		0m0.016s
 
 
 C1:
-real	1m3.768s
-user	0m59.080s
-sys		0m3.996s
+real    1m3.768s
+user    0m59.080s
+sys     0m3.996s
 
 C2:
-real	0m41.341s
-user	0m39.054s
-sys		0m0.700s
+real    0m41.341s
+user    0m39.054s
+sys     0m0.700s
 
 C3:
-real	0m38.694s
-user	0m38.546s
-sys		0m0.136s
+real    0m38.694s
+user    0m38.546s
+sys     0m0.136s
 
  */
 
@@ -183,17 +183,17 @@ load_persistent_fst2("/home/paumier/unitex/French/Graphs/essai_poids.fst2");
 #define N 100
 
 for (int i=0;i<N;i++) {
-	exec_unitex_command(main_Normalize,"Normalize",PFX"/home/paumier/tmp/toto.txt","-r/home/paumier/unitex/French/Norm.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Fst2Txt,"Fst2Txt","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/Preprocessing/Sentence/Sentence.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-M","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Fst2Txt,"Fst2Txt","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/Preprocessing/Replace/Replace.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-R","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Tokenize,"Tokenize",PFX"/home/paumier/tmp/toto.snt","-a/home/paumier/unitex/French/Alphabet.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Dico,"Dico","-t"PFX"/home/paumier/tmp/toto.snt","-a/home/paumier/unitex/French/Alphabet.txt","-m/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-m/home/paumier/unitex/French/Dela/communesFR+.bin","/home/paumier/unitex/French/Dela/la_N-r+.fst2","/home/paumier/unitex/French/Dela/fogg-r-.fst2","/home/paumier/unitex/French/Dela/fogg-r.fst2","/home/paumier/Unitex3.0beta/French/Dela/Suffixes+.fst2","/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/dlf","-l"PFX"/home/paumier/tmp/toto_snt/dlf.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/dlc","-l"PFX"/home/paumier/tmp/toto_snt/dlc.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/err","-l"PFX"/home/paumier/tmp/toto_snt/err.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/tags_err","-l"PFX"/home/paumier/tmp/toto_snt/tags_err.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Locate,"Locate","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/essai_poids.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-L","-M","--all","-m/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-m/home/paumier/unitex/French/Dela/communesFR+.bin","-b","-Y","-qutf8-no-bom",NULL);
-	exec_unitex_command(main_Concord,"Concord",PFX"/home/paumier/tmp/toto_snt/concord.ind","-fCourier 10 Pitch","-s12","-l40","-r55","--html","-a/home/paumier/unitex/French/Alphabet_sort.txt","--CL","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Normalize,"Normalize",PFX"/home/paumier/tmp/toto.txt","-r/home/paumier/unitex/French/Norm.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Fst2Txt,"Fst2Txt","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/Preprocessing/Sentence/Sentence.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-M","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Fst2Txt,"Fst2Txt","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/Preprocessing/Replace/Replace.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-R","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Tokenize,"Tokenize",PFX"/home/paumier/tmp/toto.snt","-a/home/paumier/unitex/French/Alphabet.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Dico,"Dico","-t"PFX"/home/paumier/tmp/toto.snt","-a/home/paumier/unitex/French/Alphabet.txt","-m/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-m/home/paumier/unitex/French/Dela/communesFR+.bin","/home/paumier/unitex/French/Dela/la_N-r+.fst2","/home/paumier/unitex/French/Dela/fogg-r-.fst2","/home/paumier/unitex/French/Dela/fogg-r.fst2","/home/paumier/Unitex3.0beta/French/Dela/Suffixes+.fst2","/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/dlf","-l"PFX"/home/paumier/tmp/toto_snt/dlf.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/dlc","-l"PFX"/home/paumier/tmp/toto_snt/dlc.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/err","-l"PFX"/home/paumier/tmp/toto_snt/err.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_SortTxt,"SortTxt",PFX"/home/paumier/tmp/toto_snt/tags_err","-l"PFX"/home/paumier/tmp/toto_snt/tags_err.n","-o/home/paumier/unitex/French/Alphabet_sort.txt","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Locate,"Locate","-t"PFX"/home/paumier/tmp/toto.snt","/home/paumier/unitex/French/Graphs/essai_poids.fst2","-a/home/paumier/unitex/French/Alphabet.txt","-L","-M","--all","-m/home/paumier/Unitex3.0beta/French/Dela/dela-fr-public.bin","-m/home/paumier/unitex/French/Dela/communesFR+.bin","-b","-Y","-qutf8-no-bom",NULL);
+    exec_unitex_command(main_Concord,"Concord",PFX"/home/paumier/tmp/toto_snt/concord.ind","-fCourier 10 Pitch","-s12","-l40","-r55","--html","-a/home/paumier/unitex/French/Alphabet_sort.txt","--CL","-qutf8-no-bom",NULL);
 }
 #endif
 
@@ -205,17 +205,17 @@ VersatileEncodingConfig vec=VEC_DEFAULT;
 ~/workspace/C++/bin/Test ~/unitex/French/Graphs/a.grf ~/unitex/French/Graphs/a_beautiful.grf
  */
 if (argc!=3) {
-	fatal_error("Usage: Test <grf> <output grf>\n");
-	return 1;
+    fatal_error("Usage: Test <grf> <output grf>\n");
+    return 1;
 }
 Grf* grf=load_Grf(&vec,argv[1]);
 if (grf==NULL) {
-	fatal_error("Cannot load %s\n",argv[1]);
+    fatal_error("Cannot load %s\n",argv[1]);
 }
 beautify(grf,NULL);
 U_FILE* f=u_fopen(&vec,argv[2],U_WRITE);
 if (f==NULL) {
-	fatal_error("Cannot create %s\n",argv[2]);
+    fatal_error("Cannot create %s\n",argv[2]);
 }
 save_Grf(f,grf);
 u_fclose(f);

--- a/Main_UnitexTool.cpp
+++ b/Main_UnitexTool.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Main_UnitexToolLogger.cpp
+++ b/Main_UnitexToolLogger.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -99,7 +99,7 @@ if (argc>3) {
             }
         }
     }
-    
+
     if (skip_arg == 0) {
         pInstallLogger = new InstallLogger();
     }
@@ -116,14 +116,14 @@ if ((argc-skip_arg)>1) {
         return_value = main_UnpackFile(argc-(skip_arg+1),argv+skip_arg+1);
     }
 
- 
+
     if (strcmp(argv[1+skip_arg],"PackFile")==0)
     {
         done = 1;
         return_value = main_PackFile(argc-(skip_arg+1),argv+skip_arg+1);
     }
 
- 
+
     if (strcmp(argv[1+skip_arg],"InstallLingResourcePackage")==0)
     {
         done = 1;

--- a/Main_UnitexToolLogger.cpp
+++ b/Main_UnitexToolLogger.cpp
@@ -56,7 +56,7 @@
 using namespace unitex;
 using namespace unitex::logger;
 
-const char*	usage_RunLog_mini = "Usage: UnitexToolLogger RunLog [OPTIONS] <ulp>\n"
+const char* usage_RunLog_mini = "Usage: UnitexToolLogger RunLog [OPTIONS] <ulp>\n"
                                 "or \n"
                                 "Usage: UnitexToolLogger InstallLingResourcePackage [OPTIONS]\n"
                                 "or \n"

--- a/Main_Untokenize.cpp
+++ b/Main_Untokenize.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/MappedFileHelper.h
+++ b/MappedFileHelper.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/MappedFileHelperDummy.cpp
+++ b/MappedFileHelperDummy.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -110,7 +110,7 @@ const void* iomap_get_mapfile_pointer(MAPFILE* mf, size_t pos, size_t sizemap)
 }
 
 void iomap_release_mapfile_pointer(MAPFILE *mf, const void*buf, size_t sizemap)
-{    
+{
     MAPFILE_REAL* mfr=(MAPFILE_REAL*)mf;
     if (mfr==NULL)
         return ;

--- a/MappedFileHelperPosix.cpp
+++ b/MappedFileHelperPosix.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/MappedFileHelperPosix.cpp
+++ b/MappedFileHelperPosix.cpp
@@ -69,9 +69,9 @@ MAPFILE* iomap_open_mapfile(const char*name,int /* option*/, size_t /*value_for_
         free(mfr);
         return NULL;
     }
-	fseek(mfr->f,0,SEEK_END);
+    fseek(mfr->f,0,SEEK_END);
     mfr->filesize=ftell(mfr->f);
-	fseek(mfr->f,0,SEEK_SET);
+    fseek(mfr->f,0,SEEK_SET);
 
     return (MAPFILE*)mfr;
 }

--- a/MappedFileHelperWin.cpp
+++ b/MappedFileHelperWin.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/MappedFileHelperWin.cpp
+++ b/MappedFileHelperWin.cpp
@@ -73,14 +73,14 @@ MAPFILE* iomap_open_mapfile(const char*name,int /* option*/, size_t /*value_for_
     mfr->hFile = mfr->hMap = NULL;
 
 #ifdef UNITEX_USING_WINRT_API
-	WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
-	MultiByteToWideChar(CP_ACP,0,name,-1,filenameW,FILENAME_MAX + 0x200);
-	WIN32_FILE_ATTRIBUTE_DATA fad;
-	GetFileAttributesExW(filenameW,GetFileExInfoStandard,&fad);
-	//mfr->len = fad.nFileSizeLow;
-	mfr->li_size.u.LowPart = fad.nFileSizeLow;
-	mfr->li_size.u.HighPart = fad.nFileSizeHigh;
-	mfr->hFile = CreateFile2(filenameW, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, /*FILE_FLAG_RANDOM_ACCESS,*/ NULL);
+    WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+    MultiByteToWideChar(CP_ACP,0,name,-1,filenameW,FILENAME_MAX + 0x200);
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    GetFileAttributesExW(filenameW,GetFileExInfoStandard,&fad);
+    //mfr->len = fad.nFileSizeLow;
+    mfr->li_size.u.LowPart = fad.nFileSizeLow;
+    mfr->li_size.u.HighPart = fad.nFileSizeHigh;
+    mfr->hFile = CreateFile2(filenameW, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, /*FILE_FLAG_RANDOM_ACCESS,*/ NULL);
     if ((mfr->hFile != INVALID_HANDLE_VALUE) && (mfr->hFile != NULL))
         mfr->hMap = CreateFileMappingFromApp(mfr->hFile, NULL,
                         PAGE_READONLY, 0, NULL);

--- a/Match.h
+++ b/Match.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef MatchH
 #define MatchH
 
@@ -40,7 +40,7 @@ typedef struct {
    int end_pos_in_token;
 
    /* Those fields are used for Korean
-    * xxx_char=offset of the char in the token 
+    * xxx_char=offset of the char in the token
     * xxx_letter=offset of the logical letter in the char */
    int start_pos_in_char;
    int end_pos_in_char;

--- a/MorphologicalFilters.cpp
+++ b/MorphologicalFilters.cpp
@@ -161,8 +161,8 @@ for (int i=0;i<n;i++) {
    if (filters->filter[i].options!= NULL) free(filters->filter[i].options);
    if (filters->filter[i].content!= NULL) free(filters->filter[i].content);
    if (filters->filter[i].matcher!= NULL) {
-	   regex_facade_regfree(filters->filter[i].matcher);
-	   free(filters->filter[i].matcher);
+       regex_facade_regfree(filters->filter[i].matcher);
+       free(filters->filter[i].matcher);
    }
 }
 free(filters->filter);

--- a/MorphologicalFilters.h
+++ b/MorphologicalFilters.h
@@ -27,9 +27,9 @@
  * in the form of POSIX regular expressions. Such filters can be used in
  * Locate grammars (example: <<able$>> = something that ends with "able").
  * These filters are manipulated with the TRE regular expression library:
- * 
+ *
  * http://laurikari.net/tre/
- * 
+ *
  * The integration of these filters in Unitex has been made by
  * Claude Devis (devis@tedm.ucl.ac.be).
  */
@@ -72,7 +72,7 @@ typedef struct {
    int size;
    MorphoFilter* filter;
 } FilterSet;
-               
+
 
 /**
  * This structure is used to know for each token of a text if it verifies or
@@ -83,12 +83,12 @@ typedef struct {
    int size;
    /* Each filter is associated to a bit array so that (filter #x)->bit[y]=1 means
     * that the filter number x can match the token number y.
-    * 
+    *
     * Note that a bit array can be NULL if the filter matches no token at all. */
    struct bit_array** matching_tokens;
 } FilterMatchIndex;
-                       
-                                                                       
+
+
 FilterSet* new_FilterSet(Fst2*,Alphabet*);
 void free_FilterSet(FilterSet*);
 

--- a/MorphologicalLocate.cpp
+++ b/MorphologicalLocate.cpp
@@ -50,38 +50,38 @@ namespace unitex {
 #endif
 
 static void morphological_locate(/*int, */int, int, int, /*int, */struct parsing_info**, int,
-		struct list_context*, struct locate_parameters*,
-		unichar*, int, unichar*);
+        struct list_context*, struct locate_parameters*,
+        unichar*, int, unichar*);
 int input_is_token(Fst2Tag tag);
 static void explore_dic_in_morpho_mode(struct locate_parameters* p, int pos,
-		int pos_in_token, struct parsing_info* *matches,
-		struct pattern* pattern, int save_dela_entry, unichar* jamo,
-		int pos_in_jamo);
+        int pos_in_token, struct parsing_info* *matches,
+        struct pattern* pattern, int save_dela_entry, unichar* jamo,
+        int pos_in_jamo);
 int is_entry_compatible_with_pattern(const struct dela_entry* entry,
-		const struct pattern* pattern);
+        const struct pattern* pattern);
 
 /**
  * Stores in 'content' the string corresponding to the given range.
  */
 static void get_content(unichar* content, struct locate_parameters* p, int pos,
-		int pos_in_token, int pos2, int pos_in_token2) {
-	int i = 0;
-	unichar* current_token =
-			p->tokens->value[p->buffer[pos + p->current_origin]];
-	while (!(pos == pos2 && pos_in_token == pos_in_token2)) {
-		content[i++] = current_token[pos_in_token++];
-		if (current_token[pos_in_token] == '\0' && !(pos == pos2
-				&& pos_in_token == pos_in_token2)) {
-			pos++;
-			pos_in_token = 0;
-			int token_number = p->buffer[pos + p->current_origin];
-			if (token_number == -1 || token_number == p->STOP) {
-				fatal_error("Unexpected end of array or {STOP} tag in get_content\n");
-			}
-			current_token = p->tokens->value[token_number];
-		}
-	}
-	content[i] = '\0';
+        int pos_in_token, int pos2, int pos_in_token2) {
+    int i = 0;
+    unichar* current_token =
+            p->tokens->value[p->buffer[pos + p->current_origin]];
+    while (!(pos == pos2 && pos_in_token == pos_in_token2)) {
+        content[i++] = current_token[pos_in_token++];
+        if (current_token[pos_in_token] == '\0' && !(pos == pos2
+                && pos_in_token == pos_in_token2)) {
+            pos++;
+            pos_in_token = 0;
+            int token_number = p->buffer[pos + p->current_origin];
+            if (token_number == -1 || token_number == p->STOP) {
+                fatal_error("Unexpected end of array or {STOP} tag in get_content\n");
+            }
+            current_token = p->tokens->value[token_number];
+        }
+    }
+    content[i] = '\0';
 }
 
 /**
@@ -89,16 +89,16 @@ static void get_content(unichar* content, struct locate_parameters* p, int pos,
  * variable name; 0 otherwise.
  */
 static int is_morpho_variable_output(unichar* s, unichar* var_name) {
-	if (s == NULL || s[0] != '$')
-		return 0;
-	int i, j = 0;
-	for (i = 1; s[i] != '$' && s[i] != '\0'; i++) {
-		if (!is_variable_char(s[i]))
-			return 0;
-		var_name[j++] = s[i];
-	}
-	var_name[j] = '\0';
-	return (i != 1 && s[i] == '$' && s[i + 1] == '\0');
+    if (s == NULL || s[0] != '$')
+        return 0;
+    int i, j = 0;
+    for (i = 1; s[i] != '$' && s[i] != '\0'; i++) {
+        if (!is_variable_char(s[i]))
+            return 0;
+        var_name[j++] = s[i];
+    }
+    var_name[j] = '\0';
+    return (i != 1 && s[i] == '$' && s[i + 1] == '\0');
 }
 
 /**
@@ -108,81 +108,81 @@ static int is_morpho_variable_output(unichar* s, unichar* var_name) {
  * 2=the tag matches a part of the jamo sequence
  */
 static int get_jamo_longest_prefix(unichar* jamo, int *new_pos_in_jamo,
-		int *new_pos_in_token, unichar* tag_token, struct locate_parameters* p,
-		unichar* token) {
-	unichar tmp[128];
-	if (tag_token[0] == KR_SYLLABLE_BOUND && tag_token[1] == '\0') {
-		u_strcpy(tmp, tag_token);
-	} else {
-		Hanguls_to_Jamos(tag_token, tmp, p->korean, 0);
-		/*error("conversion depuis <%S> vers <%S><",tag_token,tmp);
-		for (int i=0;tmp[i]!='\0';i++) {
-			error("%X ",tmp[i]);
-		}
-		error(">\n");*/
-	}
-	int i = 0;
-	if (token == NULL) {
-		token = tag_token;
-	}
-	//set_debug(0 && token[0]==0xB2A5);
-	//error("on compare text=_%S/%S_ et tag=_%S/%S\n",token,jamo/*+(*new_pos_in_jamo)*/,tag_token,tmp);
-	/*error("on compare text=<%S><",token);
-	for (int i=(*new_pos_in_jamo);jamo[i]!='\0';i++) {
-		error("(%C) ",jamo[i]);
-	}
-	error("> et tag=<%S><",tag_token);
-	for (int i=0;tmp[i]!='\0';i++) {
-		error("(%C) ",tmp[i]);
-	}
-	error(">\n");*/
-	while (tmp[i] != '\0' && jamo[(*new_pos_in_jamo)] != '\0') {
+        int *new_pos_in_token, unichar* tag_token, struct locate_parameters* p,
+        unichar* token) {
+    unichar tmp[128];
+    if (tag_token[0] == KR_SYLLABLE_BOUND && tag_token[1] == '\0') {
+        u_strcpy(tmp, tag_token);
+    } else {
+        Hanguls_to_Jamos(tag_token, tmp, p->korean, 0);
+        /*error("conversion depuis <%S> vers <%S><",tag_token,tmp);
+        for (int i=0;tmp[i]!='\0';i++) {
+            error("%X ",tmp[i]);
+        }
+        error(">\n");*/
+    }
+    int i = 0;
+    if (token == NULL) {
+        token = tag_token;
+    }
+    //set_debug(0 && token[0]==0xB2A5);
+    //error("on compare text=_%S/%S_ et tag=_%S/%S\n",token,jamo/*+(*new_pos_in_jamo)*/,tag_token,tmp);
+    /*error("on compare text=<%S><",token);
+    for (int i=(*new_pos_in_jamo);jamo[i]!='\0';i++) {
+        error("(%C) ",jamo[i]);
+    }
+    error("> et tag=<%S><",tag_token);
+    for (int i=0;tmp[i]!='\0';i++) {
+        error("(%C) ",tmp[i]);
+    }
+    error(">\n");*/
+    while (tmp[i] != '\0' && jamo[(*new_pos_in_jamo)] != '\0') {
 #if 2
-		/* We ignore syllable bounds in both tfst and fst2 tags */
-		if (tmp[i] == KR_SYLLABLE_BOUND && jamo[(*new_pos_in_jamo)] != KR_SYLLABLE_BOUND) {
-			i++;
-			//debug("ignoring . in tag: %S\n",tmp+i);
-			continue;
-		}
+        /* We ignore syllable bounds in both tfst and fst2 tags */
+        if (tmp[i] == KR_SYLLABLE_BOUND && jamo[(*new_pos_in_jamo)] != KR_SYLLABLE_BOUND) {
+            i++;
+            //debug("ignoring . in tag: %S\n",tmp+i);
+            continue;
+        }
 #endif
-		if (jamo[(*new_pos_in_jamo)] == KR_SYLLABLE_BOUND) {
-			if (tmp[i] != KR_SYLLABLE_BOUND) return 0;
-			i++;
-			(*new_pos_in_jamo)++;
-			(*new_pos_in_token)++;
-			//debug("ignoring . in text: %S\n",jamo+((*new_pos_in_jamo)));
-			continue;
-		}
-		if (tmp[i] != jamo[(*new_pos_in_jamo)]) {
-			/* If a character doesn't match */
-			//debug("match failed between text=%S and fst2=%S\n",jamo,tmp);
-			return 0;
-		}
-		i++;
-		(*new_pos_in_jamo)++;
-		//debug("moving in tag: %S\n",tmp+i);
-		//debug("moving in text: %S\n",jamo+((*new_pos_in_jamo)));
-	}
-	if (tmp[i] == '\0' && jamo[(*new_pos_in_jamo)] == '\0') {
-		/* If we are at both ends of strings, it's a full match */
-		//debug("XX full match between text=%S and fst2=%S\n",jamo,tmp);
-		return 1;
-	}
-	if (tmp[i] == '\0') {
-		/* If the tag has not consumed all the jamo sequence, it's a partial match */
-		//debug("XX partial match between text=%S and fst2=%S\n",jamo,tmp);
-		return 2;
-	}
-	/* If we are at the end of the jamo sequence, but not at the end of the tag, it's a failure */
-	//debug("match failed #2 between text=%S and fst2=%S\n",jamo,tmp);
-	//set_debug(0);
-	return 0;
+        if (jamo[(*new_pos_in_jamo)] == KR_SYLLABLE_BOUND) {
+            if (tmp[i] != KR_SYLLABLE_BOUND) return 0;
+            i++;
+            (*new_pos_in_jamo)++;
+            (*new_pos_in_token)++;
+            //debug("ignoring . in text: %S\n",jamo+((*new_pos_in_jamo)));
+            continue;
+        }
+        if (tmp[i] != jamo[(*new_pos_in_jamo)]) {
+            /* If a character doesn't match */
+            //debug("match failed between text=%S and fst2=%S\n",jamo,tmp);
+            return 0;
+        }
+        i++;
+        (*new_pos_in_jamo)++;
+        //debug("moving in tag: %S\n",tmp+i);
+        //debug("moving in text: %S\n",jamo+((*new_pos_in_jamo)));
+    }
+    if (tmp[i] == '\0' && jamo[(*new_pos_in_jamo)] == '\0') {
+        /* If we are at both ends of strings, it's a full match */
+        //debug("XX full match between text=%S and fst2=%S\n",jamo,tmp);
+        return 1;
+    }
+    if (tmp[i] == '\0') {
+        /* If the tag has not consumed all the jamo sequence, it's a partial match */
+        //debug("XX partial match between text=%S and fst2=%S\n",jamo,tmp);
+        return 2;
+    }
+    /* If we are at the end of the jamo sequence, but not at the end of the tag, it's a failure */
+    //debug("match failed #2 between text=%S and fst2=%S\n",jamo,tmp);
+    //set_debug(0);
+    return 0;
 }
 
 static void update_last_position(struct locate_parameters* p, int pos) {
-	if (pos > p->last_tested_position) {
-		p->last_tested_position = pos;
-	}
+    if (pos > p->last_tested_position) {
+        p->last_tested_position = pos;
+    }
 }
 
 /**
@@ -205,1084 +205,1084 @@ unichar* content_buffer /* reusable unichar 4096 buffer for content */
 //,variable_backup_memory_reserve* backup_reserve
 ) {
 
-	int old_weight=p->weight;
-	if ((p->counting_step.count_cancel_trying) == 0) {
+    int old_weight=p->weight;
+    if ((p->counting_step.count_cancel_trying) == 0) {
 
-		if (p->is_in_cancel_state != 0)
-			return;
+        if (p->is_in_cancel_state != 0)
+            return;
 
-		if (p->is_in_trace_state == 0) {
+        if (p->is_in_trace_state == 0) {
 
-			if ((p->max_count_call) > 0) {
-				if ((p->counting_step.count_call) >= (p->max_count_call)) {
-					p->counting_step.count_cancel_trying = 0;
-					p->is_in_cancel_state = 1;
-					return;
-				}
-			}
+            if ((p->max_count_call) > 0) {
+                if ((p->counting_step.count_call) >= (p->max_count_call)) {
+                    p->counting_step.count_cancel_trying = 0;
+                    p->is_in_cancel_state = 1;
+                    return;
+                }
+            }
 
-			p->counting_step.count_cancel_trying = COUNT_CANCEL_TRYING_INIT_CONST;
-			if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
-					+COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
-				p->counting_step.count_cancel_trying = (p->max_count_call) - (p->counting_step.count_call);
-			}
+            p->counting_step.count_cancel_trying = COUNT_CANCEL_TRYING_INIT_CONST;
+            if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
+                    +COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
+                p->counting_step.count_cancel_trying = (p->max_count_call) - (p->counting_step.count_call);
+            }
 
-			if (is_cancelling_requested() != 0) {
-				p->counting_step.count_cancel_trying = 0;
-				p->is_in_cancel_state = 2;
-				return;
-			}
-			(p->counting_step.count_call) += (p->counting_step.count_cancel_trying);
-		}
-		else
-		{
-			if ((p->fnc_locate_trace_step != NULL)) {
-				locate_trace_info* lti;
-				lti = (locate_trace_info*)malloc_cb(sizeof(locate_trace_info),p->al.prv_alloc_trace_info_allocator);
-				if (lti==NULL) {
-					fatal_alloc_error("morphological_locate");
-				}
-				lti->size_struct_locate_trace_info = (int)sizeof(locate_trace_info);
-				lti->is_on_morphlogical = 1;
+            if (is_cancelling_requested() != 0) {
+                p->counting_step.count_cancel_trying = 0;
+                p->is_in_cancel_state = 2;
+                return;
+            }
+            (p->counting_step.count_call) += (p->counting_step.count_cancel_trying);
+        }
+        else
+        {
+            if ((p->fnc_locate_trace_step != NULL)) {
+                locate_trace_info* lti;
+                lti = (locate_trace_info*)malloc_cb(sizeof(locate_trace_info),p->al.prv_alloc_trace_info_allocator);
+                if (lti==NULL) {
+                    fatal_alloc_error("morphological_locate");
+                }
+                lti->size_struct_locate_trace_info = (int)sizeof(locate_trace_info);
+                lti->is_on_morphlogical = 1;
 
-				lti->pos_in_tokens=pos_in_tokens;
+                lti->pos_in_tokens=pos_in_tokens;
 
-				lti->current_state=NULL;
+                lti->current_state=NULL;
 
-				lti->current_state_index=current_state_index;
-				lti->pos_in_chars=pos_in_chars;
+                lti->current_state_index=current_state_index;
+                lti->pos_in_chars=pos_in_chars;
 
-				lti->matches=matches;
-				lti->n_matches=n_matches;
-				lti->ctx=ctx;
-				lti->p=p;
+                lti->matches=matches;
+                lti->n_matches=n_matches;
+                lti->ctx=ctx;
+                lti->p=p;
 
-				lti->step_number=p->counting_step.count_call-p->counting_step_count_cancel_trying_real_in_debug_or_trace;
+                lti->step_number=p->counting_step.count_call-p->counting_step_count_cancel_trying_real_in_debug_or_trace;
 
-				lti->jamo=jamo;
-				lti->pos_in_jamo=pos_in_jamo;
+                lti->jamo=jamo;
+                lti->pos_in_jamo=pos_in_jamo;
 
-				p->is_in_cancel_state = (*(p->fnc_locate_trace_step))(lti,p->private_param_locate_trace);
-				free_cb(lti,p->al.prv_alloc_trace_info_allocator);
-			}
+                p->is_in_cancel_state = (*(p->fnc_locate_trace_step))(lti,p->private_param_locate_trace);
+                free_cb(lti,p->al.prv_alloc_trace_info_allocator);
+            }
 
-			if ((p->counting_step_count_cancel_trying_real_in_debug_or_trace) == 0) {
-				if ((p->max_count_call) > 0) {
-					if ((p->counting_step.count_call) >= (p->max_count_call)) {
-						p->counting_step.count_cancel_trying = 0;
-						p->is_in_cancel_state = 1;
-						return;
-					}
-				}
+            if ((p->counting_step_count_cancel_trying_real_in_debug_or_trace) == 0) {
+                if ((p->max_count_call) > 0) {
+                    if ((p->counting_step.count_call) >= (p->max_count_call)) {
+                        p->counting_step.count_cancel_trying = 0;
+                        p->is_in_cancel_state = 1;
+                        return;
+                    }
+                }
 
-				p->counting_step_count_cancel_trying_real_in_debug_or_trace = COUNT_CANCEL_TRYING_INIT_CONST;
-				if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
-						+COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
-					p->counting_step_count_cancel_trying_real_in_debug_or_trace = (p->max_count_call) - (p->counting_step.count_call);
-				}
+                p->counting_step_count_cancel_trying_real_in_debug_or_trace = COUNT_CANCEL_TRYING_INIT_CONST;
+                if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
+                        +COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
+                    p->counting_step_count_cancel_trying_real_in_debug_or_trace = (p->max_count_call) - (p->counting_step.count_call);
+                }
 
-				if (is_cancelling_requested() != 0) {
-					p->counting_step.count_cancel_trying = 0;
-					p->is_in_cancel_state = 2;
-					return;
-				}
-				(p->counting_step.count_call) += (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
-			}
+                if (is_cancelling_requested() != 0) {
+                    p->counting_step.count_cancel_trying = 0;
+                    p->is_in_cancel_state = 2;
+                    return;
+                }
+                (p->counting_step.count_call) += (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
+            }
 
-			p->counting_step_count_cancel_trying_real_in_debug_or_trace --;
-			//  prepare now to be at 0 after the "--" (we don't want another test for performance */
-			(p->counting_step.count_cancel_trying)++;
-		}
-	}
-	(p->counting_step.count_cancel_trying)--;
+            p->counting_step_count_cancel_trying_real_in_debug_or_trace --;
+            //  prepare now to be at 0 after the "--" (we don't want another test for performance */
+            (p->counting_step.count_cancel_trying)++;
+        }
+    }
+    (p->counting_step.count_cancel_trying)--;
 
 
-	OptimizedFst2State current_state = p->optimized_states[current_state_index];
-	Fst2State current_state_old = p->fst2->states[current_state_index];
-	int token;
-	Transition* t;
-	int stack_top = p->stack->stack_pointer;
-	int captured_chars;
-	/* The following static variable holds the number of matches at
-	 * one position in text. */
+    OptimizedFst2State current_state = p->optimized_states[current_state_index];
+    Fst2State current_state_old = p->fst2->states[current_state_index];
+    int token;
+    Transition* t;
+    int stack_top = p->stack->stack_pointer;
+    int captured_chars;
+    /* The following static variable holds the number of matches at
+     * one position in text. */
 
-	p->explore_depth ++ ;
+    p->explore_depth ++ ;
     /*
-	if (depth == 0) {
-		// We reset if this is first call to 'locate' from a given position in the text
-		p->p_token_error_ctx->n_matches_at_token_pos__morphological_locate = 0;
-	}*/
+    if (depth == 0) {
+        // We reset if this is first call to 'locate' from a given position in the text
+        p->p_token_error_ctx->n_matches_at_token_pos__morphological_locate = 0;
+    }*/
 
-	if (p->explore_depth > p->stack_max) {
-		/* If there are too much recursive calls */
-		error_at_token_pos("\nMaximal stack size reached!\n"
-			"(There may be longer matches not recognized!)", p->current_origin,
-				pos_in_tokens, p, current_state);
-		p->explore_depth -- ;
-		return;
-	}
-	if ((p->token_error_ctx.n_matches_at_token_pos__morphological_locate)
-			> p->max_matches_at_token_pos) {
-		/* If there are too much matches from the current origin in the text */
-		error_at_token_pos(
-				"\nToo many (ambiguous) matches starting from one position in text!",
-				p->current_origin, pos_in_tokens, p, current_state);
-		p->explore_depth -- ;
-		return;
-	}
-	if (current_state->control & 1) {
-		/* If we are in a final state... */
-		/* In we are in the top level graph, it's an error, since we are not supposed
-		 * to reach the end of the graph (we should find a $>) */
-		if (p->graph_depth == 0) {
-			error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-			fatal_error("Unexpected end of graph in morphological mode!\n");
-		} else {
-			/* If we are in a subgraph */
-			if (n_matches == p->max_matches_per_subgraph) {
-				/* If there are too much matches, we suspect an error in the grammar
-				 * like an infinite recursion */
-				error_at_token_pos(
-						"\nMaximal number of matches per subgraph reached!",
-						p->current_origin, pos_in_tokens, p, current_state);
-				p->explore_depth -- ;
-				return;
-			} else {
-				/* If everything is fine, we add this match to the match list of the
-				 * current graph level */
-				n_matches++;
-				p->stack->stack[stack_top + 1] = '\0';
-				if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-					(*matches) = insert_if_different(pos_in_tokens, pos_in_chars, -1,
-							(*matches), p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
-							pos_in_jamo, NULL, p->weight,&p->al.pa);
-				} else {
-					(*matches) = insert_if_absent(pos_in_tokens, pos_in_chars, -1,
-							(*matches), p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
-							pos_in_jamo, NULL, p->weight,&p->al.pa);
-				}
-			}
-		}
-	}
+    if (p->explore_depth > p->stack_max) {
+        /* If there are too much recursive calls */
+        error_at_token_pos("\nMaximal stack size reached!\n"
+            "(There may be longer matches not recognized!)", p->current_origin,
+                pos_in_tokens, p, current_state);
+        p->explore_depth -- ;
+        return;
+    }
+    if ((p->token_error_ctx.n_matches_at_token_pos__morphological_locate)
+            > p->max_matches_at_token_pos) {
+        /* If there are too much matches from the current origin in the text */
+        error_at_token_pos(
+                "\nToo many (ambiguous) matches starting from one position in text!",
+                p->current_origin, pos_in_tokens, p, current_state);
+        p->explore_depth -- ;
+        return;
+    }
+    if (current_state->control & 1) {
+        /* If we are in a final state... */
+        /* In we are in the top level graph, it's an error, since we are not supposed
+         * to reach the end of the graph (we should find a $>) */
+        if (p->graph_depth == 0) {
+            error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+            fatal_error("Unexpected end of graph in morphological mode!\n");
+        } else {
+            /* If we are in a subgraph */
+            if (n_matches == p->max_matches_per_subgraph) {
+                /* If there are too much matches, we suspect an error in the grammar
+                 * like an infinite recursion */
+                error_at_token_pos(
+                        "\nMaximal number of matches per subgraph reached!",
+                        p->current_origin, pos_in_tokens, p, current_state);
+                p->explore_depth -- ;
+                return;
+            } else {
+                /* If everything is fine, we add this match to the match list of the
+                 * current graph level */
+                n_matches++;
+                p->stack->stack[stack_top + 1] = '\0';
+                if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+                    (*matches) = insert_if_different(pos_in_tokens, pos_in_chars, -1,
+                            (*matches), p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
+                            pos_in_jamo, NULL, p->weight,&p->al.pa);
+                } else {
+                    (*matches) = insert_if_absent(pos_in_tokens, pos_in_chars, -1,
+                            (*matches), p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
+                            pos_in_jamo, NULL, p->weight,&p->al.pa);
+                }
+            }
+        }
+    }
 
-	/* If we have reached the end of the token buffer, we indicate it by setting
-	 * the current tokens to -1 */
-	if (pos_in_tokens + p->current_origin >= p->buffer_size) {
-		token = -1;
-	} else {
-		token = p->buffer[pos_in_tokens + p->current_origin];
-	}
-	unichar* current_token;
-	int current_token_length = 0;
-	if (token == -1 || token == p->STOP) {
-		current_token = NULL;
-		jamo = NULL;
-	} else {
-		current_token = p->tokens->value[p->buffer[p->current_origin + pos_in_tokens]];
-		current_token_length = u_strlen(current_token);
-	}
+    /* If we have reached the end of the token buffer, we indicate it by setting
+     * the current tokens to -1 */
+    if (pos_in_tokens + p->current_origin >= p->buffer_size) {
+        token = -1;
+    } else {
+        token = p->buffer[pos_in_tokens + p->current_origin];
+    }
+    unichar* current_token;
+    int current_token_length = 0;
+    if (token == -1 || token == p->STOP) {
+        current_token = NULL;
+        jamo = NULL;
+    } else {
+        current_token = p->tokens->value[p->buffer[p->current_origin + pos_in_tokens]];
+        current_token_length = u_strlen(current_token);
+    }
 
-	/**
-	 * SUBGRAPHS
-	 */
-	struct opt_graph_call* graph_call_list=current_state->unoptimized_graph_calls;
-	if (graph_call_list != NULL) {
-		/* If there are subgraphs, we process them */
-		int old_StackBase = p->stack_base;
-		int* save_previous_ptr_var = NULL;
-		int* var_backup = NULL;
-		//int create_new_reserve_done = 0;
-		variable_backup_memory_reserve* reserve_previous = NULL;
+    /**
+     * SUBGRAPHS
+     */
+    struct opt_graph_call* graph_call_list=current_state->unoptimized_graph_calls;
+    if (graph_call_list != NULL) {
+        /* If there are subgraphs, we process them */
+        int old_StackBase = p->stack_base;
+        int* save_previous_ptr_var = NULL;
+        int* var_backup = NULL;
+        //int create_new_reserve_done = 0;
+        variable_backup_memory_reserve* reserve_previous = NULL;
 
-		/* We save all kind of variables */
-		struct dic_variable* dic_variables_backup = NULL;
-		if (p->dic_variables != NULL) {
-			dic_variables_backup = clone_dic_variable_list(p->dic_variables);
-		}
-		/* We do this to be sure there will be no complicated case leading to
-		 * memory leaks */
-		clear_dic_variable_list(&(p->dic_variables));
+        /* We save all kind of variables */
+        struct dic_variable* dic_variables_backup = NULL;
+        if (p->dic_variables != NULL) {
+            dic_variables_backup = clone_dic_variable_list(p->dic_variables);
+        }
+        /* We do this to be sure there will be no complicated case leading to
+         * memory leaks */
+        clear_dic_variable_list(&(p->dic_variables));
 
-		OutputVariablesBackup* output_variable_backup=NULL;
-		if (p->output_policy!=IGNORE_OUTPUTS) {
-			if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
-					p->backup_memory_reserve) == 0) {
-				reserve_previous = p->backup_memory_reserve;
-				p->backup_memory_reserve = create_variable_backup_memory_reserve(
-						p->input_variables,0);
-				//create_new_reserve_done = 1;
-			}
-			if (p->graph_depth == 0) {
-			  var_backup = create_variable_backup_using_reserve(p->input_variables,
-					p->backup_memory_reserve);
-			}
-			if (p->nb_output_variables != 0) {
-				output_variable_backup=create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
-			}
-		}
-		do {
-			/* For each graph call, we look all the reachable states */
-			t = graph_call_list->transition;
-			if (p->output_policy!=IGNORE_OUTPUTS) {
-				if (p->nb_output_variables != 0) {
-				    install_output_variable_backup(p->output_variables,output_variable_backup);
-				}
-			}
-			while (t != NULL) {
-				struct parsing_info* L = NULL;
-				p->stack_base = p->stack->stack_pointer;
+        OutputVariablesBackup* output_variable_backup=NULL;
+        if (p->output_policy!=IGNORE_OUTPUTS) {
+            if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
+                    p->backup_memory_reserve) == 0) {
+                reserve_previous = p->backup_memory_reserve;
+                p->backup_memory_reserve = create_variable_backup_memory_reserve(
+                        p->input_variables,0);
+                //create_new_reserve_done = 1;
+            }
+            if (p->graph_depth == 0) {
+              var_backup = create_variable_backup_using_reserve(p->input_variables,
+                    p->backup_memory_reserve);
+            }
+            if (p->nb_output_variables != 0) {
+                output_variable_backup=create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
+            }
+        }
+        do {
+            /* For each graph call, we look all the reachable states */
+            t = graph_call_list->transition;
+            if (p->output_policy!=IGNORE_OUTPUTS) {
+                if (p->nb_output_variables != 0) {
+                    install_output_variable_backup(p->output_variables,output_variable_backup);
+                }
+            }
+            while (t != NULL) {
+                struct parsing_info* L = NULL;
+                p->stack_base = p->stack->stack_pointer;
 
-				p->graph_depth ++ ;
+                p->graph_depth ++ ;
 
-				p->dic_variables = NULL;
-				if (dic_variables_backup != NULL) {
-					p->dic_variables = clone_dic_variable_list(dic_variables_backup);
-				}
+                p->dic_variables = NULL;
+                if (dic_variables_backup != NULL) {
+                    p->dic_variables = clone_dic_variable_list(dic_variables_backup);
+                }
 
-				p->weight=old_weight;
-				morphological_locate(/*graph_depth + 1,*/ /* Exploration of the subgraph */
-						p->fst2->initial_states[graph_call_list->graph_number], pos_in_tokens,
-						pos_in_chars, &L, 0, NULL, p,
-						jamo, pos_in_jamo, content_buffer);
-				p->graph_depth -- ;
+                p->weight=old_weight;
+                morphological_locate(/*graph_depth + 1,*/ /* Exploration of the subgraph */
+                        p->fst2->initial_states[graph_call_list->graph_number], pos_in_tokens,
+                        pos_in_chars, &L, 0, NULL, p,
+                        jamo, pos_in_jamo, content_buffer);
+                p->graph_depth -- ;
 
-				clear_dic_variable_list(&(p->dic_variables));
+                clear_dic_variable_list(&(p->dic_variables));
 
-				p->stack_base = old_StackBase;
-				if (L != NULL) {
-					struct parsing_info* L_first = L;
-					/* If there is at least one match, we process the match list */
-					do {
-						/* We restore the settings that we had at the end of the subgraph exploration */
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							u_strcpy(&(p->stack->stack[stack_top + 1]),
-									L->stack);
-							p->stack->stack_pointer = L->stack_pointer;
-							p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
-							if (p->nb_output_variables != 0) {
-								install_output_variable_backup(p->output_variables,L->output_variable_backup);
-							}
-							if (save_previous_ptr_var == NULL && (var_backup != NULL)) {
-								save_previous_ptr_var
-										= install_variable_backup_preserving(
-												p->input_variables, p->backup_memory_reserve,
-												L->input_variable_backup);
-							} else {
-								install_variable_backup(p->input_variables,
-										L->input_variable_backup);
-							}
-						}
-						/* And we continue the exploration */
-						/* We reset the weight since its a value that is graph specific */
-						p->weight=old_weight;
-						morphological_locate(/*graph_depth,*/ t->state_number,
-								L->pos_in_tokens, L->pos_in_chars,
-								matches, n_matches, ctx, p,
-								L->jamo, L->pos_in_jamo, content_buffer);
-						clear_dic_variable_list(&(p->dic_variables));
-						p->stack->stack_pointer = stack_top;
-						L = L->next;
-					} while (L != NULL);
-					/* We free all subgraph matches */
-					free_parsing_info(L_first,&p->al.pa);
-				}
-				t = t->next;
-			} /* end of while (t!=NULL) */
-		} while ((graph_call_list = graph_call_list->next) != NULL);
-		/* Finally, we have to restore the stack and other backup stuff */
-		p->weight=old_weight;
-		p->stack->stack_pointer = stack_top;
-		p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
-		if (p->nb_output_variables != 0) {
-			install_output_variable_backup(p->output_variables,output_variable_backup);
-			free_output_variable_backup(output_variable_backup,p->al.pa.prv_alloc_backup_growing_recycle);
-		}
-		/* We restore the original dic variables */
-		p->dic_variables=dic_variables_backup;
-		if (save_previous_ptr_var != NULL) {
-			restore_variable_array(p->input_variables, p->backup_memory_reserve,
-			                          save_previous_ptr_var);
-			save_previous_ptr_var = NULL;
-		}
-
-
-		if (var_backup!=NULL) {
-				int reserve_freeable = free_variable_backup_using_reserve(
-						p->backup_memory_reserve);
-
-				if (reserve_previous != NULL) {
-					if (reserve_freeable == 0) {
-							fatal_error("incoherent reserve free result\n");
-					}
-					free_reserve(p->backup_memory_reserve);
-					p->backup_memory_reserve = reserve_previous;
-				}
-			}
-	} /* End of processing subgraphs */
+                p->stack_base = old_StackBase;
+                if (L != NULL) {
+                    struct parsing_info* L_first = L;
+                    /* If there is at least one match, we process the match list */
+                    do {
+                        /* We restore the settings that we had at the end of the subgraph exploration */
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            u_strcpy(&(p->stack->stack[stack_top + 1]),
+                                    L->stack);
+                            p->stack->stack_pointer = L->stack_pointer;
+                            p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
+                            if (p->nb_output_variables != 0) {
+                                install_output_variable_backup(p->output_variables,L->output_variable_backup);
+                            }
+                            if (save_previous_ptr_var == NULL && (var_backup != NULL)) {
+                                save_previous_ptr_var
+                                        = install_variable_backup_preserving(
+                                                p->input_variables, p->backup_memory_reserve,
+                                                L->input_variable_backup);
+                            } else {
+                                install_variable_backup(p->input_variables,
+                                        L->input_variable_backup);
+                            }
+                        }
+                        /* And we continue the exploration */
+                        /* We reset the weight since its a value that is graph specific */
+                        p->weight=old_weight;
+                        morphological_locate(/*graph_depth,*/ t->state_number,
+                                L->pos_in_tokens, L->pos_in_chars,
+                                matches, n_matches, ctx, p,
+                                L->jamo, L->pos_in_jamo, content_buffer);
+                        clear_dic_variable_list(&(p->dic_variables));
+                        p->stack->stack_pointer = stack_top;
+                        L = L->next;
+                    } while (L != NULL);
+                    /* We free all subgraph matches */
+                    free_parsing_info(L_first,&p->al.pa);
+                }
+                t = t->next;
+            } /* end of while (t!=NULL) */
+        } while ((graph_call_list = graph_call_list->next) != NULL);
+        /* Finally, we have to restore the stack and other backup stuff */
+        p->weight=old_weight;
+        p->stack->stack_pointer = stack_top;
+        p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
+        if (p->nb_output_variables != 0) {
+            install_output_variable_backup(p->output_variables,output_variable_backup);
+            free_output_variable_backup(output_variable_backup,p->al.pa.prv_alloc_backup_growing_recycle);
+        }
+        /* We restore the original dic variables */
+        p->dic_variables=dic_variables_backup;
+        if (save_previous_ptr_var != NULL) {
+            restore_variable_array(p->input_variables, p->backup_memory_reserve,
+                                      save_previous_ptr_var);
+            save_previous_ptr_var = NULL;
+        }
 
 
+        if (var_backup!=NULL) {
+                int reserve_freeable = free_variable_backup_using_reserve(
+                        p->backup_memory_reserve);
 
-	/* This variable will be used to store the results provided by <DIC>. It
-	 * is useful to cache the exploration of the morphological dictionaries,
-	 * so that there will only be one even if there are several patterns requiring it,
-	 * like <DIC>, <A>, <N:s>, etc */
-	int DIC_cached=0;
-	struct parsing_info* DIC_consultation = NULL;
+                if (reserve_previous != NULL) {
+                    if (reserve_freeable == 0) {
+                            fatal_error("incoherent reserve free result\n");
+                    }
+                    free_reserve(p->backup_memory_reserve);
+                    p->backup_memory_reserve = reserve_previous;
+                }
+            }
+    } /* End of processing subgraphs */
 
 
-	/**
-	 * METAS
-	 */
-	struct opt_meta* meta_list=current_state->unoptimized_metas;
-	while (meta_list != NULL) {
-		/* We process all the meta of the list */
-		t = meta_list->transition;
-		int match_one_letter;
-		while (t != NULL) {
-			if (t->tag_number==203 && t->state_number==4000) {
-				//error("Looking at tag 203 for i=%d\n",i);
-			}
-			match_one_letter = 0;
-			switch (meta_list->meta) {
 
-			case META_EPSILON:
-			case META_SHARP: /* # is no longer considered a problem in morphological mode, because
-			                  * it may have been inserted by Grf2Fst2 */
-				/* We could have an output associated to an epsilon or a #, so we handle this case */
-				captured_chars=0;
-				if (p->output_policy != IGNORE_OUTPUTS) {
-					if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
-						break;
-					}
-				}
-				morphological_locate(/*graph_depth,*/
-						t->state_number, pos_in_tokens, pos_in_chars,
-						matches, n_matches, ctx, p,
-						jamo, pos_in_jamo, content_buffer);
-				p->weight=old_weight;
-				p->stack->stack_pointer = stack_top;
-				remove_chars_from_output_variables(p->output_variables,captured_chars);
-				break;
+    /* This variable will be used to store the results provided by <DIC>. It
+     * is useful to cache the exploration of the morphological dictionaries,
+     * so that there will only be one even if there are several patterns requiring it,
+     * like <DIC>, <A>, <N:s>, etc */
+    int DIC_cached=0;
+    struct parsing_info* DIC_consultation = NULL;
 
-			case META_SPACE:
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				if (current_token[pos_in_chars] == ' ') {
-					match_one_letter = 1;
-				}
-				break;
 
-			case META_LETTER:
-			case META_LETTRE:
-			case META_MOT:
-			case META_WORD:
-			/* In morphological mode, this tag matches a letter, as defined in the alphabet file */
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				if (XOR(is_letter(current_token[pos_in_chars], p->alphabet),
-						meta_list->negation)) {
-					match_one_letter = 1;
-				}
-				break;
+    /**
+     * METAS
+     */
+    struct opt_meta* meta_list=current_state->unoptimized_metas;
+    while (meta_list != NULL) {
+        /* We process all the meta of the list */
+        t = meta_list->transition;
+        int match_one_letter;
+        while (t != NULL) {
+            if (t->tag_number==203 && t->state_number==4000) {
+                //error("Looking at tag 203 for i=%d\n",i);
+            }
+            match_one_letter = 0;
+            switch (meta_list->meta) {
 
-			case META_DIC: {
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				struct parsing_info* L2 = NULL;
-				int len_var_name = 0;
-				if (p->tags[t->tag_number]->output != NULL) {
-					len_var_name = 31;//u_strlen(p->tags[t->tag_number]->output);
-				}
+            case META_EPSILON:
+            case META_SHARP: /* # is no longer considered a problem in morphological mode, because
+                              * it may have been inserted by Grf2Fst2 */
+                /* We could have an output associated to an epsilon or a #, so we handle this case */
+                captured_chars=0;
+                if (p->output_policy != IGNORE_OUTPUTS) {
+                    if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
+                        break;
+                    }
+                }
+                morphological_locate(/*graph_depth,*/
+                        t->state_number, pos_in_tokens, pos_in_chars,
+                        matches, n_matches, ctx, p,
+                        jamo, pos_in_jamo, content_buffer);
+                p->weight=old_weight;
+                p->stack->stack_pointer = stack_top;
+                remove_chars_from_output_variables(p->output_variables,captured_chars);
+                break;
+
+            case META_SPACE:
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                if (current_token[pos_in_chars] == ' ') {
+                    match_one_letter = 1;
+                }
+                break;
+
+            case META_LETTER:
+            case META_LETTRE:
+            case META_MOT:
+            case META_WORD:
+            /* In morphological mode, this tag matches a letter, as defined in the alphabet file */
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                if (XOR(is_letter(current_token[pos_in_chars], p->alphabet),
+                        meta_list->negation)) {
+                    match_one_letter = 1;
+                }
+                break;
+
+            case META_DIC: {
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                struct parsing_info* L2 = NULL;
+                int len_var_name = 0;
+                if (p->tags[t->tag_number]->output != NULL) {
+                    len_var_name = 31;//u_strlen(p->tags[t->tag_number]->output);
+                }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-				unichar *var_name;
-				var_name=(unichar*)malloc(sizeof(unichar)*(len_var_name+1));
-				if (var_name==NULL) {
-					fatal_alloc_error("morphological_locate");
-				}
+                unichar *var_name;
+                var_name=(unichar*)malloc(sizeof(unichar)*(len_var_name+1));
+                if (var_name==NULL) {
+                    fatal_alloc_error("morphological_locate");
+                }
 #else
-				unichar var_name[len_var_name + 1];
+                unichar var_name[len_var_name + 1];
 #endif
-				int save_dic_entry = (p->output_policy != IGNORE_OUTPUTS
-						&& !capture_mode(p->output_variables)
-						&& is_morpho_variable_output(
-								p->tags[t->tag_number]->output, var_name));
-				/*explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &L2, NULL,
-						save_dic_entry, jamo, pos_in_jamo);*/
-				/* In order to make the cache system work, we always have to save dic entries */
-				if (!DIC_cached) {
-					DIC_cached=1;
-					explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &DIC_consultation, NULL,
-											1, jamo, pos_in_jamo);
-				}
-				L2=DIC_consultation;
-				unichar *content1 = content_buffer;
-				if (L2 != NULL) {
-					/* If there is at least one match, we process the match list */
-					do {
-						get_content(content1, p, pos_in_tokens, pos_in_chars,
-								L2->pos_in_tokens, L2->pos_in_chars);
+                int save_dic_entry = (p->output_policy != IGNORE_OUTPUTS
+                        && !capture_mode(p->output_variables)
+                        && is_morpho_variable_output(
+                                p->tags[t->tag_number]->output, var_name));
+                /*explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &L2, NULL,
+                        save_dic_entry, jamo, pos_in_jamo);*/
+                /* In order to make the cache system work, we always have to save dic entries */
+                if (!DIC_cached) {
+                    DIC_cached=1;
+                    explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &DIC_consultation, NULL,
+                                            1, jamo, pos_in_jamo);
+                }
+                L2=DIC_consultation;
+                unichar *content1 = content_buffer;
+                if (L2 != NULL) {
+                    /* If there is at least one match, we process the match list */
+                    do {
+                        get_content(content1, p, pos_in_tokens, pos_in_chars,
+                                L2->pos_in_tokens, L2->pos_in_chars);
 #ifdef REGEX_FACADE_ENGINE
-						int filter_number =
-								p->tags[t->tag_number]->filter_number;
-						int morpho_filter_OK = (filter_number == -1
-								|| string_match_filter(p->filters, content1,
-										filter_number,
-										p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
-						if (!morpho_filter_OK) {
-							p->stack->stack_pointer = stack_top;
-							L2 = L2->next;
-							continue;
-						}
+                        int filter_number =
+                                p->tags[t->tag_number]->filter_number;
+                        int morpho_filter_OK = (filter_number == -1
+                                || string_match_filter(p->filters, content1,
+                                        filter_number,
+                                        p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
+                        if (!morpho_filter_OK) {
+                            p->stack->stack_pointer = stack_top;
+                            L2 = L2->next;
+                            continue;
+                        }
 #endif
 
-						/* WARNING: we don't process the tag's output as usual if it
-						 *          is a variable declaration like $abc$. Note that it could
-						 *          make a difference if a variable with the same
-						 *          name was declared before entering the morphological mode */
-						captured_chars=0;
-						if (!save_dic_entry && p->output_policy	!= IGNORE_OUTPUTS) {
-							if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
-								break;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							push_input_string(p->stack, content1,
-									p->protect_dic_chars);
-						}
-						unichar* reached_token =
-								p->tokens->value[p->buffer[p->current_origin
-										+ L2->pos_in_tokens]];
-						int new_pos, new_pos_in_token;
-						if (reached_token[L2->pos_in_chars] == '\0') {
-							/* If we are at the end of the last token matched by the <DIC> tag */
-							new_pos = L2->pos_in_tokens + 1;
-							new_pos_in_token = 0;
-						} else {
-							/* If not */
-							new_pos = L2->pos_in_tokens;
-							new_pos_in_token = L2->pos_in_chars;
-						}
-						/* We continue the exploration */
-						struct dela_entry* old_value = NULL;
-						if (save_dic_entry) {
-							old_value = clone_dela_entry(get_dic_variable(
-									var_name, p->dic_variables));
-							set_dic_variable(var_name, L2->dic_entry,
-									&(p->dic_variables),1);
-						}
-						morphological_locate(/*graph_depth,*/
-								t->state_number, new_pos,
-								new_pos_in_token, matches,
-								n_matches, ctx, p, L2->jamo,
-								L2->pos_in_jamo, content_buffer);
-						p->weight=old_weight;
-						if (save_dic_entry) {
-							set_dic_variable(var_name, old_value,
-									&(p->dic_variables),0);
-						}
-						p->stack->stack_pointer = stack_top;
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-						L2 = L2->next;
-					} while (L2 != NULL);
-					/* With the cache system, we must not free the parsing information list
-					 * free_parsing_info(L_first, p->prv_alloc_alternative, p->prv_alloc);
-					 */
-				}
+                        /* WARNING: we don't process the tag's output as usual if it
+                         *          is a variable declaration like $abc$. Note that it could
+                         *          make a difference if a variable with the same
+                         *          name was declared before entering the morphological mode */
+                        captured_chars=0;
+                        if (!save_dic_entry && p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
+                                break;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            push_input_string(p->stack, content1,
+                                    p->protect_dic_chars);
+                        }
+                        unichar* reached_token =
+                                p->tokens->value[p->buffer[p->current_origin
+                                        + L2->pos_in_tokens]];
+                        int new_pos, new_pos_in_token;
+                        if (reached_token[L2->pos_in_chars] == '\0') {
+                            /* If we are at the end of the last token matched by the <DIC> tag */
+                            new_pos = L2->pos_in_tokens + 1;
+                            new_pos_in_token = 0;
+                        } else {
+                            /* If not */
+                            new_pos = L2->pos_in_tokens;
+                            new_pos_in_token = L2->pos_in_chars;
+                        }
+                        /* We continue the exploration */
+                        struct dela_entry* old_value = NULL;
+                        if (save_dic_entry) {
+                            old_value = clone_dela_entry(get_dic_variable(
+                                    var_name, p->dic_variables));
+                            set_dic_variable(var_name, L2->dic_entry,
+                                    &(p->dic_variables),1);
+                        }
+                        morphological_locate(/*graph_depth,*/
+                                t->state_number, new_pos,
+                                new_pos_in_token, matches,
+                                n_matches, ctx, p, L2->jamo,
+                                L2->pos_in_jamo, content_buffer);
+                        p->weight=old_weight;
+                        if (save_dic_entry) {
+                            set_dic_variable(var_name, old_value,
+                                    &(p->dic_variables),0);
+                        }
+                        p->stack->stack_pointer = stack_top;
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                        L2 = L2->next;
+                    } while (L2 != NULL);
+                    /* With the cache system, we must not free the parsing information list
+                     * free_parsing_info(L_first, p->prv_alloc_alternative, p->prv_alloc);
+                     */
+                }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-				free(var_name);
+                free(var_name);
 #endif
-				/* end of usage of content1 */
-				break;
-			}
+                /* end of usage of content1 */
+                break;
+            }
 
-			case META_SDIC:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <SDIC> tag in morphological mode\n");
-				break;
+            case META_SDIC:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <SDIC> tag in morphological mode\n");
+                break;
 
-			case META_CDIC:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <CDIC> tag in morphological mode\n");
-				break;
+            case META_CDIC:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <CDIC> tag in morphological mode\n");
+                break;
 
-			case META_TDIC:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <TDIC> tag in morphological mode\n");
-				break;
+            case META_TDIC:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <TDIC> tag in morphological mode\n");
+                break;
 
-			case META_TEXT_START:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <^> tag in morphological mode\n");
-				break;
+            case META_TEXT_START:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <^> tag in morphological mode\n");
+                break;
 
-			case META_TEXT_END:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <$> tag in morphological mode\n");
-				break;
+            case META_TEXT_END:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <$> tag in morphological mode\n");
+                break;
 
                         case META_UPPER: case META_MAJ: /* In morphological mode, this tag matches an uppercase letter, as defined in
-			 the alphabet file */
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				if (XOR(is_upper(current_token[pos_in_chars], p->alphabet),
-						meta_list->negation)) {
-					match_one_letter = 1;
-				}
-				break;
+             the alphabet file */
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                if (XOR(is_upper(current_token[pos_in_chars], p->alphabet),
+                        meta_list->negation)) {
+                    match_one_letter = 1;
+                }
+                break;
 
                         case META_LOWER: case META_MIN: /* In morphological mode, this tag matches a lowercase letter, as defined in
-			 the alphabet file */
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				if (XOR(is_lower(current_token[pos_in_chars], p->alphabet),
-						meta_list->negation)) {
-					match_one_letter = 1;
-				}
-				break;
+             the alphabet file */
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                if (XOR(is_lower(current_token[pos_in_chars], p->alphabet),
+                        meta_list->negation)) {
+                    match_one_letter = 1;
+                }
+                break;
 
-			case META_PRE:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <PRE> tag in morphological mode\n");
-				break;
+            case META_PRE:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <PRE> tag in morphological mode\n");
+                break;
                         case META_FIRST:
                                 error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
                                 fatal_error("Unexpected <FIRST> tag in morphological mode\n");
                                 break;
-			case META_NB:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected <NB> tag in morphological mode\n");
-				break;
+            case META_NB:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected <NB> tag in morphological mode\n");
+                break;
 
-			case META_TOKEN: {
-				if (token == -1)
-					break;
-				update_last_position(p, pos_in_tokens);
-				if (token == p->STOP)
-					break;
-				unichar one_letter[2];
-				one_letter[0] = current_token[pos_in_chars];
-				one_letter[1] = '\0';
+            case META_TOKEN: {
+                if (token == -1)
+                    break;
+                update_last_position(p, pos_in_tokens);
+                if (token == p->STOP)
+                    break;
+                unichar one_letter[2];
+                one_letter[0] = current_token[pos_in_chars];
+                one_letter[1] = '\0';
 #ifdef REGEX_FACADE_ENGINE
-				int filter_number = p->tags[t->tag_number]->filter_number;
-				int morpho_filter_OK = (filter_number == -1
-						|| string_match_filter(p->filters, one_letter,
-								filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
-				if (morpho_filter_OK) {
-					match_one_letter = 1;
-				}
+                int filter_number = p->tags[t->tag_number]->filter_number;
+                int morpho_filter_OK = (filter_number == -1
+                        || string_match_filter(p->filters, one_letter,
+                                filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
+                if (morpho_filter_OK) {
+                    match_one_letter = 1;
+                }
 #endif
-				break;
-			}
+                break;
+            }
 
-			case META_LEFT_CONTEXT:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected left context mark in morphological mode\n");
-				break;
+            case META_LEFT_CONTEXT:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected left context mark in morphological mode\n");
+                break;
 
-			case META_BEGIN_MORPHO:
-				error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-				fatal_error("Unexpected morphological mode begin tag $<\n");
-				break;
+            case META_BEGIN_MORPHO:
+                error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                fatal_error("Unexpected morphological mode begin tag $<\n");
+                break;
 
-			case META_END_MORPHO:
-				/* Should happen, but only at the same level than the $< tag */
-				if ((p->graph_depth) != 0) {
-					error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-					fatal_error("Unexpected end of morphological mode at a different\nlevel than the $< tag\n");
-				}
-				if (pos_in_chars != 0 || (jamo != NULL && pos_in_jamo != 0)) {
-					/* If the end of the morphological mode occurs in the middle
-					 * of a token, we don't take this "match" into account */
-					break;
-				}
-				/* If the end of the morphological mode occurs at the beginning of a token,
-				 * then we have a match. We note the state number that corresponds to the state
-				 * that follows the current $> tag transition, so that we know where to continue
-				 * the exploration in the 'enter_morphological_mode' function. */
-				p->stack->stack[stack_top + 1] = '\0';
-				if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-					(*matches) = insert_if_different(pos_in_tokens, pos_in_chars,
-							t->state_number, (*matches),
-							p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
-							pos_in_jamo, NULL, p->weight,&p->al.pa);
-				} else {
-					(*matches) = insert_if_absent(pos_in_tokens, pos_in_chars,
-							t->state_number, (*matches),
-							p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
-							pos_in_jamo, NULL, p->weight,&p->al.pa);
-				}
-				break;
+            case META_END_MORPHO:
+                /* Should happen, but only at the same level than the $< tag */
+                if ((p->graph_depth) != 0) {
+                    error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                    fatal_error("Unexpected end of morphological mode at a different\nlevel than the $< tag\n");
+                }
+                if (pos_in_chars != 0 || (jamo != NULL && pos_in_jamo != 0)) {
+                    /* If the end of the morphological mode occurs in the middle
+                     * of a token, we don't take this "match" into account */
+                    break;
+                }
+                /* If the end of the morphological mode occurs at the beginning of a token,
+                 * then we have a match. We note the state number that corresponds to the state
+                 * that follows the current $> tag transition, so that we know where to continue
+                 * the exploration in the 'enter_morphological_mode' function. */
+                p->stack->stack[stack_top + 1] = '\0';
+                if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+                    (*matches) = insert_if_different(pos_in_tokens, pos_in_chars,
+                            t->state_number, (*matches),
+                            p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
+                            pos_in_jamo, NULL, p->weight,&p->al.pa);
+                } else {
+                    (*matches) = insert_if_absent(pos_in_tokens, pos_in_chars,
+                            t->state_number, (*matches),
+                            p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables, p->dic_variables, -1, -1, jamo,
+                            pos_in_jamo, NULL, p->weight,&p->al.pa);
+                }
+                break;
 
-			} /* End of the switch */
-			if (match_one_letter) {
-				/* We factorize here the cases <MOT>, <MIN>, <LETTER>, <UPPER>, <LOWER> and <MAJ> that all correspond
-				 * to matching one letter */
-				captured_chars=0;
-				if (p->output_policy != IGNORE_OUTPUTS) {
-					if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
-						goto next;
-					}
-				}
-				if (p->output_policy == MERGE_OUTPUTS) {
-					/* If needed, we push the character that was matched */
-					push_input_char(p->stack, current_token[pos_in_chars],
-							p->protect_dic_chars);
-				}
-				int new_pos;
-				int new_pos_in_token;
-				unichar* new_jamo = NULL;
-				int new_pos_in_jamo = 0;
-				if (pos_in_chars + 1 == current_token_length) {
-					/* If we are at the end of the current token */
-					new_pos = pos_in_tokens + 1;
-					new_pos_in_token = 0;
-					/* We also update the Jamo things */
-					new_jamo = NULL;
-					if (p->jamo_tags != NULL) {
-						new_jamo = p->jamo_tags[p->buffer[new_pos
-								+ p->current_origin]];
-					}
-					new_pos_in_jamo = 0;
-				} else {
-					/* If not */
-					new_pos = pos_in_tokens;
-					new_pos_in_token = pos_in_chars + 1;
-					new_jamo = jamo;
-					/* If we are in Korean mode, we have to move in the Jamo sequence */
-					if (jamo != NULL) {
-						new_pos_in_jamo = pos_in_jamo + 1;
-						while (jamo[new_pos_in_jamo] != '\0') {
-							if (jamo[new_pos_in_jamo] == KR_SYLLABLE_BOUND) {
-								/* A syllable bound is OK: we go on the following Jamo */
-								new_pos_in_jamo++;
-								if (!u_is_Hangul_Jamo(jamo[new_pos_in_jamo])) {
-									error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-									fatal_error("Unexpected non Jamo character after a syllable bound\n");
-								}
-								break;
-							}
-							if (u_is_Hangul(jamo[new_pos_in_jamo])) {
-								/* A Hangul is OK */
-								break;
-							}
-							if (u_is_Hangul_Jamo(jamo[new_pos_in_jamo])) {
-								/* If we have a Jamo, we must go on */
-								new_pos_in_jamo++;
-							} else {
-								/* Any other char is OK */
-								break;
-							}
-						}
-						/*if (jamo[new_pos_in_jamo] != '\0') {
-							fatal_error("Unexpected end of Jamo sequence\n");
-						}*/
-					}
-				}
-				morphological_locate(/*graph_depth,*/ t->state_number, new_pos,
-						new_pos_in_token, matches, n_matches, ctx,
-						p, new_jamo, new_pos_in_jamo,
-						content_buffer);
-				p->weight=old_weight;
-				p->stack->stack_pointer = stack_top;
-				remove_chars_from_output_variables(p->output_variables,captured_chars);
-			}
-			next: t = t->next;
-		}
-		meta_list = meta_list->next;
-	} /* End of meta processing */
+            } /* End of the switch */
+            if (match_one_letter) {
+                /* We factorize here the cases <MOT>, <MIN>, <LETTER>, <UPPER>, <LOWER> and <MAJ> that all correspond
+                 * to matching one letter */
+                captured_chars=0;
+                if (p->output_policy != IGNORE_OUTPUTS) {
+                    if (!deal_with_output(p->tags[t->tag_number]->output,p,&captured_chars)) {
+                        goto next;
+                    }
+                }
+                if (p->output_policy == MERGE_OUTPUTS) {
+                    /* If needed, we push the character that was matched */
+                    push_input_char(p->stack, current_token[pos_in_chars],
+                            p->protect_dic_chars);
+                }
+                int new_pos;
+                int new_pos_in_token;
+                unichar* new_jamo = NULL;
+                int new_pos_in_jamo = 0;
+                if (pos_in_chars + 1 == current_token_length) {
+                    /* If we are at the end of the current token */
+                    new_pos = pos_in_tokens + 1;
+                    new_pos_in_token = 0;
+                    /* We also update the Jamo things */
+                    new_jamo = NULL;
+                    if (p->jamo_tags != NULL) {
+                        new_jamo = p->jamo_tags[p->buffer[new_pos
+                                + p->current_origin]];
+                    }
+                    new_pos_in_jamo = 0;
+                } else {
+                    /* If not */
+                    new_pos = pos_in_tokens;
+                    new_pos_in_token = pos_in_chars + 1;
+                    new_jamo = jamo;
+                    /* If we are in Korean mode, we have to move in the Jamo sequence */
+                    if (jamo != NULL) {
+                        new_pos_in_jamo = pos_in_jamo + 1;
+                        while (jamo[new_pos_in_jamo] != '\0') {
+                            if (jamo[new_pos_in_jamo] == KR_SYLLABLE_BOUND) {
+                                /* A syllable bound is OK: we go on the following Jamo */
+                                new_pos_in_jamo++;
+                                if (!u_is_Hangul_Jamo(jamo[new_pos_in_jamo])) {
+                                    error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+                                    fatal_error("Unexpected non Jamo character after a syllable bound\n");
+                                }
+                                break;
+                            }
+                            if (u_is_Hangul(jamo[new_pos_in_jamo])) {
+                                /* A Hangul is OK */
+                                break;
+                            }
+                            if (u_is_Hangul_Jamo(jamo[new_pos_in_jamo])) {
+                                /* If we have a Jamo, we must go on */
+                                new_pos_in_jamo++;
+                            } else {
+                                /* Any other char is OK */
+                                break;
+                            }
+                        }
+                        /*if (jamo[new_pos_in_jamo] != '\0') {
+                            fatal_error("Unexpected end of Jamo sequence\n");
+                        }*/
+                    }
+                }
+                morphological_locate(/*graph_depth,*/ t->state_number, new_pos,
+                        new_pos_in_token, matches, n_matches, ctx,
+                        p, new_jamo, new_pos_in_jamo,
+                        content_buffer);
+                p->weight=old_weight;
+                p->stack->stack_pointer = stack_top;
+                remove_chars_from_output_variables(p->output_variables,captured_chars);
+            }
+            next: t = t->next;
+        }
+        meta_list = meta_list->next;
+    } /* End of meta processing */
 
-	/**
-	 * OUTPUT VARIABLE STARTS
-	 */
-	struct opt_variable* variable_list=current_state->unoptimized_output_variable_starts;
-	Ustring* recycle_Ustring=NULL;
-	while (variable_list != NULL) {
-	  if (recycle_Ustring==NULL) {
-	    recycle_Ustring=new_Ustring();
-	  } else {
-	    empty(recycle_Ustring);
-	  }
-	  swap_output_variable_content(p->output_variables, variable_list->variable_number, recycle_Ustring);
-		set_output_variable_pending(p->output_variables,variable_list->variable_number);
-		morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
-				pos_in_chars, matches, n_matches, ctx,
-				p, jamo, pos_in_jamo,
-				content_buffer);
-		p->weight=old_weight;
+    /**
+     * OUTPUT VARIABLE STARTS
+     */
+    struct opt_variable* variable_list=current_state->unoptimized_output_variable_starts;
+    Ustring* recycle_Ustring=NULL;
+    while (variable_list != NULL) {
+      if (recycle_Ustring==NULL) {
+        recycle_Ustring=new_Ustring();
+      } else {
+        empty(recycle_Ustring);
+      }
+      swap_output_variable_content(p->output_variables, variable_list->variable_number, recycle_Ustring);
+        set_output_variable_pending(p->output_variables,variable_list->variable_number);
+        morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
+                pos_in_chars, matches, n_matches, ctx,
+                p, jamo, pos_in_jamo,
+                content_buffer);
+        p->weight=old_weight;
     unset_output_variable_pending(p->output_variables,variable_list->variable_number);
     swap_output_variable_content(p->output_variables, variable_list->variable_number, recycle_Ustring);
-		p->stack->stack_pointer = stack_top;
-		variable_list=variable_list->next;
-	}
+        p->stack->stack_pointer = stack_top;
+        variable_list=variable_list->next;
+    }
 
-	/**
-	 * OUTPUT VARIABLE ENDS
-	 */
-	variable_list=current_state->unoptimized_output_variable_ends;
-	while (variable_list != NULL) {
-		unset_output_variable_pending(p->output_variables,variable_list->variable_number);
-		morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
-				pos_in_chars, matches, n_matches, ctx,
-				p, jamo, pos_in_jamo,
-				content_buffer);
-		p->weight=old_weight;
-		p->stack->stack_pointer = stack_top;
-		set_output_variable_pending(p->output_variables,variable_list->variable_number);
-		variable_list=variable_list->next;
-	}
+    /**
+     * OUTPUT VARIABLE ENDS
+     */
+    variable_list=current_state->unoptimized_output_variable_ends;
+    while (variable_list != NULL) {
+        unset_output_variable_pending(p->output_variables,variable_list->variable_number);
+        morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
+                pos_in_chars, matches, n_matches, ctx,
+                p, jamo, pos_in_jamo,
+                content_buffer);
+        p->weight=old_weight;
+        p->stack->stack_pointer = stack_top;
+        set_output_variable_pending(p->output_variables,variable_list->variable_number);
+        variable_list=variable_list->next;
+    }
 
-	/**
-	 * VARIABLE STARTS
-	 */
-	variable_list=current_state->unoptimized_input_variable_starts;
-	while (variable_list != NULL) {
-		inc_dirty(p->backup_memory_reserve);
-		int old_in_token = get_variable_start(p->input_variables,
-				variable_list->variable_number);
-		int old_in_char = get_variable_start_in_chars(p->input_variables,
-						variable_list->variable_number);
-		set_variable_start(p->input_variables, variable_list->variable_number, pos_in_tokens);
-		set_variable_start_in_chars(p->input_variables, variable_list->variable_number, pos_in_chars);
-		//error("var start=tok=%d char=%d\n",pos_in_tokens,pos_in_chars);
-		morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
-						pos_in_chars, matches, n_matches, ctx,
-						p, jamo, pos_in_jamo,
-						content_buffer);
-		p->weight=old_weight;
-		p->stack->stack_pointer = stack_top;
-		if (ctx == NULL) {
-			/* We do not restore previous value if we are inside a context, in order
-			 * to allow extracting things from contexts (see the
-			 * "the cat is white" example in Unitex manual). */
-			set_variable_start(p->input_variables, variable_list->variable_number,
-					old_in_token);
-			set_variable_start_in_chars(p->input_variables, variable_list->variable_number,
-								old_in_char);
-			dec_dirty(p->backup_memory_reserve);
-			// restore dirty
-		}
-		variable_list = variable_list->next;
-	}
+    /**
+     * VARIABLE STARTS
+     */
+    variable_list=current_state->unoptimized_input_variable_starts;
+    while (variable_list != NULL) {
+        inc_dirty(p->backup_memory_reserve);
+        int old_in_token = get_variable_start(p->input_variables,
+                variable_list->variable_number);
+        int old_in_char = get_variable_start_in_chars(p->input_variables,
+                        variable_list->variable_number);
+        set_variable_start(p->input_variables, variable_list->variable_number, pos_in_tokens);
+        set_variable_start_in_chars(p->input_variables, variable_list->variable_number, pos_in_chars);
+        //error("var start=tok=%d char=%d\n",pos_in_tokens,pos_in_chars);
+        morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
+                        pos_in_chars, matches, n_matches, ctx,
+                        p, jamo, pos_in_jamo,
+                        content_buffer);
+        p->weight=old_weight;
+        p->stack->stack_pointer = stack_top;
+        if (ctx == NULL) {
+            /* We do not restore previous value if we are inside a context, in order
+             * to allow extracting things from contexts (see the
+             * "the cat is white" example in Unitex manual). */
+            set_variable_start(p->input_variables, variable_list->variable_number,
+                    old_in_token);
+            set_variable_start_in_chars(p->input_variables, variable_list->variable_number,
+                                old_in_char);
+            dec_dirty(p->backup_memory_reserve);
+            // restore dirty
+        }
+        variable_list = variable_list->next;
+    }
 
-	/**
-	 * VARIABLE ENDS
-	 */
-	variable_list=current_state->unoptimized_input_variable_ends;
-	while (variable_list != NULL) {
-		inc_dirty(p->backup_memory_reserve);
-		int old_in_token =
-				get_variable_end(p->input_variables, variable_list->variable_number);
-		int old_in_char = get_variable_end_in_chars(p->input_variables, variable_list->variable_number);
-		int new_end_in_token;
-		int new_end_in_chars;
-		if (pos_in_chars==0) {
-			/* If we have just started a new token, then the variable
-			 * ends on the end of the previous one */
-			new_end_in_token=pos_in_tokens;
-			new_end_in_chars=-1;
-		} else  {
-			new_end_in_token=pos_in_tokens+1;
-			new_end_in_chars=pos_in_chars-1;
-		}
-		//error("var end=tok=%d char=%d\n",new_end_in_token,new_end_in_chars);
-		set_variable_end(p->input_variables, variable_list->variable_number, new_end_in_token);
-		set_variable_end_in_chars(p->input_variables, variable_list->variable_number,new_end_in_chars);
-		morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
-						pos_in_chars, matches, n_matches, ctx,
-						p, jamo, pos_in_jamo,
-						content_buffer);
-		p->weight=old_weight;
-		p->stack->stack_pointer = stack_top;
-		if (ctx == NULL) {
-			/* We do not restore previous value if we are inside a context, in order
-			 * to allow extracting things from contexts (see the
-			 * "the cat is white" example in Unitex manual). */
-			set_variable_end(p->input_variables, variable_list->variable_number, old_in_token);
-			set_variable_end_in_chars(p->input_variables, variable_list->variable_number, old_in_char);
-			dec_dirty(p->backup_memory_reserve);
-		}
-		variable_list = variable_list->next;
-	}
+    /**
+     * VARIABLE ENDS
+     */
+    variable_list=current_state->unoptimized_input_variable_ends;
+    while (variable_list != NULL) {
+        inc_dirty(p->backup_memory_reserve);
+        int old_in_token =
+                get_variable_end(p->input_variables, variable_list->variable_number);
+        int old_in_char = get_variable_end_in_chars(p->input_variables, variable_list->variable_number);
+        int new_end_in_token;
+        int new_end_in_chars;
+        if (pos_in_chars==0) {
+            /* If we have just started a new token, then the variable
+             * ends on the end of the previous one */
+            new_end_in_token=pos_in_tokens;
+            new_end_in_chars=-1;
+        } else  {
+            new_end_in_token=pos_in_tokens+1;
+            new_end_in_chars=pos_in_chars-1;
+        }
+        //error("var end=tok=%d char=%d\n",new_end_in_token,new_end_in_chars);
+        set_variable_end(p->input_variables, variable_list->variable_number, new_end_in_token);
+        set_variable_end_in_chars(p->input_variables, variable_list->variable_number,new_end_in_chars);
+        morphological_locate(/*graph_depth,*/ variable_list->transition->state_number, pos_in_tokens,
+                        pos_in_chars, matches, n_matches, ctx,
+                        p, jamo, pos_in_jamo,
+                        content_buffer);
+        p->weight=old_weight;
+        p->stack->stack_pointer = stack_top;
+        if (ctx == NULL) {
+            /* We do not restore previous value if we are inside a context, in order
+             * to allow extracting things from contexts (see the
+             * "the cat is white" example in Unitex manual). */
+            set_variable_end(p->input_variables, variable_list->variable_number, old_in_token);
+            set_variable_end_in_chars(p->input_variables, variable_list->variable_number, old_in_char);
+            dec_dirty(p->backup_memory_reserve);
+        }
+        variable_list = variable_list->next;
+    }
 
 
-	if (token == -1 || token == p->STOP) {
-		/* We can't match anything if we are at the end of the buffer or if
-		 * we have the forbidden token {STOP} that must never be matched. */
-		p->explore_depth -- ;
-		return;
-	}
+    if (token == -1 || token == p->STOP) {
+        /* We can't match anything if we are at the end of the buffer or if
+         * we have the forbidden token {STOP} that must never be matched. */
+        p->explore_depth -- ;
+        return;
+    }
 
-	/**
-	 * CONTEXTS
-	 */
-	struct opt_contexts* contexts = current_state->contexts;
-	if (contexts != NULL) {
-		error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
-		fatal_error("Unexpected use of contexts in morphological mode\n");
-	}
+    /**
+     * CONTEXTS
+     */
+    struct opt_contexts* contexts = current_state->contexts;
+    if (contexts != NULL) {
+        error("Error in graph %S:\n",p->fst2->graph_names[get_graph_index(p->fst2,current_state_index)]);
+        fatal_error("Unexpected use of contexts in morphological mode\n");
+    }
 
-	/**
-	 * TOKENS
-	 */
-	Transition* trans = current_state_old->transitions;
-	while (trans != NULL) {
-		if (trans->tag_number < 0) {
-			/* We don't take subgraph transitions into account */
-			trans = trans->next;
-			continue;
-		}
-		Fst2Tag tag = p->tags[trans->tag_number];
-		if (tag->pattern != NULL) {
-			update_last_position(p, pos_in_tokens);
-			if (tag->pattern->type == TOKEN_PATTERN) {
-				unichar* tag_token = tag->pattern->inflected;
-				int comma = -1;
-				if (tag_token[0] == '{' && u_strcmp(tag_token, "{")
-						&& u_strcmp(tag_token, "{S}")) {
-					/* If we have a tag like {eats,eat.V:P3s} */
-					tag_token++; /* We ignore the { */
-					while (tag_token[comma] != ',') {
-						comma++;
-					}
-					/* We want to avoid a copy */
-					tag_token[comma] = '\0';
-				}
-				int tag_token_length = u_strlen(tag_token);
-				if (jamo != NULL) {
-					/* KOREAN token matching */
-					//error("comparing txt=<%S> and tag=<%S>\n",jamo,tag_token);
-					int new_pos_in_jamo = pos_in_jamo;
-					int new_pos_in_token = pos_in_chars;
-					int result = get_jamo_longest_prefix(jamo,
-							&new_pos_in_jamo, &new_pos_in_token, tag_token, p,
-							current_token);
-					if (comma != -1) {
-						/* If necessary, we restore the tag */
-						tag_token[comma] = ',';
-					}
-					if (result != 0) {
-						/* Nothing to do if the match failed */
-						int new_pos = pos_in_tokens;
-						unichar* new_jamo = jamo;
-						if (result == 1) {
-							/* The text token has been fully matched, so we go on the next one */
-							new_pos_in_token = 0;
-							new_pos = pos_in_tokens + 1;
-							new_jamo = p->jamo_tags[p->buffer[new_pos
-									+ p->current_origin]];
-							new_pos_in_jamo = 0;
-						}
-						/* If we can match the tag's token, we process the output, if we have to */
-						captured_chars=0;
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(tag->output,p,&captured_chars)) {
-								continue;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							fatal_error(
-									"Unsupported MERGE mode in Korean morphological mode\n");
-							//push_input_substring(p->stack,current_token+pos_in_token,prefix_length,p->protect_dic_chars);
-						}
-						morphological_locate(/*graph_depth,*/ trans->state_number,
-								new_pos, new_pos_in_token, matches,
-								n_matches, ctx, p, new_jamo,
-								new_pos_in_jamo, content_buffer);
-						p->weight=old_weight;
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-						p->stack->stack_pointer = stack_top;
-					}
-					/* End of KOREAN token matching */
-				} else {
-					/* Non Korean token matching*/
-					int prefix_length;
-					if (tag->control & RESPECT_CASE_TAG_BIT_MASK) {
-						/* If we must have a perfect match */
-						prefix_length = get_longuest_prefix(current_token
-								+ pos_in_chars, tag_token);
-					} else {
-						prefix_length = get_longuest_prefix_ignoring_case(
-								current_token + pos_in_chars, tag_token,
-								p->alphabet);
-					}
-					if (prefix_length == tag_token_length) {
-						/* If we can match the tag's token, we process the output, if we have to */
-						captured_chars=0;
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(tag->output,p,&captured_chars)) {
-								continue;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							push_input_substring(p->stack, current_token
-									+ pos_in_chars, prefix_length,
-									p->protect_dic_chars);
-						}
-						int new_pos, new_pos_in_token;
-						if (pos_in_chars + prefix_length < current_token_length) {
-							/* If we didn't reach the end of the current token */
-							new_pos = pos_in_tokens;
-							new_pos_in_token = pos_in_chars + prefix_length;
-						} else {
-							/* If we must go on the next token */
-							new_pos = pos_in_tokens + 1;
-							new_pos_in_token = 0;
-						}
-						morphological_locate(/*graph_depth,*/ trans->state_number,
-								new_pos, new_pos_in_token, matches,
-								n_matches, ctx, p, jamo,
-								pos_in_jamo, content_buffer);
-						p->weight=old_weight;
-						p->stack->stack_pointer = stack_top;
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-					} else {
-						/* No else here, because a grammar tag is not supposed to match a sequence that
-						 * overlaps two text tokens. */
-					}
-					/* End of non Korean token matching */
-				}
-			} else {
-				/* Here, we deal with all the "real" patterns: <be>, <N+z1:ms>, <be.V:K> and <am,be.V> */
-				struct parsing_info* L = NULL;
-				int len_var_name = 0;
-				if (tag->output != NULL) {
-					len_var_name = 31;//u_strlen(tag->output);
-				}
+    /**
+     * TOKENS
+     */
+    Transition* trans = current_state_old->transitions;
+    while (trans != NULL) {
+        if (trans->tag_number < 0) {
+            /* We don't take subgraph transitions into account */
+            trans = trans->next;
+            continue;
+        }
+        Fst2Tag tag = p->tags[trans->tag_number];
+        if (tag->pattern != NULL) {
+            update_last_position(p, pos_in_tokens);
+            if (tag->pattern->type == TOKEN_PATTERN) {
+                unichar* tag_token = tag->pattern->inflected;
+                int comma = -1;
+                if (tag_token[0] == '{' && u_strcmp(tag_token, "{")
+                        && u_strcmp(tag_token, "{S}")) {
+                    /* If we have a tag like {eats,eat.V:P3s} */
+                    tag_token++; /* We ignore the { */
+                    while (tag_token[comma] != ',') {
+                        comma++;
+                    }
+                    /* We want to avoid a copy */
+                    tag_token[comma] = '\0';
+                }
+                int tag_token_length = u_strlen(tag_token);
+                if (jamo != NULL) {
+                    /* KOREAN token matching */
+                    //error("comparing txt=<%S> and tag=<%S>\n",jamo,tag_token);
+                    int new_pos_in_jamo = pos_in_jamo;
+                    int new_pos_in_token = pos_in_chars;
+                    int result = get_jamo_longest_prefix(jamo,
+                            &new_pos_in_jamo, &new_pos_in_token, tag_token, p,
+                            current_token);
+                    if (comma != -1) {
+                        /* If necessary, we restore the tag */
+                        tag_token[comma] = ',';
+                    }
+                    if (result != 0) {
+                        /* Nothing to do if the match failed */
+                        int new_pos = pos_in_tokens;
+                        unichar* new_jamo = jamo;
+                        if (result == 1) {
+                            /* The text token has been fully matched, so we go on the next one */
+                            new_pos_in_token = 0;
+                            new_pos = pos_in_tokens + 1;
+                            new_jamo = p->jamo_tags[p->buffer[new_pos
+                                    + p->current_origin]];
+                            new_pos_in_jamo = 0;
+                        }
+                        /* If we can match the tag's token, we process the output, if we have to */
+                        captured_chars=0;
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(tag->output,p,&captured_chars)) {
+                                continue;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            fatal_error(
+                                    "Unsupported MERGE mode in Korean morphological mode\n");
+                            //push_input_substring(p->stack,current_token+pos_in_token,prefix_length,p->protect_dic_chars);
+                        }
+                        morphological_locate(/*graph_depth,*/ trans->state_number,
+                                new_pos, new_pos_in_token, matches,
+                                n_matches, ctx, p, new_jamo,
+                                new_pos_in_jamo, content_buffer);
+                        p->weight=old_weight;
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                        p->stack->stack_pointer = stack_top;
+                    }
+                    /* End of KOREAN token matching */
+                } else {
+                    /* Non Korean token matching*/
+                    int prefix_length;
+                    if (tag->control & RESPECT_CASE_TAG_BIT_MASK) {
+                        /* If we must have a perfect match */
+                        prefix_length = get_longuest_prefix(current_token
+                                + pos_in_chars, tag_token);
+                    } else {
+                        prefix_length = get_longuest_prefix_ignoring_case(
+                                current_token + pos_in_chars, tag_token,
+                                p->alphabet);
+                    }
+                    if (prefix_length == tag_token_length) {
+                        /* If we can match the tag's token, we process the output, if we have to */
+                        captured_chars=0;
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(tag->output,p,&captured_chars)) {
+                                continue;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            push_input_substring(p->stack, current_token
+                                    + pos_in_chars, prefix_length,
+                                    p->protect_dic_chars);
+                        }
+                        int new_pos, new_pos_in_token;
+                        if (pos_in_chars + prefix_length < current_token_length) {
+                            /* If we didn't reach the end of the current token */
+                            new_pos = pos_in_tokens;
+                            new_pos_in_token = pos_in_chars + prefix_length;
+                        } else {
+                            /* If we must go on the next token */
+                            new_pos = pos_in_tokens + 1;
+                            new_pos_in_token = 0;
+                        }
+                        morphological_locate(/*graph_depth,*/ trans->state_number,
+                                new_pos, new_pos_in_token, matches,
+                                n_matches, ctx, p, jamo,
+                                pos_in_jamo, content_buffer);
+                        p->weight=old_weight;
+                        p->stack->stack_pointer = stack_top;
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                    } else {
+                        /* No else here, because a grammar tag is not supposed to match a sequence that
+                         * overlaps two text tokens. */
+                    }
+                    /* End of non Korean token matching */
+                }
+            } else {
+                /* Here, we deal with all the "real" patterns: <be>, <N+z1:ms>, <be.V:K> and <am,be.V> */
+                struct parsing_info* L = NULL;
+                int len_var_name = 0;
+                if (tag->output != NULL) {
+                    len_var_name = 31;//u_strlen(tag->output);
+                }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-				unichar *var_name;
-				var_name=(unichar*)malloc(sizeof(unichar)*(len_var_name+1));
-				if (var_name==NULL) {
-					fatal_alloc_error("morphological_locate");
-				}
+                unichar *var_name;
+                var_name=(unichar*)malloc(sizeof(unichar)*(len_var_name+1));
+                if (var_name==NULL) {
+                    fatal_alloc_error("morphological_locate");
+                }
 #else
-				unichar var_name[len_var_name + 1];
+                unichar var_name[len_var_name + 1];
 #endif
 
-				int save_dic_entry = (p->output_policy != IGNORE_OUTPUTS
-						&& is_morpho_variable_output(tag->output, var_name));
+                int save_dic_entry = (p->output_policy != IGNORE_OUTPUTS
+                        && is_morpho_variable_output(tag->output, var_name));
 
-				/*explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &L,
-						tag->pattern, save_dic_entry, jamo, pos_in_jamo);*/
-				if (!DIC_cached) {
-					DIC_cached=1;
-					explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &DIC_consultation,
-											NULL, 1, jamo, pos_in_jamo);
-				}
-				L=DIC_consultation;
-				unichar *content2 = content_buffer;
-				if (L != NULL) {
-					/* If there is at least one match, we process the match list */
-					do {
-						if (!is_entry_compatible_with_pattern(L->dic_entry,tag->pattern)) {
-							/* We take all <DIC> entries from the cache, and we compare them
-							 * with the actual <X> pattern of the current tag */
-							p->stack->stack_pointer = stack_top;
-							L = L->next;
-							continue;
-						}
-						get_content(content2, p, pos_in_tokens, pos_in_chars,
-								L->pos_in_tokens, L->pos_in_chars);
+                /*explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &L,
+                        tag->pattern, save_dic_entry, jamo, pos_in_jamo);*/
+                if (!DIC_cached) {
+                    DIC_cached=1;
+                    explore_dic_in_morpho_mode(p, pos_in_tokens, pos_in_chars, &DIC_consultation,
+                                            NULL, 1, jamo, pos_in_jamo);
+                }
+                L=DIC_consultation;
+                unichar *content2 = content_buffer;
+                if (L != NULL) {
+                    /* If there is at least one match, we process the match list */
+                    do {
+                        if (!is_entry_compatible_with_pattern(L->dic_entry,tag->pattern)) {
+                            /* We take all <DIC> entries from the cache, and we compare them
+                             * with the actual <X> pattern of the current tag */
+                            p->stack->stack_pointer = stack_top;
+                            L = L->next;
+                            continue;
+                        }
+                        get_content(content2, p, pos_in_tokens, pos_in_chars,
+                                L->pos_in_tokens, L->pos_in_chars);
 #ifdef REGEX_FACADE_ENGINE
-						int filter_number =
-								p->tags[trans->tag_number]->filter_number;
-						int morpho_filter_OK = (filter_number == -1
-								|| string_match_filter(p->filters, content2,
-										filter_number,
-										p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
-						if (!morpho_filter_OK) {
-							p->stack->stack_pointer = stack_top;
-							L = L->next;
-							continue;
-						}
+                        int filter_number =
+                                p->tags[trans->tag_number]->filter_number;
+                        int morpho_filter_OK = (filter_number == -1
+                                || string_match_filter(p->filters, content2,
+                                        filter_number,
+                                        p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER));
+                        if (!morpho_filter_OK) {
+                            p->stack->stack_pointer = stack_top;
+                            L = L->next;
+                            continue;
+                        }
 #endif
-						/* WARNING: we don't process the tag's output as usual if it
-						 *          is a variable declaration like $abc$. Note that it could
-						 *          make a difference if a variable with the same
-						 *          name was declared before entering the morphological mode */
-						captured_chars=0;
-						if (!save_dic_entry && p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(tag->output,p,&captured_chars)) {
-								continue;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							push_input_string(p->stack, content2,
-									p->protect_dic_chars);
-						}
-						unichar* reached_token =
-								p->tokens->value[p->buffer[p->current_origin
-										+ L->pos_in_tokens]];
-						int new_pos, new_pos_in_token, new_pos_in_jamo;
-						//error("dic match output=<%S>\n",p->stack->stack);
-						if (reached_token[L->pos_in_chars] == '\0' && (L->jamo==NULL || L->jamo[L->pos_in_jamo]=='\0')) {
-							/* If we are at the end of the last token matched by the dictionary search */
-							new_pos = L->pos_in_tokens + 1;
-							new_pos_in_token = 0;
-							new_pos_in_jamo=0;
-							//error(" => end of the token <%S>  pos=%d  jamo=<%S> pos_jamo=%d\n",reached_token,L->pos_in_chars,L->jamo,L->pos_in_jamo);
-						} else {
-							/* If not */
-							new_pos = L->pos_in_tokens;
-							new_pos_in_token = L->pos_in_chars;
-							new_pos_in_jamo=L->pos_in_jamo;
-							//error(" => token=%d char=%d\n",new_pos,new_pos_in_token);
-						}
-						/* We continue the exploration */
-						struct dela_entry* old_value = NULL;
-						if (save_dic_entry) {
-							old_value = clone_dela_entry(get_dic_variable(
-									var_name, p->dic_variables));
-							set_dic_variable(var_name, L->dic_entry,
-									&(p->dic_variables),1);
-						}
-						morphological_locate(/*graph_depth,*/ trans->state_number,
-								new_pos, new_pos_in_token, matches,
-								n_matches, ctx, p, L->jamo,
-								new_pos_in_jamo, content_buffer);
-						p->weight=old_weight;
-						if (save_dic_entry) {
-							set_dic_variable(var_name, old_value,
-									&(p->dic_variables),0);
-						}
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-						p->stack->stack_pointer = stack_top;
-						L = L->next;
-					} while (L != NULL);
-					/* No free, because of the cache system
-					 * free_parsing_info(L_first, p->prv_alloc_alternative, p->prv_alloc);
-					 */
-				}
+                        /* WARNING: we don't process the tag's output as usual if it
+                         *          is a variable declaration like $abc$. Note that it could
+                         *          make a difference if a variable with the same
+                         *          name was declared before entering the morphological mode */
+                        captured_chars=0;
+                        if (!save_dic_entry && p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(tag->output,p,&captured_chars)) {
+                                continue;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            push_input_string(p->stack, content2,
+                                    p->protect_dic_chars);
+                        }
+                        unichar* reached_token =
+                                p->tokens->value[p->buffer[p->current_origin
+                                        + L->pos_in_tokens]];
+                        int new_pos, new_pos_in_token, new_pos_in_jamo;
+                        //error("dic match output=<%S>\n",p->stack->stack);
+                        if (reached_token[L->pos_in_chars] == '\0' && (L->jamo==NULL || L->jamo[L->pos_in_jamo]=='\0')) {
+                            /* If we are at the end of the last token matched by the dictionary search */
+                            new_pos = L->pos_in_tokens + 1;
+                            new_pos_in_token = 0;
+                            new_pos_in_jamo=0;
+                            //error(" => end of the token <%S>  pos=%d  jamo=<%S> pos_jamo=%d\n",reached_token,L->pos_in_chars,L->jamo,L->pos_in_jamo);
+                        } else {
+                            /* If not */
+                            new_pos = L->pos_in_tokens;
+                            new_pos_in_token = L->pos_in_chars;
+                            new_pos_in_jamo=L->pos_in_jamo;
+                            //error(" => token=%d char=%d\n",new_pos,new_pos_in_token);
+                        }
+                        /* We continue the exploration */
+                        struct dela_entry* old_value = NULL;
+                        if (save_dic_entry) {
+                            old_value = clone_dela_entry(get_dic_variable(
+                                    var_name, p->dic_variables));
+                            set_dic_variable(var_name, L->dic_entry,
+                                    &(p->dic_variables),1);
+                        }
+                        morphological_locate(/*graph_depth,*/ trans->state_number,
+                                new_pos, new_pos_in_token, matches,
+                                n_matches, ctx, p, L->jamo,
+                                new_pos_in_jamo, content_buffer);
+                        p->weight=old_weight;
+                        if (save_dic_entry) {
+                            set_dic_variable(var_name, old_value,
+                                    &(p->dic_variables),0);
+                        }
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                        p->stack->stack_pointer = stack_top;
+                        L = L->next;
+                    } while (L != NULL);
+                    /* No free, because of the cache system
+                     * free_parsing_info(L_first, p->prv_alloc_alternative, p->prv_alloc);
+                     */
+                }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
-				free(var_name);
+                free(var_name);
 #endif
-				/* end of usage of content2 */
-			}
-		}
-		trans = trans->next;
-	}
+                /* end of usage of content2 */
+            }
+        }
+        trans = trans->next;
+    }
     p->explore_depth -- ;
     free_parsing_info(DIC_consultation,&p->al.pa);
 }
@@ -1292,7 +1292,7 @@ unichar* content_buffer /* reusable unichar 4096 buffer for content */
  * Returns 1 in that case; 0 otherwise.
  */
 int input_is_token(Fst2Tag tag) {
-	return (tag->input[0] != '<' || tag->input[1] == '\0');
+    return (tag->input[0] != '<' || tag->input[1] == '\0');
 }
 
 /**
@@ -1311,139 +1311,139 @@ struct list_context* ctx, /* information about the current context, if any */
 struct locate_parameters* p /* miscellaneous parameters needed by the function */
 //,variable_backup_memory_reserve* backup_reserve_
 ) {
-	int old_weight=p->weight;
+    int old_weight=p->weight;
     p->explore_depth ++ ;
-	unichar* content_buffer = (unichar*) malloc_cb(sizeof(unichar) * 4096, p->al.prv_alloc_recycle_morphlogical_content_buffer);
-	if (content_buffer == NULL) {
-		fatal_alloc_error("enter_morphological_mode");
-	}
-	int* var_backup = NULL;
-	OutputVariablesBackup* output_variable_backup=NULL;
-	int old_StackBase;
-	int stack_top = p->stack->stack_pointer;
-	old_StackBase = p->stack_base;
-	if (p->output_policy != IGNORE_OUTPUTS) {
-		/* For better performance when ignoring outputs */
-		var_backup = create_variable_backup(p->input_variables,p->al.pa.prv_alloc_recycle);
-		if (p->nb_output_variables != 0) {
-			output_variable_backup=create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
-		}
-	}
-	struct parsing_info* L = NULL;
-	p->stack_base = p->stack->stack_pointer;
-	struct dic_variable* dic_variable_backup = NULL;
-	if (p->dic_variables != NULL) {
-		dic_variable_backup = clone_dic_variable_list(p->dic_variables);
-	}
-	int current_token = p->buffer[pos + p->current_origin];
-	//error("current token=%d/%S  jamo=%S\n",current_token,p->tokens->value[current_token],p->jamo_tags[current_token]);
+    unichar* content_buffer = (unichar*) malloc_cb(sizeof(unichar) * 4096, p->al.prv_alloc_recycle_morphlogical_content_buffer);
+    if (content_buffer == NULL) {
+        fatal_alloc_error("enter_morphological_mode");
+    }
+    int* var_backup = NULL;
+    OutputVariablesBackup* output_variable_backup=NULL;
+    int old_StackBase;
+    int stack_top = p->stack->stack_pointer;
+    old_StackBase = p->stack_base;
+    if (p->output_policy != IGNORE_OUTPUTS) {
+        /* For better performance when ignoring outputs */
+        var_backup = create_variable_backup(p->input_variables,p->al.pa.prv_alloc_recycle);
+        if (p->nb_output_variables != 0) {
+            output_variable_backup=create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
+        }
+    }
+    struct parsing_info* L = NULL;
+    p->stack_base = p->stack->stack_pointer;
+    struct dic_variable* dic_variable_backup = NULL;
+    if (p->dic_variables != NULL) {
+        dic_variable_backup = clone_dic_variable_list(p->dic_variables);
+    }
+    int current_token = p->buffer[pos + p->current_origin];
+    //error("current token=%d/%S  jamo=%S\n",current_token,p->tokens->value[current_token],p->jamo_tags[current_token]);
 
     int backup_graph_depth = p->graph_depth;
     p->graph_depth = 0;
     p->graph_depth_backup_nested ++;
-	morphological_locate(/*0,*/ state, pos, 0, &L, 0, NULL, p,
-			(p->jamo_tags != NULL) ? p->jamo_tags[current_token] : NULL, 0,
-			content_buffer);
+    morphological_locate(/*0,*/ state, pos, 0, &L, 0, NULL, p,
+            (p->jamo_tags != NULL) ? p->jamo_tags[current_token] : NULL, 0,
+            content_buffer);
     p->graph_depth_backup_nested --;
     p->graph_depth = backup_graph_depth;
 
-	clear_dic_variable_list(&(p->dic_variables));
-	p->stack_base = old_StackBase;
-	if (L != NULL) {
-		struct parsing_info* L_first = L;
-		/* If there is at least one match, we process the match list */
-		do {
-			/* We restore the settings that we had at the end of the exploration in morphological mode */
-			if (p->output_policy != IGNORE_OUTPUTS) {
-				u_strcpy(&(p->stack->stack[stack_top + 1]), L->stack);
-				p->stack->stack_pointer = L->stack_pointer;
-				install_variable_backup(p->input_variables, L->input_variable_backup);
-				if (p->nb_output_variables != 0) {
-					install_output_variable_backup(p->output_variables,L->output_variable_backup);
-				}
-			}
-			p->dic_variables = NULL;
-			if (L->dic_variable_backup != NULL) {
-				p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
-			}
-			/* And we continue the exploration */
+    clear_dic_variable_list(&(p->dic_variables));
+    p->stack_base = old_StackBase;
+    if (L != NULL) {
+        struct parsing_info* L_first = L;
+        /* If there is at least one match, we process the match list */
+        do {
+            /* We restore the settings that we had at the end of the exploration in morphological mode */
+            if (p->output_policy != IGNORE_OUTPUTS) {
+                u_strcpy(&(p->stack->stack[stack_top + 1]), L->stack);
+                p->stack->stack_pointer = L->stack_pointer;
+                install_variable_backup(p->input_variables, L->input_variable_backup);
+                if (p->nb_output_variables != 0) {
+                    install_output_variable_backup(p->output_variables,L->output_variable_backup);
+                }
+            }
+            p->dic_variables = NULL;
+            if (L->dic_variable_backup != NULL) {
+                p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
+            }
+            /* And we continue the exploration */
 
-			variable_backup_memory_reserve* reserve_previous = NULL;
+            variable_backup_memory_reserve* reserve_previous = NULL;
 
-			if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
-					p->backup_memory_reserve) == 0) {
-				reserve_previous = p->backup_memory_reserve ;
-				p->backup_memory_reserve = create_variable_backup_memory_reserve(
-						p->input_variables,0);
-			}
+            if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
+                    p->backup_memory_reserve) == 0) {
+                reserve_previous = p->backup_memory_reserve ;
+                p->backup_memory_reserve = create_variable_backup_memory_reserve(
+                        p->input_variables,0);
+            }
 
 
-			p->weight=L->weight;
-			/* Here, we actually use the optimized_states array and not the
-			 * because we are outside the morphological mode
-			 */
-			locate(/*graph_depth, */p->optimized_states[L->state_number],
-					L->pos_in_tokens, matches, n_matches, ctx, p);
+            p->weight=L->weight;
+            /* Here, we actually use the optimized_states array and not the
+             * because we are outside the morphological mode
+             */
+            locate(/*graph_depth, */p->optimized_states[L->state_number],
+                    L->pos_in_tokens, matches, n_matches, ctx, p);
             /*
-			if ((p->max_count_call > 0) && (p->counting_step.count_call >= p->max_count_call)) {
-				u_printf("stop computing token %u after %u step computing\n",
-						p->current_origin, p->counting_step.count_call);
-			} else if ((p->max_count_call_warning > 0) && (p->counting_step.count_call
-					>= p->max_count_call_warning)) {
-				u_printf(
-						"warning : computing token %u take %u step computing\n",
-						p->current_origin, p->counting_step.count_call);
-			}
+            if ((p->max_count_call > 0) && (p->counting_step.count_call >= p->max_count_call)) {
+                u_printf("stop computing token %u after %u step computing\n",
+                        p->current_origin, p->counting_step.count_call);
+            } else if ((p->max_count_call_warning > 0) && (p->counting_step.count_call
+                    >= p->max_count_call_warning)) {
+                u_printf(
+                        "warning : computing token %u take %u step computing\n",
+                        p->current_origin, p->counting_step.count_call);
+            }
             */
 
 
 
-			if (reserve_previous != NULL) {
-					free_reserve(p->backup_memory_reserve);
-					p->backup_memory_reserve = reserve_previous;
-			}
+            if (reserve_previous != NULL) {
+                    free_reserve(p->backup_memory_reserve);
+                    p->backup_memory_reserve = reserve_previous;
+            }
 
 
 
 
-			p->stack->stack_pointer = stack_top;
-			if (p->graph_depth == 0) {
-				/* If we are at the top graph level, we restore the variables */
-				if (p->output_policy != IGNORE_OUTPUTS) {
-					install_variable_backup(p->input_variables, var_backup);
-				}
-			}
-			if ((ctx == NULL || L->next != NULL) && (p->dic_variables != NULL)) {
-				/* If we are inside a context, we don't want to free all the dic_variables that
-				 * have been set, in order to allow extracting morphological information from contexts.
-				 * To do that, we arbitrarily keep the dic_variables of the last path match. */
-				clear_dic_variable_list(&(p->dic_variables));
-			}
-			L = L->next;
-		} while (L != NULL);
-		free_parsing_info(L_first,&p->al.pa); /* free all morphological matches */
-	}
-	/* Finally, we have to restore the stack and other backup stuff */
-	p->weight=old_weight;
-	p->stack->stack_pointer = stack_top;
-	p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
-	if (p->output_policy != IGNORE_OUTPUTS) { /* For better performance (see above) */
-		install_variable_backup(p->input_variables, var_backup);
-		free_variable_backup(var_backup,p->al.pa.prv_alloc_recycle);
-		if (p->nb_output_variables != 0) {
-			install_output_variable_backup(p->output_variables,output_variable_backup);
-			free_output_variable_backup(output_variable_backup,p->al.pa.prv_alloc_backup_growing_recycle);
-		}
-	}
-	if (ctx == NULL) {
-		p->dic_variables = dic_variable_backup;
-	} else {
-		if (dic_variable_backup != NULL) {
-			clear_dic_variable_list(&dic_variable_backup);
-		}
-	}
-	free_cb(content_buffer, p->al.prv_alloc_recycle_morphlogical_content_buffer);
-	p->explore_depth -- ;
+            p->stack->stack_pointer = stack_top;
+            if (p->graph_depth == 0) {
+                /* If we are at the top graph level, we restore the variables */
+                if (p->output_policy != IGNORE_OUTPUTS) {
+                    install_variable_backup(p->input_variables, var_backup);
+                }
+            }
+            if ((ctx == NULL || L->next != NULL) && (p->dic_variables != NULL)) {
+                /* If we are inside a context, we don't want to free all the dic_variables that
+                 * have been set, in order to allow extracting morphological information from contexts.
+                 * To do that, we arbitrarily keep the dic_variables of the last path match. */
+                clear_dic_variable_list(&(p->dic_variables));
+            }
+            L = L->next;
+        } while (L != NULL);
+        free_parsing_info(L_first,&p->al.pa); /* free all morphological matches */
+    }
+    /* Finally, we have to restore the stack and other backup stuff */
+    p->weight=old_weight;
+    p->stack->stack_pointer = stack_top;
+    p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
+    if (p->output_policy != IGNORE_OUTPUTS) { /* For better performance (see above) */
+        install_variable_backup(p->input_variables, var_backup);
+        free_variable_backup(var_backup,p->al.pa.prv_alloc_recycle);
+        if (p->nb_output_variables != 0) {
+            install_output_variable_backup(p->output_variables,output_variable_backup);
+            free_output_variable_backup(output_variable_backup,p->al.pa.prv_alloc_backup_growing_recycle);
+        }
+    }
+    if (ctx == NULL) {
+        p->dic_variables = dic_variable_backup;
+    } else {
+        if (dic_variable_backup != NULL) {
+            clear_dic_variable_list(&dic_variable_backup);
+        }
+    }
+    free_cb(content_buffer, p->al.prv_alloc_recycle_morphlogical_content_buffer);
+    p->explore_depth -- ;
 }
 
 /**
@@ -1451,206 +1451,206 @@ struct locate_parameters* p /* miscellaneous parameters needed by the function *
  * given pattern. This version of the function handles the all languages but Arabic.
  */
 static void explore_dic_in_morpho_mode_standard(struct locate_parameters* p,
-		Dictionary* d, int offset,
-		unichar* current_token, unichar* inflected, int pos_in_current_token,
-		int pos_in_inflected, int pos_offset, struct parsing_info* *matches,
-		struct pattern* pattern, int save_dic_entry, unichar* jamo,
-		int pos_in_jamo, Ustring *line_buffer,Ustring* ustr,int base) {
+        Dictionary* d, int offset,
+        unichar* current_token, unichar* inflected, int pos_in_current_token,
+        int pos_in_inflected, int pos_offset, struct parsing_info* *matches,
+        struct pattern* pattern, int save_dic_entry, unichar* jamo,
+        int pos_in_jamo, Ustring *line_buffer,Ustring* ustr,int base) {
 int final,n_transitions,inf_number;
 int z=save_output(ustr);
 offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
 
 
-	if (final) {
-		//error("\narriba!\n\n\n");
-		/* If this node is final, we get the INF line number */
-		inflected[pos_in_inflected] = '\0';
-		if (pattern == NULL && !save_dic_entry) {
-			/* If any word will do with no entry saving */
-			(*matches) = insert_morphological_match(pos_offset,
-					pos_in_current_token, -1, (*matches), NULL, jamo,
-					pos_in_jamo,&p->al.pa);
-		} else {
-			/* If we have to check the pattern */
+    if (final) {
+        //error("\narriba!\n\n\n");
+        /* If this node is final, we get the INF line number */
+        inflected[pos_in_inflected] = '\0';
+        if (pattern == NULL && !save_dic_entry) {
+            /* If any word will do with no entry saving */
+            (*matches) = insert_morphological_match(pos_offset,
+                    pos_in_current_token, -1, (*matches), NULL, jamo,
+                    pos_in_jamo,&p->al.pa);
+        } else {
+            /* If we have to check the pattern */
 
 
-			Abstract_allocator explore_dic_in_morpho_mode_standard_abstract_allocator=NULL;
-			explore_dic_in_morpho_mode_standard_abstract_allocator=create_abstract_allocator("explore_dic_in_morpho_mode_standard",
+            Abstract_allocator explore_dic_in_morpho_mode_standard_abstract_allocator=NULL;
+            explore_dic_in_morpho_mode_standard_abstract_allocator=create_abstract_allocator("explore_dic_in_morpho_mode_standard",
                                                                   AllocatorFreeOnlyAtAllocatorDelete|AllocatorTipGrowingOftenRecycledObject,
                                                                   0);
 
 
-			struct list_ustring* tmp = d->inf->codes[inf_number];
-			while (tmp != NULL) {
-				/* For each compressed code of the INF line, we save the corresponding
-				 * DELAF line in 'info->dlc' */
-				uncompress_entry(inflected, tmp->string, line_buffer);
-				//error("\non decompresse la ligne _%S_\n",line_buffer->str);
-				struct dela_entry* dela_entry = tokenize_DELAF_line_opt(line_buffer->str, explore_dic_in_morpho_mode_standard_abstract_allocator);
-				if (dela_entry != NULL
-						&& (pattern == NULL
-								|| is_entry_compatible_with_pattern(dela_entry,
-										pattern))) {
-					//error("et ca matche!!\n");
-					(*matches) = insert_morphological_match(pos_offset,
-							pos_in_current_token, -1, (*matches),
-							save_dic_entry ? dela_entry : NULL, jamo,
-							pos_in_jamo,&p->al.pa);
-				}
-				free_dela_entry(dela_entry, explore_dic_in_morpho_mode_standard_abstract_allocator);
-				tmp = tmp->next;
-			}
-			close_abstract_allocator(explore_dic_in_morpho_mode_standard_abstract_allocator);
-		}
-		base=ustr->len;
-	}
+            struct list_ustring* tmp = d->inf->codes[inf_number];
+            while (tmp != NULL) {
+                /* For each compressed code of the INF line, we save the corresponding
+                 * DELAF line in 'info->dlc' */
+                uncompress_entry(inflected, tmp->string, line_buffer);
+                //error("\non decompresse la ligne _%S_\n",line_buffer->str);
+                struct dela_entry* dela_entry = tokenize_DELAF_line_opt(line_buffer->str, explore_dic_in_morpho_mode_standard_abstract_allocator);
+                if (dela_entry != NULL
+                        && (pattern == NULL
+                                || is_entry_compatible_with_pattern(dela_entry,
+                                        pattern))) {
+                    //error("et ca matche!!\n");
+                    (*matches) = insert_morphological_match(pos_offset,
+                            pos_in_current_token, -1, (*matches),
+                            save_dic_entry ? dela_entry : NULL, jamo,
+                            pos_in_jamo,&p->al.pa);
+                }
+                free_dela_entry(dela_entry, explore_dic_in_morpho_mode_standard_abstract_allocator);
+                tmp = tmp->next;
+            }
+            close_abstract_allocator(explore_dic_in_morpho_mode_standard_abstract_allocator);
+        }
+        base=ustr->len;
+    }
 
-	if (current_token[pos_in_current_token] == '\0') {
-		if (jamo == NULL) {
-			/* If we have reached the end of the current token in a non Korean language */
-			pos_offset++;
-			int token_number = (((int)(pos_offset + p->current_origin + 1)) <= (int)(p->buffer_size)) ?
-				p->buffer[pos_offset + p->current_origin] : -1;
+    if (current_token[pos_in_current_token] == '\0') {
+        if (jamo == NULL) {
+            /* If we have reached the end of the current token in a non Korean language */
+            pos_offset++;
+            int token_number = (((int)(pos_offset + p->current_origin + 1)) <= (int)(p->buffer_size)) ?
+                p->buffer[pos_offset + p->current_origin] : -1;
 
-			if (token_number == -1 || token_number == p->STOP) {
-				/* Remember 1) that we must not be out of the array's bounds and
-				 *          2) that the token {STOP} must never be matched */
-				return;
-			}
+            if (token_number == -1 || token_number == p->STOP) {
+                /* Remember 1) that we must not be out of the array's bounds and
+                 *          2) that the token {STOP} must never be matched */
+                return;
+            }
 
-			current_token = p->tokens->value[token_number];
-			pos_in_current_token = 0;
-		} else {
-			/* We are in Korean mode */
-			if (jamo[pos_in_jamo] == '\0') {
-				/* In korean, we perform a token change only if we have used all the token's jamos */
-				pos_offset++;
-				int token_number = p->buffer[pos_offset + p->current_origin];
-				if (token_number == -1 || token_number == p->STOP) {
-					/* Remember 1) that we must not be out of the array's bounds and
-					 *          2) that the token {STOP} must never be matched */
-					return;
-				}
-				current_token = p->tokens->value[token_number];
-				pos_in_current_token = 0;
-				pos_in_jamo = 0;
-				jamo = p->jamo_tags[token_number];
-			}
-		}
-	}
-	//int after_syllab_bound = 0;
-	if (jamo != NULL) {
-		/* We test whether we are in the middle of a syllable or just after a syllable bound */
-		if (jamo[pos_in_jamo] == KR_SYLLABLE_BOUND) {
-			/* If we have a syllable bound */
-			//after_syllab_bound = 1;
-			pos_in_current_token++;
-			//pos_in_jamo++;
-		} else if (pos_in_jamo > 0 && jamo[pos_in_jamo - 1]
-				== KR_SYLLABLE_BOUND) {
-			/* If we are just after a syllable bound */
-			//after_syllab_bound = 1;
-		} else {
-			/* By default, we must be in the middle of a syllable, and there's nothing to do */
-		}
-	}
+            current_token = p->tokens->value[token_number];
+            pos_in_current_token = 0;
+        } else {
+            /* We are in Korean mode */
+            if (jamo[pos_in_jamo] == '\0') {
+                /* In korean, we perform a token change only if we have used all the token's jamos */
+                pos_offset++;
+                int token_number = p->buffer[pos_offset + p->current_origin];
+                if (token_number == -1 || token_number == p->STOP) {
+                    /* Remember 1) that we must not be out of the array's bounds and
+                     *          2) that the token {STOP} must never be matched */
+                    return;
+                }
+                current_token = p->tokens->value[token_number];
+                pos_in_current_token = 0;
+                pos_in_jamo = 0;
+                jamo = p->jamo_tags[token_number];
+            }
+        }
+    }
+    //int after_syllab_bound = 0;
+    if (jamo != NULL) {
+        /* We test whether we are in the middle of a syllable or just after a syllable bound */
+        if (jamo[pos_in_jamo] == KR_SYLLABLE_BOUND) {
+            /* If we have a syllable bound */
+            //after_syllab_bound = 1;
+            pos_in_current_token++;
+            //pos_in_jamo++;
+        } else if (pos_in_jamo > 0 && jamo[pos_in_jamo - 1]
+                == KR_SYLLABLE_BOUND) {
+            /* If we are just after a syllable bound */
+            //after_syllab_bound = 1;
+        } else {
+            /* By default, we must be in the middle of a syllable, and there's nothing to do */
+        }
+    }
 
-	/* We look for outgoing transitions */
-	unichar c;
-	int adr;
-	for (int i = 0; i < n_transitions; i++) {
-		update_last_position(p, pos_offset);
-		offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
-		if (jamo == NULL) {
-			/* Non Korean mode */
-			if (is_equal_or_uppercase(c, current_token[pos_in_current_token],
-					p->alphabet)) {
-				/* We explore the rest of the dictionary only if the
-				 * dictionary char is compatible with the token char. In that case,
-				 * we copy in 'inflected' the exact character that is in the dictionary. */
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_standard(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, jamo, pos_in_jamo, line_buffer, ustr, base);
-			}
-		} else {
-			//error("la: jamo du text<%S>=%C (%04X)   char du dico=%C (%04X)\n",jamo,jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
-			/* Korean mode: we may match just the current jamo, or also the current hangul, but only if we are
-			 * after a syllable bound */
-			unichar c2[2];
-			c2[0] = c;
-			c2[1] = '\0';
-			int syllable_bounds=0;
-			/* We try to match all the jamo sequence found in the dictionary */
-			if (jamo[pos_in_jamo]==KR_SYLLABLE_BOUND) {
-				//error("jamo=<%S> %C bound dic=%C (%X)     pos_inflected=%d\n",jamo,jamo[pos_in_jamo],c,c,pos_in_inflected);
-				if (c!=KR_SYLLABLE_BOUND) {
-					/* no match */
-					restore_output(z,ustr);
-					continue;
-				}
-				syllable_bounds=1;
-			} else {
-				//error("jamo=%C (%X) dic=%C (%X)\n",jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
-			}
-			int new_pos_in_current_token = pos_in_current_token;
-			int new_pos_in_jamo = pos_in_jamo;
-			int result=0;
-			if (!syllable_bounds) {
-				result = get_jamo_longest_prefix(jamo, &new_pos_in_jamo,
-					&new_pos_in_current_token, c2, p, current_token);
-			}
-			if (result != 0 || syllable_bounds) {
-				if (syllable_bounds) {
-					new_pos_in_jamo++;
-				}
-				//error("match next pos_in_jamo=%d (%C)\n",new_pos_in_jamo,jamo[new_pos_in_jamo]);
-				//error("MATCH entre jamo du text=%C (%04X)   char du dico=%C (%04X)\n",jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
-				/* Nothing to do if the match failed */
-				int new_pos_offset = pos_offset;
-				unichar* new_jamo = jamo;
-				unichar* new_current_token = current_token;
-				if (result == 1 || (syllable_bounds && jamo[new_pos_in_jamo]=='\0')) {
-					/* The text token has been fully matched, so we go on the next one */
-					new_pos_in_current_token = 0;
-					new_pos_offset = pos_offset + 1;
-					int token_number = p->buffer[new_pos_offset
-							+ p->current_origin];
-					if (token_number == -1 || token_number == p->STOP) {
-						/* Remember 1) that we must not be out of the array's bounds and
-						 *          2) that the token {STOP} must never be matched */
-						restore_output(z,ustr);
-						return;
-					}
-					new_current_token = p->tokens->value[token_number];
-					new_jamo = p->jamo_tags[token_number];
-					new_pos_in_jamo = 0;
-				}
-				/* If we have a jamo letter match */
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_standard(p, d, adr,
-						new_current_token, inflected, new_pos_in_current_token,
-						pos_in_inflected + 1, new_pos_offset, matches, pattern,
-						save_dic_entry, new_jamo, new_pos_in_jamo, line_buffer, ustr, base);
-			} else {
-				//error("non match\n");
-			}
-			/* Then we try to match a hangul, but only if we are just after a syllable bound */
-			//error("after syllable=%d:  text=%C (%04X)   dico=%C (%04X)\n",after_syllab_bound,current_token[pos_in_current_token],current_token[pos_in_current_token],c,c);
-		}
-		restore_output(z,ustr);
-	}
+    /* We look for outgoing transitions */
+    unichar c;
+    int adr;
+    for (int i = 0; i < n_transitions; i++) {
+        update_last_position(p, pos_offset);
+        offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
+        if (jamo == NULL) {
+            /* Non Korean mode */
+            if (is_equal_or_uppercase(c, current_token[pos_in_current_token],
+                    p->alphabet)) {
+                /* We explore the rest of the dictionary only if the
+                 * dictionary char is compatible with the token char. In that case,
+                 * we copy in 'inflected' the exact character that is in the dictionary. */
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_standard(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, jamo, pos_in_jamo, line_buffer, ustr, base);
+            }
+        } else {
+            //error("la: jamo du text<%S>=%C (%04X)   char du dico=%C (%04X)\n",jamo,jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
+            /* Korean mode: we may match just the current jamo, or also the current hangul, but only if we are
+             * after a syllable bound */
+            unichar c2[2];
+            c2[0] = c;
+            c2[1] = '\0';
+            int syllable_bounds=0;
+            /* We try to match all the jamo sequence found in the dictionary */
+            if (jamo[pos_in_jamo]==KR_SYLLABLE_BOUND) {
+                //error("jamo=<%S> %C bound dic=%C (%X)     pos_inflected=%d\n",jamo,jamo[pos_in_jamo],c,c,pos_in_inflected);
+                if (c!=KR_SYLLABLE_BOUND) {
+                    /* no match */
+                    restore_output(z,ustr);
+                    continue;
+                }
+                syllable_bounds=1;
+            } else {
+                //error("jamo=%C (%X) dic=%C (%X)\n",jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
+            }
+            int new_pos_in_current_token = pos_in_current_token;
+            int new_pos_in_jamo = pos_in_jamo;
+            int result=0;
+            if (!syllable_bounds) {
+                result = get_jamo_longest_prefix(jamo, &new_pos_in_jamo,
+                    &new_pos_in_current_token, c2, p, current_token);
+            }
+            if (result != 0 || syllable_bounds) {
+                if (syllable_bounds) {
+                    new_pos_in_jamo++;
+                }
+                //error("match next pos_in_jamo=%d (%C)\n",new_pos_in_jamo,jamo[new_pos_in_jamo]);
+                //error("MATCH entre jamo du text=%C (%04X)   char du dico=%C (%04X)\n",jamo[pos_in_jamo],jamo[pos_in_jamo],c,c);
+                /* Nothing to do if the match failed */
+                int new_pos_offset = pos_offset;
+                unichar* new_jamo = jamo;
+                unichar* new_current_token = current_token;
+                if (result == 1 || (syllable_bounds && jamo[new_pos_in_jamo]=='\0')) {
+                    /* The text token has been fully matched, so we go on the next one */
+                    new_pos_in_current_token = 0;
+                    new_pos_offset = pos_offset + 1;
+                    int token_number = p->buffer[new_pos_offset
+                            + p->current_origin];
+                    if (token_number == -1 || token_number == p->STOP) {
+                        /* Remember 1) that we must not be out of the array's bounds and
+                         *          2) that the token {STOP} must never be matched */
+                        restore_output(z,ustr);
+                        return;
+                    }
+                    new_current_token = p->tokens->value[token_number];
+                    new_jamo = p->jamo_tags[token_number];
+                    new_pos_in_jamo = 0;
+                }
+                /* If we have a jamo letter match */
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_standard(p, d, adr,
+                        new_current_token, inflected, new_pos_in_current_token,
+                        pos_in_inflected + 1, new_pos_offset, matches, pattern,
+                        save_dic_entry, new_jamo, new_pos_in_jamo, line_buffer, ustr, base);
+            } else {
+                //error("non match\n");
+            }
+            /* Then we try to match a hangul, but only if we are just after a syllable bound */
+            //error("after syllable=%d:  text=%C (%04X)   dico=%C (%04X)\n",after_syllab_bound,current_token[pos_in_current_token],current_token[pos_in_current_token],c,c);
+        }
+        restore_output(z,ustr);
+    }
 }
 
 static int shadda_may_be_omitted(ArabicTypoRules r) {
-	return r.shadda_damma_omission || r.shadda_damma_omission_at_end
-			|| r.shadda_dammatan_omission_at_end || r.shadda_fatha_omission
-			|| r.shadda_fatha_omission_at_end
-			|| r.shadda_fathatan_omission_at_end || r.shadda_kasra_omission
-			|| r.shadda_kasra_omission_at_end
-			|| r.shadda_kasratan_omission_at_end
-			|| r.shadda_superscript_alef_omission;
+    return r.shadda_damma_omission || r.shadda_damma_omission_at_end
+            || r.shadda_dammatan_omission_at_end || r.shadda_fatha_omission
+            || r.shadda_fatha_omission_at_end
+            || r.shadda_fathatan_omission_at_end || r.shadda_kasra_omission
+            || r.shadda_kasra_omission_at_end
+            || r.shadda_kasratan_omission_at_end
+            || r.shadda_superscript_alef_omission;
 }
 
 /**
@@ -1665,463 +1665,463 @@ static int shadda_may_be_omitted(ArabicTypoRules r) {
 #define YF_EXPECTED 16
 
 static void explore_dic_in_morpho_mode_arabic(struct locate_parameters* p,
-		Dictionary* d, int offset,
-		unichar* current_token, unichar* inflected, int pos_in_current_token,
-		int pos_in_inflected, int pos_offset, struct parsing_info* *matches,
-		struct pattern* pattern, int save_dic_entry, Ustring* line_buffer,
-		int expected, unichar last_dic_char, Ustring* ustr, int base) {
+        Dictionary* d, int offset,
+        unichar* current_token, unichar* inflected, int pos_in_current_token,
+        int pos_in_inflected, int pos_offset, struct parsing_info* *matches,
+        struct pattern* pattern, int save_dic_entry, Ustring* line_buffer,
+        int expected, unichar last_dic_char, Ustring* ustr, int base) {
 int old_offset=offset;
 int final,n_transitions,inf_number;
 int z=save_output(ustr);
 offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
-	if (final) {
-		if (expected & NO_END_OF_WORD_EXPECTED) {
-			/* If we were not supposed to find the end of the word */
-			return;
-		}
-		if (expected & AL_EXPECTED) {
-			/* If we were only supposed to match a Al */
-			if (pos_in_inflected!=2 || inflected[pos_in_inflected-1]!=AR_LAM) return;
-		}
-		/* If this node is final, we get the INF line number */
-		inflected[pos_in_inflected] = '\0';
-		if (pattern == NULL && !save_dic_entry) {
-			/* If any word will do with no entry saving */
-			(*matches) = insert_morphological_match(pos_offset,
-					pos_in_current_token, -1, (*matches), NULL, NULL, 0,&p->al.pa);
-		} else {
-			/* If we have to check the pattern */
+    if (final) {
+        if (expected & NO_END_OF_WORD_EXPECTED) {
+            /* If we were not supposed to find the end of the word */
+            return;
+        }
+        if (expected & AL_EXPECTED) {
+            /* If we were only supposed to match a Al */
+            if (pos_in_inflected!=2 || inflected[pos_in_inflected-1]!=AR_LAM) return;
+        }
+        /* If this node is final, we get the INF line number */
+        inflected[pos_in_inflected] = '\0';
+        if (pattern == NULL && !save_dic_entry) {
+            /* If any word will do with no entry saving */
+            (*matches) = insert_morphological_match(pos_offset,
+                    pos_in_current_token, -1, (*matches), NULL, NULL, 0,&p->al.pa);
+        } else {
+            /* If we have to check the pattern */
 
-			Abstract_allocator explore_dic_in_morpho_mode_arabic_abstract_allocator=NULL;
-			explore_dic_in_morpho_mode_arabic_abstract_allocator=create_abstract_allocator("explore_dic_in_morpho_mode_arabic",
+            Abstract_allocator explore_dic_in_morpho_mode_arabic_abstract_allocator=NULL;
+            explore_dic_in_morpho_mode_arabic_abstract_allocator=create_abstract_allocator("explore_dic_in_morpho_mode_arabic",
                                                                   AllocatorFreeOnlyAtAllocatorDelete|AllocatorTipGrowingOftenRecycledObject,
                                                                   0);
 
-			struct list_ustring* tmp = d->inf->codes[inf_number];
-			while (tmp != NULL) {
-				/* For each compressed code of the INF line, we save the corresponding
-				 * DELAF line in 'info->dlc' */
-				uncompress_entry(inflected, tmp->string, line_buffer);
-				//error("on a decompresse la ligne %S\n",line);
+            struct list_ustring* tmp = d->inf->codes[inf_number];
+            while (tmp != NULL) {
+                /* For each compressed code of the INF line, we save the corresponding
+                 * DELAF line in 'info->dlc' */
+                uncompress_entry(inflected, tmp->string, line_buffer);
+                //error("on a decompresse la ligne %S\n",line);
 
-				struct dela_entry* dela_entry = tokenize_DELAF_line_opt(line_buffer->str, explore_dic_in_morpho_mode_arabic_abstract_allocator);
-				if (dela_entry != NULL
-						&& (pattern == NULL
-								|| is_entry_compatible_with_pattern(dela_entry,
-										pattern))) {
-					//error("et ca matche!\n");
-					(*matches) = insert_morphological_match(pos_offset,
-							pos_in_current_token, -1, (*matches),
-							save_dic_entry ? dela_entry : NULL, NULL, 0,&p->al.pa);
-				}
-				free_dela_entry(dela_entry, explore_dic_in_morpho_mode_arabic_abstract_allocator);
-				tmp = tmp->next;
-			}
-			close_abstract_allocator(explore_dic_in_morpho_mode_arabic_abstract_allocator);
-		}
-		base=ustr->len;
-	}
-	if (expected & END_OF_WORD_EXPECTED) {
-		/* If we were supposed to reach the end of the word, then we don't have to
-		 * explore more transitions */
-		return;
-	}
-	if (current_token[pos_in_current_token] == '\0') {
-		/* If we have reached the end of the current token */
-		pos_offset++;
-		int token_number = p->buffer[pos_offset + p->current_origin];
-		if (token_number == -1 || token_number == p->STOP) {
-			/* Remember 1) that we must not be out of the array's bounds and
-			 *          2) that the token {STOP} must never be matched */
-			return;
-		}
-		current_token = p->tokens->value[token_number];
-		pos_in_current_token = 0;
-	}
+                struct dela_entry* dela_entry = tokenize_DELAF_line_opt(line_buffer->str, explore_dic_in_morpho_mode_arabic_abstract_allocator);
+                if (dela_entry != NULL
+                        && (pattern == NULL
+                                || is_entry_compatible_with_pattern(dela_entry,
+                                        pattern))) {
+                    //error("et ca matche!\n");
+                    (*matches) = insert_morphological_match(pos_offset,
+                            pos_in_current_token, -1, (*matches),
+                            save_dic_entry ? dela_entry : NULL, NULL, 0,&p->al.pa);
+                }
+                free_dela_entry(dela_entry, explore_dic_in_morpho_mode_arabic_abstract_allocator);
+                tmp = tmp->next;
+            }
+            close_abstract_allocator(explore_dic_in_morpho_mode_arabic_abstract_allocator);
+        }
+        base=ustr->len;
+    }
+    if (expected & END_OF_WORD_EXPECTED) {
+        /* If we were supposed to reach the end of the word, then we don't have to
+         * explore more transitions */
+        return;
+    }
+    if (current_token[pos_in_current_token] == '\0') {
+        /* If we have reached the end of the current token */
+        pos_offset++;
+        int token_number = p->buffer[pos_offset + p->current_origin];
+        if (token_number == -1 || token_number == p->STOP) {
+            /* Remember 1) that we must not be out of the array's bounds and
+             *          2) that the token {STOP} must never be matched */
+            return;
+        }
+        current_token = p->tokens->value[token_number];
+        pos_in_current_token = 0;
+    }
 
-	unichar c;
-	int adr;
-	for (int i = 0; i < n_transitions; i++) {
-		update_last_position(p, pos_offset);
-		offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
-		/* Standard case: matching the char in the dictionary */
-		if (c==current_token[pos_in_current_token]) {
-			/* We explore the rest of the dictionary only if the
-			 * dictionary char is compatible with the token char. In that case,
-			 * we copy in 'inflected' the exact character that is in the dictionary. */
-			int can_go_on=0;
-			int next = NOTHING_EXPECTED;
-			if (last_dic_char == AR_SHADDA
-					&& (pos_in_current_token==0	|| current_token[pos_in_current_token-1]!=AR_SHADDA)) {
-				/* Additional test: if we have matched X, we must check whether there was a shadda X
-				 * rule pending with a omitted shadda. In that case, we must check whether we are
-				 * allowed to go on or not. Moreover, we must determine the end of word is
-				 * expected now or not */
-				switch (c) {
-				case AR_FATHATAN: {
-					if (p->arabic.shadda_fathatan_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					break;
-				}
-				case AR_DAMMATAN: {
-					if (p->arabic.shadda_dammatan_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					break;
-				}
-				case AR_KASRATAN: {
-					if (p->arabic.shadda_kasratan_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					break;
-				}
-				case AR_FATHA: {
-					if (p->arabic.shadda_fatha_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
+    unichar c;
+    int adr;
+    for (int i = 0; i < n_transitions; i++) {
+        update_last_position(p, pos_offset);
+        offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
+        /* Standard case: matching the char in the dictionary */
+        if (c==current_token[pos_in_current_token]) {
+            /* We explore the rest of the dictionary only if the
+             * dictionary char is compatible with the token char. In that case,
+             * we copy in 'inflected' the exact character that is in the dictionary. */
+            int can_go_on=0;
+            int next = NOTHING_EXPECTED;
+            if (last_dic_char == AR_SHADDA
+                    && (pos_in_current_token==0 || current_token[pos_in_current_token-1]!=AR_SHADDA)) {
+                /* Additional test: if we have matched X, we must check whether there was a shadda X
+                 * rule pending with a omitted shadda. In that case, we must check whether we are
+                 * allowed to go on or not. Moreover, we must determine the end of word is
+                 * expected now or not */
+                switch (c) {
+                case AR_FATHATAN: {
+                    if (p->arabic.shadda_fathatan_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    break;
+                }
+                case AR_DAMMATAN: {
+                    if (p->arabic.shadda_dammatan_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    break;
+                }
+                case AR_KASRATAN: {
+                    if (p->arabic.shadda_kasratan_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    break;
+                }
+                case AR_FATHA: {
+                    if (p->arabic.shadda_fatha_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
 #if 0
-					if (p->arabic.shadda_fatha_omission) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					if (p->arabic.shadda_fatha_omission_at_end) can_go_on=1;
+                    if (p->arabic.shadda_fatha_omission) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    if (p->arabic.shadda_fatha_omission_at_end) can_go_on=1;
 #endif
-					break;
-				}
-				case AR_DAMMA: {
-					if (p->arabic.shadda_damma_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
+                    break;
+                }
+                case AR_DAMMA: {
+                    if (p->arabic.shadda_damma_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
 #if 0
-					if (p->arabic.shadda_damma_omission) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					if (p->arabic.shadda_damma_omission_at_end) can_go_on=1;
+                    if (p->arabic.shadda_damma_omission) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    if (p->arabic.shadda_damma_omission_at_end) can_go_on=1;
 #endif
-					break;
-				}
-				case AR_KASRA: {
-					if (p->arabic.shadda_kasra_omission_at_end) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
+                    break;
+                }
+                case AR_KASRA: {
+                    if (p->arabic.shadda_kasra_omission_at_end) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
 #if 0
-					if (p->arabic.shadda_kasra_omission) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					if (p->arabic.shadda_kasra_omission_at_end) can_go_on=1;
+                    if (p->arabic.shadda_kasra_omission) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    if (p->arabic.shadda_kasra_omission_at_end) can_go_on=1;
 #endif
-					break;
-				}
-				case AR_SUPERSCRIPT_ALEF: {
-					if (p->arabic.shadda_superscript_alef_omission) {
-						can_go_on=1;
-						next=next | END_OF_WORD_EXPECTED;
-					}
-					break;
-				}
-				default: break;
-					//fatal_error("Invalid switch value %C in explore_dic_in_morpho_mode_arabic!\n",c);
-				}
-			} else {
-				can_go_on=1;
-			}
+                    break;
+                }
+                case AR_SUPERSCRIPT_ALEF: {
+                    if (p->arabic.shadda_superscript_alef_omission) {
+                        can_go_on=1;
+                        next=next | END_OF_WORD_EXPECTED;
+                    }
+                    break;
+                }
+                default: break;
+                    //fatal_error("Invalid switch value %C in explore_dic_in_morpho_mode_arabic!\n",c);
+                }
+            } else {
+                can_go_on=1;
+            }
 
-			/*error("on compare %C et %C pour le token %S\n",to_buckwalter_plusplus(c),to_buckwalter_plusplus(current_token[pos_in_current_token]),current_token);
-			error("pos+1=%d => %X\n",pos_in_current_token+1,current_token[pos_in_current_token+1]);
-			for (int i=0;current_token[i];i++) {
-				error("%C",to_buckwalter_plusplus(current_token[i]));
-			}
-			error("\n");*/
-			if (can_go_on) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, next, c, ustr, base);
-			}
-		} else {
-			/* If the dictionary char and the text char have not matched:
-			 *
-			 * it may be because of Al written Ll */
-			if (c==AR_ALEF && current_token[pos_in_current_token]==AR_ALEF_WASLA
-					&& pos_in_inflected==0 && p->arabic.al_with_wasla) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, AL_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of an initial O written A */
-			else if (c==AR_ALEF_WITH_HAMZA_ABOVE && current_token[pos_in_current_token]==AR_ALEF
-					&& pos_in_inflected==0 && p->arabic.alef_hamza_above_O_to_A) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of an initial I written A */
-			else if (c==AR_ALEF_WITH_HAMZA_BELOW && current_token[pos_in_current_token]==AR_ALEF
-					&& pos_in_inflected==0 && p->arabic.alef_hamza_below_I_to_A) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of an initial I written L */
-			else if (c==AR_ALEF_WITH_HAMZA_BELOW && current_token[pos_in_current_token]==AR_ALEF_WASLA
-					&& pos_in_inflected==0 && p->arabic.alef_hamza_below_I_to_L) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of the FA -> AF rule, matching the first char */
-			else if (c==AR_FATHATAN && current_token[pos_in_current_token]==AR_ALEF
-					&& p->arabic.fathatan_alef_equiv_alef_fathatan) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, AF_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of the FA -> AF rule, matching the second char */
-			else if (c==AR_ALEF && current_token[pos_in_current_token]==AR_FATHATAN
-					&& expected==AF_EXPECTED
-					&& p->arabic.fathatan_alef_equiv_alef_fathatan) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, END_OF_WORD_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of the FY -> YF rule, matching the first char */
-			else if (c==AR_FATHATAN && current_token[pos_in_current_token]==AR_ALEF_MAQSURA
-					&& p->arabic.fathatan_alef_maqsura_equiv_alef_maqsura_fathatan) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, YF_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of the FY -> YF rule, matching the second char */
-			else if (c==AR_ALEF_MAQSURA && current_token[pos_in_current_token]==AR_FATHATAN
-					&& expected==YF_EXPECTED
-					&& p->arabic.fathatan_alef_maqsura_equiv_alef_maqsura_fathatan) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected + 1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer, END_OF_WORD_EXPECTED, c, ustr, base);
-			}
-			/* or it may be because of the solar assimilation rule */
-			else if (p->arabic.solar_assimilation
-					&& current_token[pos_in_current_token]==AR_SHADDA && pos_in_inflected==1
-					&& is_solar(inflected[0])
-					&& was_Al_before(current_token,pos_in_current_token-1,p->arabic)) {
-				explore_dic_in_morpho_mode_arabic(p, d, old_offset,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char, ustr, base);
-			}
-			/* Or it may be because of the lunar assimilation rule */
-			else if (p->arabic.lunar_assimilation
-					&& pos_in_inflected==0
-					&& is_lunar(c)
-					&& current_token[pos_in_current_token]==AR_SUKUN
-					&& was_Al_before(current_token,pos_in_current_token,p->arabic)) {
-				explore_dic_in_morpho_mode_arabic(p, d, old_offset,
-						current_token, inflected, pos_in_current_token + 1,
-						pos_in_inflected, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char,ustr, base);
-			}
-			/* Or it may be because of the Yc => e rule at the end of a word, when
-			 * we are on the Y */
-			else if (p->arabic.alef_maqsura_hamza_equiv_hamza_above_yeh
-					&& current_token[pos_in_current_token]==AR_YEH_WITH_HAMZA_ABOVE
-					&& c==AR_ALEF_MAQSURA) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token,
-						pos_in_inflected+1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char,ustr, base);
-			}
-			/* Or it may be because of the Yc => e rule at the end of a word, when
-			 * we are on the c */
-			else if (p->arabic.alef_maqsura_hamza_equiv_hamza_above_yeh
-					&& current_token[pos_in_current_token]==AR_YEH_WITH_HAMZA_ABOVE
-					&& c==AR_HAMZA
-					&& last_dic_char==AR_ALEF_MAQSURA) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr,
-						current_token, inflected, pos_in_current_token,
-						pos_in_inflected+1, pos_offset, matches, pattern,
-						save_dic_entry, line_buffer,END_OF_WORD_EXPECTED,last_dic_char,ustr, base);
-			}
-		}
-		/* Rule that always applies about tatweel */
-		if (c != AR_TATWEEL && current_token[pos_in_current_token]
-				== AR_TATWEEL) {
-			explore_dic_in_morpho_mode_arabic(p, d, old_offset, current_token,
-					inflected, pos_in_current_token + 1, pos_in_inflected,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.fatha_omission && c == AR_FATHA
-				&& current_token[pos_in_current_token] != AR_FATHA
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.damma_omission && c == AR_DAMMA
-				&& current_token[pos_in_current_token] != AR_DAMMA
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.kasra_omission && c == AR_KASRA
-				&& current_token[pos_in_current_token] != AR_KASRA
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.sukun_omission && c == AR_SUKUN
-				&& current_token[pos_in_current_token] != AR_SUKUN) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.superscript_alef_omission && c == AR_SUPERSCRIPT_ALEF
-				&& current_token[pos_in_current_token] != AR_SUPERSCRIPT_ALEF
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.fathatan_omission_at_end && c == AR_FATHATAN
-				&& current_token[pos_in_current_token] != AR_FATHATAN
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					END_OF_WORD_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.dammatan_omission_at_end && c == AR_DAMMATAN
-				&& current_token[pos_in_current_token] != AR_DAMMATAN
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					END_OF_WORD_EXPECTED, c, ustr, base);
-		}
-		if (p->arabic.kasratan_omission_at_end && c == AR_KASRATAN
-				&& current_token[pos_in_current_token] != AR_KASRATAN
-				&& last_dic_char != AR_SHADDA) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					END_OF_WORD_EXPECTED, c, ustr, base);
-		}
-		/* If the dictionary contains a shadda that we may be allowed to skip */
-		if (c == AR_SHADDA && current_token[pos_in_current_token] != AR_SHADDA
-				&& shadda_may_be_omitted(p->arabic)) {
-			inflected[pos_in_inflected] = c;
-			explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-					inflected, pos_in_current_token, pos_in_inflected + 1,
-					pos_offset, matches, pattern, save_dic_entry, line_buffer,
-					NOTHING_EXPECTED, c, ustr, base);
-		}
-		/* If the dictionary contains a shadda X, and the text contains either only shadda or nothing.
-		 * The test (c!=current_token[pos_in_current_token]) is used to avoid
-		 * duplicate calculus with the normal case */
-		if (last_dic_char==AR_SHADDA
-				/* The rules are the same regardless if the previous token char was a shadda or not,
-				 * so the following test must not be performed. We keep it in comment to
-				 * remind that it is pure luck that we can factorize two cases by skipping it
-				 *
-				 * && (pos_in_current_token>0 && current_token[pos_in_current_token-1]==AR_SHADDA)*/
-				&& c!=current_token[pos_in_current_token]) {
-			int can_go_on=0;
-			int next=NOTHING_EXPECTED;
-			switch(c) {
-			case AR_FATHA: {
-				if (p->arabic.shadda_fatha_omission || p->arabic.shadda_fatha_omission_at_end) can_go_on=1;
-				break;
-			}
-			case AR_FATHATAN: {
-				if (p->arabic.shadda_fathatan_omission_at_end) {
-					can_go_on=1;
-					/* I know a simple affectation could work, but I prefer doing it
-					 * the general case to prevent bugs if one day, several flags can co-occur */
-					next=next | END_OF_WORD_EXPECTED;
-				}
-				break;
-			}
-			case AR_DAMMA: {
-				if (p->arabic.shadda_damma_omission || p->arabic.shadda_damma_omission_at_end) can_go_on=1;
-				break;
-			}
-			case AR_DAMMATAN: {
-				if (p->arabic.shadda_dammatan_omission_at_end) {
-					can_go_on=1;
-					next=next | END_OF_WORD_EXPECTED;
-				}
-				break;
-			}
-			case AR_KASRA: {
-				if (p->arabic.shadda_kasra_omission || p->arabic.shadda_kasra_omission_at_end) can_go_on=1;
-				break;
-			}
-			case AR_KASRATAN: {
-				if (p->arabic.shadda_kasratan_omission_at_end) {
-					can_go_on=1;
-					next=next | END_OF_WORD_EXPECTED;
-				}
-				break;
-			}
-			case AR_SUPERSCRIPT_ALEF: {
-				if (p->arabic.shadda_superscript_alef_omission) can_go_on=1;
-				break;
-			}
-			default: break; /*fatal_error("Invalid switch value #2 %C in explore_dic_in_morpho_mode_arabic!\n",c);*/
-			}
-			if (can_go_on) {
-				inflected[pos_in_inflected] = c;
-				explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
-						inflected, pos_in_current_token, pos_in_inflected + 1,
-						pos_offset, matches, pattern, save_dic_entry, line_buffer,
-						next, c, ustr, base);
-			}
-		}
-		restore_output(z,ustr);
-	}
+            /*error("on compare %C et %C pour le token %S\n",to_buckwalter_plusplus(c),to_buckwalter_plusplus(current_token[pos_in_current_token]),current_token);
+            error("pos+1=%d => %X\n",pos_in_current_token+1,current_token[pos_in_current_token+1]);
+            for (int i=0;current_token[i];i++) {
+                error("%C",to_buckwalter_plusplus(current_token[i]));
+            }
+            error("\n");*/
+            if (can_go_on) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, next, c, ustr, base);
+            }
+        } else {
+            /* If the dictionary char and the text char have not matched:
+             *
+             * it may be because of Al written Ll */
+            if (c==AR_ALEF && current_token[pos_in_current_token]==AR_ALEF_WASLA
+                    && pos_in_inflected==0 && p->arabic.al_with_wasla) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, AL_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of an initial O written A */
+            else if (c==AR_ALEF_WITH_HAMZA_ABOVE && current_token[pos_in_current_token]==AR_ALEF
+                    && pos_in_inflected==0 && p->arabic.alef_hamza_above_O_to_A) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of an initial I written A */
+            else if (c==AR_ALEF_WITH_HAMZA_BELOW && current_token[pos_in_current_token]==AR_ALEF
+                    && pos_in_inflected==0 && p->arabic.alef_hamza_below_I_to_A) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of an initial I written L */
+            else if (c==AR_ALEF_WITH_HAMZA_BELOW && current_token[pos_in_current_token]==AR_ALEF_WASLA
+                    && pos_in_inflected==0 && p->arabic.alef_hamza_below_I_to_L) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, NOTHING_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of the FA -> AF rule, matching the first char */
+            else if (c==AR_FATHATAN && current_token[pos_in_current_token]==AR_ALEF
+                    && p->arabic.fathatan_alef_equiv_alef_fathatan) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, AF_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of the FA -> AF rule, matching the second char */
+            else if (c==AR_ALEF && current_token[pos_in_current_token]==AR_FATHATAN
+                    && expected==AF_EXPECTED
+                    && p->arabic.fathatan_alef_equiv_alef_fathatan) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, END_OF_WORD_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of the FY -> YF rule, matching the first char */
+            else if (c==AR_FATHATAN && current_token[pos_in_current_token]==AR_ALEF_MAQSURA
+                    && p->arabic.fathatan_alef_maqsura_equiv_alef_maqsura_fathatan) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, YF_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of the FY -> YF rule, matching the second char */
+            else if (c==AR_ALEF_MAQSURA && current_token[pos_in_current_token]==AR_FATHATAN
+                    && expected==YF_EXPECTED
+                    && p->arabic.fathatan_alef_maqsura_equiv_alef_maqsura_fathatan) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected + 1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer, END_OF_WORD_EXPECTED, c, ustr, base);
+            }
+            /* or it may be because of the solar assimilation rule */
+            else if (p->arabic.solar_assimilation
+                    && current_token[pos_in_current_token]==AR_SHADDA && pos_in_inflected==1
+                    && is_solar(inflected[0])
+                    && was_Al_before(current_token,pos_in_current_token-1,p->arabic)) {
+                explore_dic_in_morpho_mode_arabic(p, d, old_offset,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char, ustr, base);
+            }
+            /* Or it may be because of the lunar assimilation rule */
+            else if (p->arabic.lunar_assimilation
+                    && pos_in_inflected==0
+                    && is_lunar(c)
+                    && current_token[pos_in_current_token]==AR_SUKUN
+                    && was_Al_before(current_token,pos_in_current_token,p->arabic)) {
+                explore_dic_in_morpho_mode_arabic(p, d, old_offset,
+                        current_token, inflected, pos_in_current_token + 1,
+                        pos_in_inflected, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char,ustr, base);
+            }
+            /* Or it may be because of the Yc => e rule at the end of a word, when
+             * we are on the Y */
+            else if (p->arabic.alef_maqsura_hamza_equiv_hamza_above_yeh
+                    && current_token[pos_in_current_token]==AR_YEH_WITH_HAMZA_ABOVE
+                    && c==AR_ALEF_MAQSURA) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token,
+                        pos_in_inflected+1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer,NOTHING_EXPECTED,last_dic_char,ustr, base);
+            }
+            /* Or it may be because of the Yc => e rule at the end of a word, when
+             * we are on the c */
+            else if (p->arabic.alef_maqsura_hamza_equiv_hamza_above_yeh
+                    && current_token[pos_in_current_token]==AR_YEH_WITH_HAMZA_ABOVE
+                    && c==AR_HAMZA
+                    && last_dic_char==AR_ALEF_MAQSURA) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr,
+                        current_token, inflected, pos_in_current_token,
+                        pos_in_inflected+1, pos_offset, matches, pattern,
+                        save_dic_entry, line_buffer,END_OF_WORD_EXPECTED,last_dic_char,ustr, base);
+            }
+        }
+        /* Rule that always applies about tatweel */
+        if (c != AR_TATWEEL && current_token[pos_in_current_token]
+                == AR_TATWEEL) {
+            explore_dic_in_morpho_mode_arabic(p, d, old_offset, current_token,
+                    inflected, pos_in_current_token + 1, pos_in_inflected,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.fatha_omission && c == AR_FATHA
+                && current_token[pos_in_current_token] != AR_FATHA
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.damma_omission && c == AR_DAMMA
+                && current_token[pos_in_current_token] != AR_DAMMA
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.kasra_omission && c == AR_KASRA
+                && current_token[pos_in_current_token] != AR_KASRA
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.sukun_omission && c == AR_SUKUN
+                && current_token[pos_in_current_token] != AR_SUKUN) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.superscript_alef_omission && c == AR_SUPERSCRIPT_ALEF
+                && current_token[pos_in_current_token] != AR_SUPERSCRIPT_ALEF
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.fathatan_omission_at_end && c == AR_FATHATAN
+                && current_token[pos_in_current_token] != AR_FATHATAN
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    END_OF_WORD_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.dammatan_omission_at_end && c == AR_DAMMATAN
+                && current_token[pos_in_current_token] != AR_DAMMATAN
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    END_OF_WORD_EXPECTED, c, ustr, base);
+        }
+        if (p->arabic.kasratan_omission_at_end && c == AR_KASRATAN
+                && current_token[pos_in_current_token] != AR_KASRATAN
+                && last_dic_char != AR_SHADDA) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    END_OF_WORD_EXPECTED, c, ustr, base);
+        }
+        /* If the dictionary contains a shadda that we may be allowed to skip */
+        if (c == AR_SHADDA && current_token[pos_in_current_token] != AR_SHADDA
+                && shadda_may_be_omitted(p->arabic)) {
+            inflected[pos_in_inflected] = c;
+            explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                    inflected, pos_in_current_token, pos_in_inflected + 1,
+                    pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                    NOTHING_EXPECTED, c, ustr, base);
+        }
+        /* If the dictionary contains a shadda X, and the text contains either only shadda or nothing.
+         * The test (c!=current_token[pos_in_current_token]) is used to avoid
+         * duplicate calculus with the normal case */
+        if (last_dic_char==AR_SHADDA
+                /* The rules are the same regardless if the previous token char was a shadda or not,
+                 * so the following test must not be performed. We keep it in comment to
+                 * remind that it is pure luck that we can factorize two cases by skipping it
+                 *
+                 * && (pos_in_current_token>0 && current_token[pos_in_current_token-1]==AR_SHADDA)*/
+                && c!=current_token[pos_in_current_token]) {
+            int can_go_on=0;
+            int next=NOTHING_EXPECTED;
+            switch(c) {
+            case AR_FATHA: {
+                if (p->arabic.shadda_fatha_omission || p->arabic.shadda_fatha_omission_at_end) can_go_on=1;
+                break;
+            }
+            case AR_FATHATAN: {
+                if (p->arabic.shadda_fathatan_omission_at_end) {
+                    can_go_on=1;
+                    /* I know a simple affectation could work, but I prefer doing it
+                     * the general case to prevent bugs if one day, several flags can co-occur */
+                    next=next | END_OF_WORD_EXPECTED;
+                }
+                break;
+            }
+            case AR_DAMMA: {
+                if (p->arabic.shadda_damma_omission || p->arabic.shadda_damma_omission_at_end) can_go_on=1;
+                break;
+            }
+            case AR_DAMMATAN: {
+                if (p->arabic.shadda_dammatan_omission_at_end) {
+                    can_go_on=1;
+                    next=next | END_OF_WORD_EXPECTED;
+                }
+                break;
+            }
+            case AR_KASRA: {
+                if (p->arabic.shadda_kasra_omission || p->arabic.shadda_kasra_omission_at_end) can_go_on=1;
+                break;
+            }
+            case AR_KASRATAN: {
+                if (p->arabic.shadda_kasratan_omission_at_end) {
+                    can_go_on=1;
+                    next=next | END_OF_WORD_EXPECTED;
+                }
+                break;
+            }
+            case AR_SUPERSCRIPT_ALEF: {
+                if (p->arabic.shadda_superscript_alef_omission) can_go_on=1;
+                break;
+            }
+            default: break; /*fatal_error("Invalid switch value #2 %C in explore_dic_in_morpho_mode_arabic!\n",c);*/
+            }
+            if (can_go_on) {
+                inflected[pos_in_inflected] = c;
+                explore_dic_in_morpho_mode_arabic(p, d, adr, current_token,
+                        inflected, pos_in_current_token, pos_in_inflected + 1,
+                        pos_offset, matches, pattern, save_dic_entry, line_buffer,
+                        next, c, ustr, base);
+            }
+        }
+        restore_output(z,ustr);
+    }
 }
 
 /**
@@ -2131,39 +2131,39 @@ offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
  * pattern.
  */
 static void explore_dic_in_morpho_mode(struct locate_parameters* p, int pos,
-		int pos_in_token, struct parsing_info* *matches,
-		struct pattern* pattern, int save_dic_entry, unichar* jamo,
-		int pos_in_jamo) {
-	unichar* buffer_line_buffer_inflected;
-	buffer_line_buffer_inflected = (unichar*) malloc(sizeof(unichar) * (4096
-			+ DIC_LINE_SIZE));
-	if (buffer_line_buffer_inflected == NULL) {
-		fatal_alloc_error("explore_dic_in_morpho_mode");
-	}
-	unichar* inflected = buffer_line_buffer_inflected;
-	Ustring* line_buffer=new_Ustring(4096);
-	Ustring* ustr=new_Ustring();
-	for (int i = 0; i < p->n_morpho_dics; i++) {
-		if (p->morpho_dic[i] != NULL) {
-			/* Can't match anything in an empty dictionary */
-			if (p->arabic.rules_enabled) {
-				explore_dic_in_morpho_mode_arabic(p, p->morpho_dic[i],
-						p->morpho_dic[i]->initial_state_offset,
-						p->tokens->value[p->buffer[p->current_origin + pos]],
-						inflected, pos_in_token, 0, pos, matches, pattern,
-						save_dic_entry, line_buffer, NOTHING_EXPECTED, '\0', ustr,0);
-			} else {
-				explore_dic_in_morpho_mode_standard(p, p->morpho_dic[i],
-						p->morpho_dic[i]->initial_state_offset,
-						p->tokens->value[p->buffer[p->current_origin + pos]],
-						inflected, pos_in_token, 0, pos, matches, pattern,
-						save_dic_entry, jamo, pos_in_jamo, line_buffer, ustr, 0);
-			}
-		}
-	}
-	free_Ustring(ustr);
-	free_Ustring(line_buffer);
-	free(buffer_line_buffer_inflected);
+        int pos_in_token, struct parsing_info* *matches,
+        struct pattern* pattern, int save_dic_entry, unichar* jamo,
+        int pos_in_jamo) {
+    unichar* buffer_line_buffer_inflected;
+    buffer_line_buffer_inflected = (unichar*) malloc(sizeof(unichar) * (4096
+            + DIC_LINE_SIZE));
+    if (buffer_line_buffer_inflected == NULL) {
+        fatal_alloc_error("explore_dic_in_morpho_mode");
+    }
+    unichar* inflected = buffer_line_buffer_inflected;
+    Ustring* line_buffer=new_Ustring(4096);
+    Ustring* ustr=new_Ustring();
+    for (int i = 0; i < p->n_morpho_dics; i++) {
+        if (p->morpho_dic[i] != NULL) {
+            /* Can't match anything in an empty dictionary */
+            if (p->arabic.rules_enabled) {
+                explore_dic_in_morpho_mode_arabic(p, p->morpho_dic[i],
+                        p->morpho_dic[i]->initial_state_offset,
+                        p->tokens->value[p->buffer[p->current_origin + pos]],
+                        inflected, pos_in_token, 0, pos, matches, pattern,
+                        save_dic_entry, line_buffer, NOTHING_EXPECTED, '\0', ustr,0);
+            } else {
+                explore_dic_in_morpho_mode_standard(p, p->morpho_dic[i],
+                        p->morpho_dic[i]->initial_state_offset,
+                        p->tokens->value[p->buffer[p->current_origin + pos]],
+                        inflected, pos_in_token, 0, pos, matches, pattern,
+                        save_dic_entry, jamo, pos_in_jamo, line_buffer, ustr, 0);
+            }
+        }
+    }
+    free_Ustring(ustr);
+    free_Ustring(line_buffer);
+    free(buffer_line_buffer_inflected);
 }
 
 } // namespace unitex

--- a/MorphologicalLocate.cpp
+++ b/MorphologicalLocate.cpp
@@ -43,7 +43,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
  see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1
@@ -309,7 +309,7 @@ unichar* content_buffer /* reusable unichar 4096 buffer for content */
 	p->explore_depth ++ ;
     /*
 	if (depth == 0) {
-		// We reset if this is first call to 'locate' from a given position in the text 
+		// We reset if this is first call to 'locate' from a given position in the text
 		p->p_token_error_ctx->n_matches_at_token_pos__morphological_locate = 0;
 	}*/
 
@@ -503,13 +503,13 @@ unichar* content_buffer /* reusable unichar 4096 buffer for content */
 		}
 		/* We restore the original dic variables */
 		p->dic_variables=dic_variables_backup;
-		if (save_previous_ptr_var != NULL) { 
+		if (save_previous_ptr_var != NULL) {
 			restore_variable_array(p->input_variables, p->backup_memory_reserve,
 			                          save_previous_ptr_var);
 			save_previous_ptr_var = NULL;
 		}
 
-        
+
 		if (var_backup!=NULL) {
 				int reserve_freeable = free_variable_backup_using_reserve(
 						p->backup_memory_reserve);
@@ -1473,7 +1473,7 @@ offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
 		} else {
 			/* If we have to check the pattern */
 
-			
+
 			Abstract_allocator explore_dic_in_morpho_mode_standard_abstract_allocator=NULL;
 			explore_dic_in_morpho_mode_standard_abstract_allocator=create_abstract_allocator("explore_dic_in_morpho_mode_standard",
                                                                   AllocatorFreeOnlyAtAllocatorDelete|AllocatorTipGrowingOftenRecycledObject,
@@ -1511,7 +1511,7 @@ offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
 			pos_offset++;
 			int token_number = (((int)(pos_offset + p->current_origin + 1)) <= (int)(p->buffer_size)) ?
 				p->buffer[pos_offset + p->current_origin] : -1;
-			
+
 			if (token_number == -1 || token_number == p->STOP) {
 				/* Remember 1) that we must not be out of the array's bounds and
 				 *          2) that the token {STOP} must never be matched */

--- a/MultiFlex.cpp
+++ b/MultiFlex.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
- /* 
+ /*
   *Originally created by Agata Savary (savary@univ-tours.fr)
   */
 #include <stdio.h>
@@ -59,7 +59,7 @@ const char* usage_MultiFlex =
          "                          files and inflection graphs for single and compound words.\n"
 	       "  -K/--korean: tells MultiFlex that it works on Korean\n"
 		     "  -s/--only-simple-words: the program will consider compound words as errors\n"
-		     "  -c/--only-compound-words: the program will consider simple words as errors\n"     
+		     "  -c/--only-compound-words: the program will consider simple words as errors\n"
          "  -p DIR/--pkgdir=DIR: path of the default graph repository\n"
          "  -r XXX/--named_repositories=XXX: declaration of named repositories. XXX is\n"
 		     "                                   made of one or more X=Y sequences, separated by ;\n"
@@ -196,7 +196,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_MultiFlex,lopts_MultiFle
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_MultiFlex[index].name);
              free(named);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              free(named);
@@ -208,13 +208,13 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_MultiFlex,lopts_MultiFle
 if (options.vars()->optind!=argc-1) {
    error("Invalid arguments: rerun with --help\n");
    free(named);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 
 if (output[0]=='\0') {
    error("You must specify the output DELAF name\n");
    free(named);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
@@ -247,7 +247,7 @@ if (is_korean) {
    if (alph==NULL) {
       error("Cannot initialize Korean data with a NULL alphabet\n");
       free(named);
-      return DEFAULT_ERROR_CODE;      
+      return DEFAULT_ERROR_CODE;
    }
 	korean=new Korean(alph);
 }

--- a/MultiFlex.cpp
+++ b/MultiFlex.cpp
@@ -57,14 +57,14 @@ const char* usage_MultiFlex =
          "  -a ALPH/--alphabet=ALPH: the alphabet file \n"
          "  -d DIR/--directory=DIR: the directory containing 'Morphology' and 'Equivalences'\n"
          "                          files and inflection graphs for single and compound words.\n"
-	       "  -K/--korean: tells MultiFlex that it works on Korean\n"
-		     "  -s/--only-simple-words: the program will consider compound words as errors\n"
-		     "  -c/--only-compound-words: the program will consider simple words as errors\n"
+           "  -K/--korean: tells MultiFlex that it works on Korean\n"
+             "  -s/--only-simple-words: the program will consider compound words as errors\n"
+             "  -c/--only-compound-words: the program will consider simple words as errors\n"
          "  -p DIR/--pkgdir=DIR: path of the default graph repository\n"
          "  -r XXX/--named_repositories=XXX: declaration of named repositories. XXX is\n"
-		     "                                   made of one or more X=Y sequences, separated by ;\n"
-		     "                                   where X is the name of the repository denoted by\n"
-		     "                                   the pathname Y. You can use this option several times\n"
+             "                                   made of one or more X=Y sequences, separated by ;\n"
+             "                                   where X is the name of the repository denoted by\n"
+             "                                   the pathname Y. You can use this option several times\n"
          " Graph recompilation options:\n"
          "  -f/--always-recompile-graphs:        forces graph recompiling even if the fst is up to date\n"
          "  -n/--never-recompile-graphs:         avoids graph recompiling even if the fst is not up to date\n"
@@ -176,7 +176,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_MultiFlex,lopts_MultiFle
                      return ALLOC_ERROR_CODE;
                   }
              } else {
-            	   char* more_names = (char*)realloc((void*)named,strlen(named)+strlen(options.vars()->optarg)+2);
+                   char* more_names = (char*)realloc((void*)named,strlen(named)+strlen(options.vars()->optarg)+2);
                  if (more_names) {
                   named = more_names;
                  } else {
@@ -249,7 +249,7 @@ if (is_korean) {
       free(named);
       return DEFAULT_ERROR_CODE;
    }
-	korean=new Korean(alph);
+    korean=new Korean(alph);
 }
 MultiFlex_ctx* p_multiFlex_ctx=new_MultiFlex_ctx(config_dir,
                                                  morphology,
@@ -275,7 +275,7 @@ free_alphabet(alph);
 free_MultiFlex_ctx(p_multiFlex_ctx);
 
 if (korean!=NULL) {
-	delete korean;
+    delete korean;
 }
 
 u_printf("Done.\n");

--- a/NewLineShifts.cpp
+++ b/NewLineShifts.cpp
@@ -73,7 +73,7 @@ if (t==NULL) {
    return 0;
 }
 if (n%3!=0) {
-	fatal_error("Invalid array size %d in find_snt_shift_by_dichotomy\n",n);
+    fatal_error("Invalid array size %d in find_snt_shift_by_dichotomy\n",n);
 }
 if (n==0) {
    return 0;
@@ -86,15 +86,15 @@ start_position=0;
 while (start_position<=n) {
    middle_position=(start_position+n)/2;
    if (t[3*middle_position]==a) {
-	   /* If we have an exact hit for the token at pos #a, then it's not
-	    * the shift after this token that we have to take into account,
-	    * but the shift before it */
-	   return t[3*middle_position+1];
+       /* If we have an exact hit for the token at pos #a, then it's not
+        * the shift after this token that we have to take into account,
+        * but the shift before it */
+       return t[3*middle_position+1];
    }
    if (t[3*middle_position]<a) {
       start_position=middle_position+1;
    } else {
-	   n=middle_position-1;
+       n=middle_position-1;
    }
 }
 return t[3*n+2];

--- a/NormalizationFst2.cpp
+++ b/NormalizationFst2.cpp
@@ -263,7 +263,7 @@ while (trans!=NULL) {
  * Tokens are represented by integers.
  */
 struct normalization_tree* load_normalization_fst2(const VersatileEncodingConfig* vec,const char* grammar,
-		const Alphabet* alph,struct text_tokens* tok) {
+        const Alphabet* alph,struct text_tokens* tok) {
 struct FST2_free_info fst2_free;
 Fst2* fst2=load_abstract_fst2(vec,grammar,0,&fst2_free);
 if (fst2==NULL) {

--- a/Normalize.cpp
+++ b/Normalize.cpp
@@ -138,8 +138,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Normalize,lopts_Normaliz
              strcpy(output_offsets,options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Normalize[index].name);
@@ -147,7 +147,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Normalize,lopts_Normaliz
              break;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
-             return USAGE_ERROR_CODE;  
+             return USAGE_ERROR_CODE;
              break;
    }
    index=-1;
@@ -159,7 +159,7 @@ if (options.vars()->optind!=argc-1) {
 }
 
 if (only_verify_arguments) {
-  // freeing all allocated memory 
+  // freeing all allocated memory
   return SUCCESS_RETURN_CODE;
 }
 
@@ -196,8 +196,8 @@ remove_extension(argv[options.vars()->optind],dest_file);
 strcat(dest_file,".snt");
 u_printf("Normalizing %s...\n",argv[options.vars()->optind]);
 
-int return_value = normalize(tmp_file, 
-                             dest_file, 
+int return_value = normalize(tmp_file,
+                             dest_file,
                              &vec,
                              mode,
                              convLFtoCRLF,

--- a/NormalizeAsRoutine.cpp
+++ b/NormalizeAsRoutine.cpp
@@ -36,36 +36,36 @@ namespace unitex {
 #define SIZE_OUTPUT_BUFFER 0x100
 
 struct OUTBUF {
-	unichar outbuf[SIZE_OUTPUT_BUFFER + 1];
-	int pos;
+    unichar outbuf[SIZE_OUTPUT_BUFFER + 1];
+    int pos;
 };
 
 static void WriteOufBuf(struct OUTBUF* pOutBuf, int convLFtoCRLF, const unichar* str, U_FILE *f,
-		int flush) {
-	for (;;) {
+        int flush) {
+    for (;;) {
 
-		while (((*str) != 0) && (pOutBuf->pos < SIZE_OUTPUT_BUFFER)) {
-			pOutBuf->outbuf[pOutBuf->pos] = *str;
-			pOutBuf->pos++;
-			str++;
-		}
+        while (((*str) != 0) && (pOutBuf->pos < SIZE_OUTPUT_BUFFER)) {
+            pOutBuf->outbuf[pOutBuf->pos] = *str;
+            pOutBuf->pos++;
+            str++;
+        }
 
-		if ((pOutBuf->pos == SIZE_OUTPUT_BUFFER) || (flush != 0)) {
-			pOutBuf->outbuf[pOutBuf->pos] = 0; // add null terminating marker
-			u_fprintf_conv_lf_to_crlf_option(f,convLFtoCRLF, "%S", pOutBuf->outbuf);
-			pOutBuf->pos = 0;
-		}
+        if ((pOutBuf->pos == SIZE_OUTPUT_BUFFER) || (flush != 0)) {
+            pOutBuf->outbuf[pOutBuf->pos] = 0; // add null terminating marker
+            u_fprintf_conv_lf_to_crlf_option(f,convLFtoCRLF, "%S", pOutBuf->outbuf);
+            pOutBuf->pos = 0;
+        }
 
-		if ((*str) == 0)
-			break;
-	}
+        if ((*str) == 0)
+            break;
+    }
 }
 
 static void WriteOufBuf(struct OUTBUF* pOutBuf, int convLFtoCRLF, unichar c, U_FILE *f, int flush) {
-	unichar u_array[2];
-	u_array[0] = c;
-	u_array[1] = 0;
-	WriteOufBuf(pOutBuf,convLFtoCRLF, u_array, f, flush);
+    unichar u_array[2];
+    u_array[0] = c;
+    u_array[1] = 0;
+    WriteOufBuf(pOutBuf,convLFtoCRLF, u_array, f, flush);
 }
 
 
@@ -82,9 +82,9 @@ if (*pfx==key_size) return 0;
 int i=key_size-1;
 int j=u_strlen(value)-1;
 while (i!=*pfx && j>=0 && key[i]==value[j]) {
-	(*sfx)++;
-	i--;
-	j--;
+    (*sfx)++;
+    i--;
+    j--;
 }
 return 1;
 }
@@ -123,7 +123,7 @@ while (s[*ptr]!='\0') {
 
       if ((s[(*ptr) + 1] != '\r') && (s[(*ptr)+1]!='\n')) {
          /* If there is a protection character (backslash) before end of line, we do like this is not a protection char */
-		 is_protection_char=1;
+         is_protection_char=1;
       }
    }
 
@@ -134,7 +134,7 @@ while (s[*ptr]!='\0') {
          return P_BACKSLASH_AT_END;
       }
       //if (chars_to_keep_protected==NULL) IS TRUE
-	  {
+      {
          /* If the character must keep its backslash (only when chars_to_keep_protected is not NULL) */
          u_strcat(result,PROTECTION_CHAR);
       }
@@ -176,308 +176,308 @@ return P_OK;
  * Note that 'replacements' is supposed to contain replacement rules for { and }
  */
 int normalize(const char *fin, const char *fout, const VersatileEncodingConfig* vec,
-		int carriage_return_policy, int convLFtoCRLF,const char *rules,
-		vector_offset* offsets,
-		int separator_normalization) {
-	U_FILE* input;
-	input = u_fopen(vec, fin, U_READ);
-	if (input == NULL) {
-		error("Cannot open file %s\n", fin);
-		return 1;
-	}
+        int carriage_return_policy, int convLFtoCRLF,const char *rules,
+        vector_offset* offsets,
+        int separator_normalization) {
+    U_FILE* input;
+    input = u_fopen(vec, fin, U_READ);
+    if (input == NULL) {
+        error("Cannot open file %s\n", fin);
+        return 1;
+    }
 
-	U_FILE* output;
-	output = u_fopen(vec, fout, U_WRITE);
-	if (output == NULL) {
-		error("Cannot create file %s\n", fout);
-		u_fclose(input);
-		return 1;
-	}
-	struct string_hash* replacements = NULL;
-	if (rules != NULL && rules[0] != '\0') {
-		replacements = load_key_value_list(rules, vec, '\t');
-		if (replacements == NULL) {
-			error("Cannot load replacement rules file %s\n", rules);
-			replacements = new_string_hash();
-		}
-	}
-	/* If there is no replacement rules file, we simulate one */
-	else {
-		replacements = new_string_hash();
-	}
+    U_FILE* output;
+    output = u_fopen(vec, fout, U_WRITE);
+    if (output == NULL) {
+        error("Cannot create file %s\n", fout);
+        u_fclose(input);
+        return 1;
+    }
+    struct string_hash* replacements = NULL;
+    if (rules != NULL && rules[0] != '\0') {
+        replacements = load_key_value_list(rules, vec, '\t');
+        if (replacements == NULL) {
+            error("Cannot load replacement rules file %s\n", rules);
+            replacements = new_string_hash();
+        }
+    }
+    /* If there is no replacement rules file, we simulate one */
+    else {
+        replacements = new_string_hash();
+    }
 
-	/* If there is a replacement rule file, we ensure that there are replacement
-	 * rules for { and }. If not, we add our default ones, so that in any case,
-	 * we are sure to have rules for { and } */
-	unichar key[2];
-	unichar value[2];
-	u_strcpy(key, "{");
-	u_strcpy(value, "[");
-	get_value_index(key, replacements, INSERT_IF_NEEDED, value);
-	u_strcpy(key, "}");
-	u_strcpy(value, "]");
-	get_value_index(key, replacements, INSERT_IF_NEEDED, value);
-	// now we'll assume length of adding new line is 1 + convLFtoCRLF
-	convLFtoCRLF = (convLFtoCRLF == 0) ? 0 : 1;
-	struct OUTBUF OutBuf;
-	OutBuf.pos = 0;
-	Ustring* tmp = new_Ustring(MAX_EXPECTED_TAG_LENGTH);
-	//struct buffer* buffer=new_buffer_for_file(UNICHAR_BUFFER,input);
+    /* If there is a replacement rule file, we ensure that there are replacement
+     * rules for { and }. If not, we add our default ones, so that in any case,
+     * we are sure to have rules for { and } */
+    unichar key[2];
+    unichar value[2];
+    u_strcpy(key, "{");
+    u_strcpy(value, "[");
+    get_value_index(key, replacements, INSERT_IF_NEEDED, value);
+    u_strcpy(key, "}");
+    u_strcpy(value, "]");
+    get_value_index(key, replacements, INSERT_IF_NEEDED, value);
+    // now we'll assume length of adding new line is 1 + convLFtoCRLF
+    convLFtoCRLF = (convLFtoCRLF == 0) ? 0 : 1;
+    struct OUTBUF OutBuf;
+    OutBuf.pos = 0;
+    Ustring* tmp = new_Ustring(MAX_EXPECTED_TAG_LENGTH);
+    //struct buffer* buffer=new_buffer_for_file(UNICHAR_BUFFER,input);
 
-	long save_pos = ftell(input);
-	fseek(input, 0, SEEK_END);
-	long file_size_input = ftell(input);
-	fseek(input, save_pos, SEEK_SET);
+    long save_pos = ftell(input);
+    fseek(input, 0, SEEK_END);
+    long file_size_input = ftell(input);
+    fseek(input, save_pos, SEEK_SET);
 
-	int
-			line_buffer_size = (int) (((file_size_input + 1)
-					< MAX_LINE_BUFFER_SIZE) ? (file_size_input + 1)
-					: MAX_LINE_BUFFER_SIZE);
+    int
+            line_buffer_size = (int) (((file_size_input + 1)
+                    < MAX_LINE_BUFFER_SIZE) ? (file_size_input + 1)
+                    : MAX_LINE_BUFFER_SIZE);
 
-	unichar *line_read;
-	line_read = (unichar*) malloc((line_buffer_size + 0x10) * sizeof(unichar));
-	if (line_read == NULL) {
-		fatal_alloc_error("normalize");
-	}
+    unichar *line_read;
+    line_read = (unichar*) malloc((line_buffer_size + 0x10) * sizeof(unichar));
+    if (line_read == NULL) {
+        fatal_alloc_error("normalize");
+    }
 
-	/* We define some things that will be used for parsing the buffer */
+    /* We define some things that will be used for parsing the buffer */
 
-	static const unichar stop_chars[] = { '{', '}', 0 };
-	static const unichar forbidden_chars[] = { '\n', 0 };
-	static const unichar open_bracket[] = { '{', 0 };
-	static const unichar close_bracket[] = { '}', 0 };
-	static const unichar empty_string[] = { 0 };
+    static const unichar stop_chars[] = { '{', '}', 0 };
+    static const unichar forbidden_chars[] = { '\n', 0 };
+    static const unichar open_bracket[] = { '{', 0 };
+    static const unichar close_bracket[] = { '}', 0 };
+    static const unichar empty_string[] = { 0 };
 
-	int eof_found = 0;
-	/* First, we fill the buffer */
+    int eof_found = 0;
+    /* First, we fill the buffer */
 
-	int lastline_was_terminated = 0;
+    int lastline_was_terminated = 0;
 
-	/* Here are the two variables used to compute offset diffs before and after
-	 * normalization. We used old_start_pos as a global position variable, whereas
-	 * current_start_pos is an index that is local to the current buffer */
-	int old_start_pos=0,new_start_pos=0;
+    /* Here are the two variables used to compute offset diffs before and after
+     * normalization. We used old_start_pos as a global position variable, whereas
+     * current_start_pos is an index that is local to the current buffer */
+    int old_start_pos=0,new_start_pos=0;
 
-	/* Beginning of the big loop */
-	while (eof_found == 0) {
-		int current_start_pos = 0;
-		const unichar* buff = line_read;
-		int result_read = 0;
-		result_read=u_fread_raw(line_read,line_buffer_size,input);
-		if (result_read==0) break;
-		while (current_start_pos < result_read) {
-			if (/*(lastline_was_terminated == 0) &&*/ (eof_found == 0)
-					&& (current_start_pos
-							+ MINIMAL_CHAR_IN_BUFFER_BEFORE_CONTINUE_LINE
-							>= result_read)) {
-				int i;
-				int nb_to_keep = result_read - current_start_pos;
-				for (i = 0; i < nb_to_keep; i++)
-					line_read[i] = line_read[current_start_pos + i];
-				/* This is required to avoid bound checking */
-				line_read[i]='\0';
-				int result_read_continue = u_fread_raw(line_read+ nb_to_keep,
-						line_buffer_size - nb_to_keep, input);
-				if (result_read_continue == 0) {
-					eof_found = lastline_was_terminated = 1;
-				} else {
-					/* This is required to avoid bound checking */
-					line_read[nb_to_keep+result_read_continue]='\0';
-				}
-				result_read = nb_to_keep;
-				current_start_pos = 0;
+    /* Beginning of the big loop */
+    while (eof_found == 0) {
+        int current_start_pos = 0;
+        const unichar* buff = line_read;
+        int result_read = 0;
+        result_read=u_fread_raw(line_read,line_buffer_size,input);
+        if (result_read==0) break;
+        while (current_start_pos < result_read) {
+            if (/*(lastline_was_terminated == 0) &&*/ (eof_found == 0)
+                    && (current_start_pos
+                            + MINIMAL_CHAR_IN_BUFFER_BEFORE_CONTINUE_LINE
+                            >= result_read)) {
+                int i;
+                int nb_to_keep = result_read - current_start_pos;
+                for (i = 0; i < nb_to_keep; i++)
+                    line_read[i] = line_read[current_start_pos + i];
+                /* This is required to avoid bound checking */
+                line_read[i]='\0';
+                int result_read_continue = u_fread_raw(line_read+ nb_to_keep,
+                        line_buffer_size - nb_to_keep, input);
+                if (result_read_continue == 0) {
+                    eof_found = lastline_was_terminated = 1;
+                } else {
+                    /* This is required to avoid bound checking */
+                    line_read[nb_to_keep+result_read_continue]='\0';
+                }
+                result_read = nb_to_keep;
+                current_start_pos = 0;
 
-				if (result_read_continue > 0)
-					result_read += result_read_continue;
-			}
-			/* Now that we have a buffer ready to be processed, we will normalize it */
-			if (buff[current_start_pos] == '{') {
-				/* If we have a {, we try to find a sequence like {....}, that does not contain
-				 * new lines. If the sequence contains protected character, we want to keep them
-				 * protected. */
-				int old_position = current_start_pos;
-				/* If we don't increase the position, the parse will stop on the initial { */
-				current_start_pos++;
+                if (result_read_continue > 0)
+                    result_read += result_read_continue;
+            }
+            /* Now that we have a buffer ready to be processed, we will normalize it */
+            if (buff[current_start_pos] == '{') {
+                /* If we have a {, we try to find a sequence like {....}, that does not contain
+                 * new lines. If the sequence contains protected character, we want to keep them
+                 * protected. */
+                int old_position = current_start_pos;
+                /* If we don't increase the position, the parse will stop on the initial { */
+                current_start_pos++;
 
-				u_strcpy(tmp,"{");
-				int code = parse_string_into_brace(buff, &current_start_pos, tmp);
-				if (code == P_FORBIDDEN_CHAR || code == P_BACKSLASH_AT_END
-						|| buff[current_start_pos] != '}') {
-					/* If we have found a new line or a {, or if there is
-					 * a backslash at the end of the buffer, or if we have reached the end
-					 * of the buffer, we assume that the initial
-					 * { was not a tag beginning, so we print the substitute of { */
-					unichar* foo=replacements->value[get_value_index(open_bracket, replacements)];
-					if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+u_strlen(foo));
-						WriteOufBuf(&OutBuf, convLFtoCRLF, foo, output, 0);
-					/* And we rewind the current position after the { */
-					current_start_pos = old_position + 1;
-					old_start_pos++;
-					new_start_pos=new_start_pos+u_strlen(foo);
-				} else {
-					/* If we have read a sequence like {....}, we assume that there won't be
-					 * a buffer overflow if we add the } */
-					u_strcat(tmp, close_bracket);
-					if (!u_strcmp(tmp->str, "{S}") || !u_strcmp(tmp->str, "{STOP}")
-							|| check_tag_token(tmp->str,0)) {
-						/* If this is a special tag or a valid tag token, we just print
-						 * it to the output */
-						WriteOufBuf(&OutBuf, convLFtoCRLF, tmp->str, output, 0);
-						current_start_pos++;
-						int l=u_strlen(tmp);
-						old_start_pos=old_start_pos+l;
-						new_start_pos=new_start_pos+l;
-					} else {
-						/* If we have a non valid tag token, we print the equivalent of {
-						 * and we rewind the current position after the { */
-						unichar* foo=replacements->value[get_value_index(open_bracket, replacements)];
-						if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+u_strlen(foo));
-						WriteOufBuf(&OutBuf, convLFtoCRLF, foo, output, 0);
-						current_start_pos = old_position + 1;
-						old_start_pos++;
-						new_start_pos=new_start_pos+u_strlen(foo);
-					}
-				}
-			} else {
-				/* If we have a character that is not {, first we try to look if there
-				 * is a replacement to do */
-				int key_length;
-				int index = get_longest_key_index(&buff[current_start_pos],
-						&key_length, replacements);
-				if (index != NO_VALUE_INDEX) {
-					/* If there is something to replace */
-					unichar* foo=replacements->value[index];
-					int common_prefix,common_suffix;
-					int ret=get_real_replacement(buff+current_start_pos,key_length,foo,
-							&common_prefix,&common_suffix);
-					if (offsets!=NULL && ret) vector_offset_add(offsets,old_start_pos+common_prefix,old_start_pos+key_length-common_suffix,new_start_pos+common_prefix,new_start_pos+u_strlen(foo)-common_suffix);
-					/* If we have a replacement rule, we must use it rawly, in case it
-					 * deals with separators. To do that, we flush the buffer first */
-					WriteOufBuf(&OutBuf, convLFtoCRLF, U_EMPTY, output, 1);
-					int len;
-					for (len=0;foo[len]!='\0';len++) {
-						u_fputc_raw(foo[len],output);
-					}
-					current_start_pos = current_start_pos + key_length;
-					old_start_pos = old_start_pos + key_length;
-					new_start_pos=new_start_pos+len;
-				} else {
-					int old_position=current_start_pos;
-					if (separator_normalization && (buff[current_start_pos] == ' '
-							|| buff[current_start_pos] == '\t'
-							|| buff[current_start_pos] == '\n'
-							|| buff[current_start_pos] == 0x0d
-							|| is_unicode_space(buff[current_start_pos]))) {
-						/* If we have a separator, we try to read the longest separator sequence
-						 * that we can read. By the way, we note if it contains a new line */
-						int new_line = 0;
-						while (buff[current_start_pos] == ' '
-								|| buff[current_start_pos] == '\t'
-								|| buff[current_start_pos] == '\n'
-								|| buff[current_start_pos] == 0x0d
-								|| is_unicode_space(buff[current_start_pos])) {
-							/* Note 1: no bound check is needed, since an unichar buffer is always
-							 *        ended by a \0
-							 *
-							 * Note 2: we don't take into account the case of a buffer ended by
-							 *         separator while it's not the end of file: that would mean
-							 *         that the text contains something like MARGIN_BEFORE_BUFFER_END
-							 *         contiguous separators. Such a text would not be a reasonable one.
-							 */
-							if (buff[current_start_pos] == '\n'
-									|| buff[current_start_pos] == 0x0d) {
-								new_line = 1;
-							}
-							current_start_pos++;
-						}
-						int delta=current_start_pos-old_position;
-						if (new_line && (carriage_return_policy
-								== KEEP_CARRIAGE_RETURN)) {
-							/* We print a new line if the sequence contains one and if we are
-							 * allowed to; otherwise, we print a space. */
-							if (offsets)
-							{
-								int must_push_offset = 1;
-								// if we replace exactly a CR LF by a CR LF, don't push offset
-								if ((convLFtoCRLF) && (delta == 2))
-								{
-									if ((buff[old_position] == '\r') && (buff[old_position + 1] == '\n'))
-										must_push_offset = 0;
-								}
-								if ((!convLFtoCRLF) && (delta == 1))
-								{
-									if (buff[old_position] == '\n')
-										must_push_offset = 0;
-								}
-								if (must_push_offset)
-								{
-									vector_offset_add(offsets, old_start_pos, old_start_pos + delta, new_start_pos, new_start_pos + 1 + convLFtoCRLF);
-								}
-							}
+                u_strcpy(tmp,"{");
+                int code = parse_string_into_brace(buff, &current_start_pos, tmp);
+                if (code == P_FORBIDDEN_CHAR || code == P_BACKSLASH_AT_END
+                        || buff[current_start_pos] != '}') {
+                    /* If we have found a new line or a {, or if there is
+                     * a backslash at the end of the buffer, or if we have reached the end
+                     * of the buffer, we assume that the initial
+                     * { was not a tag beginning, so we print the substitute of { */
+                    unichar* foo=replacements->value[get_value_index(open_bracket, replacements)];
+                    if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+u_strlen(foo));
+                        WriteOufBuf(&OutBuf, convLFtoCRLF, foo, output, 0);
+                    /* And we rewind the current position after the { */
+                    current_start_pos = old_position + 1;
+                    old_start_pos++;
+                    new_start_pos=new_start_pos+u_strlen(foo);
+                } else {
+                    /* If we have read a sequence like {....}, we assume that there won't be
+                     * a buffer overflow if we add the } */
+                    u_strcat(tmp, close_bracket);
+                    if (!u_strcmp(tmp->str, "{S}") || !u_strcmp(tmp->str, "{STOP}")
+                            || check_tag_token(tmp->str,0)) {
+                        /* If this is a special tag or a valid tag token, we just print
+                         * it to the output */
+                        WriteOufBuf(&OutBuf, convLFtoCRLF, tmp->str, output, 0);
+                        current_start_pos++;
+                        int l=u_strlen(tmp);
+                        old_start_pos=old_start_pos+l;
+                        new_start_pos=new_start_pos+l;
+                    } else {
+                        /* If we have a non valid tag token, we print the equivalent of {
+                         * and we rewind the current position after the { */
+                        unichar* foo=replacements->value[get_value_index(open_bracket, replacements)];
+                        if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+u_strlen(foo));
+                        WriteOufBuf(&OutBuf, convLFtoCRLF, foo, output, 0);
+                        current_start_pos = old_position + 1;
+                        old_start_pos++;
+                        new_start_pos=new_start_pos+u_strlen(foo);
+                    }
+                }
+            } else {
+                /* If we have a character that is not {, first we try to look if there
+                 * is a replacement to do */
+                int key_length;
+                int index = get_longest_key_index(&buff[current_start_pos],
+                        &key_length, replacements);
+                if (index != NO_VALUE_INDEX) {
+                    /* If there is something to replace */
+                    unichar* foo=replacements->value[index];
+                    int common_prefix,common_suffix;
+                    int ret=get_real_replacement(buff+current_start_pos,key_length,foo,
+                            &common_prefix,&common_suffix);
+                    if (offsets!=NULL && ret) vector_offset_add(offsets,old_start_pos+common_prefix,old_start_pos+key_length-common_suffix,new_start_pos+common_prefix,new_start_pos+u_strlen(foo)-common_suffix);
+                    /* If we have a replacement rule, we must use it rawly, in case it
+                     * deals with separators. To do that, we flush the buffer first */
+                    WriteOufBuf(&OutBuf, convLFtoCRLF, U_EMPTY, output, 1);
+                    int len;
+                    for (len=0;foo[len]!='\0';len++) {
+                        u_fputc_raw(foo[len],output);
+                    }
+                    current_start_pos = current_start_pos + key_length;
+                    old_start_pos = old_start_pos + key_length;
+                    new_start_pos=new_start_pos+len;
+                } else {
+                    int old_position=current_start_pos;
+                    if (separator_normalization && (buff[current_start_pos] == ' '
+                            || buff[current_start_pos] == '\t'
+                            || buff[current_start_pos] == '\n'
+                            || buff[current_start_pos] == 0x0d
+                            || is_unicode_space(buff[current_start_pos]))) {
+                        /* If we have a separator, we try to read the longest separator sequence
+                         * that we can read. By the way, we note if it contains a new line */
+                        int new_line = 0;
+                        while (buff[current_start_pos] == ' '
+                                || buff[current_start_pos] == '\t'
+                                || buff[current_start_pos] == '\n'
+                                || buff[current_start_pos] == 0x0d
+                                || is_unicode_space(buff[current_start_pos])) {
+                            /* Note 1: no bound check is needed, since an unichar buffer is always
+                             *        ended by a \0
+                             *
+                             * Note 2: we don't take into account the case of a buffer ended by
+                             *         separator while it's not the end of file: that would mean
+                             *         that the text contains something like MARGIN_BEFORE_BUFFER_END
+                             *         contiguous separators. Such a text would not be a reasonable one.
+                             */
+                            if (buff[current_start_pos] == '\n'
+                                    || buff[current_start_pos] == 0x0d) {
+                                new_line = 1;
+                            }
+                            current_start_pos++;
+                        }
+                        int delta=current_start_pos-old_position;
+                        if (new_line && (carriage_return_policy
+                                == KEEP_CARRIAGE_RETURN)) {
+                            /* We print a new line if the sequence contains one and if we are
+                             * allowed to; otherwise, we print a space. */
+                            if (offsets)
+                            {
+                                int must_push_offset = 1;
+                                // if we replace exactly a CR LF by a CR LF, don't push offset
+                                if ((convLFtoCRLF) && (delta == 2))
+                                {
+                                    if ((buff[old_position] == '\r') && (buff[old_position + 1] == '\n'))
+                                        must_push_offset = 0;
+                                }
+                                if ((!convLFtoCRLF) && (delta == 1))
+                                {
+                                    if (buff[old_position] == '\n')
+                                        must_push_offset = 0;
+                                }
+                                if (must_push_offset)
+                                {
+                                    vector_offset_add(offsets, old_start_pos, old_start_pos + delta, new_start_pos, new_start_pos + 1 + convLFtoCRLF);
+                                }
+                            }
 
-							old_start_pos=old_start_pos+delta;
-							new_start_pos+=1+convLFtoCRLF;
-							WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
-						} else {
-							if ((delta!=1) || (buff[old_position] != ' ')) {
-								if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+delta,new_start_pos,new_start_pos+1);
-							}
-							old_start_pos=old_start_pos+delta;
-							new_start_pos++;
-							WriteOufBuf(&OutBuf, convLFtoCRLF, ' ', output, 0);
-						}
-					} else {
-						/* If, finally, we have a normal character to normalize, we just print it */
-						unichar c=buff[current_start_pos];
-						if (c=='\r') {
-							if (buff[current_start_pos+1]=='\n') {
-								/* If we have a real \r\n, we write \n if convLFtoCRLF=0 and keep unmodified \r\n if convLFtoCRLF=1 */
-								old_start_pos+=2;
-								new_start_pos+=1+convLFtoCRLF;
-								// we use 1 as param for convLFtoCRLF of WriteOufBuf to really write a \r\n
-								if ((offsets != NULL) && (!convLFtoCRLF)) {
-									vector_offset_add(offsets, old_start_pos, old_start_pos + 2, new_start_pos, new_start_pos + 1);
-								}
-								current_start_pos+=2;
-								WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
-							} else {
-								/* The text contains only \r and we will have to turn
-								 * it into \n if convLFtoCRLF==0, and \r\n if convLFtoCRLF==1 so there we be a shift of 1 or 2 */
-								if (offsets != NULL) {
-									vector_offset_add(offsets, old_start_pos, old_start_pos + 1, new_start_pos, new_start_pos + 1 + convLFtoCRLF);
-								}
-								old_start_pos++;
-								new_start_pos+=1+convLFtoCRLF;
-								current_start_pos++;
-								WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
-							}
-						} else if ((c=='\n') && convLFtoCRLF) {
-							/* \n => \r\n means a shift of 1 */
-							if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+2);
-							old_start_pos++;
-							new_start_pos+=2;
-							current_start_pos++;
-							WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
-						} else {
-							old_start_pos++;
-							new_start_pos++;
-							current_start_pos++;
-							WriteOufBuf(&OutBuf, convLFtoCRLF, c, output, 0);
-						}
-					}
-				}
-			}
-		}
-	}
+                            old_start_pos=old_start_pos+delta;
+                            new_start_pos+=1+convLFtoCRLF;
+                            WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
+                        } else {
+                            if ((delta!=1) || (buff[old_position] != ' ')) {
+                                if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+delta,new_start_pos,new_start_pos+1);
+                            }
+                            old_start_pos=old_start_pos+delta;
+                            new_start_pos++;
+                            WriteOufBuf(&OutBuf, convLFtoCRLF, ' ', output, 0);
+                        }
+                    } else {
+                        /* If, finally, we have a normal character to normalize, we just print it */
+                        unichar c=buff[current_start_pos];
+                        if (c=='\r') {
+                            if (buff[current_start_pos+1]=='\n') {
+                                /* If we have a real \r\n, we write \n if convLFtoCRLF=0 and keep unmodified \r\n if convLFtoCRLF=1 */
+                                old_start_pos+=2;
+                                new_start_pos+=1+convLFtoCRLF;
+                                // we use 1 as param for convLFtoCRLF of WriteOufBuf to really write a \r\n
+                                if ((offsets != NULL) && (!convLFtoCRLF)) {
+                                    vector_offset_add(offsets, old_start_pos, old_start_pos + 2, new_start_pos, new_start_pos + 1);
+                                }
+                                current_start_pos+=2;
+                                WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
+                            } else {
+                                /* The text contains only \r and we will have to turn
+                                 * it into \n if convLFtoCRLF==0, and \r\n if convLFtoCRLF==1 so there we be a shift of 1 or 2 */
+                                if (offsets != NULL) {
+                                    vector_offset_add(offsets, old_start_pos, old_start_pos + 1, new_start_pos, new_start_pos + 1 + convLFtoCRLF);
+                                }
+                                old_start_pos++;
+                                new_start_pos+=1+convLFtoCRLF;
+                                current_start_pos++;
+                                WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
+                            }
+                        } else if ((c=='\n') && convLFtoCRLF) {
+                            /* \n => \r\n means a shift of 1 */
+                            if (offsets!=NULL) vector_offset_add(offsets,old_start_pos,old_start_pos+1,new_start_pos,new_start_pos+2);
+                            old_start_pos++;
+                            new_start_pos+=2;
+                            current_start_pos++;
+                            WriteOufBuf(&OutBuf, convLFtoCRLF, '\n', output, 0);
+                        } else {
+                            old_start_pos++;
+                            new_start_pos++;
+                            current_start_pos++;
+                            WriteOufBuf(&OutBuf, convLFtoCRLF, c, output, 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	WriteOufBuf(&OutBuf, convLFtoCRLF, empty_string, output, 1);
+    WriteOufBuf(&OutBuf, convLFtoCRLF, empty_string, output, 1);
 
-	free(line_read);
-	free_string_hash(replacements);
-	free_Ustring(tmp);
-	u_fclose(input);
-	u_fclose(output);
-	return 0;
+    free(line_read);
+    free_string_hash(replacements);
+    free_Ustring(tmp);
+    u_fclose(input);
+    u_fclose(output);
+    return 0;
 }
 
 } // namespace unitex

--- a/NormalizeAsRoutine.cpp
+++ b/NormalizeAsRoutine.cpp
@@ -120,7 +120,7 @@ while (s[*ptr]!='\0') {
          /* It must not appear at the end of the string */
          return P_BACKSLASH_AT_END;
       }
-      
+
       if ((s[(*ptr) + 1] != '\r') && (s[(*ptr)+1]!='\n')) {
          /* If there is a protection character (backslash) before end of line, we do like this is not a protection char */
 		 is_protection_char=1;

--- a/NormalizeAsRoutine.h
+++ b/NormalizeAsRoutine.h
@@ -41,7 +41,7 @@ namespace unitex {
 
 
 int normalize(const char*, const char*, const VersatileEncodingConfig*, int, int, const char*,
-		vector_offset*,int);
+        vector_offset*,int);
 
 } // namespace unitex
 

--- a/NorwegianCompounds.cpp
+++ b/NorwegianCompounds.cpp
@@ -56,25 +56,25 @@ namespace unitex {
  * Norwegian unknown words.
  */
 struct norwegian_infos {
-	/* The norwegian alphabet */
-	const Alphabet* alphabet;
-	Dictionary* d;
-	/* The file where to read the words to analyze from */
-	U_FILE* unknown_word_list;
-	/* The file where new dictionary lines will be written */
-	U_FILE* output;
-	/* The file where to print information about the analysis */
-	U_FILE* info_output;
-	/* The file where to write words that cannot be analyzed as
-	 * compound words */
-	U_FILE* new_unknown_word_list;
-	/* Set of words that cannot be part of compound words */
-	struct string_hash* forbidden_words;
-	/* These arrays indicates for each INF code if it can be
-	 * viewed as a valid code for a left/right component of a
-	 * compound word. */
-	char* valid_left_component;
-	char* valid_right_component;
+    /* The norwegian alphabet */
+    const Alphabet* alphabet;
+    Dictionary* d;
+    /* The file where to read the words to analyze from */
+    U_FILE* unknown_word_list;
+    /* The file where new dictionary lines will be written */
+    U_FILE* output;
+    /* The file where to print information about the analysis */
+    U_FILE* info_output;
+    /* The file where to write words that cannot be analyzed as
+     * compound words */
+    U_FILE* new_unknown_word_list;
+    /* Set of words that cannot be part of compound words */
+    struct string_hash* forbidden_words;
+    /* These arrays indicates for each INF code if it can be
+     * viewed as a valid code for a left/right component of a
+     * compound word. */
+    char* valid_left_component;
+    char* valid_right_component;
 };
 
 
@@ -96,7 +96,7 @@ struct word_decomposition_list {
 void analyse_norwegian_unknown_words(struct norwegian_infos*);
 int analyse_norwegian_word(const unichar* word,struct norwegian_infos*);
 void explore_state(int,unichar*,int,const unichar*,int,const unichar*,const unichar*,
-					struct word_decomposition_list**,int,struct norwegian_infos*,Ustring*,int);
+                    struct word_decomposition_list**,int,struct norwegian_infos*,Ustring*,int);
 void check_valid_right_component(char*,const struct INF_codes*);
 void check_valid_left_component(char*,const struct INF_codes*);
 char check_valid_left_component_for_an_INF_line(const struct list_ustring*);
@@ -120,9 +120,9 @@ void free_word_decomposition_list(struct word_decomposition_list*);
  * This function analyzes a list of unknown Norwegian words.
  */
 void analyse_norwegian_unknown_words(const Alphabet* alphabet,Dictionary* d,
-								U_FILE* unknown_word_list,U_FILE* output,U_FILE* info_output,
-								U_FILE* new_unknown_word_list,
-								struct string_hash* forbidden_words) {
+                                U_FILE* unknown_word_list,U_FILE* output,U_FILE* info_output,
+                                U_FILE* new_unknown_word_list,
+                                struct string_hash* forbidden_words) {
 /* We create a structure that will contain all settings */
 struct norwegian_infos infos;
 infos.alphabet=alphabet;
@@ -134,7 +134,7 @@ infos.new_unknown_word_list=new_unknown_word_list;
 infos.forbidden_words=forbidden_words;
 infos.valid_left_component=(char*)malloc(sizeof(char)*(d->inf->N));
 if (infos.valid_left_component==NULL) {
-	fatal_alloc_error("analyse_norwegian_unknown_words");
+    fatal_alloc_error("analyse_norwegian_unknown_words");
 }
 infos.valid_right_component=(char*)malloc(sizeof(char)*(d->inf->N));
 if (infos.valid_right_component==NULL) {
@@ -170,10 +170,10 @@ for (int i=0;i<inf->N;i++) {
  */
 char check_valid_right_component_for_an_INF_line(const struct list_ustring* INF_codes) {
 while (INF_codes!=NULL) {
-	if (check_valid_right_component_for_one_INF_code(INF_codes->string)) {
-		return 1;
-	}
-	INF_codes=INF_codes->next;
+    if (check_valid_right_component_for_one_INF_code(INF_codes->string)) {
+        return 1;
+    }
+    INF_codes=INF_codes->next;
 }
 return 0;
 }
@@ -198,10 +198,10 @@ for (int i=0;i<inf->N;i++) {
  */
 char check_valid_left_component_for_an_INF_line(const struct list_ustring* INF_codes) {
 while (INF_codes!=NULL) {
-	if (check_valid_left_component_for_one_INF_code(INF_codes->string)) {
-		return 1;
-	}
-	INF_codes=INF_codes->next;
+    if (check_valid_left_component_for_one_INF_code(INF_codes->string)) {
+        return 1;
+    }
+    INF_codes=INF_codes->next;
 }
 return 0;
 }
@@ -245,19 +245,19 @@ void get_first_valid_left_component(struct list_ustring* INF_codes,unichar* code
 int tmp;
 code[0]='\0';
 while (INF_codes!=NULL) {
-	tmp=get_valid_left_component_type_for_one_INF_code(INF_codes->string);
-	if (tmp==N_SIA || tmp==N_SIE || tmp==N_SIG) {
-		/* If we find an N, then we return it */
-		u_strcpy(code,INF_codes->string);
-		return;
-	}
-	if (tmp!=INVALID_LEFT_COMPONENT) {
-		/* If we find a valid left component, then we copy it,
-		 * but we do not return now, since we can find later
-		 * a N that has an higher priority */
-		u_strcpy(code,INF_codes->string);
-	}
-	INF_codes=INF_codes->next;
+    tmp=get_valid_left_component_type_for_one_INF_code(INF_codes->string);
+    if (tmp==N_SIA || tmp==N_SIE || tmp==N_SIG) {
+        /* If we find an N, then we return it */
+        u_strcpy(code,INF_codes->string);
+        return;
+    }
+    if (tmp!=INVALID_LEFT_COMPONENT) {
+        /* If we find a valid left component, then we copy it,
+         * but we do not return now, since we can find later
+         * a N that has an higher priority */
+        u_strcpy(code,INF_codes->string);
+    }
+    INF_codes=INF_codes->next;
 }
 }
 
@@ -539,9 +539,9 @@ while (EOF!=readline(line,infos->unknown_word_list)) {
       * new unknown word file */
      u_fprintf(infos->new_unknown_word_list,"%S\n",line->str);
   } else {
-  		/* Otherwise, we increase the number of analyzed words */
-  		n++;
-  	}
+        /* Otherwise, we increase the number of analyzed words */
+        n++;
+    }
 }
 free_Ustring(line);
 u_printf("%d words decomposed as compound words\n",n);
@@ -567,8 +567,8 @@ Ustring* ustr=new_Ustring();
 explore_state(infos->d->initial_state_offset,correct_word,0,word,0,decomposition,dela_line,&l,1,infos,ustr,0);
 free_Ustring(ustr);
 if (l==NULL) {
-	/* If there is no decomposition, we return */
-	return 0;
+    /* If there is no decomposition, we return */
+    return 0;
 }
 /* Otherwise, we will choose the one to keep */
 struct word_decomposition_list* tmp=l;
@@ -580,59 +580,59 @@ int is_a_valid_right_A=0;
  * of components. By the way, we note if there is a minimal
  * analysis ending by a noun or an adjective. */
 while (tmp!=NULL) {
-	if (tmp->element->n_parts<=n) {
-		if (tmp->element->n_parts<n) {
-			/* If we change of component number, we reset the
-			 * 'is_a_valid_right_N' and 'is_a_valid_right_A' fields,
-			 * because they only concern the head word. */
-			is_a_valid_right_N=0;
-			is_a_valid_right_A=0;
-		}
-		n=tmp->element->n_parts;
-		if (tmp->element->is_a_valid_right_N) {
-			is_a_valid_right_N=1;
-		}
-		if (tmp->element->is_a_valid_right_A) {
-			is_a_valid_right_A=1;
-		}
-	}
-	tmp=tmp->next;
+    if (tmp->element->n_parts<=n) {
+        if (tmp->element->n_parts<n) {
+            /* If we change of component number, we reset the
+             * 'is_a_valid_right_N' and 'is_a_valid_right_A' fields,
+             * because they only concern the head word. */
+            is_a_valid_right_N=0;
+            is_a_valid_right_A=0;
+        }
+        n=tmp->element->n_parts;
+        if (tmp->element->is_a_valid_right_N) {
+            is_a_valid_right_N=1;
+        }
+        if (tmp->element->is_a_valid_right_A) {
+            is_a_valid_right_A=1;
+        }
+    }
+    tmp=tmp->next;
 }
 tmp=l;
 while (tmp!=NULL) {
-	if (n==tmp->element->n_parts) {
-		/* We only consider the words that have shortest decompositions.
-		 * The test (tmp->element->n_parts==1) is used to
-		 * match simple words that would have been wrongly considered
-		 * as unknown words. */
-		int OK=0;
-		if (tmp->element->n_parts==1) {
-			/* Simple words must be matched */
-			OK=1;
-		}
-		else if (is_a_valid_right_N) {
-			 	if (tmp->element->is_a_valid_right_N) {
-					/* We give priority to analysis that ends with a noun */
-					OK=1;
-			 	}
-			}
-		else if (is_a_valid_right_A) {
-				if (tmp->element->is_a_valid_right_A) {
-					/* Our second priority goes to analysis that ends with an adjective */
-					OK=1;
-				}
-			}
-		else OK=1;
-		/* We put a restriction on the grammatical code:
-		 * we don't produce a x<A> or x<V> analysis when a x<N> exists */
-		if (OK) {
-			if (infos->info_output!=NULL) {
-				u_fprintf(infos->info_output,"%S = %S\n",word,tmp->element->decomposition);
-			}
-			u_fprintf(infos->output,"%S\n",tmp->element->dela_line);
-		}
-	}
-	tmp=tmp->next;
+    if (n==tmp->element->n_parts) {
+        /* We only consider the words that have shortest decompositions.
+         * The test (tmp->element->n_parts==1) is used to
+         * match simple words that would have been wrongly considered
+         * as unknown words. */
+        int OK=0;
+        if (tmp->element->n_parts==1) {
+            /* Simple words must be matched */
+            OK=1;
+        }
+        else if (is_a_valid_right_N) {
+                if (tmp->element->is_a_valid_right_N) {
+                    /* We give priority to analysis that ends with a noun */
+                    OK=1;
+                }
+            }
+        else if (is_a_valid_right_A) {
+                if (tmp->element->is_a_valid_right_A) {
+                    /* Our second priority goes to analysis that ends with an adjective */
+                    OK=1;
+                }
+            }
+        else OK=1;
+        /* We put a restriction on the grammatical code:
+         * we don't produce a x<A> or x<V> analysis when a x<N> exists */
+        if (OK) {
+            if (infos->info_output!=NULL) {
+                u_fprintf(infos->info_output,"%S = %S\n",word,tmp->element->decomposition);
+            }
+            u_fprintf(infos->output,"%S\n",tmp->element->dela_line);
+        }
+    }
+    tmp=tmp->next;
 }
 free_word_decomposition_list(l);
 return 1;
@@ -687,10 +687,10 @@ return tmp;
 void free_word_decomposition_list(struct word_decomposition_list* l) {
 struct word_decomposition_list* tmp;
 while (l!=NULL) {
-	free_word_decomposition(l->element);
-	tmp=l->next;
-	free(l);
-	l=tmp;
+    free_word_decomposition(l->element);
+    tmp=l->next;
+    free(l);
+    l=tmp;
 }
 }
 
@@ -738,210 +738,210 @@ int final,n_transitions,inf_number;
 int z=save_output(ustr);
 offset=read_dictionary_state(infos->d,offset,&final,&n_transitions,&inf_number);
 if (final) {
-	/* If we are in a final state, we can set the end of our current component */
-	current_component[pos_in_current_component]='\0';
-	/* We do not consider words of length 1 */
-	if (pos_in_current_component>1) {
-		/* We don't consider components with a length of 1 */
-		if (word_to_analyze[pos_in_word_to_analyze]=='\0') {
-			/* If we have explored the entire original word */
-			if (get_value_index(current_component,infos->forbidden_words,DONT_INSERT)==NO_VALUE_INDEX) {
-				/* And if we do not have forbidden word in last position */
-				struct list_ustring* l=infos->d->inf->codes[inf_number];
-				/* We will look at all the INF codes of the last component in order
-				 * to produce analysis */
-				while (l!=NULL) {
-					unichar* dec_ = dec_buffer;
-					u_strcpy(dec_,analysis);
-					if (dec_[0]!='\0') {
-						/* If we have already something in the analysis (i.e. if
-						 * we have not a simple word), we insert the concatenation
-						 * mark before the entry to come */
-						u_strcat(dec_," +++ ");
-					}
-					Ustring* entry=new_Ustring(4096);
-					/* We get the dictionary line that corresponds to the current INF code */
-					uncompress_entry(current_component,l->string,entry);
-					/* And we add it to the analysis */
-					u_strcat(dec_,entry->str);
-					unichar* new_dela_line = (unichar*)malloc(sizeof(unichar) * 4096);
-					if (new_dela_line == NULL) {
-						fatal_alloc_error("explore_state");
-					}
-					/* We copy the current output DELA line that contains
-					 * the concatenation of the previous components */
-					u_strcpy(new_dela_line,output_dela_line);
-					/* Then we tokenize the DELA line that corresponds the current INF
-					 * code in order to obtain its lemma and grammatical/inflectional
-					 * information */
-					struct dela_entry* tmp_entry=tokenize_DELAF_line(entry->str,1);
-					/* We concatenate the inflected form of the last component to
-					 * the output DELA line */
-					u_strcat(new_dela_line,tmp_entry->inflected);
-					/* We put the comma that separates the inflected form and the lemma */
-					u_strcat(new_dela_line,",");
-					/* And we build the lemma in the same way than the inflected form */
-					u_strcat(new_dela_line,output_dela_line);
-					u_strcat(new_dela_line,tmp_entry->lemma);
-					/* We put the dot that separates the the lemma and the grammatical/inflectional
-					 * information */
-					u_strcat(new_dela_line,".");
-					/* And finally we put the grammatical/inflectional information */
-					u_strcat(new_dela_line,tmp_entry->semantic_codes[0]);
-					int k;
-					for (k=1;k<tmp_entry->n_semantic_codes;k++) {
-						u_strcat(new_dela_line,"+");
-						u_strcat(new_dela_line,tmp_entry->semantic_codes[k]);
-					}
-					for (k=0;k<tmp_entry->n_inflectional_codes;k++) {
-						u_strcat(new_dela_line,":");
-						u_strcat(new_dela_line,tmp_entry->inflectional_codes[k]);
-					}
-					free_dela_entry(tmp_entry);
-					/*
-					 * Now we can build an analysis in the form of a word decomposition
-					 * structure, but only if the last component is a valid
-					 * right one or if it is a verb long enough, or if we find out
-					 * that the word to analyze was in fact a simple word
-					 * in the dictionary */
-					if (verb_of_more_than_4_letters(entry->str)
-						|| check_valid_right_component_for_one_INF_code(l->string)
-						|| number_of_components==1) {
-						/*
-						 * We set the number of components, the analysis, the actual
-						 * DELA line and information about
-						 */
-						struct word_decomposition* wd=new_word_decomposition();
-						wd->n_parts=number_of_components;
-						u_strcpy(wd->decomposition,dec_);
-						u_strcpy(wd->dela_line,new_dela_line);
-						wd->is_a_valid_right_N=check_N_right_component(l->string);
-						wd->is_a_valid_right_A=check_A_right_component(l->string);
-						/* Then we add the decomposition word structure to the list that
-						 * contains all the analysis for the word to analyze */
-						struct word_decomposition_list* wdl=new_word_decomposition_list();
-						wdl->element=wd;
-						wdl->next=(*L);
-						(*L)=wdl;
-					}
-					free_Ustring(entry);
-					free(new_dela_line);
-					/* We go on with the next INF code of the last component */
-					l=l->next;
-				}
-			}
-			/* If are at the end of the word to analyze, we have nothing more to do */
-			return;
-		} else {
-			/* If we are not at the end of the word to analyze, we must
-			 * 1) look if the current component is a valid left one
-			 * 2) look if it is not a forbidden component and
-			 * 3) explore the rest of the original word
-			 */
-			if (infos->valid_left_component[inf_number] &&
-				(get_value_index(current_component,infos->forbidden_words,DONT_INSERT)==NO_VALUE_INDEX)) {
-				/* If we have a valid component, we look first if we are
-				 * in the case of a word ending by a double letter like "kupp" */
-				if (pos_in_current_component>2 &&
-					(current_component[pos_in_current_component-1]==current_component[pos_in_current_component-2])) {
-					/* If we have such a word, we add it to the current analysis,
-					 * putting "+++" if the current component is not the first one */
-					unichar* dec_ = dec_buffer;
-					u_strcpy(dec_,analysis);
-					if (dec_[0]!='\0') {
-						u_strcat(dec_," +++ ");
-					}
-					/* In order to print the component in the analysis, we arbitrary
-					 * take a valid left component among all those that are available
-					 * for the current component */
-					unichar* multi_buffer_alloc = (unichar*)malloc(sizeof(unichar)*4096*3);
-					if (multi_buffer_alloc==NULL) {
-					  fatal_alloc_error("explore_state");
-					}
+    /* If we are in a final state, we can set the end of our current component */
+    current_component[pos_in_current_component]='\0';
+    /* We do not consider words of length 1 */
+    if (pos_in_current_component>1) {
+        /* We don't consider components with a length of 1 */
+        if (word_to_analyze[pos_in_word_to_analyze]=='\0') {
+            /* If we have explored the entire original word */
+            if (get_value_index(current_component,infos->forbidden_words,DONT_INSERT)==NO_VALUE_INDEX) {
+                /* And if we do not have forbidden word in last position */
+                struct list_ustring* l=infos->d->inf->codes[inf_number];
+                /* We will look at all the INF codes of the last component in order
+                 * to produce analysis */
+                while (l!=NULL) {
+                    unichar* dec_ = dec_buffer;
+                    u_strcpy(dec_,analysis);
+                    if (dec_[0]!='\0') {
+                        /* If we have already something in the analysis (i.e. if
+                         * we have not a simple word), we insert the concatenation
+                         * mark before the entry to come */
+                        u_strcat(dec_," +++ ");
+                    }
+                    Ustring* entry=new_Ustring(4096);
+                    /* We get the dictionary line that corresponds to the current INF code */
+                    uncompress_entry(current_component,l->string,entry);
+                    /* And we add it to the analysis */
+                    u_strcat(dec_,entry->str);
+                    unichar* new_dela_line = (unichar*)malloc(sizeof(unichar) * 4096);
+                    if (new_dela_line == NULL) {
+                        fatal_alloc_error("explore_state");
+                    }
+                    /* We copy the current output DELA line that contains
+                     * the concatenation of the previous components */
+                    u_strcpy(new_dela_line,output_dela_line);
+                    /* Then we tokenize the DELA line that corresponds the current INF
+                     * code in order to obtain its lemma and grammatical/inflectional
+                     * information */
+                    struct dela_entry* tmp_entry=tokenize_DELAF_line(entry->str,1);
+                    /* We concatenate the inflected form of the last component to
+                     * the output DELA line */
+                    u_strcat(new_dela_line,tmp_entry->inflected);
+                    /* We put the comma that separates the inflected form and the lemma */
+                    u_strcat(new_dela_line,",");
+                    /* And we build the lemma in the same way than the inflected form */
+                    u_strcat(new_dela_line,output_dela_line);
+                    u_strcat(new_dela_line,tmp_entry->lemma);
+                    /* We put the dot that separates the the lemma and the grammatical/inflectional
+                     * information */
+                    u_strcat(new_dela_line,".");
+                    /* And finally we put the grammatical/inflectional information */
+                    u_strcat(new_dela_line,tmp_entry->semantic_codes[0]);
+                    int k;
+                    for (k=1;k<tmp_entry->n_semantic_codes;k++) {
+                        u_strcat(new_dela_line,"+");
+                        u_strcat(new_dela_line,tmp_entry->semantic_codes[k]);
+                    }
+                    for (k=0;k<tmp_entry->n_inflectional_codes;k++) {
+                        u_strcat(new_dela_line,":");
+                        u_strcat(new_dela_line,tmp_entry->inflectional_codes[k]);
+                    }
+                    free_dela_entry(tmp_entry);
+                    /*
+                     * Now we can build an analysis in the form of a word decomposition
+                     * structure, but only if the last component is a valid
+                     * right one or if it is a verb long enough, or if we find out
+                     * that the word to analyze was in fact a simple word
+                     * in the dictionary */
+                    if (verb_of_more_than_4_letters(entry->str)
+                        || check_valid_right_component_for_one_INF_code(l->string)
+                        || number_of_components==1) {
+                        /*
+                         * We set the number of components, the analysis, the actual
+                         * DELA line and information about
+                         */
+                        struct word_decomposition* wd=new_word_decomposition();
+                        wd->n_parts=number_of_components;
+                        u_strcpy(wd->decomposition,dec_);
+                        u_strcpy(wd->dela_line,new_dela_line);
+                        wd->is_a_valid_right_N=check_N_right_component(l->string);
+                        wd->is_a_valid_right_A=check_A_right_component(l->string);
+                        /* Then we add the decomposition word structure to the list that
+                         * contains all the analysis for the word to analyze */
+                        struct word_decomposition_list* wdl=new_word_decomposition_list();
+                        wdl->element=wd;
+                        wdl->next=(*L);
+                        (*L)=wdl;
+                    }
+                    free_Ustring(entry);
+                    free(new_dela_line);
+                    /* We go on with the next INF code of the last component */
+                    l=l->next;
+                }
+            }
+            /* If are at the end of the word to analyze, we have nothing more to do */
+            return;
+        } else {
+            /* If we are not at the end of the word to analyze, we must
+             * 1) look if the current component is a valid left one
+             * 2) look if it is not a forbidden component and
+             * 3) explore the rest of the original word
+             */
+            if (infos->valid_left_component[inf_number] &&
+                (get_value_index(current_component,infos->forbidden_words,DONT_INSERT)==NO_VALUE_INDEX)) {
+                /* If we have a valid component, we look first if we are
+                 * in the case of a word ending by a double letter like "kupp" */
+                if (pos_in_current_component>2 &&
+                    (current_component[pos_in_current_component-1]==current_component[pos_in_current_component-2])) {
+                    /* If we have such a word, we add it to the current analysis,
+                     * putting "+++" if the current component is not the first one */
+                    unichar* dec_ = dec_buffer;
+                    u_strcpy(dec_,analysis);
+                    if (dec_[0]!='\0') {
+                        u_strcat(dec_," +++ ");
+                    }
+                    /* In order to print the component in the analysis, we arbitrary
+                     * take a valid left component among all those that are available
+                     * for the current component */
+                    unichar* multi_buffer_alloc = (unichar*)malloc(sizeof(unichar)*4096*3);
+                    if (multi_buffer_alloc==NULL) {
+                      fatal_alloc_error("explore_state");
+                    }
 
-					unichar* sia_code = sia_code_buffer;
-					unichar* line = multi_buffer_alloc;
-					Ustring* entry=new_Ustring(4096);
-					get_first_valid_left_component(infos->d->inf->codes[inf_number],sia_code);
-					uncompress_entry(current_component,sia_code,entry);
-					u_strcat(dec_,entry->str);
-					free_Ustring(entry);
-					u_strcpy(line,output_dela_line);
-					u_strcat(line,current_component);
-					/* As we have a double letter at the end of the word,
-					 * we must remove a character */
-					line[u_strlen(line)-1]='\0';
-					unichar* temp = multi_buffer_alloc + 4096;
-					unichar* dec_temp = multi_buffer_alloc + 4096 + 4096;
-					u_strcpy(dec_temp,dec_);
-					/* Then, we explore the dictionary in order to analyze the
-					 * next component. We start at the root of the dictionary
-					 * (offset=4) and we go back one position in the word to analyze.
-					 * For instance, if we have "kupplaner", we read "kupp" and then
-					 * we try to analyze "planner". */
-					Ustring* foo=new_Ustring();
-					explore_state(infos->d->initial_state_offset,temp,0,word_to_analyze,pos_in_word_to_analyze-1,
-						dec_temp,line,L,number_of_components+1,infos,ustr,0,dec_buffer,sia_code_buffer);
-					free_Ustring(foo);
-					free(multi_buffer_alloc);
-				}
-				/* Now, we try to analyze the component normally, even if
-				 * it was ended by double letter, because we can have things
-				 * like "oppbrent = opp,.ADV +++ brent,brenne.V:K" */
-				unichar* dec_ = dec_buffer;
+                    unichar* sia_code = sia_code_buffer;
+                    unichar* line = multi_buffer_alloc;
+                    Ustring* entry=new_Ustring(4096);
+                    get_first_valid_left_component(infos->d->inf->codes[inf_number],sia_code);
+                    uncompress_entry(current_component,sia_code,entry);
+                    u_strcat(dec_,entry->str);
+                    free_Ustring(entry);
+                    u_strcpy(line,output_dela_line);
+                    u_strcat(line,current_component);
+                    /* As we have a double letter at the end of the word,
+                     * we must remove a character */
+                    line[u_strlen(line)-1]='\0';
+                    unichar* temp = multi_buffer_alloc + 4096;
+                    unichar* dec_temp = multi_buffer_alloc + 4096 + 4096;
+                    u_strcpy(dec_temp,dec_);
+                    /* Then, we explore the dictionary in order to analyze the
+                     * next component. We start at the root of the dictionary
+                     * (offset=4) and we go back one position in the word to analyze.
+                     * For instance, if we have "kupplaner", we read "kupp" and then
+                     * we try to analyze "planner". */
+                    Ustring* foo=new_Ustring();
+                    explore_state(infos->d->initial_state_offset,temp,0,word_to_analyze,pos_in_word_to_analyze-1,
+                        dec_temp,line,L,number_of_components+1,infos,ustr,0,dec_buffer,sia_code_buffer);
+                    free_Ustring(foo);
+                    free(multi_buffer_alloc);
+                }
+                /* Now, we try to analyze the component normally, even if
+                 * it was ended by double letter, because we can have things
+                 * like "oppbrent = opp,.ADV +++ brent,brenne.V:K" */
+                unichar* dec_ = dec_buffer;
 
-				unichar* multi_buffer_alloc = (unichar*)malloc(sizeof(unichar) * 4096 * 3);
-				if (multi_buffer_alloc == NULL) {
-					fatal_alloc_error("explore_state");
-				}
-				unichar *line = multi_buffer_alloc;
-				u_strcpy(dec_,analysis);
-				if (dec_[0]!='\0') {
-					/* We add the "+++" mark if the current component is not the first one */
-					u_strcat(dec_," +++ ");
-				}
-				unichar* sia_code = sia_code_buffer;
-				Ustring* entry=new_Ustring(4096);
-				/* In order to print the component in the analysis, we arbitrary
-				 * take a valid left component among all those that are available
-				 * for the current component */
-				get_first_valid_left_component(infos->d->inf->codes[inf_number],sia_code);
-				uncompress_entry(current_component,sia_code,entry);
-				u_strcat(dec_,entry->str);
-				free_Ustring(entry);
-				u_strcpy(line,output_dela_line);
-				u_strcat(line,current_component);
-				unichar* temp = multi_buffer_alloc + 4096;
-				unichar* dec_temp = multi_buffer_alloc + 4096 + 4096;
-				u_strcpy(dec_temp,dec_);
-				/* Then, we explore the dictionary in order to analyze the
-				 * next component. We start at the root of the dictionary
-				 * (offset=4). */
-				Ustring* foo=new_Ustring();
-				explore_state(infos->d->initial_state_offset,temp,0,word_to_analyze,pos_in_word_to_analyze,
-					dec_temp,line,L,number_of_components+1,infos,foo,0,dec_buffer,sia_code_buffer);
-				free_Ustring(foo);
-				free(multi_buffer_alloc);
-			}
-		}
-	}
-	/* Once we have finished to deal with the current final dictionary node,
-	 * we go on because we may match a longer word */
-	base=ustr->len;
+                unichar* multi_buffer_alloc = (unichar*)malloc(sizeof(unichar) * 4096 * 3);
+                if (multi_buffer_alloc == NULL) {
+                    fatal_alloc_error("explore_state");
+                }
+                unichar *line = multi_buffer_alloc;
+                u_strcpy(dec_,analysis);
+                if (dec_[0]!='\0') {
+                    /* We add the "+++" mark if the current component is not the first one */
+                    u_strcat(dec_," +++ ");
+                }
+                unichar* sia_code = sia_code_buffer;
+                Ustring* entry=new_Ustring(4096);
+                /* In order to print the component in the analysis, we arbitrary
+                 * take a valid left component among all those that are available
+                 * for the current component */
+                get_first_valid_left_component(infos->d->inf->codes[inf_number],sia_code);
+                uncompress_entry(current_component,sia_code,entry);
+                u_strcat(dec_,entry->str);
+                free_Ustring(entry);
+                u_strcpy(line,output_dela_line);
+                u_strcat(line,current_component);
+                unichar* temp = multi_buffer_alloc + 4096;
+                unichar* dec_temp = multi_buffer_alloc + 4096 + 4096;
+                u_strcpy(dec_temp,dec_);
+                /* Then, we explore the dictionary in order to analyze the
+                 * next component. We start at the root of the dictionary
+                 * (offset=4). */
+                Ustring* foo=new_Ustring();
+                explore_state(infos->d->initial_state_offset,temp,0,word_to_analyze,pos_in_word_to_analyze,
+                    dec_temp,line,L,number_of_components+1,infos,foo,0,dec_buffer,sia_code_buffer);
+                free_Ustring(foo);
+                free(multi_buffer_alloc);
+            }
+        }
+    }
+    /* Once we have finished to deal with the current final dictionary node,
+     * we go on because we may match a longer word */
+    base=ustr->len;
 }
 /* We examine each transition that goes out from the node */
 unichar uc;
 int adr;
 for (int i=0;i<n_transitions;i++) {
-	offset=read_dictionary_transition(infos->d,offset,&uc,&adr,ustr);
-	if (is_equal_or_uppercase(uc,word_to_analyze[pos_in_word_to_analyze],infos->alphabet)) {
-		/* If the transition's letter is case compatible with the current letter of the
-		 * word to analyze, we follow it */
-		current_component[pos_in_current_component]=uc;
-		explore_state(adr,current_component,pos_in_current_component+1,word_to_analyze,pos_in_word_to_analyze+1,
-			analysis,output_dela_line,L,number_of_components,infos,ustr,base,dec_buffer,sia_code_buffer);
-	}
-	restore_output(z,ustr);
+    offset=read_dictionary_transition(infos->d,offset,&uc,&adr,ustr);
+    if (is_equal_or_uppercase(uc,word_to_analyze[pos_in_word_to_analyze],infos->alphabet)) {
+        /* If the transition's letter is case compatible with the current letter of the
+         * word to analyze, we follow it */
+        current_component[pos_in_current_component]=uc;
+        explore_state(adr,current_component,pos_in_current_component+1,word_to_analyze,pos_in_word_to_analyze+1,
+            analysis,output_dela_line,L,number_of_components,infos,ustr,base,dec_buffer,sia_code_buffer);
+    }
+    restore_output(z,ustr);
 }
 }
 
@@ -959,6 +959,6 @@ void explore_state(int offset,unichar* current_component,int pos_in_current_comp
                    word_to_analyze,pos_in_word_to_analyze,analysis,
                    output_dela_line,L,
                    number_of_components,infos,ustr,base,
-				   dec_buffer,sia_code_buffer);
+                   dec_buffer,sia_code_buffer);
 }
 } // namespace unitex

--- a/NorwegianCompounds.h
+++ b/NorwegianCompounds.h
@@ -35,7 +35,7 @@
 namespace unitex {
 
 void analyse_norwegian_unknown_words(const Alphabet*,Dictionary*,U_FILE*,
-									U_FILE*,U_FILE*,U_FILE*,struct string_hash*);
+                                    U_FILE*,U_FILE*,U_FILE*,struct string_hash*);
 
 } // namespace unitex
 

--- a/Offsets.cpp
+++ b/Offsets.cpp
@@ -265,7 +265,7 @@ vector_offset* common_offsets_to_modified(const vector_offset* common_offsets, i
 
 		if ((modified_offset.old_end > modified_offset.old_start) ||
 			(modified_offset.new_end > modified_offset.new_start)) {
-			vector_offset_add(modifed_vector_offset, modified_offset);			
+			vector_offset_add(modifed_vector_offset, modified_offset);
 		}
 		latest_common = current_common;
 	}
@@ -431,7 +431,7 @@ vector_offset* process_offsets(const vector_offset* first_offsets, const vector_
 
 	int size_possible_file_0 = size_possible_file_1 - global_shift_first;
 	int size_possible_file_2 = size_possible_file_1 + global_shift_second;
-	
+
 	// if we add the same positive integer to size_possible_file_0, size_possible_file_1, size_possible_file_2
 	// the merged_modified result will be the same
 	vector_offset* first_offset_common = modified_offsets_to_common(first_offsets, size_possible_file_0, size_possible_file_1);
@@ -773,7 +773,7 @@ if ((nb_translations == 0) || (ofs == NULL)) {
 }
 int i;
 int sorted_by_position = 1;
-for (i = 1;i < nb_translations;i++) 
+for (i = 1;i < nb_translations;i++)
 	if (((ofs + i)->position_to_translate) < ((ofs + i - 1)->position_to_translate)) {
 		sorted_by_position = 0;
 		break;

--- a/Offsets.cpp
+++ b/Offsets.cpp
@@ -42,10 +42,10 @@ if (f==NULL) return NULL;
 int a,b,c,d,n;
 vector_offset* res=new_vector_offset();
 while ((n=u_fscanf(f,"%d%d%d%d",&a,&b,&c,&d))!=EOF) {
-	if (n!=4) {
-		fatal_error("Corrupted offset file %s\n",name);
-	}
-	vector_offset_add(res,a,b,c,d);
+    if (n!=4) {
+        fatal_error("Corrupted offset file %s\n",name);
+    }
+    vector_offset_add(res,a,b,c,d);
 }
 u_fclose(f);
 return res;
@@ -60,13 +60,13 @@ u_fprintf(f, "%d %d %d %d\n", a, b, c, d);
 
 void save_offsets(U_FILE* f, const vector_offset* offsets) {
 if (offsets == NULL) {
-	return;
+    return;
 }
 int nb_offsets_items = offsets->nbelems;
 
 for (int i = 0; i < nb_offsets_items; i++) {
-	Offsets x = offsets->tab[i];
-	save_offsets(f, x.old_start, x.old_end, x.new_start, x.new_end);
+    Offsets x = offsets->tab[i];
+    save_offsets(f, x.old_start, x.old_end, x.new_start, x.new_end);
 }
 }
 
@@ -75,8 +75,8 @@ for (int i = 0; i < nb_offsets_items; i++) {
 /*static void save_offsets(U_FILE* f,vector_offset* v) {
 if (v==NULL) return;
 for (int i=0;i<v->nbelems;i++) {
-	Offsets o=v->tab[i];
-	save_offsets(f,o.old_start,o.old_end,o.new_start,o.new_end);
+    Offsets o=v->tab[i];
+    save_offsets(f,o.old_start,o.old_end,o.new_start,o.new_end);
 }
 }*/
 
@@ -97,24 +97,24 @@ default: return "OOOOOOOOPS";
 
 
 int save_offsets(const VersatileEncodingConfig* vec, const char* filename, const vector_offset* offsets) {
-	U_FILE* f_output_offsets = u_fopen(vec, filename, U_WRITE);
-	if (f_output_offsets == NULL) {
-		error("Cannot create offset file %s\n", filename);
-		return 1;
-	}
-	save_offsets(f_output_offsets, offsets);
-	u_fclose(f_output_offsets);
-	return 0;
+    U_FILE* f_output_offsets = u_fopen(vec, filename, U_WRITE);
+    if (f_output_offsets == NULL) {
+        error("Cannot create offset file %s\n", filename);
+        return 1;
+    }
+    save_offsets(f_output_offsets, offsets);
+    u_fclose(f_output_offsets);
+    return 0;
 }
 
 
 static inline int vector_offset_add(vector_offset* vec, Offsets o) {
-	while (vec->nbelems >= vec->size) {
-		vector_offset_resize(vec, vec->size * 2);
-	}
-	vec->tab[vec->nbelems] = o;
-	vec->nbelems++;
-	return vec->nbelems - 1;
+    while (vec->nbelems >= vec->size) {
+        vector_offset_resize(vec, vec->size * 2);
+    }
+    vec->tab[vec->nbelems] = o;
+    vec->nbelems++;
+    return vec->nbelems - 1;
 }
 
 
@@ -122,16 +122,16 @@ static inline int vector_offset_add(vector_offset* vec, Offsets o) {
  * add offset, merge with previous if possible
  */
 static inline int vector_offset_add_with_merging(vector_offset* vec, Offsets o) {
-	if (vec->nbelems > 0) {
-		Offsets* latest = &(vec->tab[vec->nbelems - 1]);
-		if ((latest->old_end == o.old_start) && (latest->new_end == o.new_start)) {
-			latest->old_end = o.old_end;
-			latest->new_end = o.new_end;
-			return vec->nbelems - 1;
-		}
-	}
+    if (vec->nbelems > 0) {
+        Offsets* latest = &(vec->tab[vec->nbelems - 1]);
+        if ((latest->old_end == o.old_start) && (latest->new_end == o.new_start)) {
+            latest->old_end = o.old_end;
+            latest->new_end = o.new_end;
+            return vec->nbelems - 1;
+        }
+    }
 
-	return vector_offset_add(vec, o);
+    return vector_offset_add(vec, o);
 }
 
 
@@ -139,34 +139,34 @@ static inline int vector_offset_add_with_merging(vector_offset* vec, Offsets o) 
  * Check if a Common offset item is valid
  */
 static int DetectCommonIncoherency(
-	int old_size, int old_pos, int old_limit,
-	int new_size, int new_pos, int new_limit)
+    int old_size, int old_pos, int old_limit,
+    int new_size, int new_pos, int new_limit)
 {
-	if ((old_limit < old_pos) || (new_limit < new_pos)) {
-		return 1;
-	}
-	else if ((old_limit > old_size) || (new_limit > new_size)) {
-		return 1;
-	}
-	else if ((old_limit - old_pos) != (new_limit - new_pos)) {
-		return 1;
-	}
-	return 0;
+    if ((old_limit < old_pos) || (new_limit < new_pos)) {
+        return 1;
+    }
+    else if ((old_limit > old_size) || (new_limit > new_size)) {
+        return 1;
+    }
+    else if ((old_limit - old_pos) != (new_limit - new_pos)) {
+        return 1;
+    }
+    return 0;
 }
 
 
 
 static int global_shift_from_modified_offsets(const vector_offset* offsets) {
-	int nb_offsets_items = offsets->nbelems;
-	int global_shift = 0;
-	for (int i = 0; i < nb_offsets_items; i++) {
-		Offsets x = offsets->tab[i];
-		int size_old_sequence = x.old_end - x.old_start;
-		int size_new_sequence = x.new_end - x.new_start;
-		global_shift += (size_new_sequence - size_old_sequence);
-	}
-	//u_printf("SHIFT %d\n\n", global_shift);
-	return global_shift;
+    int nb_offsets_items = offsets->nbelems;
+    int global_shift = 0;
+    for (int i = 0; i < nb_offsets_items; i++) {
+        Offsets x = offsets->tab[i];
+        int size_old_sequence = x.old_end - x.old_start;
+        int size_new_sequence = x.new_end - x.new_start;
+        global_shift += (size_new_sequence - size_old_sequence);
+    }
+    //u_printf("SHIFT %d\n\n", global_shift);
+    return global_shift;
 }
 
 
@@ -175,159 +175,159 @@ static int global_shift_from_modified_offsets(const vector_offset* offsets) {
  *
  */
 vector_offset* modified_offsets_to_common(const vector_offset* offsets, int old_size, int new_size) {
-	if ((old_size == -1) && (new_size != -1)) {
-		old_size = new_size - global_shift_from_modified_offsets(offsets);
-	} else if ((old_size != -1) && (new_size == -1)) {
-		new_size = old_size + global_shift_from_modified_offsets(offsets);
-	}
+    if ((old_size == -1) && (new_size != -1)) {
+        old_size = new_size - global_shift_from_modified_offsets(offsets);
+    } else if ((old_size != -1) && (new_size == -1)) {
+        new_size = old_size + global_shift_from_modified_offsets(offsets);
+    }
 
-	int nb_offsets_items = offsets->nbelems;
-	vector_offset* inverted_vector_offset = new_vector_offset(nb_offsets_items + 1);
-	for (int i = 0; i < nb_offsets_items; i++) {
-		Offsets curOffset = offsets->tab[i];
-		Offsets prevOffset;
-		if (i > 0) {
-			prevOffset = offsets->tab[i - 1];
-		}
-		else {
-			prevOffset.old_end = prevOffset.new_end = 0;
-		}
+    int nb_offsets_items = offsets->nbelems;
+    vector_offset* inverted_vector_offset = new_vector_offset(nb_offsets_items + 1);
+    for (int i = 0; i < nb_offsets_items; i++) {
+        Offsets curOffset = offsets->tab[i];
+        Offsets prevOffset;
+        if (i > 0) {
+            prevOffset = offsets->tab[i - 1];
+        }
+        else {
+            prevOffset.old_end = prevOffset.new_end = 0;
+        }
 
-		Offsets CommonOffset;
-		CommonOffset.old_start = prevOffset.old_end;
-		CommonOffset.old_end = curOffset.old_start;
-		CommonOffset.new_start = prevOffset.new_end;
-		CommonOffset.new_end = curOffset.new_start;
-		if (DetectCommonIncoherency(old_size, CommonOffset.old_start, CommonOffset.old_end,
-			new_size, CommonOffset.new_start, CommonOffset.new_end)) {
-			free_vector_offset(inverted_vector_offset);
-			error("coherency problem on offset file");
-			return NULL;
-		}
+        Offsets CommonOffset;
+        CommonOffset.old_start = prevOffset.old_end;
+        CommonOffset.old_end = curOffset.old_start;
+        CommonOffset.new_start = prevOffset.new_end;
+        CommonOffset.new_end = curOffset.new_start;
+        if (DetectCommonIncoherency(old_size, CommonOffset.old_start, CommonOffset.old_end,
+            new_size, CommonOffset.new_start, CommonOffset.new_end)) {
+            free_vector_offset(inverted_vector_offset);
+            error("coherency problem on offset file");
+            return NULL;
+        }
 
-		if (CommonOffset.new_start != CommonOffset.new_end) {
-			vector_offset_add(inverted_vector_offset, CommonOffset);
-		}
-	}
+        if (CommonOffset.new_start != CommonOffset.new_end) {
+            vector_offset_add(inverted_vector_offset, CommonOffset);
+        }
+    }
 
-	Offsets LastCommonOffset;
-	if (nb_offsets_items > 0) {
-		LastCommonOffset.old_start = offsets->tab[nb_offsets_items - 1].old_end;
-		LastCommonOffset.new_start = offsets->tab[nb_offsets_items - 1].new_end;
-	} else {
-		LastCommonOffset.old_start = 0;
-		LastCommonOffset.new_start = 0;
-	}
-	LastCommonOffset.old_end = old_size;
-	LastCommonOffset.new_end = new_size;
+    Offsets LastCommonOffset;
+    if (nb_offsets_items > 0) {
+        LastCommonOffset.old_start = offsets->tab[nb_offsets_items - 1].old_end;
+        LastCommonOffset.new_start = offsets->tab[nb_offsets_items - 1].new_end;
+    } else {
+        LastCommonOffset.old_start = 0;
+        LastCommonOffset.new_start = 0;
+    }
+    LastCommonOffset.old_end = old_size;
+    LastCommonOffset.new_end = new_size;
 
 
-	if (DetectCommonIncoherency(old_size, LastCommonOffset.old_start, LastCommonOffset.old_end,
-		new_size, LastCommonOffset.new_start, LastCommonOffset.new_end)) {
-		free_vector_offset(inverted_vector_offset);
-		error("coherency problem on offset file");
-		return NULL;
-	}
+    if (DetectCommonIncoherency(old_size, LastCommonOffset.old_start, LastCommonOffset.old_end,
+        new_size, LastCommonOffset.new_start, LastCommonOffset.new_end)) {
+        free_vector_offset(inverted_vector_offset);
+        error("coherency problem on offset file");
+        return NULL;
+    }
 
-	if (LastCommonOffset.new_start != LastCommonOffset.new_end) {
-		vector_offset_add(inverted_vector_offset, LastCommonOffset);
-	}
+    if (LastCommonOffset.new_start != LastCommonOffset.new_end) {
+        vector_offset_add(inverted_vector_offset, LastCommonOffset);
+    }
 
-	return inverted_vector_offset;
+    return inverted_vector_offset;
 }
 
 
 vector_offset* common_offsets_to_modified(const vector_offset* common_offsets, int old_size, int new_size) {
-	if (common_offsets == NULL) {
-		return NULL;
-	}
-	int nb_common_offsets_items = common_offsets->nbelems;
-	vector_offset* modifed_vector_offset = new_vector_offset(nb_common_offsets_items + 2);
+    if (common_offsets == NULL) {
+        return NULL;
+    }
+    int nb_common_offsets_items = common_offsets->nbelems;
+    vector_offset* modifed_vector_offset = new_vector_offset(nb_common_offsets_items + 2);
 
-	Offsets latest_common;
-	latest_common.old_start = latest_common.old_end = latest_common.new_start = latest_common.new_end = 0;
-	for (int i = 0; i < nb_common_offsets_items; i++) {
-		Offsets current_common = common_offsets->tab[i];
+    Offsets latest_common;
+    latest_common.old_start = latest_common.old_end = latest_common.new_start = latest_common.new_end = 0;
+    for (int i = 0; i < nb_common_offsets_items; i++) {
+        Offsets current_common = common_offsets->tab[i];
 
-		if ((current_common.old_end - current_common.old_start) !=
-			(current_common.new_end - current_common.new_start)) {
-			error("Mismatch in length in common offset");
-			free_vector_offset(modifed_vector_offset);
-			return NULL;
-		}
+        if ((current_common.old_end - current_common.old_start) !=
+            (current_common.new_end - current_common.new_start)) {
+            error("Mismatch in length in common offset");
+            free_vector_offset(modifed_vector_offset);
+            return NULL;
+        }
 
-		Offsets modified_offset;
-		modified_offset.old_start = latest_common.old_end;
-		modified_offset.new_start = latest_common.new_end;
+        Offsets modified_offset;
+        modified_offset.old_start = latest_common.old_end;
+        modified_offset.new_start = latest_common.new_end;
 
-		modified_offset.old_end = current_common.old_start;
-		modified_offset.new_end = current_common.new_start;
+        modified_offset.old_end = current_common.old_start;
+        modified_offset.new_end = current_common.new_start;
 
-		if ((modified_offset.old_end > modified_offset.old_start) ||
-			(modified_offset.new_end > modified_offset.new_start)) {
-			vector_offset_add(modifed_vector_offset, modified_offset);
-		}
-		latest_common = current_common;
-	}
+        if ((modified_offset.old_end > modified_offset.old_start) ||
+            (modified_offset.new_end > modified_offset.new_start)) {
+            vector_offset_add(modifed_vector_offset, modified_offset);
+        }
+        latest_common = current_common;
+    }
 
-	Offsets latest_modified_offset;
-	latest_modified_offset.old_start = latest_common.old_end;
-	latest_modified_offset.new_start = latest_common.new_end;
+    Offsets latest_modified_offset;
+    latest_modified_offset.old_start = latest_common.old_end;
+    latest_modified_offset.new_start = latest_common.new_end;
 
-	latest_modified_offset.old_end = old_size;
-	latest_modified_offset.new_end = new_size;
+    latest_modified_offset.old_end = old_size;
+    latest_modified_offset.new_end = new_size;
 
-	if ((latest_modified_offset.old_end > latest_modified_offset.old_start) ||
-		(latest_modified_offset.new_end > latest_modified_offset.new_start)) {
-		vector_offset_add(modifed_vector_offset, latest_modified_offset);
-	}
+    if ((latest_modified_offset.old_end > latest_modified_offset.old_start) ||
+        (latest_modified_offset.new_end > latest_modified_offset.new_start)) {
+        vector_offset_add(modifed_vector_offset, latest_modified_offset);
+    }
 
-	return modifed_vector_offset;
+    return modifed_vector_offset;
 }
 
 
 vector_offset* common_offsets_to_modifed(const vector_offset* offsets, int old_size, int new_size) {
 
-	int nb_offsets_items = offsets->nbelems;
-	vector_offset* inverted_vector_offset = new_vector_offset(nb_offsets_items + 2);
-	for (int i = 0; i < nb_offsets_items; i++) {
-		Offsets curOffset = offsets->tab[i];
-		Offsets prevOffset;
-		if (i > 0) {
-			prevOffset = offsets->tab[i - 1];
-		}
-		else {
-			prevOffset.old_end = prevOffset.new_end = 0;
-		}
+    int nb_offsets_items = offsets->nbelems;
+    vector_offset* inverted_vector_offset = new_vector_offset(nb_offsets_items + 2);
+    for (int i = 0; i < nb_offsets_items; i++) {
+        Offsets curOffset = offsets->tab[i];
+        Offsets prevOffset;
+        if (i > 0) {
+            prevOffset = offsets->tab[i - 1];
+        }
+        else {
+            prevOffset.old_end = prevOffset.new_end = 0;
+        }
 
-		Offsets DifferentOffset;
-		DifferentOffset.old_start = prevOffset.old_end;
-		DifferentOffset.old_end = curOffset.old_start;
-		DifferentOffset.new_start = prevOffset.new_end;
-		DifferentOffset.new_end = curOffset.new_start;
+        Offsets DifferentOffset;
+        DifferentOffset.old_start = prevOffset.old_end;
+        DifferentOffset.old_end = curOffset.old_start;
+        DifferentOffset.new_start = prevOffset.new_end;
+        DifferentOffset.new_end = curOffset.new_start;
 
-		vector_offset_add(inverted_vector_offset, DifferentOffset);
-	}
+        vector_offset_add(inverted_vector_offset, DifferentOffset);
+    }
 
-	Offsets LastDifferentOffset;
-	if (nb_offsets_items > 0) {
-		LastDifferentOffset.old_start = offsets->tab[nb_offsets_items - 1].old_end;
-		LastDifferentOffset.new_start = offsets->tab[nb_offsets_items - 1].new_end;
-	}
-	else {
-		LastDifferentOffset.old_start = 0;
-		LastDifferentOffset.new_start = 0;
-	}
-	LastDifferentOffset.old_end = old_size;
-	LastDifferentOffset.new_end = new_size;
+    Offsets LastDifferentOffset;
+    if (nb_offsets_items > 0) {
+        LastDifferentOffset.old_start = offsets->tab[nb_offsets_items - 1].old_end;
+        LastDifferentOffset.new_start = offsets->tab[nb_offsets_items - 1].new_end;
+    }
+    else {
+        LastDifferentOffset.old_start = 0;
+        LastDifferentOffset.new_start = 0;
+    }
+    LastDifferentOffset.old_end = old_size;
+    LastDifferentOffset.new_end = new_size;
 
-	if ((LastDifferentOffset.old_start != LastDifferentOffset.old_end) ||
-		(LastDifferentOffset.old_start != LastDifferentOffset.old_end)) {
+    if ((LastDifferentOffset.old_start != LastDifferentOffset.old_end) ||
+        (LastDifferentOffset.old_start != LastDifferentOffset.old_end)) {
 
-		vector_offset_add(inverted_vector_offset, LastDifferentOffset);
-	}
+        vector_offset_add(inverted_vector_offset, LastDifferentOffset);
+    }
 
-	return inverted_vector_offset;
+    return inverted_vector_offset;
 }
 
 
@@ -337,73 +337,73 @@ vector_offset* common_offsets_to_modifed(const vector_offset* offsets, int old_s
 
 vector_offset* process_common_offsets(const vector_offset* first_offsets, const vector_offset* second_offsets)
 {
-	if ((first_offsets == NULL) || (second_offsets == NULL)) {
-		return NULL;
-	}
-	int first_nb_offsets_items = first_offsets->nbelems;
-	int second_nb_offsets_items = second_offsets->nbelems;
-	vector_offset* merged_vector_offset = new_vector_offset(first_nb_offsets_items + second_nb_offsets_items + 1);
+    if ((first_offsets == NULL) || (second_offsets == NULL)) {
+        return NULL;
+    }
+    int first_nb_offsets_items = first_offsets->nbelems;
+    int second_nb_offsets_items = second_offsets->nbelems;
+    vector_offset* merged_vector_offset = new_vector_offset(first_nb_offsets_items + second_nb_offsets_items + 1);
 
-	int pos_in_first_offsets = 0;
-	for (int i = 0; i < second_nb_offsets_items; i++)
-	{
-		Offsets common_offset_in_second = second_offsets->tab[i];
-		if ((common_offset_in_second.old_end - common_offset_in_second.old_start) !=
-			(common_offset_in_second.new_end - common_offset_in_second.new_start))
-		{
-			free_vector_offset(merged_vector_offset);
-			error("Invalid common offset file");
-			return NULL;
-		}
+    int pos_in_first_offsets = 0;
+    for (int i = 0; i < second_nb_offsets_items; i++)
+    {
+        Offsets common_offset_in_second = second_offsets->tab[i];
+        if ((common_offset_in_second.old_end - common_offset_in_second.old_start) !=
+            (common_offset_in_second.new_end - common_offset_in_second.new_start))
+        {
+            free_vector_offset(merged_vector_offset);
+            error("Invalid common offset file");
+            return NULL;
+        }
 
-		while ((common_offset_in_second.old_end - common_offset_in_second.old_start) != 0) {
-			for (;;)
-			{
-				if (pos_in_first_offsets == first_nb_offsets_items) {
-					// we have no common part in first file to process
-					return merged_vector_offset;
-				}
+        while ((common_offset_in_second.old_end - common_offset_in_second.old_start) != 0) {
+            for (;;)
+            {
+                if (pos_in_first_offsets == first_nb_offsets_items) {
+                    // we have no common part in first file to process
+                    return merged_vector_offset;
+                }
 
-				if (first_offsets->tab[pos_in_first_offsets].new_end > common_offset_in_second.old_start) {
-					break;
-				}
-				pos_in_first_offsets++;
-			}
+                if (first_offsets->tab[pos_in_first_offsets].new_end > common_offset_in_second.old_start) {
+                    break;
+                }
+                pos_in_first_offsets++;
+            }
 
-			int nb_common = 0;
-			Offsets current_common_in_first = first_offsets->tab[pos_in_first_offsets];
-			if (current_common_in_first.new_start > common_offset_in_second.old_start) {
-				int skip_second = current_common_in_first.new_start - common_offset_in_second.old_start;
-				common_offset_in_second.old_start += skip_second;
-				common_offset_in_second.new_start += skip_second;
-			}
-			if (current_common_in_first.new_start < common_offset_in_second.old_start) {
-				int skip_first = common_offset_in_second.old_start - current_common_in_first.new_start;
-				current_common_in_first.old_start += skip_first;
-				current_common_in_first.new_start += skip_first;
-			}
+            int nb_common = 0;
+            Offsets current_common_in_first = first_offsets->tab[pos_in_first_offsets];
+            if (current_common_in_first.new_start > common_offset_in_second.old_start) {
+                int skip_second = current_common_in_first.new_start - common_offset_in_second.old_start;
+                common_offset_in_second.old_start += skip_second;
+                common_offset_in_second.new_start += skip_second;
+            }
+            if (current_common_in_first.new_start < common_offset_in_second.old_start) {
+                int skip_first = common_offset_in_second.old_start - current_common_in_first.new_start;
+                current_common_in_first.old_start += skip_first;
+                current_common_in_first.new_start += skip_first;
+            }
 
-			int len_common = offset_min(current_common_in_first.new_end - current_common_in_first.new_start,
-				common_offset_in_second.old_end - common_offset_in_second.old_start);
-			if (len_common > 0) {
-				Offsets CommonOffsetToWrite;
-				nb_common = len_common;
-				int shift_in_first = 0;//common_offset_in_second.old_start >= current_common_in_first.new_start;
-				CommonOffsetToWrite.old_start = current_common_in_first.old_start + shift_in_first;
-				CommonOffsetToWrite.old_end = CommonOffsetToWrite.old_start + nb_common;
-				CommonOffsetToWrite.new_start = common_offset_in_second.new_start;
-				CommonOffsetToWrite.new_end = CommonOffsetToWrite.new_start + nb_common;
-				vector_offset_add_with_merging(merged_vector_offset, CommonOffsetToWrite);
-				common_offset_in_second.old_start += nb_common;
-				common_offset_in_second.new_start += nb_common;
-			}
-			else {
-				break;
-			}
-		}
-	}
+            int len_common = offset_min(current_common_in_first.new_end - current_common_in_first.new_start,
+                common_offset_in_second.old_end - common_offset_in_second.old_start);
+            if (len_common > 0) {
+                Offsets CommonOffsetToWrite;
+                nb_common = len_common;
+                int shift_in_first = 0;//common_offset_in_second.old_start >= current_common_in_first.new_start;
+                CommonOffsetToWrite.old_start = current_common_in_first.old_start + shift_in_first;
+                CommonOffsetToWrite.old_end = CommonOffsetToWrite.old_start + nb_common;
+                CommonOffsetToWrite.new_start = common_offset_in_second.new_start;
+                CommonOffsetToWrite.new_end = CommonOffsetToWrite.new_start + nb_common;
+                vector_offset_add_with_merging(merged_vector_offset, CommonOffsetToWrite);
+                common_offset_in_second.old_start += nb_common;
+                common_offset_in_second.new_start += nb_common;
+            }
+            else {
+                break;
+            }
+        }
+    }
 
-	return merged_vector_offset;
+    return merged_vector_offset;
 }
 
 
@@ -414,36 +414,36 @@ vector_offset* process_common_offsets(const vector_offset* first_offsets, const 
 vector_offset* process_offsets(const vector_offset* first_offsets, const vector_offset* second_offsets) {
 
 
-	// We don't known the size of the two file.
-	// We calculate possible value
-	int global_shift_first = global_shift_from_modified_offsets(first_offsets);
-	int global_shift_second = global_shift_from_modified_offsets(second_offsets);
+    // We don't known the size of the two file.
+    // We calculate possible value
+    int global_shift_first = global_shift_from_modified_offsets(first_offsets);
+    int global_shift_second = global_shift_from_modified_offsets(second_offsets);
 
-	int last_pos_mentionned_file0 = (first_offsets->nbelems > 0) ? first_offsets->tab[first_offsets->nbelems-1].old_end : 0;
-	int last_pos_mentionned_file1a = (first_offsets->nbelems > 0) ? first_offsets->tab[first_offsets->nbelems-1].new_end : 0;
-	int last_pos_mentionned_file1b = (second_offsets->nbelems > 0) ? second_offsets->tab[second_offsets->nbelems-1].old_end : 0;
-	int last_pos_mentionned_file2 = (second_offsets->nbelems > 0) ? second_offsets->tab[second_offsets->nbelems-1].new_end : 0;
+    int last_pos_mentionned_file0 = (first_offsets->nbelems > 0) ? first_offsets->tab[first_offsets->nbelems-1].old_end : 0;
+    int last_pos_mentionned_file1a = (first_offsets->nbelems > 0) ? first_offsets->tab[first_offsets->nbelems-1].new_end : 0;
+    int last_pos_mentionned_file1b = (second_offsets->nbelems > 0) ? second_offsets->tab[second_offsets->nbelems-1].old_end : 0;
+    int last_pos_mentionned_file2 = (second_offsets->nbelems > 0) ? second_offsets->tab[second_offsets->nbelems-1].new_end : 0;
 
 
-	int size_possible_file_1a = offset_max(last_pos_mentionned_file0 + global_shift_first, last_pos_mentionned_file1a);
-	int size_possible_file_1b = offset_max(last_pos_mentionned_file2 - global_shift_second, last_pos_mentionned_file1b);
-	int size_possible_file_1 = offset_max(size_possible_file_1a, size_possible_file_1b);
+    int size_possible_file_1a = offset_max(last_pos_mentionned_file0 + global_shift_first, last_pos_mentionned_file1a);
+    int size_possible_file_1b = offset_max(last_pos_mentionned_file2 - global_shift_second, last_pos_mentionned_file1b);
+    int size_possible_file_1 = offset_max(size_possible_file_1a, size_possible_file_1b);
 
-	int size_possible_file_0 = size_possible_file_1 - global_shift_first;
-	int size_possible_file_2 = size_possible_file_1 + global_shift_second;
+    int size_possible_file_0 = size_possible_file_1 - global_shift_first;
+    int size_possible_file_2 = size_possible_file_1 + global_shift_second;
 
-	// if we add the same positive integer to size_possible_file_0, size_possible_file_1, size_possible_file_2
-	// the merged_modified result will be the same
-	vector_offset* first_offset_common = modified_offsets_to_common(first_offsets, size_possible_file_0, size_possible_file_1);
-	vector_offset* second_offset_common = modified_offsets_to_common(second_offsets, size_possible_file_1, size_possible_file_2);
-	vector_offset* merged_common = process_common_offsets(first_offset_common, second_offset_common);
-	vector_offset* merged_modified = common_offsets_to_modified(merged_common, size_possible_file_0, size_possible_file_2);
+    // if we add the same positive integer to size_possible_file_0, size_possible_file_1, size_possible_file_2
+    // the merged_modified result will be the same
+    vector_offset* first_offset_common = modified_offsets_to_common(first_offsets, size_possible_file_0, size_possible_file_1);
+    vector_offset* second_offset_common = modified_offsets_to_common(second_offsets, size_possible_file_1, size_possible_file_2);
+    vector_offset* merged_common = process_common_offsets(first_offset_common, second_offset_common);
+    vector_offset* merged_modified = common_offsets_to_modified(merged_common, size_possible_file_0, size_possible_file_2);
 
-	free_vector_offset(first_offset_common);
-	free_vector_offset(second_offset_common);
-	free_vector_offset(merged_common);
+    free_vector_offset(first_offset_common);
+    free_vector_offset(second_offset_common);
+    free_vector_offset(merged_common);
 
-	return merged_modified;
+    return merged_modified;
 }
 
 
@@ -463,13 +463,13 @@ vector_offset* process_offsets(const vector_offset* first_offsets, const vector_
 void process_offsets(const vector_offset* first_offsets, const vector_offset* second_offsets, U_FILE* f) {
 if (f == NULL || second_offsets == NULL) return;
 if (first_offsets == NULL) {
-	save_offsets(f, second_offsets);
+    save_offsets(f, second_offsets);
 }
 else {
-	vector_offset* processed_offset = process_offsets(first_offsets, second_offsets);
-	save_offsets(f, processed_offset);
+    vector_offset* processed_offset = process_offsets(first_offsets, second_offsets);
+    save_offsets(f, processed_offset);
 
-	free_vector_offset(processed_offset);
+    free_vector_offset(processed_offset);
 }
 }
 
@@ -491,167 +491,167 @@ else {
 * without any modification.
 */
 void process_offsets(const vector_offset* old_offsets, const vector_offset* new_offsets, U_FILE* f) {
-	if (f == NULL || new_offsets == NULL) return;
-	if (old_offsets == NULL) {
-		/* If there are no old offsets, we just have to save the new ones */
-		Offsets x;
-		for (int i = 0;i<new_offsets->nbelems;i++) {
-			x = new_offsets->tab[i];
-			save_offsets(f, x.old_start, x.old_end, x.new_start, x.new_end);
-		}
-		return;
-	}
-	int i = 0, j = 0;
-	/* shift_A is the current shift between original text and input text. It is
-	* to be used when B is before A, in order to adjust B's old coordinates */
-	int shift_A = 0;
-	/* shift_B is the current shift between input text and output text. It is
-	* to be used when A is before B, in order to adjust A's new coordinates */
-	int shift_B = 0;
-	int A_includes_B_shift = 0;
-	int B_includes_A_shift = 0;
-	Offsets x, y;
-	Overlap o;
-	while (j < new_offsets->nbelems) {
-		y = x = new_offsets->tab[j++];
-		o = (Overlap)-1;
-		for (; i < old_offsets->nbelems; i++) {
-			x = old_offsets->tab[i];
-			/* Note: below, A stands for x's new interval and B stands for y's old interval */
-			/*error("\n\nTEST OVERLAP entre %d;%d->%d;%d et %d;%d->%d;%d\n",
-			x.old_start,x.old_end,x.new_start,x.new_end,
-			y.old_start,y.old_end,y.new_start,y.new_end);*/
-			o = overlap(x.new_start, x.new_end, y.old_start, y.old_end);
-			//error("o==%s\n",N(o));
-			if (o == A_BEFORE_B) {
-				save_offsets(f,
-					x.old_start,
-					x.old_end,
-					x.new_start + shift_B,
-					x.new_end + shift_B + A_includes_B_shift);
-				A_includes_B_shift = 0;
-				shift_A = x.old_end - x.new_end;
-			}
-			else {
-				break;
-			}
-		}
-		if (i < old_offsets->nbelems) {
-			/* There may be an overlap */
-			if (o == A_INCLUDES_B) {
-				/* If A includes B, then we just have to stay on A, note
-				* the shift induced by B and then ignore B */
-				//error("A includes B entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
-				int b_old_length = y.old_end - y.old_start;
-				int b_new_length = y.new_end - y.new_start;
-				A_includes_B_shift += b_new_length - b_old_length;
-				continue;
-			}
-			if (o == B_INCLUDES_A) {
-				/* If B includes A, then we just have to stay on B, note
-				* the shift induced by A and then ignore A */
-				//error("B includes A entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
-				int a_old_length = x.old_end - x.old_start;
-				int a_new_length = x.new_end - x.new_start;
-				/* Note: it is normal this shift is not computed in the same way than A_includes_B_shift */
-				B_includes_A_shift += a_old_length - a_new_length;
-				/* j--: we want to stay on B
-				* i++: we want to skip A */
-				j--;
-				i++;
-				continue;
-			}
-			if (o == A_BEFORE_B_OVERLAP) {
-				/* If A overlaps B starting before B, then we have to produce an output */
-				//error("A before B overlap entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
-				int new_shift_A = x.old_end - x.new_end;
-				save_offsets(f,
-					x.old_start + shift_A,
-					y.old_end + shift_A + B_includes_A_shift + new_shift_A,
-					x.new_start + shift_B,
-					y.new_end + shift_B + A_includes_B_shift);
-				A_includes_B_shift = 0;
-				B_includes_A_shift = 0;
-				shift_A += new_shift_A;
-				shift_B = y.new_end - y.old_end;
-				/* We skip A */
-				i++;
-				continue;
-			}
-			if (o == A_AFTER_B_OVERLAP) {
-				/* If A overlaps B starting after B, then we have to produce an output */
-				//error("A after B overlap entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
-				int new_shift_B = y.new_end - y.old_end;
-				//error("new shift B = %d\n",new_shift_B);
+    if (f == NULL || new_offsets == NULL) return;
+    if (old_offsets == NULL) {
+        /* If there are no old offsets, we just have to save the new ones */
+        Offsets x;
+        for (int i = 0;i<new_offsets->nbelems;i++) {
+            x = new_offsets->tab[i];
+            save_offsets(f, x.old_start, x.old_end, x.new_start, x.new_end);
+        }
+        return;
+    }
+    int i = 0, j = 0;
+    /* shift_A is the current shift between original text and input text. It is
+    * to be used when B is before A, in order to adjust B's old coordinates */
+    int shift_A = 0;
+    /* shift_B is the current shift between input text and output text. It is
+    * to be used when A is before B, in order to adjust A's new coordinates */
+    int shift_B = 0;
+    int A_includes_B_shift = 0;
+    int B_includes_A_shift = 0;
+    Offsets x, y;
+    Overlap o;
+    while (j < new_offsets->nbelems) {
+        y = x = new_offsets->tab[j++];
+        o = (Overlap)-1;
+        for (; i < old_offsets->nbelems; i++) {
+            x = old_offsets->tab[i];
+            /* Note: below, A stands for x's new interval and B stands for y's old interval */
+            /*error("\n\nTEST OVERLAP entre %d;%d->%d;%d et %d;%d->%d;%d\n",
+            x.old_start,x.old_end,x.new_start,x.new_end,
+            y.old_start,y.old_end,y.new_start,y.new_end);*/
+            o = overlap(x.new_start, x.new_end, y.old_start, y.old_end);
+            //error("o==%s\n",N(o));
+            if (o == A_BEFORE_B) {
+                save_offsets(f,
+                    x.old_start,
+                    x.old_end,
+                    x.new_start + shift_B,
+                    x.new_end + shift_B + A_includes_B_shift);
+                A_includes_B_shift = 0;
+                shift_A = x.old_end - x.new_end;
+            }
+            else {
+                break;
+            }
+        }
+        if (i < old_offsets->nbelems) {
+            /* There may be an overlap */
+            if (o == A_INCLUDES_B) {
+                /* If A includes B, then we just have to stay on A, note
+                * the shift induced by B and then ignore B */
+                //error("A includes B entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
+                int b_old_length = y.old_end - y.old_start;
+                int b_new_length = y.new_end - y.new_start;
+                A_includes_B_shift += b_new_length - b_old_length;
+                continue;
+            }
+            if (o == B_INCLUDES_A) {
+                /* If B includes A, then we just have to stay on B, note
+                * the shift induced by A and then ignore A */
+                //error("B includes A entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
+                int a_old_length = x.old_end - x.old_start;
+                int a_new_length = x.new_end - x.new_start;
+                /* Note: it is normal this shift is not computed in the same way than A_includes_B_shift */
+                B_includes_A_shift += a_old_length - a_new_length;
+                /* j--: we want to stay on B
+                * i++: we want to skip A */
+                j--;
+                i++;
+                continue;
+            }
+            if (o == A_BEFORE_B_OVERLAP) {
+                /* If A overlaps B starting before B, then we have to produce an output */
+                //error("A before B overlap entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
+                int new_shift_A = x.old_end - x.new_end;
+                save_offsets(f,
+                    x.old_start + shift_A,
+                    y.old_end + shift_A + B_includes_A_shift + new_shift_A,
+                    x.new_start + shift_B,
+                    y.new_end + shift_B + A_includes_B_shift);
+                A_includes_B_shift = 0;
+                B_includes_A_shift = 0;
+                shift_A += new_shift_A;
+                shift_B = y.new_end - y.old_end;
+                /* We skip A */
+                i++;
+                continue;
+            }
+            if (o == A_AFTER_B_OVERLAP) {
+                /* If A overlaps B starting after B, then we have to produce an output */
+                //error("A after B overlap entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
+                int new_shift_B = y.new_end - y.old_end;
+                //error("new shift B = %d\n",new_shift_B);
 
-				// Bugfix 2015/05/01, svn revision 3828
-				// remove the + shift_B on the two last parameters of save_offsets
-				// do a #define IGNORE_BUGFIX to revert and compare if needed
+                // Bugfix 2015/05/01, svn revision 3828
+                // remove the + shift_B on the two last parameters of save_offsets
+                // do a #define IGNORE_BUGFIX to revert and compare if needed
 #ifdef IGNORE_BUGFIX
-				save_offsets(f,
-					y.old_start + shift_A,
-					x.old_end + shift_A + B_includes_A_shift,
-					y.new_start + shift_B,
-					x.new_end + shift_B + A_includes_B_shift + new_shift_B);
+                save_offsets(f,
+                    y.old_start + shift_A,
+                    x.old_end + shift_A + B_includes_A_shift,
+                    y.new_start + shift_B,
+                    x.new_end + shift_B + A_includes_B_shift + new_shift_B);
 #else
-				save_offsets(f,
-					y.old_start + shift_A,
-					x.old_end + shift_A + B_includes_A_shift,
-					y.new_start,
-					x.new_end + A_includes_B_shift + new_shift_B);
+                save_offsets(f,
+                    y.old_start + shift_A,
+                    x.old_end + shift_A + B_includes_A_shift,
+                    y.new_start,
+                    x.new_end + A_includes_B_shift + new_shift_B);
 #endif
 
-				A_includes_B_shift = 0;
-				B_includes_A_shift = 0;
-				shift_B += new_shift_B;
-				shift_A = x.old_end - x.new_end;
-				/* We skip A */
-				i++;
-				continue;
-			}
-			if (o == A_EQUALS_B) {
-				/* If A equals B starting after B, then we have to produce an output */
-				//error("A equals B entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
-				save_offsets(f,
-					x.old_start + shift_A,
-					x.old_end + shift_A + B_includes_A_shift,
-					y.new_start + shift_B,
-					y.new_end + shift_B + A_includes_B_shift);
-				A_includes_B_shift = 0;
-				B_includes_A_shift = 0;
-				shift_A = x.old_end - x.new_end;
-				shift_B = y.new_end - y.old_end;
-				/* We skip A */
-				i++;
-				continue;
-			}
-		}
-		if (o != (Overlap)-1 && o != A_AFTER_B && i != old_offsets->nbelems)
-			fatal_error("o==%d\n", o);
-		/* Default case: A_AFTER_B */
-		save_offsets(f,
-			y.old_start + shift_A,
-			y.old_end + shift_A + B_includes_A_shift,
-			y.new_start,
-			y.new_end);
-		/* The following line was introduced as a bug fix in r2771, but
-		* it caused several problems. Since commenting it out solve
-		* all those issues, let's do. If someone steps again on the bug
-		* that this line was fixing, we will check this out again.
-		*/
-		//shift_A+=B_includes_A_shift;
-		B_includes_A_shift = 0;
-		shift_B = y.new_end - y.old_end;
-	}
-	while (i < old_offsets->nbelems) {
-		x = old_offsets->tab[i++];
-		save_offsets(f,
-			x.old_start,
-			x.old_end,
-			x.new_start + shift_B,
-			x.new_end + shift_B + A_includes_B_shift);
-		A_includes_B_shift = 0;
-	}
+                A_includes_B_shift = 0;
+                B_includes_A_shift = 0;
+                shift_B += new_shift_B;
+                shift_A = x.old_end - x.new_end;
+                /* We skip A */
+                i++;
+                continue;
+            }
+            if (o == A_EQUALS_B) {
+                /* If A equals B starting after B, then we have to produce an output */
+                //error("A equals B entre %d;%d et %d;%d\n",x.new_start,x.new_end,y.old_start,y.old_end);
+                save_offsets(f,
+                    x.old_start + shift_A,
+                    x.old_end + shift_A + B_includes_A_shift,
+                    y.new_start + shift_B,
+                    y.new_end + shift_B + A_includes_B_shift);
+                A_includes_B_shift = 0;
+                B_includes_A_shift = 0;
+                shift_A = x.old_end - x.new_end;
+                shift_B = y.new_end - y.old_end;
+                /* We skip A */
+                i++;
+                continue;
+            }
+        }
+        if (o != (Overlap)-1 && o != A_AFTER_B && i != old_offsets->nbelems)
+            fatal_error("o==%d\n", o);
+        /* Default case: A_AFTER_B */
+        save_offsets(f,
+            y.old_start + shift_A,
+            y.old_end + shift_A + B_includes_A_shift,
+            y.new_start,
+            y.new_end);
+        /* The following line was introduced as a bug fix in r2771, but
+        * it caused several problems. Since commenting it out solve
+        * all those issues, let's do. If someone steps again on the bug
+        * that this line was fixing, we will check this out again.
+        */
+        //shift_A+=B_includes_A_shift;
+        B_includes_A_shift = 0;
+        shift_B = y.new_end - y.old_end;
+    }
+    while (i < old_offsets->nbelems) {
+        x = old_offsets->tab[i++];
+        save_offsets(f,
+            x.old_start,
+            x.old_end,
+            x.new_start + shift_B,
+            x.new_end + shift_B + A_includes_B_shift);
+        A_includes_B_shift = 0;
+    }
 }
 #endif
 
@@ -662,10 +662,10 @@ void process_offsets(const vector_offset* old_offsets, const vector_offset* new_
  */
 int save_snt_offsets(vector_int* snt_offsets,const char* name) {
 if (snt_offsets==NULL) {
-	fatal_error("Unexpected NULL offsets in save_snt_offsets\n");
+    fatal_error("Unexpected NULL offsets in save_snt_offsets\n");
 }
 if (snt_offsets->nbelems%3 != 0) {
-	fatal_error("Invalid offsets in save_snt_offsets\n");
+    fatal_error("Invalid offsets in save_snt_offsets\n");
 }
 U_FILE* f=u_fopen(BINARY,name,U_WRITE);
 if (f==NULL) return 0;
@@ -683,18 +683,18 @@ U_FILE* f=u_fopen(BINARY,name,U_READ);
 if (f==NULL) return NULL;
 long size=get_file_size(f);
 if (size%(3*sizeof(int))!=0) {
-	u_fclose(f);
-	return NULL;
+    u_fclose(f);
+    return NULL;
 }
 vector_int* v=new_vector_int((int)(size/sizeof(int)));
 if (size!=0) {
-	int n=(int)fread(v->tab,sizeof(int),size/sizeof(int),f);
-	u_fclose(f);
-	if (n!=(int)(size/sizeof(int))) {
-		free_vector_int(v);
-		return NULL;
-	}
-	v->nbelems=v->size;
+    int n=(int)fread(v->tab,sizeof(int),size/sizeof(int),f);
+    u_fclose(f);
+    if (n!=(int)(size/sizeof(int))) {
+        free_vector_int(v);
+        return NULL;
+    }
+    v->nbelems=v->size;
 }
 return v;
 }
@@ -724,9 +724,9 @@ vector_int* v=new_vector_int();
 Ustring* line=new_Ustring();
 int a,b,c;
 while (EOF!=readline(line,f)) {
-	u_sscanf(line->str,"%d%d%d",&a,&b,&c);
-	vector_int_add(v,b);
-	vector_int_add(v,c);
+    u_sscanf(line->str,"%d%d%d",&a,&b,&c);
+    vector_int_add(v,b);
+    vector_int_add(v,c);
 }
 free_Ustring(line);
 u_fclose(f);
@@ -737,25 +737,25 @@ return (vector_uima_offset*)v;
 
 
 static int compare_offset_translation_by_position(const void* a, const void* b) {
-	const offset_translation* translation_a = (const offset_translation*)a;
-	const offset_translation* translation_b = (const offset_translation*)b;
-	if (translation_a->position_to_translate < translation_b->position_to_translate) return -1;
-	if (translation_a->position_to_translate > translation_b->position_to_translate) return 1;
-	if (translation_a->sort_order < translation_b->sort_order) return -1;
-	if (translation_a->sort_order > translation_b->sort_order) return 1;
-	return 0;
+    const offset_translation* translation_a = (const offset_translation*)a;
+    const offset_translation* translation_b = (const offset_translation*)b;
+    if (translation_a->position_to_translate < translation_b->position_to_translate) return -1;
+    if (translation_a->position_to_translate > translation_b->position_to_translate) return 1;
+    if (translation_a->sort_order < translation_b->sort_order) return -1;
+    if (translation_a->sort_order > translation_b->sort_order) return 1;
+    return 0;
 }
 
 
 static int compare_offset_translation_by_sort_order(const void* a, const void* b) {
-	const offset_translation* translation_a = (const offset_translation*)a;
-	const offset_translation* translation_b = (const offset_translation*)b;
+    const offset_translation* translation_a = (const offset_translation*)a;
+    const offset_translation* translation_b = (const offset_translation*)b;
 
-	if (translation_a->sort_order < translation_b->sort_order) return -1;
-	if (translation_a->sort_order > translation_b->sort_order) return 1;
-	if (translation_a->position_to_translate < translation_b->position_to_translate) return -1;
-	if (translation_a->position_to_translate > translation_b->position_to_translate) return 1;
-	return 0;
+    if (translation_a->sort_order < translation_b->sort_order) return -1;
+    if (translation_a->sort_order > translation_b->sort_order) return 1;
+    if (translation_a->position_to_translate < translation_b->position_to_translate) return -1;
+    if (translation_a->position_to_translate > translation_b->position_to_translate) return 1;
+    return 0;
 }
 /**
  * translate a set of offset
@@ -766,25 +766,25 @@ static int compare_offset_translation_by_sort_order(const void* a, const void* b
  */
 void translate_offset(offset_translation* ofs, int nb_translations, const vector_offset* offsets, int revert) {
 if (offsets == NULL) {
-	return;
+    return;
 }
 if ((nb_translations == 0) || (ofs == NULL)) {
-	return;
+    return;
 }
 int i;
 int sorted_by_position = 1;
 for (i = 1;i < nb_translations;i++)
-	if (((ofs + i)->position_to_translate) < ((ofs + i - 1)->position_to_translate)) {
-		sorted_by_position = 0;
-		break;
-	}
+    if (((ofs + i)->position_to_translate) < ((ofs + i - 1)->position_to_translate)) {
+        sorted_by_position = 0;
+        break;
+    }
 if (!sorted_by_position) {
-	qsort(ofs,nb_translations,sizeof(offset_translation), compare_offset_translation_by_position);
+    qsort(ofs,nb_translations,sizeof(offset_translation), compare_offset_translation_by_position);
 }
 
 int last_position_in_offsets = revert ?
-	(offsets->tab[offsets->nbelems - 1].new_start + offsets->tab[offsets->nbelems-1].new_end) :
-	(offsets->tab[offsets->nbelems - 1].old_start + offsets->tab[offsets->nbelems-1].old_end);
+    (offsets->tab[offsets->nbelems - 1].new_start + offsets->tab[offsets->nbelems-1].new_end) :
+    (offsets->tab[offsets->nbelems - 1].old_start + offsets->tab[offsets->nbelems-1].old_end);
 int last_position_to_translate = (ofs + nb_translations - 1)->position_to_translate;
 int minimal_filesize = offset_max(last_position_in_offsets, last_position_to_translate);
 
@@ -793,53 +793,53 @@ vector_offset* common_offsets = modified_offsets_to_common(offsets, -1, minimal_
 
 int pos_common_offsets = 0;
 for (i = 0; i < nb_translations; i++) {
-	int pos_to_translate = (ofs + i)->position_to_translate;
-	for (;;) {
-		if (pos_common_offsets == common_offsets->nbelems)
-			break;
-		int end_current_common = revert ?
-			(common_offsets->tab[pos_common_offsets].new_end) :
-			(common_offsets->tab[pos_common_offsets].old_end);
-		if (end_current_common > pos_to_translate)
-			break;
-		pos_common_offsets++;
-	}
+    int pos_to_translate = (ofs + i)->position_to_translate;
+    for (;;) {
+        if (pos_common_offsets == common_offsets->nbelems)
+            break;
+        int end_current_common = revert ?
+            (common_offsets->tab[pos_common_offsets].new_end) :
+            (common_offsets->tab[pos_common_offsets].old_end);
+        if (end_current_common > pos_to_translate)
+            break;
+        pos_common_offsets++;
+    }
 
-	int current_common_start = -1;
-	int current_common_end = -1;
+    int current_common_start = -1;
+    int current_common_end = -1;
 
-	if (pos_common_offsets < common_offsets->nbelems) {
-		current_common_start = revert ?
-			(common_offsets->tab[pos_common_offsets].new_start) :
-			(common_offsets->tab[pos_common_offsets].old_start);
-		current_common_end = revert ?
-			(common_offsets->tab[pos_common_offsets].new_end) :
-			(common_offsets->tab[pos_common_offsets].old_end);
-		int translate_common_start = revert ?
-			(common_offsets->tab[pos_common_offsets].old_start) :
-			(common_offsets->tab[pos_common_offsets].new_start);
+    if (pos_common_offsets < common_offsets->nbelems) {
+        current_common_start = revert ?
+            (common_offsets->tab[pos_common_offsets].new_start) :
+            (common_offsets->tab[pos_common_offsets].old_start);
+        current_common_end = revert ?
+            (common_offsets->tab[pos_common_offsets].new_end) :
+            (common_offsets->tab[pos_common_offsets].old_end);
+        int translate_common_start = revert ?
+            (common_offsets->tab[pos_common_offsets].old_start) :
+            (common_offsets->tab[pos_common_offsets].new_start);
 
-		if ((pos_to_translate >= current_common_start) && (pos_to_translate < current_common_end)) {
-			(ofs + i)->translated_position = translate_common_start + (pos_to_translate - current_common_start);
-			(ofs + i)->translation_pos_in_common = 1;
-		}
-		else {
-			(ofs + i)->translated_position = translate_common_start + (current_common_end - current_common_start);
-			(ofs + i)->translation_pos_in_common = -1;
-		}
+        if ((pos_to_translate >= current_common_start) && (pos_to_translate < current_common_end)) {
+            (ofs + i)->translated_position = translate_common_start + (pos_to_translate - current_common_start);
+            (ofs + i)->translation_pos_in_common = 1;
+        }
+        else {
+            (ofs + i)->translated_position = translate_common_start + (current_common_end - current_common_start);
+            (ofs + i)->translation_pos_in_common = -1;
+        }
 
 
-	} else {
-		int last_pos_translated = 0;
-		if (common_offsets->nbelems > 0)
-			last_pos_translated = revert ?
-				((common_offsets->tab[common_offsets->nbelems-1].old_start) -1) :
-				((common_offsets->tab[common_offsets->nbelems-1].new_start) -1);
-		if (last_pos_translated == -1)
-			last_pos_translated = 0;
-		(ofs + i)->translated_position = last_pos_translated;
-		(ofs + i)->translation_pos_in_common = -1;
-	}
+    } else {
+        int last_pos_translated = 0;
+        if (common_offsets->nbelems > 0)
+            last_pos_translated = revert ?
+                ((common_offsets->tab[common_offsets->nbelems-1].old_start) -1) :
+                ((common_offsets->tab[common_offsets->nbelems-1].new_start) -1);
+        if (last_pos_translated == -1)
+            last_pos_translated = 0;
+        (ofs + i)->translated_position = last_pos_translated;
+        (ofs + i)->translation_pos_in_common = -1;
+    }
 
 }
 
@@ -847,12 +847,12 @@ free_vector_offset(common_offsets);
 
 int sorted_by_sort_order = 1;
 for (i = 1;i < nb_translations;i++)
-	if (((ofs + i)->sort_order) < ((ofs + i - 1)->sort_order)) {
-		sorted_by_sort_order = 0;
-		break;
-	}
+    if (((ofs + i)->sort_order) < ((ofs + i - 1)->sort_order)) {
+        sorted_by_sort_order = 0;
+        break;
+    }
 if (!sorted_by_sort_order) {
-	qsort(ofs, nb_translations, sizeof(offset_translation), compare_offset_translation_by_sort_order);
+    qsort(ofs, nb_translations, sizeof(offset_translation), compare_offset_translation_by_sort_order);
 }
 }
 

--- a/Offsets.h
+++ b/Offsets.h
@@ -54,10 +54,10 @@ namespace unitex {
  */
 
 typedef struct {
-	int old_start;
-	int old_end;
-	int new_start;
-	int new_end;
+    int old_start;
+    int old_end;
+    int new_start;
+    int new_end;
 } Offsets;
 
 
@@ -123,7 +123,7 @@ return vec->nbelems-1;
 
 vector_offset* load_offsets(const VersatileEncodingConfig*,const char*);
 void process_offsets(const vector_offset* old_offsets, const vector_offset* new_offsets,
-		U_FILE* f);
+        U_FILE* f);
 vector_offset* modified_offsets_to_common(const vector_offset* offsets, int old_size, int new_size);
 vector_offset* common_offsets_to_modified(const vector_offset* offsets, int old_size, int new_size);
 vector_offset* process_common_offsets(const vector_offset* old_offsets, const vector_offset* new_offsets);
@@ -142,25 +142,25 @@ typedef vector_int vector_uima_offset;
 vector_uima_offset* load_uima_offsets(const VersatileEncodingConfig*,const char* name);
 
 inline int uima_offset_token_start_pos(const vector_uima_offset* v,int token) {
-	return ((const vector_int*) v)->tab[token * 2];
+    return ((const vector_int*) v)->tab[token * 2];
 }
 
 inline int uima_offset_token_end_pos(const vector_uima_offset* v, int token) {
-	return ((const vector_int*) v)->tab[(token * 2)+1];
+    return ((const vector_int*) v)->tab[(token * 2)+1];
 }
 
 inline int uima_offset_tokens_count(const vector_uima_offset* v) {
-	return (((const vector_int*)v)->nbelems) / 2;
+    return (((const vector_int*)v)->nbelems) / 2;
 }
 
 inline void free_uima_offsets(vector_uima_offset* v) {
-	free_vector_int((vector_int*)v);
+    free_vector_int((vector_int*)v);
 }
 typedef struct {
-	int position_to_translate; // in
-	int sort_order; // in
-	int translated_position; // out
-	int translation_pos_in_common; // out
+    int position_to_translate; // in
+    int sort_order; // in
+    int translated_position; // out
+    int translation_pos_in_common; // out
 } offset_translation;
 
 void translate_offset(offset_translation* ofs, int nb_translations, const vector_offset* offsets, int revert);

--- a/OptimizedFst2.cpp
+++ b/OptimizedFst2.cpp
@@ -59,8 +59,8 @@ while (ptr!=NULL) {
       switch (tag->type) {
          /* If we have a morphological mode end mark */
          case END_MORPHO_TAG: {
-        	 add_transition_if_not_present(list,ptr->tag_number,ptr->state_number,prv_alloc);
-        	 break;
+             add_transition_if_not_present(list,ptr->tag_number,ptr->state_number,prv_alloc);
+             break;
          }
          /* If we an another type of transition, we follow it */
          default: look_for_closing_morphological_mode(fst2,ptr->state_number,list,marker,nesting_level,prv_alloc);
@@ -68,7 +68,7 @@ while (ptr!=NULL) {
    }
    else {
       /* If we have a graph call, we follow it */
-	   look_for_closing_morphological_mode(fst2,ptr->state_number,list,marker,nesting_level,prv_alloc);
+       look_for_closing_morphological_mode(fst2,ptr->state_number,list,marker,nesting_level,prv_alloc);
    }
    ptr=ptr->next;
 }
@@ -350,8 +350,8 @@ return ptr;
 
 void foo(Transition* list) {
 while (list!=NULL) {
-	error("(%d,%d) ",list->tag_number,list->state_number);
-	list=list->next;
+    error("(%d,%d) ",list->tag_number,list->state_number);
+    list=list->next;
 }
 error("\n");
 }
@@ -379,15 +379,15 @@ error("LIST BEFORE: ");
 foo(ptr->transition);
 // Then, we add the transitions to the meta
 if (ptr->transition==NULL) {
-	// No transition yet ? Easy!
-	ptr->transition=transitions;
+    // No transition yet ? Easy!
+    ptr->transition=transitions;
 } else {
-	// We look for the last element
-	Transition* tmp=ptr->transition;
-	while (tmp->next!=NULL) {
-		tmp=tmp->next;
-	}
-	tmp->next=transitions;
+    // We look for the last element
+    Transition* tmp=ptr->transition;
+    while (tmp->next!=NULL) {
+        tmp=tmp->next;
+    }
+    tmp->next=transitions;
 }
 error("LIST AFTER: ");
 foo(ptr->transition);
@@ -401,7 +401,7 @@ return ptr;
  * Allocates, initializes and returns a new optimized variable.
  */
 static struct opt_variable* new_opt_variable(int variable_number,Transition* transition,
-										Abstract_allocator prv_alloc) {
+                                        Abstract_allocator prv_alloc) {
 struct opt_variable* v;
 v=(struct opt_variable*)malloc_cb(sizeof(struct opt_variable),prv_alloc);
 if (v==NULL) {
@@ -435,7 +435,7 @@ while (list!=NULL) {
  * given variable, because it cannot happen if the grammar is deterministic.
  */
 static void add_input_variable(Variables* var,unichar* variable,Transition* transition,
-		struct opt_variable** variable_list,Abstract_allocator prv_alloc) {
+        struct opt_variable** variable_list,Abstract_allocator prv_alloc) {
 int n=get_value_index(variable,var->variable_index,DONT_INSERT);
 struct opt_variable* v=new_opt_variable(n,transition,prv_alloc);
 v->next=(*variable_list);
@@ -449,7 +449,7 @@ v->next=(*variable_list);
  * given variable, because it cannot happen if the grammar is deterministic.
  */
 void add_output_variable(OutputVariables* var,unichar* variable,Transition* transition,
-		struct opt_variable** variable_list,Abstract_allocator prv_alloc) {
+        struct opt_variable** variable_list,Abstract_allocator prv_alloc) {
 int n=get_value_index(variable,var->variable_index,DONT_INSERT);
 struct opt_variable* v=new_opt_variable(n,transition,prv_alloc);
 v->next=(*variable_list);
@@ -499,7 +499,7 @@ state->contexts->end_mark=new_Transition(transition->tag_number,transition->stat
  * This function optimizes the given transition.
  */
 static void optimize_transition(Variables* v,OutputVariables* output,Fst2* fst2,Transition* transition,
-						OptimizedFst2State state,Fst2Tag* tags,Abstract_allocator prv_alloc) {
+                        OptimizedFst2State state,Fst2Tag* tags,Abstract_allocator prv_alloc) {
 if (transition->tag_number<0) {
    /* If the transition is a graph call */
    add_graph_call(transition,&(state->graph_calls),prv_alloc);
@@ -522,58 +522,58 @@ switch (tag->type) {
    case PATTERN_NUMBER_TAG: add_pattern(tag->pattern_number,transition,&(state->patterns),negation,prv_alloc);
                             return;
    case META_TAG: {
-	   add_meta(tag->meta,transition,&(state->metas),negation,prv_alloc);
-	   add_meta(tag->meta,transition,&(state->unoptimized_metas),negation,prv_alloc);
+       add_meta(tag->meta,transition,&(state->metas),negation,prv_alloc);
+       add_meta(tag->meta,transition,&(state->unoptimized_metas),negation,prv_alloc);
        return;
    }
    case BEGIN_VAR_TAG: {
-	   add_input_variable(v,tag->variable,transition,&(state->input_variable_starts),prv_alloc);
-	   add_input_variable(v,tag->variable,transition,&(state->unoptimized_input_variable_starts),prv_alloc);
+       add_input_variable(v,tag->variable,transition,&(state->input_variable_starts),prv_alloc);
+       add_input_variable(v,tag->variable,transition,&(state->unoptimized_input_variable_starts),prv_alloc);
        return;
    }
    case END_VAR_TAG: {
-	   add_input_variable(v,tag->variable,transition,&(state->input_variable_ends),prv_alloc);
-	   add_input_variable(v,tag->variable,transition,&(state->unoptimized_input_variable_ends),prv_alloc);
+       add_input_variable(v,tag->variable,transition,&(state->input_variable_ends),prv_alloc);
+       add_input_variable(v,tag->variable,transition,&(state->unoptimized_input_variable_ends),prv_alloc);
        return;
    }
    case BEGIN_OUTPUT_VAR_TAG: {
-	   add_output_variable(output,tag->variable,transition,&(state->output_variable_starts),prv_alloc);
-	   add_output_variable(output,tag->variable,transition,&(state->unoptimized_output_variable_starts),prv_alloc);
+       add_output_variable(output,tag->variable,transition,&(state->output_variable_starts),prv_alloc);
+       add_output_variable(output,tag->variable,transition,&(state->unoptimized_output_variable_starts),prv_alloc);
        return;
    }
    case END_OUTPUT_VAR_TAG: {
-	   add_output_variable(output,tag->variable,transition,&(state->output_variable_ends),prv_alloc);
-	   add_output_variable(output,tag->variable,transition,&(state->unoptimized_output_variable_ends),prv_alloc);
+       add_output_variable(output,tag->variable,transition,&(state->output_variable_ends),prv_alloc);
+       add_output_variable(output,tag->variable,transition,&(state->unoptimized_output_variable_ends),prv_alloc);
        return;
    }
    case BEGIN_POSITIVE_CONTEXT_TAG: add_positive_context(fst2,state,transition,prv_alloc); return;
    case BEGIN_NEGATIVE_CONTEXT_TAG: add_negative_context(fst2,state,transition,prv_alloc); return;
    case END_CONTEXT_TAG: add_end_context(state,transition,prv_alloc); return;
    case LEFT_CONTEXT_TAG: {
-	   add_meta(META_LEFT_CONTEXT,transition,&(state->metas),0,prv_alloc);
-	   add_meta(META_LEFT_CONTEXT,transition,&(state->unoptimized_metas),0,prv_alloc);
-	   return;
+       add_meta(META_LEFT_CONTEXT,transition,&(state->metas),0,prv_alloc);
+       add_meta(META_LEFT_CONTEXT,transition,&(state->unoptimized_metas),0,prv_alloc);
+       return;
    }
    case BEGIN_MORPHO_TAG: {
-	   struct opt_meta* new_meta=add_meta(META_BEGIN_MORPHO,transition,&(state->metas),0,prv_alloc);
-	   get_reachable_closing_morphological_mode(fst2,transition->state_number,&(new_meta->morphological_mode_ends),prv_alloc);
-	   add_meta(META_BEGIN_MORPHO,transition,&(state->unoptimized_metas),0,prv_alloc);
-	   return;
+       struct opt_meta* new_meta=add_meta(META_BEGIN_MORPHO,transition,&(state->metas),0,prv_alloc);
+       get_reachable_closing_morphological_mode(fst2,transition->state_number,&(new_meta->morphological_mode_ends),prv_alloc);
+       add_meta(META_BEGIN_MORPHO,transition,&(state->unoptimized_metas),0,prv_alloc);
+       return;
    }
    case END_MORPHO_TAG: {
-	   add_meta(META_END_MORPHO,transition,&(state->metas),0,prv_alloc);
-	   add_meta(META_END_MORPHO,transition,&(state->unoptimized_metas),0,prv_alloc);
-	   return;
+       add_meta(META_END_MORPHO,transition,&(state->metas),0,prv_alloc);
+       add_meta(META_END_MORPHO,transition,&(state->unoptimized_metas),0,prv_alloc);
+       return;
    }
    case TEXT_START_TAG: {
-	   add_meta(META_TEXT_START,transition,&(state->metas),0,prv_alloc);
-	   add_meta(META_TEXT_START,transition,&(state->unoptimized_metas),0,prv_alloc);
-	   return;
+       add_meta(META_TEXT_START,transition,&(state->metas),0,prv_alloc);
+       add_meta(META_TEXT_START,transition,&(state->unoptimized_metas),0,prv_alloc);
+       return;
    }
    case TEXT_END_TAG: {
-	   add_meta(META_TEXT_END,transition,&(state->metas),0,prv_alloc);
-	   add_meta(META_TEXT_END,transition,&(state->unoptimized_metas),0,prv_alloc);
-	   return;
+       add_meta(META_TEXT_END,transition,&(state->metas),0,prv_alloc);
+       add_meta(META_TEXT_END,transition,&(state->unoptimized_metas),0,prv_alloc);
+       return;
    }
    default: fatal_error("Unexpected transition tag type in optimize_transition\n");
 }
@@ -691,7 +691,7 @@ free_cb(state,prv_alloc);
  * was NULL.
  */
 static OptimizedFst2State optimize_state(Variables* v,OutputVariables* output,Fst2* fst2,Fst2State state,
-									Fst2Tag* tags,Abstract_allocator prv_alloc) {
+                                    Fst2Tag* tags,Abstract_allocator prv_alloc) {
 if (state==NULL) return NULL;
 OptimizedFst2State new_state=new_optimized_state(prv_alloc);
 new_state->control=state->control;
@@ -734,16 +734,16 @@ static inline int is_useless_state(OptimizedFst2State s) {
 fatal_assert(s==NULL,"NULL error in is_useless_state\n");
 
 return !(s->control&1)
-		&& s->graph_calls==NULL
-		&& s->metas==NULL
-		&& s->patterns==NULL
-		&& s->compound_patterns==NULL
-		&& s->number_of_tokens==0
-		&& s->input_variable_starts==NULL
-		&& s->input_variable_ends==NULL
-		&& s->output_variable_starts==NULL
-		&& s->output_variable_ends==NULL
-		&& (s->contexts==NULL || (s->contexts->non_NULL_positive_transitions==0 && s->contexts->size_negative==0 && s->contexts->end_mark==NULL));
+        && s->graph_calls==NULL
+        && s->metas==NULL
+        && s->patterns==NULL
+        && s->compound_patterns==NULL
+        && s->number_of_tokens==0
+        && s->input_variable_starts==NULL
+        && s->input_variable_ends==NULL
+        && s->output_variable_starts==NULL
+        && s->output_variable_ends==NULL
+        && (s->contexts==NULL || (s->contexts->non_NULL_positive_transitions==0 && s->contexts->size_negative==0 && s->contexts->end_mark==NULL));
 }
 
 
@@ -762,21 +762,21 @@ return is_useless_state(initial);
  * to a state that has no outgoing transitions.
  */
 static int remove_useless_graph_calls(struct opt_graph_call* *l,OptimizedFst2State* optimized_states,Fst2* fst2,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 int removed=0;
 struct opt_graph_call* *tmp=l;
 while ((*tmp)!=NULL) {
-	if (empty_graph((*tmp)->graph_number,optimized_states,fst2)
-			|| is_useless_state(optimized_states[(*tmp)->transition->state_number])) {
-		/* We remove the graph call */
-		removed=1;
-		struct opt_graph_call* current=(*tmp);
-		(*tmp)=current->next;
-		current->next=NULL;
-		free_opt_graph_call(current,prv_alloc);
-	} else {
-		tmp=&((*tmp)->next);
-	}
+    if (empty_graph((*tmp)->graph_number,optimized_states,fst2)
+            || is_useless_state(optimized_states[(*tmp)->transition->state_number])) {
+        /* We remove the graph call */
+        removed=1;
+        struct opt_graph_call* current=(*tmp);
+        (*tmp)=current->next;
+        current->next=NULL;
+        free_opt_graph_call(current,prv_alloc);
+    } else {
+        tmp=&((*tmp)->next);
+    }
 }
 return removed;
 }
@@ -809,11 +809,11 @@ return l;
  */
 static int can_safely_remove_morphological_mode_start(Transition* morphological_mode_ends,OptimizedFst2State* optimized_states) {
 while (morphological_mode_ends!=NULL) {
-	OptimizedFst2State dest=optimized_states[morphological_mode_ends->state_number];
-	if (!is_useless_state(dest)) {
-		return 0;
-	}
-	morphological_mode_ends=morphological_mode_ends->next;
+    OptimizedFst2State dest=optimized_states[morphological_mode_ends->state_number];
+    if (!is_useless_state(dest)) {
+        return 0;
+    }
+    morphological_mode_ends=morphological_mode_ends->next;
 }
 return 1;
 }
@@ -823,39 +823,39 @@ return 1;
  * Removes the useless metas, i.e. metas to a state that has no outgoing transitions.
  */
 static int remove_useless_metas(struct opt_meta* *l,OptimizedFst2State* optimized_states,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 int removed=0;
 struct opt_meta* *tmp=l;
 while ((*tmp)!=NULL) {
-	if ((*tmp)->meta==META_BEGIN_MORPHO &&
-			!can_safely_remove_morphological_mode_start((*tmp)->morphological_mode_ends,optimized_states)) {
-		/* We must not remove the $< meta, even if there is no outgoing transition. The reason
-		 * is that the optimization may remove transitions inside the morphological mode zone
-		 * in the graph, and that we should ignore it when entering the morphological mode
-		 * using the original unoptimized fst2. For instance, if we want to match the word
-		 * "prefix" with:
-		 *
-		 *  $<  -->  "pre"  -->  "fix"  -->  $>
-		 *
-		 * the graph would be erroneousnly emptied if the text does not contain both "pre" and
-		 * "fix" as tokens.
-		 *
-		 * The only case where we can safely remove a $< meta is when all the matching $> metas
-		 * have themselves no outgoing transitions anymore.
-		 */
-		tmp=&((*tmp)->next);
-		continue;
-	}
-	(*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
-	if ((*tmp)->transition==NULL) {
-		removed=1;
-		struct opt_meta* current=(*tmp);
-		(*tmp)=current->next;
-		current->next=NULL;
-		free_opt_meta(current,prv_alloc);
-	} else {
-		tmp=&((*tmp)->next);
-	}
+    if ((*tmp)->meta==META_BEGIN_MORPHO &&
+            !can_safely_remove_morphological_mode_start((*tmp)->morphological_mode_ends,optimized_states)) {
+        /* We must not remove the $< meta, even if there is no outgoing transition. The reason
+         * is that the optimization may remove transitions inside the morphological mode zone
+         * in the graph, and that we should ignore it when entering the morphological mode
+         * using the original unoptimized fst2. For instance, if we want to match the word
+         * "prefix" with:
+         *
+         *  $<  -->  "pre"  -->  "fix"  -->  $>
+         *
+         * the graph would be erroneousnly emptied if the text does not contain both "pre" and
+         * "fix" as tokens.
+         *
+         * The only case where we can safely remove a $< meta is when all the matching $> metas
+         * have themselves no outgoing transitions anymore.
+         */
+        tmp=&((*tmp)->next);
+        continue;
+    }
+    (*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
+    if ((*tmp)->transition==NULL) {
+        removed=1;
+        struct opt_meta* current=(*tmp);
+        (*tmp)=current->next;
+        current->next=NULL;
+        free_opt_meta(current,prv_alloc);
+    } else {
+        tmp=&((*tmp)->next);
+    }
 }
 return removed;
 }
@@ -868,17 +868,17 @@ static int remove_useless_patterns(struct opt_pattern* *l,OptimizedFst2State* op
 int removed=0;
 struct opt_pattern* *tmp=l;
 while ((*tmp)!=NULL) {
-	(*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
-	if ((*tmp)->transition==NULL) {
-		/* We remove the pattern */
-		removed=1;
-		struct opt_pattern* current=(*tmp);
-		(*tmp)=current->next;
-		current->next=NULL;
-		free_opt_pattern(current,prv_alloc);
-	} else {
-		tmp=&((*tmp)->next);
-	}
+    (*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
+    if ((*tmp)->transition==NULL) {
+        /* We remove the pattern */
+        removed=1;
+        struct opt_pattern* current=(*tmp);
+        (*tmp)=current->next;
+        current->next=NULL;
+        free_opt_pattern(current,prv_alloc);
+    } else {
+        tmp=&((*tmp)->next);
+    }
 }
 return removed;
 }
@@ -888,21 +888,21 @@ return removed;
  * Removes the useless variables, i.e. variables to a state that has no outgoing transitions.
  */
 static int remove_useless_variables(struct opt_variable* *l,OptimizedFst2State* optimized_states,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 int removed=0;
 struct opt_variable* *tmp=l;
 while ((*tmp)!=NULL) {
-	(*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
-	if ((*tmp)->transition==NULL) {
-		/* We remove the variable */
-		removed=1;
-		struct opt_variable* current=(*tmp);
-		(*tmp)=current->next;
-		current->next=NULL;
-		free_opt_variable(current,prv_alloc);
-	} else {
-		tmp=&((*tmp)->next);
-	}
+    (*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
+    if ((*tmp)->transition==NULL) {
+        /* We remove the variable */
+        removed=1;
+        struct opt_variable* current=(*tmp);
+        (*tmp)=current->next;
+        current->next=NULL;
+        free_opt_variable(current,prv_alloc);
+    } else {
+        tmp=&((*tmp)->next);
+    }
 }
 return removed;
 }
@@ -912,28 +912,28 @@ return removed;
  * Removes the useless contexts, i.e. contexts to a state that has no outgoing transitions.
  */
 static int remove_useless_contexts(struct opt_contexts* c,OptimizedFst2State* optimized_states,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 if (c==NULL) return 0;
 int removed=0;
 /* We filter the positive contexts */
 for (int i=0;i<c->size_positive;i+=2) {
-	/* We have two transitions to consider: the one outgoing from the context mark, and
-	 * the one pointing to the state after the end context mark. If either of those transitions
-	 * points to a useless states, we can remove both.
-	 */
-	if (c->positive_mark[i]==NULL || c->positive_mark[i+1]==NULL) {
-		continue;
-	}
-	int dest1=c->positive_mark[i]->state_number;
-	int dest2=c->positive_mark[i+1]->state_number;
-	if (is_useless_state(optimized_states[dest1]) || is_useless_state(optimized_states[dest2])) {
-		free_Transition_list(c->positive_mark[i],prv_alloc);
-		free_Transition_list(c->positive_mark[i+1],prv_alloc);
-		c->positive_mark[i]=NULL;
-		c->positive_mark[i+1]=NULL;
-		c->non_NULL_positive_transitions-=2;
-		removed=1;
-	}
+    /* We have two transitions to consider: the one outgoing from the context mark, and
+     * the one pointing to the state after the end context mark. If either of those transitions
+     * points to a useless states, we can remove both.
+     */
+    if (c->positive_mark[i]==NULL || c->positive_mark[i+1]==NULL) {
+        continue;
+    }
+    int dest1=c->positive_mark[i]->state_number;
+    int dest2=c->positive_mark[i+1]->state_number;
+    if (is_useless_state(optimized_states[dest1]) || is_useless_state(optimized_states[dest2])) {
+        free_Transition_list(c->positive_mark[i],prv_alloc);
+        free_Transition_list(c->positive_mark[i+1],prv_alloc);
+        c->positive_mark[i]=NULL;
+        c->positive_mark[i+1]=NULL;
+        c->non_NULL_positive_transitions-=2;
+        removed=1;
+    }
 }
 /* We don't filter the negative contexts, because inside a negative context,
  * a failure to match is significant. So, if we have a token 'foo' that cannot
@@ -943,12 +943,12 @@ for (int i=0;i<c->size_positive;i+=2) {
 
 /* Finally, we filter the end context mark, if any */
 if (c->end_mark!=NULL) {
-	int dest=c->end_mark->state_number;
-	if (is_useless_state(optimized_states[dest])) {
-		free_Transition_list(c->end_mark,prv_alloc);
-		c->end_mark=NULL;
-		removed=1;
-	}
+    int dest=c->end_mark->state_number;
+    if (is_useless_state(optimized_states[dest])) {
+        free_Transition_list(c->end_mark,prv_alloc);
+        c->end_mark=NULL;
+        removed=1;
+    }
 }
 return removed;
 }
@@ -958,23 +958,23 @@ return removed;
  * Removes the useless tokens, i.e. tokens to a state that has no outgoing transitions.
  */
 static int remove_useless_tokens(OptimizedFst2State state,OptimizedFst2State* optimized_states,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 int removed=0;
 struct opt_token* *tmp=&(state->token_list);
 while ((*tmp)!=NULL) {
-	/* For each token, we have to filter its whole transition list */
-	(*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
-	if ((*tmp)->transition==NULL) {
-		/* We remove the token if all its transitions have been removed */
-		removed=1;
-		state->number_of_tokens--;
-		struct opt_token* current=(*tmp);
-		(*tmp)=current->next;
-		current->next=NULL;
-		free_opt_token(current,prv_alloc);
-	} else {
-		tmp=&((*tmp)->next);
-	}
+    /* For each token, we have to filter its whole transition list */
+    (*tmp)->transition=filter_transitions((*tmp)->transition,optimized_states,prv_alloc);
+    if ((*tmp)->transition==NULL) {
+        /* We remove the token if all its transitions have been removed */
+        removed=1;
+        state->number_of_tokens--;
+        struct opt_token* current=(*tmp);
+        (*tmp)=current->next;
+        current->next=NULL;
+        free_opt_token(current,prv_alloc);
+    } else {
+        tmp=&((*tmp)->next);
+    }
 }
 return removed;
 }
@@ -985,13 +985,13 @@ return removed;
  * otherwise.
  */
 static int remove_useless_transitions(OptimizedFst2State s,OptimizedFst2State* optimized_states,Fst2* fst2,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 return remove_useless_graph_calls(&(s->graph_calls),optimized_states,fst2,prv_alloc)
-		+ remove_useless_metas(&(s->metas),optimized_states,prv_alloc)
-		+ remove_useless_patterns(&(s->patterns),optimized_states,prv_alloc)
-		+ remove_useless_patterns(&(s->compound_patterns),optimized_states,prv_alloc)
-		+ remove_useless_variables(&(s->input_variable_starts),optimized_states,prv_alloc)
-		+ remove_useless_variables(&(s->input_variable_ends),optimized_states,prv_alloc)
+        + remove_useless_metas(&(s->metas),optimized_states,prv_alloc)
+        + remove_useless_patterns(&(s->patterns),optimized_states,prv_alloc)
+        + remove_useless_patterns(&(s->compound_patterns),optimized_states,prv_alloc)
+        + remove_useless_variables(&(s->input_variable_starts),optimized_states,prv_alloc)
+        + remove_useless_variables(&(s->input_variable_ends),optimized_states,prv_alloc)
         + remove_useless_variables(&(s->output_variable_starts),optimized_states,prv_alloc)
         + remove_useless_variables(&(s->output_variable_ends),optimized_states,prv_alloc)
         + remove_useless_contexts(s->contexts,optimized_states,prv_alloc)
@@ -1005,27 +1005,27 @@ return remove_useless_graph_calls(&(s->graph_calls),optimized_states,fst2,prv_al
  * Returns 1 the graph becomes empty; 0 otherwise.
  */
 static int remove_useless_lexical_transitions(Fst2* fst2,int graph,OptimizedFst2State* optimized_states,
-							Abstract_allocator prv_alloc) {
+                            Abstract_allocator prv_alloc) {
 int initial=fst2->initial_states[graph];
 int last=initial+fst2->number_of_states_per_graphs[graph]-1;
 int cleaning_to_do=1;
 if (empty_graph(graph,optimized_states,fst2)) {
-	/* If the graph is already empty, there is nothing to report */
-	return 0;
+    /* If the graph is already empty, there is nothing to report */
+    return 0;
 }
 while (cleaning_to_do) {
-	cleaning_to_do=0;
-	for (int i=initial;i<=last;i++) {
-		OptimizedFst2State s=optimized_states[i];
-		int removed=remove_useless_transitions(s,optimized_states,fst2,prv_alloc);
-		if (removed && !cleaning_to_do) {
-			/* This state may now be useless */
-			if (is_useless_state(s)) {
-				/* If this is the case, we will have another round to do on this graph */
-				cleaning_to_do=1;
-			}
-		}
-	}
+    cleaning_to_do=0;
+    for (int i=initial;i<=last;i++) {
+        OptimizedFst2State s=optimized_states[i];
+        int removed=remove_useless_transitions(s,optimized_states,fst2,prv_alloc);
+        if (removed && !cleaning_to_do) {
+            /* This state may now be useless */
+            if (is_useless_state(s)) {
+                /* If this is the case, we will have another round to do on this graph */
+                cleaning_to_do=1;
+            }
+        }
+    }
 }
 return empty_graph(graph,optimized_states,fst2);
 }
@@ -1037,7 +1037,7 @@ return empty_graph(graph,optimized_states,fst2);
  * optimized states.
  */
 OptimizedFst2State* build_optimized_fst2_states(Variables* v,OutputVariables* output,Fst2* fst2,
-		Abstract_allocator prv_alloc) {
+        Abstract_allocator prv_alloc) {
 OptimizedFst2State* optimized_states=(OptimizedFst2State*)malloc_cb(fst2->number_of_states*sizeof(OptimizedFst2State),prv_alloc);
 if (optimized_states==NULL) {
    fatal_alloc_error("build_optimized_fst2_states");
@@ -1054,22 +1054,22 @@ for (int i=0;i<fst2->number_of_states;i++) {
 
    if (pos_in_current_graph >= *((fst2->number_of_states_per_graphs)+num_current_graph))
    {
-	   num_current_graph++;
-	   pos_in_current_graph=0;
+       num_current_graph++;
+       pos_in_current_graph=0;
    }
 }
 
 #ifdef AGGRESSIVE_OPTIMIZATION
 int n_graphs_emptied;
 do {
-	n_graphs_emptied=0;
-	for (int i=1;i<=fst2->number_of_graphs;i++) {
-		n_graphs_emptied+=remove_useless_lexical_transitions(fst2,i,optimized_states,prv_alloc);
-	}
+    n_graphs_emptied=0;
+    for (int i=1;i<=fst2->number_of_graphs;i++) {
+        n_graphs_emptied+=remove_useless_lexical_transitions(fst2,i,optimized_states,prv_alloc);
+    }
 } while (n_graphs_emptied!=0);
 /* Finally, we convert token lists to sorted array suitable for binary search */
 for (int i=0;i<fst2->number_of_states;i++) {
-	token_list_2_token_array(optimized_states[i],prv_alloc);
+    token_list_2_token_array(optimized_states[i],prv_alloc);
 }
 #endif // AGGRESSIVE_OPTIMIZATION
 

--- a/OptimizedTfstTagMatching.cpp
+++ b/OptimizedTfstTagMatching.cpp
@@ -64,10 +64,10 @@ return new_LocateTfstTagMatchingCache(DEFAULT_CACHE_SIZE,n_fst2_tags);
 
 /**
  * Creates a cache with a size that is estimated with the formula:
- * 
- * f(n_sentences*4): 
- *    4 is empirically a good value 
- *    f(x) = closer power of 2 greater than x 
+ *
+ * f(n_sentences*4):
+ *    4 is empirically a good value
+ *    f(x) = closer power of 2 greater than x
  */
 LocateTfstTagMatchingCache* new_LocateTfstTagMatchingCache(int n_sentences,int n_fst2_tags) {
 int size=estimate_number_of_tfs_tags(n_sentences);
@@ -85,7 +85,7 @@ return cache;
 
 
 /**
- * Estimates the number of TfstTag. 
+ * Estimates the number of TfstTag.
  */
 static int estimate_number_of_tfs_tags(int n) {
 n=n*4;
@@ -191,7 +191,7 @@ static int get_tfst_tag_index(unichar* s,LocateTfstTagMatchingCache* cache) {
 int ret;
 struct any* value=get_value(cache->table,s,HT_INSERT_IF_NEEDED,&ret);
 if (ret==HT_KEY_ADDED) {
-   /* If we had not already this tag, we insert it */ 
+   /* If we had not already this tag, we insert it */
    value->_int=cache->elements->nbelems;
    vector_ptr_add(cache->elements,new_element_array(cache->n_fst2_tags));
 }
@@ -201,7 +201,7 @@ return value->_int;
 
 /**
  * Returns the cached result for the given match, or UNKNOWN_MATCH_STATUS
- * if it has not been computed yet.  
+ * if it has not been computed yet.
  */
 int get_cached_result(LocateTfstTagMatchingCache* cache,
                       unichar* tfst_tag,int fst2_tag_index,
@@ -233,7 +233,7 @@ return UNKNOWN_MATCH_STATUS;
 
 /**
  * Sets the given result in the cache. This function is not supposed to be called
- * if the result is already in the cache. 
+ * if the result is already in the cache.
  */
 void set_cached_result(LocateTfstTagMatchingCache* cache,
                       int tfst_tag_index,int fst2_tag_index,

--- a/OptimizedTfstTagMatching.h
+++ b/OptimizedTfstTagMatching.h
@@ -53,7 +53,7 @@ void free_LocateTfstTagMatchingCache(LocateTfstTagMatchingCache*);
 
 void prepare_cache_for_new_sentence(LocateTfstTagMatchingCache*,int);
 int get_cached_result(LocateTfstTagMatchingCache* cache,
-                      unichar* tfst_tag,int fst2_tag_index,int tfst_tag_index, 
+                      unichar* tfst_tag,int fst2_tag_index,int tfst_tag_index,
                       int old_pos_fst2,int old_pos_tfst,int *new_pos_fst2,int *new_pos_tfst);
 void set_cached_result(LocateTfstTagMatchingCache* cache,
                       int tfst_tag_index,int fst2_tag_index,

--- a/OutputTransductionVariables.cpp
+++ b/OutputTransductionVariables.cpp
@@ -365,7 +365,7 @@ for (unsigned int i=0;i<nb_var;i++) {
 	size_strings += len;
 }
 OutputVariablesBackup* backup=(OutputVariablesBackup*)malloc_cb(
-	v->unichars_offset + (size_strings * sizeof(unichar)) +		
+	v->unichars_offset + (size_strings * sizeof(unichar)) +
 		((nb_var+1) * ( sizeof(uint_pack_multibits)+sizeof(unichar))),prv_alloc);
 if (backup==NULL) {
    fatal_alloc_error("create_output_variable_backup");
@@ -383,7 +383,7 @@ for (unsigned int i = 0; i<(unsigned int)nb_var; i++) {
 *((unsigned int*)(((char*)backup) + OFFSET_NB_PENDING)) = nb_pending;
 
 unsigned int* string_index = (unsigned int*)(((char*)backup) + (v->string_index_offset));
- 
+
 if ((!nb_pending) && (!size_strings)) {
 	*string_index = nb_var;
 	*((unsigned int*)(((char*)backup) + OFFSET_NB_FILLED_STRING)) = 0;
@@ -486,7 +486,7 @@ int pos_in_index = 0;
 
 for (;;) {
 	unsigned int cur_item_in_index = *(string_index + pos_in_index);
-	
+
 	if (cur_item_in_index == nb_var)
 		break;
 

--- a/OutputTransductionVariables.cpp
+++ b/OutputTransductionVariables.cpp
@@ -25,16 +25,16 @@
 #ifdef TYPE_PACK_MULTIBITS_STRUCT
 typedef struct
 {
-	unsigned char c[8];
+    unsigned char c[8];
 } pack_8_bytes;
 typedef pack_8_bytes uint_pack_multibits;
 typedef pack_8_bytes uint_pack_multiunichar;
 
 static inline uint_pack_multibits get_uint_pack_multibits_zero()
 {
-	uint_pack_multibits p;
-	p.c[0] = p.c[1] = p.c[2] = p.c[3] = p.c[4] = p.c[5] = p.c[6] = p.c[7] = 0;
-	return p;
+    uint_pack_multibits p;
+    p.c[0] = p.c[1] = p.c[2] = p.c[3] = p.c[4] = p.c[5] = p.c[6] = p.c[7] = 0;
+    return p;
 }
 
 #else
@@ -49,7 +49,7 @@ typedef uint64_t uint_pack_multiunichar;
 
 static inline uint_pack_multibits get_uint_pack_multibits_zero()
 {
-	return (uint_pack_multibits)0;
+    return (uint_pack_multibits)0;
 }
 #endif
 
@@ -70,91 +70,91 @@ namespace unitex {
 // unoptimized version
 static inline void copy_string(unichar* dest, const unichar* src, unsigned int len) {
 #ifdef COPY_STRING_USE_MEMCPY
-	memcpy(dest, src, (len + 1) * sizeof(unichar));
+    memcpy(dest, src, (len + 1) * sizeof(unichar));
 #else
-	#define factor_unichar_to_pack (sizeof(uint_pack_multiunichar)/sizeof(unichar))
+    #define factor_unichar_to_pack (sizeof(uint_pack_multiunichar)/sizeof(unichar))
 
-	unsigned int size_in_byte = (len + 1)*sizeof(unichar);
-	unsigned int len_in_pack_multiunichar = (size_in_byte + sizeof(uint_pack_multiunichar) - 1) / sizeof(uint_pack_multiunichar);
+    unsigned int size_in_byte = (len + 1)*sizeof(unichar);
+    unsigned int len_in_pack_multiunichar = (size_in_byte + sizeof(uint_pack_multiunichar) - 1) / sizeof(uint_pack_multiunichar);
 
-	for (unsigned int i = 0; i < len_in_pack_multiunichar; i++)
-	{
-		uint_pack_multiunichar mc = *(((uint_pack_multiunichar*)src) + i);
-		*(((uint_pack_multiunichar*)dest) + i) = mc;
-	}
+    for (unsigned int i = 0; i < len_in_pack_multiunichar; i++)
+    {
+        uint_pack_multiunichar mc = *(((uint_pack_multiunichar*)src) + i);
+        *(((uint_pack_multiunichar*)dest) + i) = mc;
+    }
 #endif
 }
 */
 
 static inline void copy_string(unichar* dest, const unichar* src, unsigned int len) {
 #ifdef COPY_STRING_USE_MEMCPY
-		memcpy(dest, src, (len + 1) * sizeof(unichar));
+        memcpy(dest, src, (len + 1) * sizeof(unichar));
 #else
 #define factor_unichar_to_pack (sizeof(uint_pack_multiunichar)/sizeof(unichar))
 
-		unsigned int size_in_byte = (len + 1)*sizeof(unichar);
-		unsigned int len_in_pack_multiunichar = (size_in_byte + sizeof(uint_pack_multiunichar) - 1) / sizeof(uint_pack_multiunichar);
+        unsigned int size_in_byte = (len + 1)*sizeof(unichar);
+        unsigned int len_in_pack_multiunichar = (size_in_byte + sizeof(uint_pack_multiunichar) - 1) / sizeof(uint_pack_multiunichar);
 
-		switch (len_in_pack_multiunichar)
-		{
-		case 0:
-			break;
-		case 1:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			break;
+        switch (len_in_pack_multiunichar)
+        {
+        case 0:
+            break;
+        case 1:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            break;
 
-		case 2:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			break;
+        case 2:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            break;
 
-		case 3:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			*(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
-			break;
+        case 3:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            *(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
+            break;
 
-		case 4:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			*(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
-			*(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
-			break;
+        case 4:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            *(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
+            *(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
+            break;
 
-		case 5:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			*(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
-			*(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
-			*(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
-			break;
+        case 5:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            *(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
+            *(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
+            *(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
+            break;
 
-		case 6:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			*(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
-			*(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
-			*(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
-			*(((uint_pack_multiunichar*)dest) + 5) = *(((uint_pack_multiunichar*)src) + 5);
-			break;
+        case 6:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            *(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
+            *(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
+            *(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
+            *(((uint_pack_multiunichar*)dest) + 5) = *(((uint_pack_multiunichar*)src) + 5);
+            break;
 
-		case 7:
-			*(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
-			*(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
-			*(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
-			*(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
-			*(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
-			*(((uint_pack_multiunichar*)dest) + 5) = *(((uint_pack_multiunichar*)src) + 5);
-			*(((uint_pack_multiunichar*)dest) + 6) = *(((uint_pack_multiunichar*)src) + 6);
-			break;
+        case 7:
+            *(((uint_pack_multiunichar*)dest) + 0) = *(((uint_pack_multiunichar*)src) + 0);
+            *(((uint_pack_multiunichar*)dest) + 1) = *(((uint_pack_multiunichar*)src) + 1);
+            *(((uint_pack_multiunichar*)dest) + 2) = *(((uint_pack_multiunichar*)src) + 2);
+            *(((uint_pack_multiunichar*)dest) + 3) = *(((uint_pack_multiunichar*)src) + 3);
+            *(((uint_pack_multiunichar*)dest) + 4) = *(((uint_pack_multiunichar*)src) + 4);
+            *(((uint_pack_multiunichar*)dest) + 5) = *(((uint_pack_multiunichar*)src) + 5);
+            *(((uint_pack_multiunichar*)dest) + 6) = *(((uint_pack_multiunichar*)src) + 6);
+            break;
 
-		default:
-			for (unsigned int i = 0; i < len_in_pack_multiunichar; i++)
-			{
-				uint_pack_multiunichar mc = *(((uint_pack_multiunichar*)src) + i);
-				*(((uint_pack_multiunichar*)dest) + i) = mc;
-			}
-		}
+        default:
+            for (unsigned int i = 0; i < len_in_pack_multiunichar; i++)
+            {
+                uint_pack_multiunichar mc = *(((uint_pack_multiunichar*)src) + i);
+                *(((uint_pack_multiunichar*)dest) + i) = mc;
+            }
+        }
 #endif
 }
 
@@ -179,13 +179,13 @@ static inline void remove_output_variable_from_pending_list(OutputVariables*v, O
 OutputVariables* new_OutputVariables(struct list_ustring* list,int* p_nbvar,vector_ptr* injected) {
 struct string_hash* variable_index = new_string_hash(DONT_USE_VALUES);
 while (list != NULL) {
-	get_value_index(list->string, variable_index);
-	list = list->next;
+    get_value_index(list->string, variable_index);
+    list = list->next;
 }
 if (injected != NULL) {
-	for (int i = 0;i<injected->nbelems;i += 2) {
-		get_value_index((unichar*)(injected->tab[i]), variable_index);
-	}
+    for (int i = 0;i<injected->nbelems;i += 2) {
+        get_value_index((unichar*)(injected->tab[i]), variable_index);
+    }
 }
 unsigned int nb_var = variable_index->size;
 OutputVariables* v=(OutputVariables*)malloc(sizeof(OutputVariables)+((nb_var + STEP_UNROLL_FREE_VARIABLE)*sizeof(Ustring)));
@@ -202,14 +202,14 @@ for (unsigned int i=0;i<nb_var;i++) {
 }*/
 #define START_SIZE_VARIABLE 1
 for (unsigned int i = 0; i < my_around_align(nb_var, STEP_UNROLL_FREE_VARIABLE); i++) {
-	v->variables_[i].len=0;
-	v->variables_[i].size = START_SIZE_VARIABLE;
-	v->variables_[i].str = (unichar*)malloc(v->variables_[i].size*sizeof(unichar));
-	if (v->variables_[i].str == NULL) {
-		fatal_alloc_error("new_OutputVariables");
-	}
-	*(v->variables_[i].str)=0;
-	resize(&v->variables_[i], 1);
+    v->variables_[i].len=0;
+    v->variables_[i].size = START_SIZE_VARIABLE;
+    v->variables_[i].str = (unichar*)malloc(v->variables_[i].size*sizeof(unichar));
+    if (v->variables_[i].str == NULL) {
+        fatal_alloc_error("new_OutputVariables");
+    }
+    *(v->variables_[i].str)=0;
+    resize(&v->variables_[i], 1);
 }
 v->pending=NULL;
 v->is_pending=(char*)calloc(my_around_align_intptr_size_ispending_array(my_around_align_ispending_array(nb_var*sizeof(char))),1);
@@ -229,10 +229,10 @@ if (p_nbvar!=NULL) {
     *p_nbvar = nb_var;
 }
 if (injected!=NULL) {
-	for (int i=0;i<injected->nbelems;i+=2) {
-		int index=get_value_index((unichar*)(injected->tab[i]),v->variable_index);
-		u_strcpy(&v->variables_[index],(unichar*)(injected->tab[i+1]));
-	}
+    for (int i=0;i<injected->nbelems;i+=2) {
+        int index=get_value_index((unichar*)(injected->tab[i]),v->variable_index);
+        u_strcpy(&v->variables_[index],(unichar*)(injected->tab[i+1]));
+    }
 }
 
 v->recycle_allocation = NULL;
@@ -246,17 +246,17 @@ return v;
  */
 static inline OutputVarList* alloc_OutputVarList_from_recycle_reserve(OutputVariables*v)
 {
-	OutputVarList* item = v->recycle_allocation;
-	if (item != NULL) {
-		v->recycle_allocation = item->next;
-	} else {
-		item = (OutputVarList*)malloc(sizeof(OutputVarList));
-		if (item == NULL) {
-			fatal_alloc_error("alloc_OutputVarList_from_recycle_reserve");
-		}
-	}
+    OutputVarList* item = v->recycle_allocation;
+    if (item != NULL) {
+        v->recycle_allocation = item->next;
+    } else {
+        item = (OutputVarList*)malloc(sizeof(OutputVarList));
+        if (item == NULL) {
+            fatal_alloc_error("alloc_OutputVarList_from_recycle_reserve");
+        }
+    }
 
-	return item;
+    return item;
 }
 
 
@@ -267,9 +267,9 @@ static inline OutputVarList* alloc_OutputVarList_from_recycle_reserve(OutputVari
 /*
 static inline OutputVarList* alloc_OutputVarList_from_recycle_reserve_no_alloc_needed(OutputVariables*v)
 {
-	OutputVarList* item = v->recycle_allocation;
-	v->recycle_allocation = item->next;
-	return item;
+    OutputVarList* item = v->recycle_allocation;
+    v->recycle_allocation = item->next;
+    return item;
 }
 */
 
@@ -279,8 +279,8 @@ static inline OutputVarList* alloc_OutputVarList_from_recycle_reserve_no_alloc_n
  */
 static inline void free_OutputVarList_from_recycle_reserve(OutputVariables*v, OutputVarList* item)
 {
-	item->next = v->recycle_allocation;
-	v->recycle_allocation = item;
+    item->next = v->recycle_allocation;
+    v->recycle_allocation = item;
 }
 
 
@@ -291,14 +291,14 @@ static inline void free_OutputVarList_from_recycle_reserve(OutputVariables*v, Ou
  */
 void swap_output_variable_content(OutputVariables*v, int index, Ustring* swap_string)
 {
-	Ustring t;
-	if ((v->variables_[index].size) > (swap_string->size)) {
-		resize(swap_string, v->variables_[index].size);
-	}
+    Ustring t;
+    if ((v->variables_[index].size) > (swap_string->size)) {
+        resize(swap_string, v->variables_[index].size);
+    }
 
-	t = *swap_string;
-	*swap_string = (v->variables_[index]);
-	(v->variables_[index]) = t;
+    t = *swap_string;
+    *swap_string = (v->variables_[index]);
+    (v->variables_[index]) = t;
 }
 
 
@@ -310,22 +310,22 @@ if (v==NULL) return;
 int nb_var=v->variable_index->size;
 free_string_hash(v->variable_index);
 for (unsigned int i = 0; i < my_around_align((unsigned int)nb_var, STEP_UNROLL_FREE_VARIABLE); i++) {
-	free(v->variables_[i].str);
+    free(v->variables_[i].str);
 }
 OutputVarList* l=v->pending;
 OutputVarList* tmp;
 while (l!=NULL) {
-	tmp=l;
-	l=l->next;
-	/* Don't free l->var, since it has been freed by free_Ustring above */
-	free_OutputVarList_from_recycle_reserve(v,tmp);
+    tmp=l;
+    l=l->next;
+    /* Don't free l->var, since it has been freed by free_Ustring above */
+    free_OutputVarList_from_recycle_reserve(v,tmp);
 }
 // freeing the recycle collection of OutputVarList allocated structure
 OutputVarList* tmp_recyling = v->recycle_allocation;
 while (tmp_recyling != NULL) {
-	OutputVarList* tmp_recyling_next = tmp_recyling->next;
-	free(tmp_recyling);
-	tmp_recyling = tmp_recyling_next;
+    OutputVarList* tmp_recyling_next = tmp_recyling->next;
+    free(tmp_recyling);
+    tmp_recyling = tmp_recyling_next;
 }
 free(v->is_pending);
 free(v);
@@ -361,12 +361,12 @@ if (nb_var==0) return NULL;
 unsigned int size_strings=0;
 
 for (unsigned int i=0;i<nb_var;i++) {
-	unsigned int len = v->variables_[i].len;
-	size_strings += len;
+    unsigned int len = v->variables_[i].len;
+    size_strings += len;
 }
 OutputVariablesBackup* backup=(OutputVariablesBackup*)malloc_cb(
-	v->unichars_offset + (size_strings * sizeof(unichar)) +
-		((nb_var+1) * ( sizeof(uint_pack_multibits)+sizeof(unichar))),prv_alloc);
+    v->unichars_offset + (size_strings * sizeof(unichar)) +
+        ((nb_var+1) * ( sizeof(uint_pack_multibits)+sizeof(unichar))),prv_alloc);
 if (backup==NULL) {
    fatal_alloc_error("create_output_variable_backup");
 }
@@ -375,8 +375,8 @@ unsigned int nb_pending = 0;
 unsigned int * pending_var_list = (unsigned int *)(((char*)backup) + OFFSET_PENDING_LIST);
 
 for (unsigned int i = 0; i<(unsigned int)nb_var; i++) {
-	*(pending_var_list + nb_pending) = i;
-	nb_pending+= v->is_pending[i];
+    *(pending_var_list + nb_pending) = i;
+    nb_pending+= v->is_pending[i];
 }
 *(pending_var_list + nb_pending) = nb_var;
 
@@ -385,25 +385,25 @@ for (unsigned int i = 0; i<(unsigned int)nb_var; i++) {
 unsigned int* string_index = (unsigned int*)(((char*)backup) + (v->string_index_offset));
 
 if ((!nb_pending) && (!size_strings)) {
-	*string_index = nb_var;
-	*((unsigned int*)(((char*)backup) + OFFSET_NB_FILLED_STRING)) = 0;
-	return (OutputVariablesBackup*)backup;
+    *string_index = nb_var;
+    *((unsigned int*)(((char*)backup) + OFFSET_NB_FILLED_STRING)) = 0;
+    return (OutputVariablesBackup*)backup;
 }
 
 unichar* backup_string = (unichar*)(((char*)backup) + v->unichars_offset);
 unsigned int nb_string_filled = 0;
 for (unsigned int i=0;i<(unsigned int)nb_var;i++) {
     {
-		unsigned int len = v->variables_[i].len;
-		if (len > 0)
-		{
-			*(string_index + (nb_string_filled * 2)) = i;
-			*(string_index + (nb_string_filled * 2) + 1) = len;
-			//memcpy(backup_string, v->variables[i]->str, sizeof(unichar)*(len + 1));
-			copy_string(backup_string, v->variables_[i].str, len);
-			backup_string += my_around_align(len + 1, sizeof(uint_pack_multibits));
-			nb_string_filled++;
-		}
+        unsigned int len = v->variables_[i].len;
+        if (len > 0)
+        {
+            *(string_index + (nb_string_filled * 2)) = i;
+            *(string_index + (nb_string_filled * 2) + 1) = len;
+            //memcpy(backup_string, v->variables[i]->str, sizeof(unichar)*(len + 1));
+            copy_string(backup_string, v->variables_[i].str, len);
+            backup_string += my_around_align(len + 1, sizeof(uint_pack_multibits));
+            nb_string_filled++;
+        }
     }
 }
 
@@ -432,10 +432,10 @@ if (backup==NULL) return;
 /* First, we free the previous pending list */
 OutputVarList* tmp;
 while (v->pending!=NULL) {
-	tmp=v->pending;
-	v->pending=v->pending->next;
-	/* We must not free tmp->var */
-	free_OutputVarList_from_recycle_reserve(v,tmp);
+    tmp=v->pending;
+    v->pending=v->pending->next;
+    /* We must not free tmp->var */
+    free_OutputVarList_from_recycle_reserve(v,tmp);
 }
 
 uint_pack_multibits* is_pending_erase = (uint_pack_multibits*)v->is_pending;
@@ -448,35 +448,35 @@ unsigned int nb_var = (unsigned int)v->nb_var;
 
 
 for (unsigned int i = 0; i < nb_var; i+=STEP_UNROLL_FREE_VARIABLE) {
-	v->variables_[i].str[0] = 0;
-	v->variables_[i].len = 0;
-	v->variables_[i+1].str[0] = 0;
-	v->variables_[i+1].len = 0;
-	v->variables_[i+2].str[0] = 0;
-	v->variables_[i+2].len = 0;
-	v->variables_[i+3].str[0] = 0;
-	v->variables_[i+3].len = 0;
-	v->variables_[i+4].str[0] = 0;
-	v->variables_[i+4].len = 0;
-	v->variables_[i+5].str[0] = 0;
-	v->variables_[i+5].len = 0;
-	v->variables_[i+6].str[0] = 0;
-	v->variables_[i+6].len = 0;
-	v->variables_[i+7].str[0] = 0;
-	v->variables_[i+7].len = 0;
-	*(is_pending_erase + (i/8)) = get_uint_pack_multibits_zero();
+    v->variables_[i].str[0] = 0;
+    v->variables_[i].len = 0;
+    v->variables_[i+1].str[0] = 0;
+    v->variables_[i+1].len = 0;
+    v->variables_[i+2].str[0] = 0;
+    v->variables_[i+2].len = 0;
+    v->variables_[i+3].str[0] = 0;
+    v->variables_[i+3].len = 0;
+    v->variables_[i+4].str[0] = 0;
+    v->variables_[i+4].len = 0;
+    v->variables_[i+5].str[0] = 0;
+    v->variables_[i+5].len = 0;
+    v->variables_[i+6].str[0] = 0;
+    v->variables_[i+6].len = 0;
+    v->variables_[i+7].str[0] = 0;
+    v->variables_[i+7].len = 0;
+    *(is_pending_erase + (i/8)) = get_uint_pack_multibits_zero();
 }
 
 // first int of backup is set to 0 if we have full empty backup
 if ((!nb_pending) && (!nb_filled_strings)) {
-	return;
+    return;
 }
 
 for (unsigned int loop_pending = 0; loop_pending < nb_pending; loop_pending++)
 {
-	unsigned int cur_pending_item = *(pending_var_list + loop_pending);
-	v->is_pending[cur_pending_item] = 1;
-	add_output_variable_to_pending_list(v,&(v->pending),&v->variables_[cur_pending_item]);
+    unsigned int cur_pending_item = *(pending_var_list + loop_pending);
+    v->is_pending[cur_pending_item] = 1;
+    add_output_variable_to_pending_list(v,&(v->pending),&v->variables_[cur_pending_item]);
 }
 
 
@@ -485,28 +485,28 @@ const unichar* backup_string = (const unichar*)(((const char*)backup) + v->unich
 int pos_in_index = 0;
 
 for (;;) {
-	unsigned int cur_item_in_index = *(string_index + pos_in_index);
+    unsigned int cur_item_in_index = *(string_index + pos_in_index);
 
-	if (cur_item_in_index == nb_var)
-		break;
+    if (cur_item_in_index == nb_var)
+        break;
 
-	Ustring * cur_ustr = &(v->variables_[cur_item_in_index]);
+    Ustring * cur_ustr = &(v->variables_[cur_item_in_index]);
 
-	int cur_len_in_index = *(string_index + pos_in_index + 1);
+    int cur_len_in_index = *(string_index + pos_in_index + 1);
 
-	/*
-	// this test is awful, because it break optimized IPO/LTO/WPO optimization having only internal code
-	//  we can remove it, because we restore a previous value (so buffer size is already compatible), and
-	//  when we replace with replace_output_variable_string, size became never smaller
-	if (cur_ustr->size < (unsigned int)cur_len_in_index)
-		resize(cur_ustr, cur_len_in_index + 1);
-		*/
-	cur_ustr->len = cur_len_in_index;
-	//memcpy(cur_ustr->str, backup_string, (cur_len_in_index + 1) * sizeof(unichar));
-	copy_string(cur_ustr->str, backup_string, cur_len_in_index);
-	//backup_string += cur_len_in_index + 1;
-	backup_string += my_around_align(cur_len_in_index + 1, ALIGN_BACKUP_STRING);
-	pos_in_index+=2;
+    /*
+    // this test is awful, because it break optimized IPO/LTO/WPO optimization having only internal code
+    //  we can remove it, because we restore a previous value (so buffer size is already compatible), and
+    //  when we replace with replace_output_variable_string, size became never smaller
+    if (cur_ustr->size < (unsigned int)cur_len_in_index)
+        resize(cur_ustr, cur_len_in_index + 1);
+        */
+    cur_ustr->len = cur_len_in_index;
+    //memcpy(cur_ustr->str, backup_string, (cur_len_in_index + 1) * sizeof(unichar));
+    copy_string(cur_ustr->str, backup_string, cur_len_in_index);
+    //backup_string += cur_len_in_index + 1;
+    backup_string += my_around_align(cur_len_in_index + 1, ALIGN_BACKUP_STRING);
+    pos_in_index+=2;
 }
 }
 
@@ -518,82 +518,82 @@ for (;;) {
  * install_output_variable_backup because less used.
  */
 int same_output_variables(const OutputVariablesBackup* backup, OutputVariables* v) {
-	if (v == NULL) {
-		return backup == NULL;
-	}
+    if (v == NULL) {
+        return backup == NULL;
+    }
 
-	unsigned int nb_var = (unsigned int)v->nb_var;
+    unsigned int nb_var = (unsigned int)v->nb_var;
 
-	if (nb_var == 0) return 1;
-
-
-	const unsigned int * pending_var_list_backup = (const unsigned int*)(((const char*)backup) + OFFSET_PENDING_LIST);
-	const unsigned int nb_pending_backup = *((const unsigned int*)(((const char*)backup) + OFFSET_NB_PENDING));
-	const unsigned int nb_filled_strings_backup = *((const unsigned int*)(((const char*)backup) + OFFSET_NB_FILLED_STRING));
+    if (nb_var == 0) return 1;
 
 
+    const unsigned int * pending_var_list_backup = (const unsigned int*)(((const char*)backup) + OFFSET_PENDING_LIST);
+    const unsigned int nb_pending_backup = *((const unsigned int*)(((const char*)backup) + OFFSET_NB_PENDING));
+    const unsigned int nb_filled_strings_backup = *((const unsigned int*)(((const char*)backup) + OFFSET_NB_FILLED_STRING));
 
-	// first int of backup is set to 0 if we have full empty backup
-	if ((!nb_pending_backup) && (!nb_filled_strings_backup)) {
-		for (unsigned int i = 0;i<nb_var;i++) {
-			if (0 != v->is_pending[i]) {
-				return 0;
-			}
-		}
 
-		for (unsigned int i = 0;i<nb_var;i++) {
-			if (v->variables_[i].str[0] != '\0') {
-				return 0;
-			}
-		}
 
-		return 1;
-	}
+    // first int of backup is set to 0 if we have full empty backup
+    if ((!nb_pending_backup) && (!nb_filled_strings_backup)) {
+        for (unsigned int i = 0;i<nb_var;i++) {
+            if (0 != v->is_pending[i]) {
+                return 0;
+            }
+        }
 
-	unsigned int nb_pending_v = 0;
-	for (size_t i = 0; i<nb_var; i++) {
-		if (v->is_pending[i]) {
-			if (*(pending_var_list_backup + nb_pending_v) != i) {
-				return 0;
-			}
-			nb_pending_v++;
-		}
-	}
+        for (unsigned int i = 0;i<nb_var;i++) {
+            if (v->variables_[i].str[0] != '\0') {
+                return 0;
+            }
+        }
 
-	if (*(pending_var_list_backup + nb_pending_v) != nb_var) {
-		return 0;
-	}
+        return 1;
+    }
 
-	const unsigned int* string_index = (const unsigned int*)(((const char*)backup) + (v->string_index_offset));
-	const unichar* backup_string = (const unichar*)(((const char*)backup) + v->unichars_offset);
-	unsigned int pos_in_index = 0;
-	unsigned int cur_item_in_index = *(string_index + (pos_in_index * 2));
-	for (unsigned int i = 0; i<nb_var; i++) {
-		Ustring * cur_ustr = &(v->variables_[i]);
-		if (i == cur_item_in_index)
-		{
-			unsigned int cur_len_in_index = *(string_index + (pos_in_index * 2) + 1);
-			if (cur_ustr->len != cur_len_in_index) {
-				return 0;
-			}
-			if (memcmp(cur_ustr->str, backup_string, (cur_len_in_index + 1) * sizeof(unichar)) != 0) {
-				return 0;
-			}
-			//backup_string += cur_len_in_index + 1;
-			backup_string += my_around_align(cur_len_in_index + 1, ALIGN_BACKUP_STRING);
+    unsigned int nb_pending_v = 0;
+    for (size_t i = 0; i<nb_var; i++) {
+        if (v->is_pending[i]) {
+            if (*(pending_var_list_backup + nb_pending_v) != i) {
+                return 0;
+            }
+            nb_pending_v++;
+        }
+    }
 
-			pos_in_index++;
-			cur_item_in_index = *(string_index + (pos_in_index * 2));
-		}
-		else
-		{
-			if (cur_ustr->len != 0) {
-				return 0;
-			}
-		}
-	}
+    if (*(pending_var_list_backup + nb_pending_v) != nb_var) {
+        return 0;
+    }
 
-	return 1;
+    const unsigned int* string_index = (const unsigned int*)(((const char*)backup) + (v->string_index_offset));
+    const unichar* backup_string = (const unichar*)(((const char*)backup) + v->unichars_offset);
+    unsigned int pos_in_index = 0;
+    unsigned int cur_item_in_index = *(string_index + (pos_in_index * 2));
+    for (unsigned int i = 0; i<nb_var; i++) {
+        Ustring * cur_ustr = &(v->variables_[i]);
+        if (i == cur_item_in_index)
+        {
+            unsigned int cur_len_in_index = *(string_index + (pos_in_index * 2) + 1);
+            if (cur_ustr->len != cur_len_in_index) {
+                return 0;
+            }
+            if (memcmp(cur_ustr->str, backup_string, (cur_len_in_index + 1) * sizeof(unichar)) != 0) {
+                return 0;
+            }
+            //backup_string += cur_len_in_index + 1;
+            backup_string += my_around_align(cur_len_in_index + 1, ALIGN_BACKUP_STRING);
+
+            pos_in_index++;
+            cur_item_in_index = *(string_index + (pos_in_index * 2));
+        }
+        else
+        {
+            if (cur_ustr->len != 0) {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
 }
 
 
@@ -602,11 +602,11 @@ int same_output_variables(const OutputVariablesBackup* backup, OutputVariables* 
  */
 static inline void add_output_variable_to_pending_list(OutputVariables*v, OutputVarList* *list,Ustring* s) {
 while (*list != NULL) {
-	if ((*list)->var==s) {
-		/* The pointer is already in the list */
-		return;
-	}
-	list=&((*list)->next);
+    if ((*list)->var==s) {
+        /* The pointer is already in the list */
+        return;
+    }
+    list=&((*list)->next);
 }
 (*list)=(OutputVarList*)alloc_OutputVarList_from_recycle_reserve(v);
 (*list)->var=s;
@@ -623,11 +623,11 @@ while (*list != NULL) {
 /*
 static inline void add_output_variable_to_pending_list_no_alloc_needed(OutputVariables*v, OutputVarList* *list,Ustring* s) {
 while (*list != NULL) {
-	if ((*list)->var==s) {
-		// The pointer is already in the list
-		return;
-	}
-	list=&((*list)->next);
+    if ((*list)->var==s) {
+        // The pointer is already in the list
+        return;
+    }
+    list=&((*list)->next);
 }
 (*list)=(OutputVarList*)alloc_OutputVarList_from_recycle_reserve_no_alloc_needed(v);
 (*list)->var=s;
@@ -641,14 +641,14 @@ while (*list != NULL) {
  */
 static inline void remove_output_variable_from_pending_list(OutputVariables*v, OutputVarList* *list,Ustring* s) {
 while (*list != NULL) {
-	if ((*list)->var==s) {
-		/* We have found the pointer to be removed */
-		OutputVarList* tmp=(*list);
-		(*list)=(*list)->next;
-		free_OutputVarList_from_recycle_reserve(v,tmp);
-		return;
-	}
-	list=&((*list)->next);
+    if ((*list)->var==s) {
+        /* We have found the pointer to be removed */
+        OutputVarList* tmp=(*list);
+        (*list)=(*list)->next;
+        free_OutputVarList_from_recycle_reserve(v,tmp);
+        return;
+    }
+    list=&((*list)->next);
 }
 fatal_error("Non-existent Ustring pointer in remove_output_variable\n");
 }
@@ -661,14 +661,14 @@ fatal_error("Non-existent Ustring pointer in remove_output_variable\n");
 unsigned int add_raw_string_to_output_variables(OutputVariables* var,unichar* s) {
 OutputVarList* list=var->pending;
 if (list==NULL) {
-	fatal_error("Should not invoke add_string_to_output_variables on an empty list\n");
+    fatal_error("Should not invoke add_string_to_output_variables on an empty list\n");
 }
 if (s==NULL || s[0]=='\0') return 0;
 unsigned int old=list->var->len;
 OutputVarList* first=list;
 while (list!=NULL) {
-	u_strcat(list->var,s);
-	list=list->next;
+    u_strcat(list->var,s);
+    list=list->next;
 }
 return first->var->len-old;
 }
@@ -682,11 +682,11 @@ void remove_chars_from_output_variables(OutputVariables* var,unsigned int n) {
 OutputVarList* list=var->pending;
 if (n==0) return;
 if (list==NULL) {
-	fatal_error("Should not invoke remove_chars_from_output_variables on an empty list\n");
+    fatal_error("Should not invoke remove_chars_from_output_variables on an empty list\n");
 }
 while (list!=NULL) {
-	remove_n_chars(list->var,n);
-	list=list->next;
+    remove_n_chars(list->var,n);
+    list=list->next;
 }
 }
 

--- a/OutputTransductionVariables.h
+++ b/OutputTransductionVariables.h
@@ -41,8 +41,8 @@ namespace unitex {
  * exploring a grammar
  */
 typedef struct output_var_list {
-	Ustring* var;
-	struct output_var_list* next;
+    Ustring* var;
+    struct output_var_list* next;
 } OutputVarList;
 
 

--- a/PRLG.cpp
+++ b/PRLG.cpp
@@ -33,7 +33,7 @@ namespace unitex {
 PRLG_DATA* new_PRLG_DATA(int offset,unichar* s) {
 PRLG_DATA* d=(PRLG_DATA*)malloc(sizeof(PRLG_DATA));
 if (d==NULL) {
-	fatal_alloc_error("new_PRLG_DATA");
+    fatal_alloc_error("new_PRLG_DATA");
 }
 d->offset=offset;
 d->data=u_strdup(s);
@@ -53,20 +53,20 @@ U_FILE* f=u_fopen(vec,filename,U_READ);
 if (f==NULL) return NULL;
 PRLG* p=(PRLG*)malloc(sizeof(PRLG));
 if (p==NULL) {
-	fatal_alloc_error("load_PRLG_data");
+    fatal_alloc_error("load_PRLG_data");
 }
 p->data=new_vector_ptr();
 p->max_width=0;
 Ustring* line=new_Ustring(1024);
 int offset,n;
 while (EOF!=readline(line,f)) {
-	if (1!=u_sscanf(line->str,"%d%n",&offset,&n)) {
-		fatal_error("Invalid line in PRLG file %s:\n%S\n",filename,line->str);
-	}
-	if (u_strlen(line)-n>p->max_width) {
-		p->max_width=u_strlen(line)-n;
-	}
-	vector_ptr_add(p->data,new_PRLG_DATA(offset,line->str+n));
+    if (1!=u_sscanf(line->str,"%d%n",&offset,&n)) {
+        fatal_error("Invalid line in PRLG file %s:\n%S\n",filename,line->str);
+    }
+    if (u_strlen(line)-n>p->max_width) {
+        p->max_width=u_strlen(line)-n;
+    }
+    vector_ptr_add(p->data,new_PRLG_DATA(offset,line->str+n));
 }
 free_Ustring(line);
 u_fclose(f);
@@ -92,8 +92,8 @@ free(p);
 int get_closest_offset(PRLG* p,int offset,int start,int end) {
 if (start>end) return end;
 if (start==end) {
-	if (get_offset(start)<=offset) return start;
-	return start-1;
+    if (get_offset(start)<=offset) return start;
+    return start-1;
 }
 int current=(start+end)/2;
 int current_offset=get_offset(current);

--- a/PRLG.h
+++ b/PRLG.h
@@ -37,16 +37,16 @@ namespace unitex {
  * corpus.
  */
 typedef struct {
-	int offset;
-	unichar* data;
+    int offset;
+    unichar* data;
 } PRLG_DATA;
 
 
 typedef struct {
-	/* The data */
-	vector_ptr* data;
-	/* The width of the largest data, that will be used for alignment purpose */
-	int max_width;
+    /* The data */
+    vector_ptr* data;
+    /* The width of the largest data, that will be used for alignment purpose */
+    int max_width;
 } PRLG;
 
 

--- a/ParsingInfo.cpp
+++ b/ParsingInfo.cpp
@@ -30,14 +30,14 @@ namespace unitex {
 
 size_t get_prefered_allocator_item_size_for_nb_variable(int nbvar)
 {
-    return AroundAllocAlign(sizeof(struct parsing_info)) + 
+    return AroundAllocAlign(sizeof(struct parsing_info)) +
            AroundAllocAlign(get_expected_variable_backup_size_in_byte_for_nb_variable(nbvar)) +
            AroundAllocAlign(sizeof(unichar)*(SIZE_RESERVE_NB_UNICHAR_STACK_INSAMEALLOC+1));
 }
 
 size_t get_prefered_allocator_item_size_for_variable(Variables* v)
 {
-    return AroundAllocAlign(sizeof(struct parsing_info)) + 
+    return AroundAllocAlign(sizeof(struct parsing_info)) +
            AroundAllocAlign(get_variable_backup_size_in_byte(v)) +
            AroundAllocAlign(sizeof(unichar)*(SIZE_RESERVE_NB_UNICHAR_STACK_INSAMEALLOC+1));
 }
@@ -475,7 +475,7 @@ return list;
 
 
 
-												
+
 struct parsing_info* insert_morphological_match(int pos,int pos_in_token,int state,struct parsing_info* list,
                                                 struct dela_entry* dic_entry,unichar* jamo,int pos_in_jamo,
 												struct parsing_allocator* pa) {
@@ -494,7 +494,7 @@ for (;;) {
     // If the morphological match is already in the list, we do nothing.
     // Note that this may occur when we don't take DELAF entries into account
     // (i.e. dic_entry==NULL)
-   break;   
+   break;
   }
   lnext=&(lcur->next);
 }

--- a/ParsingInfo.cpp
+++ b/ParsingInfo.cpp
@@ -82,7 +82,7 @@ struct parsing_info* new_parsing_info(int pos_in_tokens,int pos_in_chars,int sta
                                       struct dic_variable* v2,
                                       int left_ctx_shift,int left_ctx_base,unichar* jamo,int pos_int_jamo,
                                       vector_int* insertions,int weight,
-									  struct parsing_allocator* pa) {
+                                      struct parsing_allocator* pa) {
 struct parsing_info* info;
 unsigned char*buf;
 buf=(unsigned char*)malloc_cb(get_prefered_allocator_item_size_for_variable(v),pa->prv_alloc_recycle);
@@ -128,10 +128,10 @@ info->jamo=jamo;
 info->pos_in_jamo=pos_int_jamo;
 info->insertions=NULL;
 if (insertions!=NULL && insertions->nbelems!=0) {
-	info->insertions=new_vector_int(insertions->nbelems,pa->prv_alloc_vector_int_inside_token);
-	vector_int_copy(info->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
+    info->insertions=new_vector_int(insertions->nbelems,pa->prv_alloc_vector_int_inside_token);
+    vector_int_copy(info->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
 } else {
-	info->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
+    info->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
 }
 return info;
 }
@@ -167,14 +167,14 @@ while (list!=NULL) {
  * have the same weight.
  */
 static void filter_lesser_weights(int weight,struct parsing_info* *list,
-									struct parsing_allocator* pa) {
+                                    struct parsing_allocator* pa) {
 if (*list==NULL || (*list)->weight>=weight) return;
 struct parsing_info* tmp;
 while (*list!=NULL) {
-	tmp=*list;
-	(*list)=(*list)->next;
-	tmp->next=NULL;
-	free_parsing_info(tmp,pa);
+    tmp=*list;
+    (*list)=(*list)->next;
+    tmp->next=NULL;
+    free_parsing_info(tmp,pa);
 }
 }
 
@@ -198,13 +198,13 @@ if (list==NULL) return new_parsing_info(pos,pos_in_token,state,stack_pointer,sta
                                         left_ctx_shift,left_ctx_base,jamo,pos_in_jamo,insertions,
                                         weight,pa);
 if (list->pos_in_tokens==pos
-	&& list->pos_in_chars==pos_in_token
-	&& list->state_number==state
-	&& list->jamo==jamo /* We can because we only work on pointers on unique elements */
-	&& list->pos_in_jamo==pos_in_jamo
-	&& same_input_variables(list->input_variable_backup,v)
-	&& same_output_variables(list->output_variable_backup,output_var)
-	&& same_dic_variables(list->dic_variable_backup,v2)) {
+    && list->pos_in_chars==pos_in_token
+    && list->state_number==state
+    && list->jamo==jamo /* We can because we only work on pointers on unique elements */
+    && list->pos_in_jamo==pos_in_jamo
+    && same_input_variables(list->input_variable_backup,v)
+    && same_output_variables(list->output_variable_backup,output_var)
+    && same_dic_variables(list->dic_variable_backup,v2)) {
    list->stack_pointer=stack_pointer;
    /* We update the stack value */
    update_parsing_info_stack(list,stack);
@@ -232,13 +232,13 @@ if (list->pos_in_tokens==pos
    list->left_ctx_shift=left_ctx_shift;
    list->left_ctx_base=left_ctx_base;
    if (insertions!=NULL && insertions->nbelems!=0) {
-	   if (list->insertions==NULL) {
-		   list->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
-	   }
-	   vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
+       if (list->insertions==NULL) {
+           list->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
+       }
+       vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
    } else {
-	   /* We always need such a vector, even empty */
-	   if (list->insertions==NULL) list->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
+       /* We always need such a vector, even empty */
+       if (list->insertions==NULL) list->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
    }
    return list;
 }
@@ -258,7 +258,7 @@ struct parsing_info* insert_if_different(int pos,int pos_in_token,int state,stru
                                          unichar* jamo,int pos_in_jamo,
                                          vector_int* insertions,
                                          int weight, struct parsing_allocator* pa) {
-	filter_lesser_weights(weight,&list,pa);
+    filter_lesser_weights(weight,&list,pa);
 if (list==NULL) return new_parsing_info(pos,pos_in_token,state,stack_pointer,stack,v,output_var,NULL,v2,
                                         left_ctx_shift,left_ctx_base,jamo,pos_in_jamo,insertions,
                                         weight,pa);
@@ -271,8 +271,8 @@ if ((list->pos_in_tokens==pos) /* If the length is the same... */
     && list->jamo==jamo /* See comment in insert_if_absent*/
     && list->pos_in_jamo==pos_in_jamo
     && same_input_variables(list->input_variable_backup,v)
-	&& same_output_variables(list->output_variable_backup,output_var)
-	&& same_dic_variables(list->dic_variable_backup,v2)) {
+    && same_output_variables(list->output_variable_backup,output_var)
+    && same_dic_variables(list->dic_variable_backup,v2)) {
     /* then we overwrite the current list element */
    list->stack_pointer=stack_pointer;
 
@@ -297,10 +297,10 @@ if ((list->pos_in_tokens==pos) /* If the length is the same... */
       fatal_error("Unexpected non NULL dic_entry in insert_if_different\n");
    }
    if (insertions!=NULL && insertions->nbelems!=0) {
-	   if (list->insertions==NULL) {
-		   list->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
-	   }
-	   vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
+       if (list->insertions==NULL) {
+           list->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
+       }
+       vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
    }
    return list;
 }
@@ -318,9 +318,9 @@ return list;
  */
 struct parsing_info* insert_morphological_match(int pos_in_tokens,int pos_in_chars,int state,struct parsing_info* list,
                                                 struct dela_entry* dic_entry,unichar* jamo,int pos_in_jamo,
-												struct parsing_allocator* pa) {
+                                                struct parsing_allocator* pa) {
 if (list==NULL) return new_parsing_info(pos_in_tokens,pos_in_chars,state,-1,NULL,NULL,NULL,dic_entry,NULL,-1,-1,
-		jamo,pos_in_jamo,NULL,-1,pa);
+        jamo,pos_in_jamo,NULL,-1,pa);
 if (list->pos_in_tokens==pos_in_tokens && list->pos_in_chars==pos_in_chars && list->state_number==state
     && list->dic_entry==dic_entry
     && list->jamo==jamo /* See comment in insert_if_absent*/
@@ -354,14 +354,14 @@ for (;;) {
   struct parsing_info*lcur=*lnext;
 
   if (lcur==NULL) {
-	  *lnext=new_parsing_info(pos,pos_in_token,state,stack_pointer,stack,v,output_var,NULL,v2,
+      *lnext=new_parsing_info(pos,pos_in_token,state,stack_pointer,stack,v,output_var,NULL,v2,
                                         left_ctx_shift,left_ctx_base,jamo,pos_in_jamo,insertions,
                                         weight,pa);
-	  break;
+      break;
   }
   if (lcur->pos_in_chars==pos && lcur->pos_in_tokens==pos_in_token && lcur->state_number==state
-	&& lcur->jamo==jamo // We can because we only work on pointers on unique elements
-	&& lcur->pos_in_jamo==pos_in_jamo) {
+    && lcur->jamo==jamo // We can because we only work on pointers on unique elements
+    && lcur->pos_in_jamo==pos_in_jamo) {
    lcur->stack_pointer=stack_pointer;
    // We update the stack value
    update_parsing_info_stack(lcur,stack);
@@ -389,13 +389,13 @@ for (;;) {
    lcur->left_ctx_shift=left_ctx_shift;
    lcur->left_ctx_base=left_ctx_base;
    if (insertions!=NULL && insertions->nbelems!=0) {
-	   if (lcur->insertions==NULL) {
-		   lcur->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
-	   }
-	   vector_int_copy(lcur->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
+       if (lcur->insertions==NULL) {
+           lcur->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
+       }
+       vector_int_copy(lcur->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
    } else {
-	   // We always need such a vector, even empty
-	   if (lcur->insertions==NULL) lcur->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
+       // We always need such a vector, even empty
+       if (lcur->insertions==NULL) lcur->insertions=new_vector_int(1, pa->prv_alloc_vector_int_inside_token);
    }
    break;
    }
@@ -415,16 +415,16 @@ struct parsing_info* insert_if_different(int pos,int pos_in_token,int state,stru
                                          unichar* jamo,int pos_in_jamo,
                                          vector_int* insertions,
                                          int weight, struct parsing_allocator* pa) {
-	filter_lesser_weights(weight,&list,pa);
+    filter_lesser_weights(weight,&list,pa);
 
 struct parsing_info**lnext=&list;
 for (;;) {
   struct parsing_info*lcur=*lnext;
   if ((lcur)==NULL) {
-	  *lnext=new_parsing_info(pos,pos_in_token,state,stack_pointer,stack,v,output_var,NULL,v2,
+      *lnext=new_parsing_info(pos,pos_in_token,state,stack_pointer,stack,v,output_var,NULL,v2,
                                         left_ctx_shift,left_ctx_base,jamo,pos_in_jamo,insertions,
                                         weight,pa);
-	  break;
+      break;
   }
 
 if ((lcur->pos_in_chars==pos) // If the length is the same...
@@ -459,10 +459,10 @@ if ((lcur->pos_in_chars==pos) // If the length is the same...
       fatal_error("Unexpected non NULL dic_entry in insert_if_different\n");
    }
    if (insertions!=NULL && insertions->nbelems!=0) {
-	   if (lcur->insertions==NULL) {
-		   lcur->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
-	   }
-	   vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
+       if (lcur->insertions==NULL) {
+           lcur->insertions=new_vector_int(insertions->nbelems, pa->prv_alloc_vector_int_inside_token);
+       }
+       vector_int_copy(list->insertions,insertions, pa->prv_alloc_vector_int_inside_token);
    }
    break;
 }
@@ -478,14 +478,14 @@ return list;
 
 struct parsing_info* insert_morphological_match(int pos,int pos_in_token,int state,struct parsing_info* list,
                                                 struct dela_entry* dic_entry,unichar* jamo,int pos_in_jamo,
-												struct parsing_allocator* pa) {
+                                                struct parsing_allocator* pa) {
 struct parsing_info**lnext=&list;
 for (;;) {
   struct parsing_info*lcur=*lnext;
   if ((lcur)==NULL) {
-		*lnext=new_parsing_info(pos,pos_in_token,state,-1,NULL,NULL,NULL,dic_entry,NULL,-1,-1,
-		  jamo,pos_in_jamo,NULL,-1,pa);
-		break;
+        *lnext=new_parsing_info(pos,pos_in_token,state,-1,NULL,NULL,NULL,dic_entry,NULL,-1,-1,
+          jamo,pos_in_jamo,NULL,-1,pa);
+        break;
   }
   if (lcur->pos_in_chars ==pos && lcur->pos_in_tokens==pos_in_token && lcur->state_number==state
     && lcur->dic_entry==dic_entry

--- a/ParsingInfo.h
+++ b/ParsingInfo.h
@@ -108,21 +108,21 @@ struct parsing_info {
 
 
 struct parsing_allocator {
-	Abstract_allocator prv_alloc_recycle;
-	// prv_alloc_vector_int allocator is clean between each token
-	Abstract_allocator prv_alloc_vector_int_inside_token;
-	Abstract_allocator prv_alloc_backup_growing_recycle;
+    Abstract_allocator prv_alloc_recycle;
+    // prv_alloc_vector_int allocator is clean between each token
+    Abstract_allocator prv_alloc_vector_int_inside_token;
+    Abstract_allocator prv_alloc_backup_growing_recycle;
 };
 
 
 struct parsing_info* new_parsing_info(int,int,int,int,unichar*,Variables*,OutputVariables*,
-										struct dela_entry* dic_entry,struct dic_variable*,
-										int,int,unichar*,int,vector_int*,int weight,struct parsing_allocator* pa);
+                                        struct dela_entry* dic_entry,struct dic_variable*,
+                                        int,int,unichar*,int,vector_int*,int weight,struct parsing_allocator* pa);
 void free_parsing_info(struct parsing_info*,struct parsing_allocator* pa);
 struct parsing_info* insert_if_absent(int,int,int,struct parsing_info*,int,unichar*,Variables*,OutputVariables*,
-		                              struct dic_variable*,int,int,unichar*,int,vector_int*,int, struct parsing_allocator* pa);
+                                      struct dic_variable*,int,int,unichar*,int,vector_int*,int, struct parsing_allocator* pa);
 struct parsing_info* insert_if_different(int,int,int,struct parsing_info*,int,unichar*,Variables*,OutputVariables*,
-		                                 struct dic_variable*,int,int,unichar*,int,vector_int*,int, struct parsing_allocator* pa);
+                                         struct dic_variable*,int,int,unichar*,int,vector_int*,int, struct parsing_allocator* pa);
 struct parsing_info* insert_morphological_match(int pos,int pos_in_token,int state,
                                                 struct parsing_info* list,struct dela_entry*,
                                                 unichar* jamo,int pos_in_jamo,struct parsing_allocator* pa);

--- a/Pattern.cpp
+++ b/Pattern.cpp
@@ -141,13 +141,13 @@ do {
    switch(codes[pos]) {
       case '+': pos++; minus=0; break;
       case '~': if (tilde_negation_operator) {
-                  pos++; minus=1; 
+                  pos++; minus=1;
                 }
                 else
                     minus = 0;
                 break;
       case '-': if (!tilde_negation_operator) {
-                  pos++; minus=1; 
+                  pos++; minus=1;
                 }
                 else
                     minus = 0;

--- a/Pattern.cpp
+++ b/Pattern.cpp
@@ -85,7 +85,7 @@ if (s[i]!='\0') {
 }
 /* If we have no grammatical codes, we can't decide */
 if (semantic_codes==NULL) {
-	return AMBIGUOUS_PATTERN;
+    return AMBIGUOUS_PATTERN;
 }
 /* Otherwise, we test if the string is a grammatical or semantic code */
 if (get_value_index(s,semantic_codes,DONT_INSERT)!=-1) {
@@ -341,22 +341,22 @@ return 0;
  * Returns a clone of the pattern.
  */
 struct pattern* clone(const struct pattern* src,Abstract_allocator prv_alloc) {
-	struct pattern* dst;
+    struct pattern* dst;
 
-	if (src == NULL)
-		return NULL;
+    if (src == NULL)
+        return NULL;
 
-	dst=(struct pattern*)malloc_cb(sizeof(struct pattern),prv_alloc);
-	if (dst==NULL) {
-	   fatal_error("Not enough memory in new_pattern_ByCopy\n");
-	}
-	dst->inflected=u_strdup(src->inflected,prv_alloc);
-	dst->lemma=u_strdup(src->lemma,prv_alloc);
-	dst->grammatical_codes=clone(src->grammatical_codes,prv_alloc);
-	dst->inflectional_codes=clone(src->inflectional_codes,prv_alloc);
-	dst->forbidden_codes=clone(src->forbidden_codes,prv_alloc);
-	dst->type=src->type;
-	return dst;
+    dst=(struct pattern*)malloc_cb(sizeof(struct pattern),prv_alloc);
+    if (dst==NULL) {
+       fatal_error("Not enough memory in new_pattern_ByCopy\n");
+    }
+    dst->inflected=u_strdup(src->inflected,prv_alloc);
+    dst->lemma=u_strdup(src->lemma,prv_alloc);
+    dst->grammatical_codes=clone(src->grammatical_codes,prv_alloc);
+    dst->inflectional_codes=clone(src->inflectional_codes,prv_alloc);
+    dst->forbidden_codes=clone(src->forbidden_codes,prv_alloc);
+    dst->type=src->type;
+    return dst;
 }
 
 } // namespace unitex

--- a/PatternTree.cpp
+++ b/PatternTree.cpp
@@ -141,7 +141,7 @@ while (list!=NULL) {
 
 
 /**
- * This function explores a pattern tree in order to find the node that 
+ * This function explores a pattern tree in order to find the node that
  * corresponds to the given gramatical codes, creating it if needed. Note
  * that the grammatical codes are supposed to be sorted.
  */

--- a/PatternTree.h
+++ b/PatternTree.h
@@ -56,7 +56,7 @@ struct constraint_list {
  * constraint is made of an optional inflected form, an optional lemma, an optional list
  * of forbidden grammatical/semantic codes and an optional list of inflectional codes.
  * Each such constraint is associated to a unique pattern number.
- * 
+ *
  * The following structure defines a node of a pattern tree.
  */
 struct pattern_node {

--- a/PersistResource.cpp
+++ b/PersistResource.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -116,8 +116,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_PersistResource,lopts_Pe
              output_file = options.vars()->optarg; // FIXME(gvollant)
              break;
    case 'V': only_verify_arguments = true;
-             break;   
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt):
                          error("Missing argument for option --%s\n",lopts_PersistResource[index].name);

--- a/PersistResource.cpp
+++ b/PersistResource.cpp
@@ -133,71 +133,71 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_PersistResource,lopts_Pe
 }
 
 if ((res_graph+res_alphabet+res_dico) != 1) {
-	error("Invalid arguments: rerun with --help\n");
-	return USAGE_ERROR_CODE;
+    error("Invalid arguments: rerun with --help\n");
+    return USAGE_ERROR_CODE;
 }
 
 if ((output_file!=NULL) && (unpersist!=0)) {
-	error("Invalid arguments: rerun with --help\n");
-	return USAGE_ERROR_CODE;
+    error("Invalid arguments: rerun with --help\n");
+    return USAGE_ERROR_CODE;
 }
 
 if (options.vars()->optind!=argc-1) {
-	error("Invalid arguments: rerun with --help\n");
-	return USAGE_ERROR_CODE;
+    error("Invalid arguments: rerun with --help\n");
+    return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
-	// freeing all allocated memory
-	return SUCCESS_RETURN_CODE;
+    // freeing all allocated memory
+    return SUCCESS_RETURN_CODE;
 }
 
 resource_file = argv[options.vars()->optind];
 size_t size_buf_persisted_filename = strlen(resource_file) + 0x200;
 char* buf_persisted_filename = (char*)malloc(size_buf_persisted_filename +1);
 if (buf_persisted_filename == NULL) {
-	alloc_error("PersistResource's main");
-	return ALLOC_ERROR_CODE;
+    alloc_error("PersistResource's main");
+    return ALLOC_ERROR_CODE;
 }
 *buf_persisted_filename='\0';
 if (unpersist == 0) {
-	int result = 0;
-	if (res_alphabet)
-		result = standard_load_persistence_alphabet(resource_file, buf_persisted_filename, size_buf_persisted_filename);
-	if (res_graph)
-		result = standard_load_persistence_fst2(resource_file, buf_persisted_filename, size_buf_persisted_filename);
-	if (res_dico)
-		result = standard_load_persistence_dictionary(resource_file, buf_persisted_filename, size_buf_persisted_filename);
-	if (result && verbose)
-		u_printf("Success on persist %s resource %s to persisted name %s\n", resource_type, resource_file, buf_persisted_filename);
-	if (!result)
-		error("The %s resource %s cannnot be persisted\n", resource_type, resource_file);
+    int result = 0;
+    if (res_alphabet)
+        result = standard_load_persistence_alphabet(resource_file, buf_persisted_filename, size_buf_persisted_filename);
+    if (res_graph)
+        result = standard_load_persistence_fst2(resource_file, buf_persisted_filename, size_buf_persisted_filename);
+    if (res_dico)
+        result = standard_load_persistence_dictionary(resource_file, buf_persisted_filename, size_buf_persisted_filename);
+    if (result && verbose)
+        u_printf("Success on persist %s resource %s to persisted name %s\n", resource_type, resource_file, buf_persisted_filename);
+    if (!result)
+        error("The %s resource %s cannnot be persisted\n", resource_type, resource_file);
 
 
-	if (result && (output_file != NULL)) {
-		U_FILE* text = u_fopen(&vec, output_file, U_WRITE);
-		if (text == NULL) {
-			error("Cannot create text file %s\n", output_file);
-			free(buf_persisted_filename);
-			return DEFAULT_ERROR_CODE;
-		}
-		u_fprintf(text, "%s", buf_persisted_filename);
-		u_fclose(text);
-	}
+    if (result && (output_file != NULL)) {
+        U_FILE* text = u_fopen(&vec, output_file, U_WRITE);
+        if (text == NULL) {
+            error("Cannot create text file %s\n", output_file);
+            free(buf_persisted_filename);
+            return DEFAULT_ERROR_CODE;
+        }
+        u_fprintf(text, "%s", buf_persisted_filename);
+        u_fclose(text);
+    }
 
-	free(buf_persisted_filename);
-	return result ? SUCCESS_RETURN_CODE : DEFAULT_ERROR_CODE;
+    free(buf_persisted_filename);
+    return result ? SUCCESS_RETURN_CODE : DEFAULT_ERROR_CODE;
 }
 else
 {
-	if (res_alphabet)
-		standard_unload_persistence_alphabet(resource_file);
-	if (res_graph)
-		standard_unload_persistence_fst2(resource_file);
-	if (res_dico)
-		standard_unload_persistence_dictionary(resource_file);
-	u_printf("The %s resource %s unpersisted\n", resource_type, resource_file);
-	return SUCCESS_RETURN_CODE;
+    if (res_alphabet)
+        standard_unload_persistence_alphabet(resource_file);
+    if (res_graph)
+        standard_unload_persistence_fst2(resource_file);
+    if (res_dico)
+        standard_unload_persistence_dictionary(resource_file);
+    u_printf("The %s resource %s unpersisted\n", resource_type, resource_file);
+    return SUCCESS_RETURN_CODE;
 }
 
 }

--- a/PersistResource.h
+++ b/PersistResource.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Persistence.cpp
+++ b/Persistence.cpp
@@ -36,20 +36,20 @@
 namespace unitex {
 
 typedef struct PS_ {
-	char* name;
-	void* ptr;
-	struct PS_* next;
+    char* name;
+    void* ptr;
+    struct PS_* next;
 } PersistentStructure;
 
 
 class PersistenceMutexContainer
 {
 public:
-	PersistenceMutexContainer();
-	~PersistenceMutexContainer();
-	inline SYNC_Mutex_OBJECT getMutex() { return mutex; }
+    PersistenceMutexContainer();
+    ~PersistenceMutexContainer();
+    inline SYNC_Mutex_OBJECT getMutex() { return mutex; }
 private:
-	SYNC_Mutex_OBJECT mutex ;
+    SYNC_Mutex_OBJECT mutex ;
 };
 
 PersistenceMutexContainer::PersistenceMutexContainer() :
@@ -59,8 +59,8 @@ PersistenceMutexContainer::PersistenceMutexContainer() :
 
 PersistenceMutexContainer::~PersistenceMutexContainer()
 {
-	SyncDeleteMutex(mutex);
-	mutex = NULL;
+    SyncDeleteMutex(mutex);
+    mutex = NULL;
 }
 
 static PersistenceMutexContainer PersistenceMutexContainerInstance;
@@ -76,16 +76,16 @@ static PersistentStructure* list=NULL;
 void* get_persistent_structure(const char* filename) {
 SyncGetMutex(Persistence_Mutex);
 if (strstr(filename,VIRTUAL_FILE_PFX)==filename) {
-	filename=filename+strlen(VIRTUAL_FILE_PFX);
+    filename=filename+strlen(VIRTUAL_FILE_PFX);
 }
 PersistentStructure* tmp=list;
 void* res=NULL;
 while (tmp!=NULL) {
-	if (!strcmp(tmp->name,filename)) {
-		res=tmp->ptr;
-		break;
-	}
-	tmp=tmp->next;
+    if (!strcmp(tmp->name,filename)) {
+        res=tmp->ptr;
+        break;
+    }
+    tmp=tmp->next;
 }
 SyncReleaseMutex(Persistence_Mutex);
 return res;
@@ -95,13 +95,13 @@ return res;
 static PersistentStructure* remove_filename(PersistentStructure* l,const char* filename) {
 if (l==NULL) return NULL;
 if (strstr(filename,VIRTUAL_FILE_PFX)==filename) {
-	filename=filename+strlen(VIRTUAL_FILE_PFX);
+    filename=filename+strlen(VIRTUAL_FILE_PFX);
 }
 if (!strcmp(l->name,filename)) {
-	PersistentStructure* next=l->next;
-	free(l->name);
-	free(l);
-	return next;
+    PersistentStructure* next=l->next;
+    free(l->name);
+    free(l);
+    return next;
 }
 l->next=remove_filename(l->next,filename);
 return l;
@@ -115,20 +115,20 @@ return l;
 void set_persistent_structure(const char* filename,void* ptr) {
 SyncGetMutex(Persistence_Mutex);
 if (strstr(filename,VIRTUAL_FILE_PFX)==filename) {
-	filename=filename+strlen(VIRTUAL_FILE_PFX);
+    filename=filename+strlen(VIRTUAL_FILE_PFX);
 }
 if (ptr==NULL) {
-	list=remove_filename(list,filename);
-	SyncReleaseMutex(Persistence_Mutex);
-	return;
+    list=remove_filename(list,filename);
+    SyncReleaseMutex(Persistence_Mutex);
+    return;
 }
 PersistentStructure* tmp=(PersistentStructure*)malloc(sizeof(PersistentStructure));
 if (tmp==NULL) {
-	fatal_alloc_error("set_persistent_structure");
+    fatal_alloc_error("set_persistent_structure");
 }
 tmp->name=strdup(filename);
 if (tmp->name==NULL) {
-	fatal_alloc_error("set_persistent_structure");
+    fatal_alloc_error("set_persistent_structure");
 }
 tmp->ptr=ptr;
 tmp->next=list;
@@ -144,11 +144,11 @@ SyncGetMutex(Persistence_Mutex);
 int res=0;
 PersistentStructure* tmp=list;
 while (tmp!=NULL) {
-	if (tmp->ptr==ptr) {
-		res=1;
-		break;
-	}
-	tmp=tmp->next;
+    if (tmp->ptr==ptr) {
+        res=1;
+        break;
+    }
+    tmp=tmp->next;
 }
 SyncReleaseMutex(Persistence_Mutex);
 return res;

--- a/PersistenceInterface.cpp
+++ b/PersistenceInterface.cpp
@@ -42,88 +42,88 @@ namespace unitex {
 
 int standard_load_persistence_dictionary(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
-		return 0;
-	strcpy(persistent_filename_buffer,filename);
-	return load_persistent_dictionary(filename);
+    if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
+        return 0;
+    strcpy(persistent_filename_buffer,filename);
+    return load_persistent_dictionary(filename);
 }
 
 void standard_unload_persistence_dictionary(const char*filename)
 {
-	free_persistent_dictionary(filename);
+    free_persistent_dictionary(filename);
 }
 
 int standard_load_persistence_fst2(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
-		return 0;
-	strcpy(persistent_filename_buffer,filename);
-	return load_persistent_fst2(filename);
+    if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
+        return 0;
+    strcpy(persistent_filename_buffer,filename);
+    return load_persistent_fst2(filename);
 }
 
 void standard_unload_persistence_fst2(const char*filename)
 {
-	free_persistent_fst2(filename);
+    free_persistent_fst2(filename);
 }
 
 int standard_load_persistence_alphabet(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
-		return 0;
-	strcpy(persistent_filename_buffer,filename);
-	return load_persistent_alphabet(filename);
+    if ((persistent_filename_buffer == NULL) || (buffer_size <= strlen(filename)))
+        return 0;
+    strcpy(persistent_filename_buffer,filename);
+    return load_persistent_alphabet(filename);
 }
 
 void standard_unload_persistence_alphabet(const char*filename)
 {
-	free_persistent_alphabet(filename);
+    free_persistent_alphabet(filename);
 }
 
 #endif
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_load_dictionary(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	return standard_load_persistence_dictionary(filename, persistent_filename_buffer, buffer_size);
+    return standard_load_persistence_dictionary(filename, persistent_filename_buffer, buffer_size);
 }
 
 UNITEX_FUNC void UNITEX_CALL persistence_public_unload_dictionary(const char*filename)
 {
-	return standard_unload_persistence_dictionary(filename);
+    return standard_unload_persistence_dictionary(filename);
 }
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_load_fst2(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	return standard_load_persistence_fst2(filename, persistent_filename_buffer, buffer_size);
+    return standard_load_persistence_fst2(filename, persistent_filename_buffer, buffer_size);
 }
 
 UNITEX_FUNC void UNITEX_CALL persistence_public_unload_fst2(const char*filename)
 {
-	return standard_unload_persistence_fst2(filename);
+    return standard_unload_persistence_fst2(filename);
 }
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_load_alphabet(const char*filename,char* persistent_filename_buffer,size_t buffer_size)
 {
-	return standard_load_persistence_alphabet(filename, persistent_filename_buffer, buffer_size);
+    return standard_load_persistence_alphabet(filename, persistent_filename_buffer, buffer_size);
 }
 
 UNITEX_FUNC void UNITEX_CALL persistence_public_unload_alphabet(const char*filename)
 {
-	return standard_unload_persistence_alphabet(filename);
+    return standard_unload_persistence_alphabet(filename);
 }
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_is_persisted_fst2_filename(const char*filename)
 {
-	return is_abstract_or_persistent_fst2_filename(filename);
+    return is_abstract_or_persistent_fst2_filename(filename);
 }
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_is_persisted_dictionary_filename(const char*filename)
 {
-	return is_abstract_or_persistent_dictionary_filename(filename);
+    return is_abstract_or_persistent_dictionary_filename(filename);
 }
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_is_persisted_alphabet_filename(const char*filename)
 {
-	return is_abstract_or_persistent_alphabet_filename(filename);
+    return is_abstract_or_persistent_alphabet_filename(filename);
 }
 
 } // namespace unitex

--- a/PersistenceInterface.h
+++ b/PersistenceInterface.h
@@ -30,7 +30,7 @@ namespace unitex {
 extern "C" {
 #endif
 
-	
+
 int standard_load_persistence_dictionary(const char*filename,char* persistent_filename_buffer,size_t buffer_size);
 void standard_unload_persistence_dictionary(const char*filename);
 
@@ -57,18 +57,18 @@ void standard_unload_persistence_alphabet(const char*filename);
    example:
 
    const char *automatonOriginalString = "/Users/foo/myres/graphs/test.fst2";
-   
-		char PersistedFileName[0x200] = "";
-		if (persistence_public_load_fst2(automatonOriginalString, PersistedFileName, sizeof(PersistedFileName)-1) == 0) {
-			printf("Error while persisting FST2 %s", automatonOriginalString);
-			return false;
-		}
+
+        char PersistedFileName[0x200] = "";
+        if (persistence_public_load_fst2(automatonOriginalString, PersistedFileName, sizeof(PersistedFileName)-1) == 0) {
+            printf("Error while persisting FST2 %s", automatonOriginalString);
+            return false;
+        }
 
 
-		// Do a lot of work, several locate using PersistedFileName as graph
+        // Do a lot of work, several locate using PersistedFileName as graph
 
-		// when you application will free all memory
-		persistence_public_unload_fst2(PersistedFileName);
+        // when you application will free all memory
+        persistence_public_unload_fst2(PersistedFileName);
    */
 
 UNITEX_FUNC int UNITEX_CALL persistence_public_load_dictionary(const char*filename,char* persistent_filename_buffer,size_t buffer_size);

--- a/PolyLex.cpp
+++ b/PolyLex.cpp
@@ -212,8 +212,8 @@ if (language==DUTCH || language==NORWEGIAN) {
    strcat(name_inf,"ForbiddenWords.txt");
    forbiddenWords=load_key_list(&vec,name_inf);
    if (forbiddenWords==NULL) {
-	   /* If there was no file, we don't want to block the process */
-	   forbiddenWords=new_string_hash(DONT_USE_VALUES);
+       /* If there was no file, we don't want to block the process */
+       forbiddenWords=new_string_hash(DONT_USE_VALUES);
    }
 }
 

--- a/PolyLex.cpp
+++ b/PolyLex.cpp
@@ -157,8 +157,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_PolyLex,lopts_PolyLex,&i
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_PolyLex[index].name);
@@ -276,14 +276,14 @@ if ((*info)!='\0') {
 struct utags UTAG;
 
 switch(language) {
-  case DUTCH: 
+  case DUTCH:
     analyse_dutch_unknown_words(alph,
                                 d,
                                 words,
                                 res,
                                 debug,
                                 new_unknown_words,
-                                forbiddenWords); 
+                                forbiddenWords);
     break;
   case GERMAN:
     analyse_german_compounds(alph,
@@ -291,7 +291,7 @@ switch(language) {
                              words,
                              res,
                              debug,
-                             new_unknown_words); 
+                             new_unknown_words);
     break;
   case NORWEGIAN:
     analyse_norwegian_unknown_words(alph,
@@ -300,7 +300,7 @@ switch(language) {
                                     res,
                                     debug,
                                     new_unknown_words,
-                                    forbiddenWords); 
+                                    forbiddenWords);
     break;
   case RUSSIAN:
      init_russian(&UTAG);

--- a/PortugueseNormalization.cpp
+++ b/PortugueseNormalization.cpp
@@ -79,8 +79,8 @@ do {
 // passed in parameter
 //
 void build_portuguese_normalization_grammar(const Alphabet* alph,struct match_list* list,
-											Dictionary* root_dic,
-											Dictionary* inflected_dic,
+                                            Dictionary* root_dic,
+                                            Dictionary* inflected_dic,
                                             const char* res_grf_name,
                                             const VersatileEncodingConfig* vec,
                                             struct normalization_tree* norm_tree,
@@ -160,8 +160,8 @@ while (s[i]==':') {
 // it returns i if i correct lines are produced, 0 else
 //
 int replace_match_output_by_normalization_line(struct match_list* L,const Alphabet* alph,
-												Dictionary* root_dic,
-												Dictionary* inflected_dic,
+                                                Dictionary* root_dic,
+                                                Dictionary* inflected_dic,
                                                 struct normalization_tree* norm_tree) {
 if (L->output==NULL) {
    return 0;
@@ -202,7 +202,7 @@ while (lemmas!=NULL) {
    // we get the inf number associated to this lemma in the inflected form dictionary
    Ustring* ustr=new_Ustring();
    int res=get_inf_number_for_token(inflected_dic->initial_state_offset,lemmas->string,0,entry,alph,
-		   inflected_dic,ustr);
+           inflected_dic,ustr);
    free_Ustring(ustr);
    if (res==-1) {
       return 0;
@@ -378,7 +378,7 @@ return 1;
 // this function look for the lemma corresponding to the radical
 //
 int get_radical_lemma(unichar* radical,struct list_ustring** lemmas,const Alphabet* alph,
-						Dictionary* root_dic) {
+                        Dictionary* root_dic) {
 unichar entry[1000];
 // we must use the entry variable because of the upper/lower case:
 // if the radical is Dir, we want it to be dir in order to get the correct form
@@ -413,10 +413,10 @@ return 1;
 // it returns this number on success, -1 else
 //
 int get_inf_number_for_token(int pos,const unichar* content,int string_pos,
-		unichar* entry,const Alphabet* ALPH,Dictionary* d,Ustring* ustr) {
+        unichar* entry,const Alphabet* ALPH,Dictionary* d,Ustring* ustr) {
 /* Ok, it's dirty to put this redundant test here, but this code is already awfully dirty anyway */
 if (d->type!=BIN_CLASSIC) {
-	fatal_error("get_inf_number_for_token: unsupported dictionary type\n");
+    fatal_error("get_inf_number_for_token: unsupported dictionary type\n");
 }
 int final,n_transitions,inf_number;
 pos=read_dictionary_state(d,pos,&final,&n_transitions,&inf_number);
@@ -432,18 +432,18 @@ unichar c;
 int adr;
 int z=save_output(ustr);
 for (int i=0;i<n_transitions;i++) {
-	pos=read_dictionary_transition(d,pos,&c,&adr,ustr);
+    pos=read_dictionary_transition(d,pos,&c,&adr,ustr);
   if (is_equal_or_uppercase(c,content[string_pos],ALPH)) {
      // we explore the rest of the dictionary only
      // if the dico char is compatible with the token char
      entry[string_pos]=c;
      inf_number=get_inf_number_for_token(adr,content,string_pos+1,entry,ALPH,d,ustr);
      if (inf_number!=-1) {
-    	 restore_output(z,ustr);
+         restore_output(z,ustr);
         return inf_number;
      }
   }
-	restore_output(z,ustr);
+    restore_output(z,ustr);
 }
 return -1;
 }

--- a/PortugueseNormalization.h
+++ b/PortugueseNormalization.h
@@ -39,11 +39,11 @@
 namespace unitex {
 
 void build_portuguese_normalization_grammar(const Alphabet*,struct match_list*,
-											Dictionary*,Dictionary*,
+                                            Dictionary*,Dictionary*,
                                             const char*, const VersatileEncodingConfig*,
                                             struct normalization_tree*, struct normalization_tree* nasal_norm_tree);
 int replace_match_output_by_normalization_line(struct match_list*,const Alphabet*,
-												Dictionary*,Dictionary*,
+                                                Dictionary*,Dictionary*,
                                                 struct normalization_tree*);
 int tokenize_portuguese_match(const unichar*,unichar*,unichar*,unichar*,unichar*);
 int get_radical_lemma(unichar*,struct list_ustring**,const Alphabet*,Dictionary*);

--- a/ProgramInvoker.cpp
+++ b/ProgramInvoker.cpp
@@ -91,16 +91,16 @@ if (opt_name==NULL) {
 }
 int size=2+(int)strlen(opt_name)+1;
 if (opt_value!=NULL) {
-	size=size+1+(int)strlen(opt_value);
+    size=size+1+(int)strlen(opt_value);
 }
 char* tmp=(char*)malloc(size*sizeof(char));
 if (tmp==NULL) {
    fatal_alloc_error("add_long_option");
 }
 if (opt_value==NULL) {
-	sprintf(tmp,"--%s",opt_name);
+    sprintf(tmp,"--%s",opt_name);
 } else {
-	sprintf(tmp,"--%s=%s",opt_name,opt_value);
+    sprintf(tmp,"--%s=%s",opt_name,opt_value);
 }
 vector_ptr_add(invoker->args,tmp);
 }
@@ -111,7 +111,7 @@ vector_ptr_add(invoker->args,tmp);
  */
 void remove_last_argument(ProgramInvoker* invoker) {
 if (invoker->args->nbelems==0) {
-	fatal_error("remove_last_argument: cannot remove an argument from an empty invoker\n");
+    fatal_error("remove_last_argument: cannot remove an argument from an empty invoker\n");
 }
 free(invoker->args->tab[--(invoker->args->nbelems)]);
 invoker->args->tab[invoker->args->nbelems]=NULL;
@@ -131,18 +131,18 @@ int argc=invoker->args->nbelems;
  * the arguments to be reordered by getopt */
 char** argv=(char**)malloc((argc+1)*sizeof(char*));
 if (argv==NULL) {
-	fatal_alloc_error("invoke");
+    fatal_alloc_error("invoke");
 }
 for (int i=0;i<argc;i++) {
-	argv[i]=strdup((char*)(invoker->args->tab[i]));
-	if (argv[i]==NULL) {
-		fatal_alloc_error("invoke");
-	}
+    argv[i]=strdup((char*)(invoker->args->tab[i]));
+    if (argv[i]==NULL) {
+        fatal_alloc_error("invoke");
+    }
 }
 argv[argc]=NULL;
 int ret=invoker->main(argc,argv);
 for (int i=0;i<argc;i++) {
-	free(argv[i]);
+    free(argv[i]);
 }
 free(argv);
 return ret;
@@ -175,21 +175,21 @@ strcat(line,protection);
  */
 static int arg_need_protection(const char* arg)
 {
-	for (;;)
-	{
-		char c = *(arg++);
-		if (c == '\0')
-			return 0;
-		if ((c == '-') || (c == ',') || (c == '/') || (c == '_'))
-			continue;
-		if ((c >= 'A') && (c <= 'Z'))
-			continue;
-		if ((c >= 'a') && (c <= 'z'))
-			continue;
-		if ((c >= '0') && (c <= '9'))
-			continue;
-		return 1;
-	}
+    for (;;)
+    {
+        char c = *(arg++);
+        if (c == '\0')
+            return 0;
+        if ((c == '-') || (c == ',') || (c == '/') || (c == '_'))
+            continue;
+        if ((c >= 'A') && (c <= 'Z'))
+            continue;
+        if ((c >= 'a') && (c <= 'z'))
+            continue;
+        if ((c >= '0') && (c <= '9'))
+            continue;
+        return 1;
+    }
 }
 
 
@@ -238,7 +238,7 @@ return line;
  * free a command line allocated memory buffer.
  */
 void free_command_line_alloc(char* line) {
-	free(line);
+    free(line);
 }
 
 
@@ -251,7 +251,7 @@ va_list list;
 va_start(list,name);
 char* arg;
 while ((arg=va_arg(list,char*))!=NULL) {
-	add_argument(invoker,arg);
+    add_argument(invoker,arg);
 }
 va_end(list);
 int ret=invoke(invoker);

--- a/Reconstrucao.cpp
+++ b/Reconstrucao.cpp
@@ -114,7 +114,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Reconstrucao,lopts_Recon
              break;
    case 'r': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty root dictionary file name\n");
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              strcpy(root,options.vars()->optarg);
              break;
@@ -144,7 +144,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Reconstrucao,lopts_Recon
              break;
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_reading_encoding_parameter(&(vec.mask_encoding_compatibility_input),options.vars()->optarg);
              break;
@@ -155,8 +155,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Reconstrucao,lopts_Recon
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;  
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Reconstrucao[index].name);

--- a/Reconstrucao.cpp
+++ b/Reconstrucao.cpp
@@ -238,8 +238,8 @@ strcat(root_inf_file,".inf");
 u_printf("Loading radical form dictionary...\n");
 Dictionary* root_dic=new_Dictionary(&vec,root,root_inf_file);
 if ((*root)=='\0') {
-	free_alphabet(alph);
-	return DEFAULT_ERROR_CODE;
+    free_alphabet(alph);
+    return DEFAULT_ERROR_CODE;
 }
 
 u_printf("Loading inflected form dictionary...\n");
@@ -248,9 +248,9 @@ remove_extension(dictionary,inflected_inf_file);
 strcat(inflected_inf_file,".inf");
 Dictionary* inflected_dic=new_Dictionary(&vec,dictionary,inflected_inf_file);
 if (inflected_dic==NULL) {
-	free_Dictionary(root_dic);
-	free_alphabet(alph);
-	return DEFAULT_ERROR_CODE;
+    free_Dictionary(root_dic);
+    free_alphabet(alph);
+    return DEFAULT_ERROR_CODE;
 }
 
 u_printf("Loading pronoun rewriting rule grammar...\n");

--- a/Reg2Grf.cpp
+++ b/Reg2Grf.cpp
@@ -106,8 +106,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Reg2Grf,lopts_Reg2Grf,&i
                 error("You must specify a non empty output filename\n");
                 return USAGE_ERROR_CODE;
              }
-			 strcpy(grf_name, options.vars()->optarg);
-			 break;
+             strcpy(grf_name, options.vars()->optarg);
+             break;
    case 'V': only_verify_arguments = true;
              break;
    case 'h': usage();
@@ -153,7 +153,7 @@ if (grf_name[0] == '\0') {
 }
 
 if (!reg2grf(exp,grf_name,&vec)) {
-	free(exp);
+    free(exp);
   return DEFAULT_ERROR_CODE;
 }
 

--- a/Reg2Grf.cpp
+++ b/Reg2Grf.cpp
@@ -109,15 +109,15 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Reg2Grf,lopts_Reg2Grf,&i
 			 strcpy(grf_name, options.vars()->optarg);
 			 break;
    case 'V': only_verify_arguments = true;
-             break;       
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Reg2Grf[index].name);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    }
    index=-1;
 }

--- a/RegExFacade.cpp
+++ b/RegExFacade.cpp
@@ -29,24 +29,24 @@
 /*
 UNITEX_FUNC int UNITEX_CALL RegexFacadeRegcomp(regex_facade_regex_t *preg, const unichar_regex *regex, int cflags)
 {
-	return regex_facade_regcomp(preg, regex, cflags);
+    return regex_facade_regcomp(preg, regex, cflags);
 }
 
 UNITEX_FUNC size_t UNITEX_CALL RegexFacadeRegerror(int errcode, const regex_facade_regex_t *preg, char *errbuf,
-	size_t errbuf_size)
+    size_t errbuf_size)
 {
-	return regex_facade_regerror(errcode, preg, errbuf, errbuf_size);
+    return regex_facade_regerror(errcode, preg, errbuf, errbuf_size);
 }
 
 UNITEX_FUNC void UNITEX_CALL RegexFacadeRegfree(regex_facade_regex_t *preg)
 {
-	regex_facade_regfree(preg);
+    regex_facade_regfree(preg);
 }
 
 UNITEX_FUNC int UNITEX_CALL RegexFacadeRegexec(const regex_facade_regex_t *preg, const unichar_regex *string,
-	size_t nmatch, regex_regmatch_t pmatch[], int eflags)
+    size_t nmatch, regex_regmatch_t pmatch[], int eflags)
 {
-	return regex_facade_regexec(preg, string,nmatch, pmatch, eflags);
+    return regex_facade_regexec(preg, string,nmatch, pmatch, eflags);
 }
 */
 
@@ -55,24 +55,24 @@ UNITEX_FUNC int UNITEX_CALL RegexFacadeRegexec(const regex_facade_regex_t *preg,
 
 int regex_facade_regcomp(regex_facade_regex_t *preg, const unichar_regex *regex, int cflags)
 {
-	return tre_regwcomp(preg, regex, cflags);
+    return tre_regwcomp(preg, regex, cflags);
 }
 
 size_t regex_facade_regerror(int errcode, const regex_facade_regex_t *preg, char *errbuf,
-	 size_t errbuf_size)
+     size_t errbuf_size)
 {
-	return tre_regerror(errcode, preg, errbuf, errbuf_size);
+    return tre_regerror(errcode, preg, errbuf, errbuf_size);
 }
 
 void regex_facade_regfree(regex_facade_regex_t *preg)
 {
-	tre_regfree(preg);
+    tre_regfree(preg);
 }
 
 int regex_facade_regexec(const regex_facade_regex_t *preg, const unichar_regex *string,
-	 size_t nmatch, regex_regmatch_t pmatch[], int eflags)
+     size_t nmatch, regex_regmatch_t pmatch[], int eflags)
 {
-	return tre_regwexec(preg, string, nmatch, pmatch, eflags);
+    return tre_regwexec(preg, string, nmatch, pmatch, eflags);
 }
 
 
@@ -122,18 +122,18 @@ void w_strcpy(unichar_regex** target,size_t *buffer_size,const unichar* source) 
 int i=0;
 unsigned int len = u_strlen(source);
 if (((int)(len + 1)) >= (int)(*buffer_size)) {
-	if ((*buffer_size) < START_SIZE_DYNAMIC_BUFFER_REGEX) {
-		*buffer_size = START_SIZE_DYNAMIC_BUFFER_REGEX;
-	}
-	while (((int)(len + 1)) >= (int)(*buffer_size)) {
-		(*buffer_size) *= 2;
-	}
+    if ((*buffer_size) < START_SIZE_DYNAMIC_BUFFER_REGEX) {
+        *buffer_size = START_SIZE_DYNAMIC_BUFFER_REGEX;
+    }
+    while (((int)(len + 1)) >= (int)(*buffer_size)) {
+        (*buffer_size) *= 2;
+    }
 
-	*target = (unichar_regex*)(((*target) == NULL) ? malloc((*buffer_size) * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR)
-		                      : realloc((*target), (*buffer_size) * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR));
-	if (target==NULL) {
-		fatal_alloc_error("w_strcpy");
-	}
+    *target = (unichar_regex*)(((*target) == NULL) ? malloc((*buffer_size) * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR)
+                              : realloc((*target), (*buffer_size) * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR));
+    if (target==NULL) {
+        fatal_alloc_error("w_strcpy");
+    }
 }
 while (((*target)[i]=(unichar_regex)source[i])!= L'\0') i++;
 }
@@ -149,134 +149,134 @@ while ((target[i]=(unichar_regex)source[i])!= L'\0') i++;
 
 
 unichar_regex* w_strcpy_optional_buffer(unichar_regex * original_buffer, size_t original_buffer_size,
-	unichar_regex**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
+    unichar_regex**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
 {
-	size_t add_string_len = u_strlen(add_string);
-	size_t buffer_size_needed = add_string_len + 1;
-	if (len != NULL)
-		*len = add_string_len;
+    size_t add_string_len = u_strlen(add_string);
+    size_t buffer_size_needed = add_string_len + 1;
+    if (len != NULL)
+        *len = add_string_len;
 
-	if ((*allocated_buffer) == NULL)
-	{
-		if ((add_string_len + 1) < original_buffer_size)
-		{
-			w_strcpy(original_buffer, add_string);
-			return original_buffer;
-		}
-		else
-		{
-			*allocated_buffer = (unichar_regex*)malloc_cb(buffer_size_needed * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR, prv_alloc);
-			if ((*allocated_buffer) == NULL) {
-				fatal_alloc_error("u_strcpy_optional_buffer");
-			}
+    if ((*allocated_buffer) == NULL)
+    {
+        if ((add_string_len + 1) < original_buffer_size)
+        {
+            w_strcpy(original_buffer, add_string);
+            return original_buffer;
+        }
+        else
+        {
+            *allocated_buffer = (unichar_regex*)malloc_cb(buffer_size_needed * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR, prv_alloc);
+            if ((*allocated_buffer) == NULL) {
+                fatal_alloc_error("u_strcpy_optional_buffer");
+            }
 
-			w_strcpy((*allocated_buffer), add_string);
-			return *allocated_buffer;
-		}
-	}
-	else
-	{
-		free_cb(*allocated_buffer, prv_alloc);
+            w_strcpy((*allocated_buffer), add_string);
+            return *allocated_buffer;
+        }
+    }
+    else
+    {
+        free_cb(*allocated_buffer, prv_alloc);
 
-		*allocated_buffer = (unichar_regex*)malloc_cb(buffer_size_needed * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR, prv_alloc);
-		if ((*allocated_buffer) == NULL) {
-			fatal_alloc_error("u_strcpy_optional_buffer");
-		}
+        *allocated_buffer = (unichar_regex*)malloc_cb(buffer_size_needed * sizeof(unichar_regex) * UNICHAR_REGEX_ALLOC_FACTOR, prv_alloc);
+        if ((*allocated_buffer) == NULL) {
+            fatal_alloc_error("u_strcpy_optional_buffer");
+        }
 
-		w_strcpy((*allocated_buffer), add_string);
-		return *allocated_buffer;
-	}
+        w_strcpy((*allocated_buffer), add_string);
+        return *allocated_buffer;
+    }
 }
 
 void free_wstring_optional_buffer(unichar_regex** allocated_buffer, Abstract_allocator prv_alloc)
 {
-	if ((*allocated_buffer) != NULL) {
-		free_cb(*allocated_buffer, prv_alloc);
-		*allocated_buffer = NULL;
-	}
+    if ((*allocated_buffer) != NULL) {
+        free_cb(*allocated_buffer, prv_alloc);
+        *allocated_buffer = NULL;
+    }
 }
 
 
 static int test_tre_reg(const unichar* ureg, const unichar*usrch, int is_match_expecteded)
 {
-	regex_t matcher;
+    regex_t matcher;
 
 
-	unichar_regex* warray = (unichar_regex*)malloc(0x20 + (sizeof(unichar_regex)*((u_strlen(ureg) + 1) * UNICHAR_REGEX_ALLOC_FACTOR)));
-	if (warray == NULL) {
-		fatal_alloc_error("test_tre");
-	}
-	regex_facade_strcpy(warray, ureg);
+    unichar_regex* warray = (unichar_regex*)malloc(0x20 + (sizeof(unichar_regex)*((u_strlen(ureg) + 1) * UNICHAR_REGEX_ALLOC_FACTOR)));
+    if (warray == NULL) {
+        fatal_alloc_error("test_tre");
+    }
+    regex_facade_strcpy(warray, ureg);
 
-	int ccode = regex_facade_regcomp(&matcher, warray, REG_NOSUB);
-	if (ccode != 0)
-	{
-		error("cannot compile in regcomp\n");
-		return 0;
-	}
+    int ccode = regex_facade_regcomp(&matcher, warray, REG_NOSUB);
+    if (ccode != 0)
+    {
+        error("cannot compile in regcomp\n");
+        return 0;
+    }
 
-	unichar_regex* wusrch = (unichar_regex*)malloc(0x20 + (sizeof(unichar_regex)*((u_strlen(usrch) + 1)  * UNICHAR_REGEX_ALLOC_FACTOR)));
-	if (wusrch == NULL) {
-		fatal_alloc_error("test_tre");
-	}
-	regex_facade_strcpy(wusrch, usrch);
+    unichar_regex* wusrch = (unichar_regex*)malloc(0x20 + (sizeof(unichar_regex)*((u_strlen(usrch) + 1)  * UNICHAR_REGEX_ALLOC_FACTOR)));
+    if (wusrch == NULL) {
+        fatal_alloc_error("test_tre");
+    }
+    regex_facade_strcpy(wusrch, usrch);
 
 
-	int ret_regexec = regex_facade_regexec(&matcher, wusrch, 0, NULL, 0);
-	int okay = (is_match_expecteded == (!ret_regexec));
-	if (!okay) {
-		error("unexpected result of %S on %S : %d - %d\n", ureg, usrch, ret_regexec, ccode);
-	}
+    int ret_regexec = regex_facade_regexec(&matcher, wusrch, 0, NULL, 0);
+    int okay = (is_match_expecteded == (!ret_regexec));
+    if (!okay) {
+        error("unexpected result of %S on %S : %d - %d\n", ureg, usrch, ret_regexec, ccode);
+    }
 
-	regex_facade_regfree(&matcher);
+    regex_facade_regfree(&matcher);
 
-	free(wusrch);
-	free(warray);
-	return okay;
+    free(wusrch);
+    free(warray);
+    return okay;
 }
 
 
 static int internal_check_unitex()
 {
-	unichar ureg[0x200];
-	unichar usrch[0x200];
+    unichar ureg[0x200];
+    unichar usrch[0x200];
 
-	u_strcpy(ureg, "^Th[iI]s");
-	u_strcpy(usrch, "This is a test");
-	if (!test_tre_reg(ureg, usrch, 1)) {
-		return 0;
-	}
+    u_strcpy(ureg, "^Th[iI]s");
+    u_strcpy(usrch, "This is a test");
+    if (!test_tre_reg(ureg, usrch, 1)) {
+        return 0;
+    }
 
-	u_strcpy(ureg, "^Th[iI]s");
-	u_strcpy(usrch, "ThIs is a test");
-	if (!test_tre_reg(ureg, usrch, 1)) {
-		return 0;
-	}
+    u_strcpy(ureg, "^Th[iI]s");
+    u_strcpy(usrch, "ThIs is a test");
+    if (!test_tre_reg(ureg, usrch, 1)) {
+        return 0;
+    }
 
-	u_strcpy(ureg, "^Th[iI]s");
-	u_strcpy(usrch, "ThAs is a test");
-	if (!test_tre_reg(ureg, usrch, 0)) {
-		return 0;
-	}
+    u_strcpy(ureg, "^Th[iI]s");
+    u_strcpy(usrch, "ThAs is a test");
+    if (!test_tre_reg(ureg, usrch, 0)) {
+        return 0;
+    }
 
-	const unichar regUnicode[] = { 'T', '[', 0x1ce, 'a', ']', 'u', '\0' };
-	const unichar strUnicode0[] = { 'T', 0x2ce, 'u', '\0' };
-	const unichar strUnicode1[] = { 'T', 0x1ce, 'u', '\0' };
-	const unichar strUnicode2[] = { 'T', 0x1e1, 'u', '\0' };
-	const unichar strUnicode3[] = { 'T', 'a', 'u', '\0' };
-	const unichar strUnicode4[] = { 'T', 'u', '\0' };
+    const unichar regUnicode[] = { 'T', '[', 0x1ce, 'a', ']', 'u', '\0' };
+    const unichar strUnicode0[] = { 'T', 0x2ce, 'u', '\0' };
+    const unichar strUnicode1[] = { 'T', 0x1ce, 'u', '\0' };
+    const unichar strUnicode2[] = { 'T', 0x1e1, 'u', '\0' };
+    const unichar strUnicode3[] = { 'T', 'a', 'u', '\0' };
+    const unichar strUnicode4[] = { 'T', 'u', '\0' };
 
 
-	if ((!test_tre_reg(regUnicode, strUnicode0, 0)) ||
-		(!test_tre_reg(regUnicode, strUnicode1, 1)) ||
-		(!test_tre_reg(regUnicode, strUnicode2, 0)) ||
-		(!test_tre_reg(regUnicode, strUnicode3, 1)) ||
-		(!test_tre_reg(regUnicode, strUnicode4, 0)))
-	{
-		error("tre does not wotk correctly\n");
-		return 0;
-	}
-	return 1;
+    if ((!test_tre_reg(regUnicode, strUnicode0, 0)) ||
+        (!test_tre_reg(regUnicode, strUnicode1, 1)) ||
+        (!test_tre_reg(regUnicode, strUnicode2, 0)) ||
+        (!test_tre_reg(regUnicode, strUnicode3, 1)) ||
+        (!test_tre_reg(regUnicode, strUnicode4, 0)))
+    {
+        error("tre does not wotk correctly\n");
+        return 0;
+    }
+    return 1;
 }
 
 
@@ -285,12 +285,12 @@ static int internal_check_unitex()
 using namespace unitex;
 int check_regex_lib_in_unitex()
 {
-	return internal_check_unitex();
+    return internal_check_unitex();
 }
 
 UNITEX_FUNC int UNITEX_CALL CheckRegexLibInUnitex()
 {
-	return check_regex_lib_in_unitex();
+    return check_regex_lib_in_unitex();
 }
 
 #endif

--- a/RegExFacade.cpp
+++ b/RegExFacade.cpp
@@ -22,7 +22,7 @@
 
 #include "Unicode.h"
 
- 
+
 #include "RegExFacade.h"
 
 

--- a/RegExFacade.h
+++ b/RegExFacade.h
@@ -44,10 +44,10 @@ typedef regmatch_t regex_regmatch_t ;
 
 int regex_facade_regcomp(regex_facade_regex_t *preg, const unichar_regex *regex, int cflags);
 size_t regex_facade_regerror(int errcode, const regex_facade_regex_t *preg, char *errbuf,
-	 size_t errbuf_size);
+     size_t errbuf_size);
 void regex_facade_regfree(regex_facade_regex_t *preg);
 int regex_facade_regexec(const regex_facade_regex_t *preg, const unichar_regex *string,
-	 size_t nmatch, regex_regmatch_t pmatch[], int eflags);
+     size_t nmatch, regex_regmatch_t pmatch[], int eflags);
 
 int check_regex_lib_in_unitex();
 
@@ -55,10 +55,10 @@ int check_regex_lib_in_unitex();
 /*
 UNITEX_FUNC int UNITEX_CALL RegexFacadeRegcomp(regex_facade_regex_t *preg, const unichar_regex *regex, int cflags);
 UNITEX_FUNC size_t UNITEX_CALL RegexFacadeRegerror(int errcode, const regex_facade_regex_t *preg, char *errbuf,
-	size_t errbuf_size);
+    size_t errbuf_size);
 UNITEX_FUNC void UNITEX_CALL RegexFacadeRegfree(regex_facade_regex_t *preg);
 UNITEX_FUNC int UNITEX_CALL RegexFacadeRegexec(const regex_facade_regex_t *preg, const unichar_regex *string,
-	size_t nmatch, regex_regmatch_t pmatch[], int eflags);
+    size_t nmatch, regex_regmatch_t pmatch[], int eflags);
 */
 
 UNITEX_FUNC int UNITEX_CALL CheckRegexLibInUnitex();
@@ -80,7 +80,7 @@ namespace unitex {
 void w_strcpy(unichar_regex* target, const unichar* source);
 void w_strcpy(unichar_regex** target, size_t *buffer_size, const unichar* source);
 unichar_regex* w_strcpy_optional_buffer(unichar_regex * original_buffer, size_t original_buffer_size,
-	unichar_regex**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc);
+    unichar_regex**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc);
 void free_wstring_optional_buffer(unichar_regex** allocated_buffer, Abstract_allocator prv_alloc);
 
 unichar_regex* regex_facade_strcpy(unichar_regex* dest,const unichar* src);

--- a/RegularExpressions.cpp
+++ b/RegularExpressions.cpp
@@ -277,17 +277,17 @@ if (token[tmp]=='<') {
    }
    /* Now, we may have to read the extra information _f_ or _b_ */
    if (input[*pos]!='_') {
-	   return 1;
+       return 1;
    }
    token[(*pos_in_token)++]=input[(*pos)++];
    if (input[*pos]!='f' && input[*pos]!='b') {
-	  error("Invalid morphological filter option: should be _f_ or _b_\n");
-	  return 0;
+      error("Invalid morphological filter option: should be _f_ or _b_\n");
+      return 0;
    }
    token[(*pos_in_token)++]=input[(*pos)++];
    if (input[*pos]!='_') {
-	   error("Invalid morphological filter option: should be _f_ or _b_\n");
-	   return 0;
+       error("Invalid morphological filter option: should be _f_ or _b_\n");
+       return 0;
    }
    token[(*pos_in_token)++]=input[(*pos)++];
    return 1;

--- a/SelectOutput.cpp
+++ b/SelectOutput.cpp
@@ -72,8 +72,8 @@ const struct option_TS lopts_SelectOutput[] = {
  */
 int main_SelectOutput(int argc,char* const argv[]) {
 if (argc==1) {
-	usage();
-	return SUCCESS_RETURN_CODE;
+    usage();
+    return SUCCESS_RETURN_CODE;
 }
 
 VersatileEncodingConfig vec=VEC_DEFAULT;
@@ -88,24 +88,24 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_SelectOutput,lopts_Selec
              return SUCCESS_RETURN_CODE;
    case 'e':
    case 'o':
-	   {
-		   enum stdwrite_kind swk = (val == 'o') ? stdwrite_kind_out : stdwrite_kind_err;
-		   if (strcmp(options.vars()->optarg,"on") == 0)
-		   {
-		       SetStdWriteCB(swk,0,NULL,NULL);
-		   }
-		   else
-		   if (strcmp(options.vars()->optarg,"off") == 0)
-		   {
-		       SetStdWriteCB(swk,1,NULL,NULL);
-		   }
-		   else
-		   {
-		       error("Invalid option --%s, must be 'on' or 'off'\n",options.vars()->optarg);
-		       return USAGE_ERROR_CODE;
-		   }
-		   break;
-	   }
+       {
+           enum stdwrite_kind swk = (val == 'o') ? stdwrite_kind_out : stdwrite_kind_err;
+           if (strcmp(options.vars()->optarg,"on") == 0)
+           {
+               SetStdWriteCB(swk,0,NULL,NULL);
+           }
+           else
+           if (strcmp(options.vars()->optarg,"off") == 0)
+           {
+               SetStdWriteCB(swk,1,NULL,NULL);
+           }
+           else
+           {
+               error("Invalid option --%s, must be 'on' or 'off'\n",options.vars()->optarg);
+               return USAGE_ERROR_CODE;
+           }
+           break;
+       }
 
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
@@ -136,7 +136,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_SelectOutput,lopts_Selec
   }
 
 
-	return SUCCESS_RETURN_CODE;
+    return SUCCESS_RETURN_CODE;
 }
 
 } // namespace unitex

--- a/SelectOutput.cpp
+++ b/SelectOutput.cpp
@@ -43,7 +43,7 @@ const char* usage_SelectOutput =
   "  -o [on/off]/--output=[on/off]: enable (on) or disable (off) standard output\n"
   "  -e [on/off]/--error=[on/off]: enable (on) or disable (off) error output\n"
   "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"
-  "  -h/--help: this help\n"     
+  "  -h/--help: this help\n"
   "\n";
 
 
@@ -83,8 +83,8 @@ UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_SelectOutput,lopts_SelectOutput,&index))) {
    switch(val) {
    case 'V': only_verify_arguments = true;
-             break;    
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case 'e':
    case 'o':
@@ -99,14 +99,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_SelectOutput,lopts_Selec
 		   {
 		       SetStdWriteCB(swk,1,NULL,NULL);
 		   }
-		   else 
+		   else
 		   {
 		       error("Invalid option --%s, must be 'on' or 'off'\n",options.vars()->optarg);
 		       return USAGE_ERROR_CODE;
 		   }
 		   break;
 	   }
-   
+
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
                 return USAGE_ERROR_CODE;
@@ -121,7 +121,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_SelectOutput,lopts_Selec
              break;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_SelectOutput[index].name);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;

--- a/Sentence2Grf.cpp
+++ b/Sentence2Grf.cpp
@@ -47,9 +47,9 @@ int get_max_width_for_ranks(Tfst*,int*,int*,int,int);
 int get_max_width_for_ranks(SingleGraph,struct string_hash*,int*,int*,int,int);
 Grf* tfst_transitions_to_grf_states(Tfst*,int*,int,int,int*,char*,int,int);
 Grf* transitions_to_grf_states(SingleGraph automaton,
-		struct string_hash* tags,
-		int* rank,int maximum_rank,
-		int width_max,int* pos_X,int fontsize);
+        struct string_hash* tags,
+        int* rank,int maximum_rank,
+        int width_max,int* pos_X,int fontsize);
 
 
 /**
@@ -58,26 +58,26 @@ Grf* transitions_to_grf_states(SingleGraph automaton,
  * the 'EMPTIED' disclaimer.
  */
 void check_automaton_is_empty(Tfst* t) {
-	static const char* EMPTY_AUTOMATON_DISCLAIMER=EMPTY_AUTOMATON_DISCLAIMER_TEXT;
-	SingleGraph g=t->automaton;
-	if (g==NULL) {
-		fatal_error("NULL automaton error in check_automaton_is_empty\n");
-	}
-	if (g->number_of_states==0) {
-		fatal_error("Unexpected null number of states in check_automaton_is_empty\n");
-	}
-	if (g->number_of_states>1) {
-		return;
-	}
-	if (g->states[0]->outgoing_transitions!=NULL) {
-		fatal_error("check_automaton_is_empty: unexpected transitions from single state\n");
-	}
-	SingleGraphState s=add_state(g);
-	set_final_state(s);
-	TfstTag* tag=new_TfstTag(T_STD);
-	tag->content=u_strdup(EMPTY_AUTOMATON_DISCLAIMER);
-	int tag_number=vector_ptr_add(t->tags,tag);
-	add_outgoing_transition(g->states[0],tag_number,1);
+    static const char* EMPTY_AUTOMATON_DISCLAIMER=EMPTY_AUTOMATON_DISCLAIMER_TEXT;
+    SingleGraph g=t->automaton;
+    if (g==NULL) {
+        fatal_error("NULL automaton error in check_automaton_is_empty\n");
+    }
+    if (g->number_of_states==0) {
+        fatal_error("Unexpected null number of states in check_automaton_is_empty\n");
+    }
+    if (g->number_of_states>1) {
+        return;
+    }
+    if (g->states[0]->outgoing_transitions!=NULL) {
+        fatal_error("check_automaton_is_empty: unexpected transitions from single state\n");
+    }
+    SingleGraphState s=add_state(g);
+    set_final_state(s);
+    TfstTag* tag=new_TfstTag(T_STD);
+    tag->content=u_strdup(EMPTY_AUTOMATON_DISCLAIMER);
+    int tag_number=vector_ptr_add(t->tags,tag);
+    add_outgoing_transition(g->states[0],tag_number,1);
 }
 
 
@@ -90,38 +90,38 @@ void check_automaton_is_empty(Tfst* t) {
  *           2) being minimal
  */
 Grf* sentence_to_grf(Tfst* tfst,char* font,int fontsize,int sequence) {
-	check_automaton_is_empty(tfst);
-	/* The rank array will be used to store the rank of each state */
-	int* rank=(int*)malloc(sizeof(int)*tfst->automaton->number_of_states);
-	if (rank==NULL) {
-		fatal_alloc_error("sentence_to_grf");
-	}
-	int maximum_rank=compute_state_ranks(tfst->automaton,rank);
-	/* The pos_X array will be used to store the X coordinate of the grf
-	 * boxes that correspond to a given rank. We add +1 to the maximum rank,
-	 * because the rank has been computed on the fst2 states and the
-	 * X positions concerns fst2 transitions. */
-	int* pos_X=(int*)malloc(sizeof(int)*(maximum_rank+1));
-	if (pos_X==NULL) {
-		fatal_alloc_error("sentence_to_grf");
-	}
-	int width_max=get_max_width_for_ranks(tfst,pos_X,rank,maximum_rank,fontsize);
-	Grf* grf=tfst_transitions_to_grf_states(tfst,rank,maximum_rank,width_max,pos_X,font,fontsize,sequence);
-	free(rank);
-	free(pos_X);
-	return grf;
+    check_automaton_is_empty(tfst);
+    /* The rank array will be used to store the rank of each state */
+    int* rank=(int*)malloc(sizeof(int)*tfst->automaton->number_of_states);
+    if (rank==NULL) {
+        fatal_alloc_error("sentence_to_grf");
+    }
+    int maximum_rank=compute_state_ranks(tfst->automaton,rank);
+    /* The pos_X array will be used to store the X coordinate of the grf
+     * boxes that correspond to a given rank. We add +1 to the maximum rank,
+     * because the rank has been computed on the fst2 states and the
+     * X positions concerns fst2 transitions. */
+    int* pos_X=(int*)malloc(sizeof(int)*(maximum_rank+1));
+    if (pos_X==NULL) {
+        fatal_alloc_error("sentence_to_grf");
+    }
+    int width_max=get_max_width_for_ranks(tfst,pos_X,rank,maximum_rank,fontsize);
+    Grf* grf=tfst_transitions_to_grf_states(tfst,rank,maximum_rank,width_max,pos_X,font,fontsize,sequence);
+    free(rank);
+    free(pos_X);
+    return grf;
 }
 
 
 
 Grf* sentence_to_grf(SingleGraph automaton,struct string_hash* tags,int fontsize) {
 if (automaton->number_of_states==0) {
-	fatal_error("Unexpected empty automaton in sentence_to_grf\n");
+    fatal_error("Unexpected empty automaton in sentence_to_grf\n");
 }
 /* The rank array will be used to store the rank of each state */
 int* rank=(int*)malloc(sizeof(int)*automaton->number_of_states);
 if (rank==NULL) {
-	fatal_alloc_error("sentence_to_grf");
+    fatal_alloc_error("sentence_to_grf");
 }
 int maximum_rank=compute_state_ranks(automaton,rank);
 /* The pos_X array will be used to store the X coordinate of the grf
@@ -130,7 +130,7 @@ int maximum_rank=compute_state_ranks(automaton,rank);
  * X positions concerns fst2 transitions. */
 int* pos_X=(int*)malloc(sizeof(int)*(maximum_rank+1));
 if (pos_X==NULL) {
-	fatal_alloc_error("sentence_to_grf");
+    fatal_alloc_error("sentence_to_grf");
 }
 int width_max=get_max_width_for_ranks(automaton,tags,pos_X,rank,maximum_rank,fontsize);
 Grf* grf=transitions_to_grf_states(automaton,tags,rank,maximum_rank,width_max,pos_X,fontsize);
@@ -169,22 +169,22 @@ return grf;
  * total number of transitions in the automaton.
  */
 int* get_n_transitions_before_state(SingleGraph automaton) {
-	int max=automaton->number_of_states;
-	int* n_transitions_par_state=(int*)malloc((1+max)*sizeof(int));
-	if (n_transitions_par_state==NULL) {
-		fatal_alloc_error("get_n_transitions_par_state");
-	}
-	Transition* trans;
-	n_transitions_par_state[0]=0;
-	for (int i=0;i<max;i++) {
-		n_transitions_par_state[i+1]=n_transitions_par_state[i];
-		trans=automaton->states[i]->outgoing_transitions;
-		while (trans!=NULL) {
-			n_transitions_par_state[i+1]++;
-			trans=trans->next;
-		}
-	}
-	return n_transitions_par_state;
+    int max=automaton->number_of_states;
+    int* n_transitions_par_state=(int*)malloc((1+max)*sizeof(int));
+    if (n_transitions_par_state==NULL) {
+        fatal_alloc_error("get_n_transitions_par_state");
+    }
+    Transition* trans;
+    n_transitions_par_state[0]=0;
+    for (int i=0;i<max;i++) {
+        n_transitions_par_state[i+1]=n_transitions_par_state[i];
+        trans=automaton->states[i]->outgoing_transitions;
+        while (trans!=NULL) {
+            n_transitions_par_state[i+1]++;
+            trans=trans->next;
+        }
+    }
+    return n_transitions_par_state;
 }
 
 
@@ -196,13 +196,13 @@ int* get_n_transitions_before_state(SingleGraph automaton) {
  * the height of the resulting graph.
  */
 int get_maximum_difference(int* t,int size) {
-	int m=0;
-	for (int i=1;i<size;i++) {
-		if ((t[i]-t[i-1])>m) {
-			m=t[i]-t[i-1];
-		}
-	}
-	return m;
+    int m=0;
+    for (int i=1;i<size;i++) {
+        if ((t[i]-t[i-1])>m) {
+            m=t[i]-t[i-1];
+        }
+    }
+    return m;
 }
 
 
@@ -213,63 +213,63 @@ int get_maximum_difference(int* t,int size) {
  * keeps the coordinates of the rightmost state of the two.
  */
 void remove_duplicate_grf_states(Grf* grf) {
-	int j;
-	/* 2 because the initial and final states are not concerned */
-	for (int i=2;i<grf->n_states;i++) {
-		j=i+1;
-		/* We look for a state that is equal to states[i] */
-		while (j<grf->n_states) {
-			if (!u_strcmp(grf->states[i]->box_content,grf->states[j]->box_content) &&
-					vector_int_equals(grf->states[i]->transitions,grf->states[j]->transitions)) {
-				/* If we have such a state */
-				if (grf->states[i]->x<grf->states[j]->x) {
-					/* We take the rightmost coordinates */
-					grf->states[i]->x=grf->states[j]->x;
-					grf->states[i]->rank=grf->states[j]->rank;
-				}
-				/* Then we free the state #j and we swap it with the last one */
-				free_GrfState(grf->states[j]);
-				grf->states[j]=grf->states[grf->n_states-1];
-				/* We decrease the number of states */
-				(grf->n_states)--;
-				grf->states=(GrfState**)realloc(grf->states,grf->n_states*sizeof(GrfState*));
-				/* And we renumber all transitions to j into transitions to i */
-				for (int k=0;k<grf->n_states;k++) {
-					if (vector_int_remove(grf->states[k]->transitions,j)) {
-						vector_int_add(grf->states[k]->transitions,i);
-					}
-					if (vector_int_remove(grf->states[k]->transitions,grf->n_states)) {
-						vector_int_add(grf->states[k]->transitions,j);
-					}
-				}
-			} else {
-				j++;
-			}
-		}
-	}
+    int j;
+    /* 2 because the initial and final states are not concerned */
+    for (int i=2;i<grf->n_states;i++) {
+        j=i+1;
+        /* We look for a state that is equal to states[i] */
+        while (j<grf->n_states) {
+            if (!u_strcmp(grf->states[i]->box_content,grf->states[j]->box_content) &&
+                    vector_int_equals(grf->states[i]->transitions,grf->states[j]->transitions)) {
+                /* If we have such a state */
+                if (grf->states[i]->x<grf->states[j]->x) {
+                    /* We take the rightmost coordinates */
+                    grf->states[i]->x=grf->states[j]->x;
+                    grf->states[i]->rank=grf->states[j]->rank;
+                }
+                /* Then we free the state #j and we swap it with the last one */
+                free_GrfState(grf->states[j]);
+                grf->states[j]=grf->states[grf->n_states-1];
+                /* We decrease the number of states */
+                (grf->n_states)--;
+                grf->states=(GrfState**)realloc(grf->states,grf->n_states*sizeof(GrfState*));
+                /* And we renumber all transitions to j into transitions to i */
+                for (int k=0;k<grf->n_states;k++) {
+                    if (vector_int_remove(grf->states[k]->transitions,j)) {
+                        vector_int_add(grf->states[k]->transitions,i);
+                    }
+                    if (vector_int_remove(grf->states[k]->transitions,grf->n_states)) {
+                        vector_int_add(grf->states[k]->transitions,j);
+                    }
+                }
+            } else {
+                j++;
+            }
+        }
+    }
 }
 
 
 static void prepare_grf_header(Grf* grf,int width,int height,char* font,int fontsize) {
-	u_sprintf(grf->size,"SIZE %d %d",width,height);
-	if (font!=NULL) {
-		u_sprintf(grf->font,"FONT %s:  %d",font,fontsize);
-		u_sprintf(grf->ofont,"OFONT %s:B %d",font,fontsize);
-	}
-	u_sprintf(grf->bcolor,"BCOLOR 16777215");
-	u_sprintf(grf->fcolor,"FCOLOR 0");
-	u_sprintf(grf->acolor,"ACOLOR 12632256");
-	u_sprintf(grf->scolor,"SCOLOR 16711680");
-	u_sprintf(grf->ccolor,"CCOLOR 255");
-	u_sprintf(grf->dboxes,"DBOXES y");
-	u_sprintf(grf->dframe,"DFRAME y");
-	u_sprintf(grf->ddate,"DDATE y");
-	u_sprintf(grf->dfile,"DFILE y");
-	u_sprintf(grf->ddir,"DDIR y");
-	u_sprintf(grf->drig,"DRIG n");
-	u_sprintf(grf->drst,"DRST n");
-	u_sprintf(grf->fits,"FITS 100");
-	u_sprintf(grf->porient,"PORIENT L");
+    u_sprintf(grf->size,"SIZE %d %d",width,height);
+    if (font!=NULL) {
+        u_sprintf(grf->font,"FONT %s:  %d",font,fontsize);
+        u_sprintf(grf->ofont,"OFONT %s:B %d",font,fontsize);
+    }
+    u_sprintf(grf->bcolor,"BCOLOR 16777215");
+    u_sprintf(grf->fcolor,"FCOLOR 0");
+    u_sprintf(grf->acolor,"ACOLOR 12632256");
+    u_sprintf(grf->scolor,"SCOLOR 16711680");
+    u_sprintf(grf->ccolor,"CCOLOR 255");
+    u_sprintf(grf->dboxes,"DBOXES y");
+    u_sprintf(grf->dframe,"DFRAME y");
+    u_sprintf(grf->ddate,"DDATE y");
+    u_sprintf(grf->dfile,"DFILE y");
+    u_sprintf(grf->ddir,"DDIR y");
+    u_sprintf(grf->drig,"DRIG n");
+    u_sprintf(grf->drst,"DRST n");
+    u_sprintf(grf->fits,"FITS 100");
+    u_sprintf(grf->porient,"PORIENT L");
 }
 
 
@@ -277,28 +277,28 @@ static void prepare_grf_header(Grf* grf,int width,int height,char* font,int font
  * Saves the given grf states to the given file.
  */
 static void prepare_grf_for_saving(Grf* grf,
-		int maximum_rank,char* font,int fontsize) {
-	/* We count the number of boxes for each rank */
-	int* pos_Y=(int*)calloc(maximum_rank+1,sizeof(int));
-	if (pos_Y==NULL) {
-		fatal_alloc_error("prepare_grf_for_saving");
-	}
-	for (int i=0;i<grf->n_states;i++) {
-		if (grf->states[i]->rank<0) error("%d\n",grf->states[i]->rank);
-		pos_Y[grf->states[i]->rank]++;
-	}
-	/* We set the Y coordinates of all boxes */
-	grf->states[0]->y=100;
-	grf->states[1]->y=100;
-	int maxY=100;
-	for (int i=2;i<grf->n_states;i++) {
-		grf->states[i]->y=100-(50*(grf->states[i]->rank%2))+100*(--pos_Y[grf->states[i]->rank]);
-		if (grf->states[i]->y>maxY) {
-			maxY=grf->states[i]->y;
-		}
-	}
-	prepare_grf_header(grf,grf->states[1]->x+300,200+maxY,font,fontsize);
-	free(pos_Y);
+        int maximum_rank,char* font,int fontsize) {
+    /* We count the number of boxes for each rank */
+    int* pos_Y=(int*)calloc(maximum_rank+1,sizeof(int));
+    if (pos_Y==NULL) {
+        fatal_alloc_error("prepare_grf_for_saving");
+    }
+    for (int i=0;i<grf->n_states;i++) {
+        if (grf->states[i]->rank<0) error("%d\n",grf->states[i]->rank);
+        pos_Y[grf->states[i]->rank]++;
+    }
+    /* We set the Y coordinates of all boxes */
+    grf->states[0]->y=100;
+    grf->states[1]->y=100;
+    int maxY=100;
+    for (int i=2;i<grf->n_states;i++) {
+        grf->states[i]->y=100-(50*(grf->states[i]->rank%2))+100*(--pos_Y[grf->states[i]->rank]);
+        if (grf->states[i]->y>maxY) {
+            maxY=grf->states[i]->y;
+        }
+    }
+    prepare_grf_header(grf,grf->states[1]->x+300,200+maxY,font,fontsize);
+    free(pos_Y);
 }
 
 
@@ -309,89 +309,89 @@ static void prepare_grf_for_saving(Grf* grf,
  * and saves them to the given file.
  */
 Grf* tfst_transitions_to_grf_states(Tfst* tfst,
-		int* rank,int maximum_rank,
-		int width_max,int* pos_X,char* font,int fontsize, int sequences) {
-	Grf* grf=new_Grf(1);
-	int n_states=tfst->automaton->number_of_states;
-	int* n_transitions_before_state=get_n_transitions_before_state(tfst->automaton);
-	Transition* trans;
-	/* We create initial state and set its transitions. We start at 2 because
-	 * 0 and 1 are respectively reserved for the initial and the final states. */
-	add_GrfState(grf,new_GrfState("\"<E>\"",50,0,0,0));
-	int j=2;
-	trans=tfst->automaton->states[0]->outgoing_transitions;
-	while (trans!=NULL) {
-		vector_int_add_if_absent(grf->states[0]->transitions,j++);
-		trans=trans->next;
-	}
-	/* We create the final state */
-	add_GrfState(grf,new_GrfState("\"\"",(width_max+100),0,maximum_rank,1));
-	/* Then, we save all the other grf states */
-	Ustring*  content=new_Ustring();
-	for (int i=0;i<n_states;i++) {
-		trans=tfst->automaton->states[i]->outgoing_transitions;
-		while (trans!=NULL) {
-			TfstTag* t=(TfstTag*)tfst->tags->tab[trans->tag_number];
-			empty(content);
+        int* rank,int maximum_rank,
+        int width_max,int* pos_X,char* font,int fontsize, int sequences) {
+    Grf* grf=new_Grf(1);
+    int n_states=tfst->automaton->number_of_states;
+    int* n_transitions_before_state=get_n_transitions_before_state(tfst->automaton);
+    Transition* trans;
+    /* We create initial state and set its transitions. We start at 2 because
+     * 0 and 1 are respectively reserved for the initial and the final states. */
+    add_GrfState(grf,new_GrfState("\"<E>\"",50,0,0,0));
+    int j=2;
+    trans=tfst->automaton->states[0]->outgoing_transitions;
+    while (trans!=NULL) {
+        vector_int_add_if_absent(grf->states[0]->transitions,j++);
+        trans=trans->next;
+    }
+    /* We create the final state */
+    add_GrfState(grf,new_GrfState("\"\"",(width_max+100),0,maximum_rank,1));
+    /* Then, we save all the other grf states */
+    Ustring*  content=new_Ustring();
+    for (int i=0;i<n_states;i++) {
+        trans=tfst->automaton->states[i]->outgoing_transitions;
+        while (trans!=NULL) {
+            TfstTag* t=(TfstTag*)tfst->tags->tab[trans->tag_number];
+            empty(content);
 
-			if (!u_strcmp(t->content,"\"")) {
-				/* If the box content is a double quote, we must protect it in a special
-				 * way since both \ and "  are special characters in grf files. */
-				u_sprintf(content,"\"\\\\\\\"");
-			} else if(!u_strcmp(t->content,"<")){
-				u_strcpy(content,"\"\\<");
-			} else if(!u_strcmp(t->content,"\\")){
-				u_strcpy(content,"\"\\\\");
-			} else if(!u_strcmp(t->content,"+")){
-				u_strcpy(content,"\"\\+");
-			} else if(!u_strcmp(t->content,"-")){
-				u_strcpy(content,"\"\\-");
-			} else if(!u_strcmp(t->content,":")){
-				u_strcpy(content,"\"\\:");
-			} else if(!u_strcmp(t->content,"/")){
-				u_strcpy(content,"\"\\/");
-			}	else {
-				/* Otherwise, we put the content between double quotes */
-				u_strcpy(content,"\"");
-				escape(t->content,content,P_DOUBLE_QUOTE);
-			}
+            if (!u_strcmp(t->content,"\"")) {
+                /* If the box content is a double quote, we must protect it in a special
+                 * way since both \ and "  are special characters in grf files. */
+                u_sprintf(content,"\"\\\\\\\"");
+            } else if(!u_strcmp(t->content,"<")){
+                u_strcpy(content,"\"\\<");
+            } else if(!u_strcmp(t->content,"\\")){
+                u_strcpy(content,"\"\\\\");
+            } else if(!u_strcmp(t->content,"+")){
+                u_strcpy(content,"\"\\+");
+            } else if(!u_strcmp(t->content,"-")){
+                u_strcpy(content,"\"\\-");
+            } else if(!u_strcmp(t->content,":")){
+                u_strcpy(content,"\"\\:");
+            } else if(!u_strcmp(t->content,"/")){
+                u_strcpy(content,"\"\\/");
+            }   else {
+                /* Otherwise, we put the content between double quotes */
+                u_strcpy(content,"\"");
+                escape(t->content,content,P_DOUBLE_QUOTE);
+            }
 
-			if (sequences==1){
-				u_strcat(content,"\"");
-			} else {
-				u_strcatf(content,"/%d %d %d %d %d %d\"",
-						t->m.start_pos_in_token,t->m.start_pos_in_char,t->m.start_pos_in_letter,
-						t->m.end_pos_in_token,t->m.end_pos_in_char,t->m.end_pos_in_letter);
-			}
+            if (sequences==1){
+                u_strcat(content,"\"");
+            } else {
+                u_strcatf(content,"/%d %d %d %d %d %d\"",
+                        t->m.start_pos_in_token,t->m.start_pos_in_char,t->m.start_pos_in_letter,
+                        t->m.end_pos_in_token,t->m.end_pos_in_char,t->m.end_pos_in_letter);
+            }
 
-			int index=add_GrfState(grf,new_GrfState(content->str,pos_X[rank[i]],0,rank[i],grf->n_states));
-			/* Now that we have created the grf state, we set its outgoing transitions */
-			if (tfst->automaton->states[trans->state_number]->outgoing_transitions==NULL
-					|| is_final_state(tfst->automaton->states[trans->state_number])) {
-				/* If the current fst2 transition points to a final state,
-				 * we must put a transition for the current grf state to the
-				 * grf final state */
-				vector_int_add(grf->states[index]->transitions,1);
-			}
-			/* Then, we create transitions */
-			Transition* tmp=tfst->automaton->states[trans->state_number]->outgoing_transitions;
-			/* +2 because of the grf states 0 and 1 that are reserved */
-			if (tmp!=NULL) {
-				int k=2+n_transitions_before_state[trans->state_number];
-				while (tmp!=NULL) {
-					vector_int_add(grf->states[index]->transitions,k++);
-					tmp=tmp->next;
-				}
-			}
-			trans=trans->next;
-		}
-	}
-	free_Ustring(content);
-	free(n_transitions_before_state);
-	remove_duplicate_grf_states(grf);
-	/* And we prepare the grf so that it will be ready to be saved on disk */
-	prepare_grf_for_saving(grf,maximum_rank,font,fontsize);
-	return grf;
+            int index=add_GrfState(grf,new_GrfState(content->str,pos_X[rank[i]],0,rank[i],grf->n_states));
+            /* Now that we have created the grf state, we set its outgoing transitions */
+            if (tfst->automaton->states[trans->state_number]->outgoing_transitions==NULL
+                    || is_final_state(tfst->automaton->states[trans->state_number])) {
+                /* If the current fst2 transition points to a final state,
+                 * we must put a transition for the current grf state to the
+                 * grf final state */
+                vector_int_add(grf->states[index]->transitions,1);
+            }
+            /* Then, we create transitions */
+            Transition* tmp=tfst->automaton->states[trans->state_number]->outgoing_transitions;
+            /* +2 because of the grf states 0 and 1 that are reserved */
+            if (tmp!=NULL) {
+                int k=2+n_transitions_before_state[trans->state_number];
+                while (tmp!=NULL) {
+                    vector_int_add(grf->states[index]->transitions,k++);
+                    tmp=tmp->next;
+                }
+            }
+            trans=trans->next;
+        }
+    }
+    free_Ustring(content);
+    free(n_transitions_before_state);
+    remove_duplicate_grf_states(grf);
+    /* And we prepare the grf so that it will be ready to be saved on disk */
+    prepare_grf_for_saving(grf,maximum_rank,font,fontsize);
+    return grf;
 }
 
 
@@ -401,81 +401,81 @@ Grf* tfst_transitions_to_grf_states(Tfst* tfst,
  * and saves them to the given file.
  */
 Grf* transitions_to_grf_states(SingleGraph automaton,
-		struct string_hash* tags,
-		int* rank,int maximum_rank,
-		int width_max,int* pos_X,int fontsize) {
-	Grf* grf=new_Grf(1);
-	int n_states=automaton->number_of_states;
-	int* n_transitions_before_state=get_n_transitions_before_state(automaton);
-	Transition* trans;
-	/* We create initial state and set its transitions. We start at 2 because
-	 * 0 and 1 are respectively reserved for the initial and the final states. */
-	add_GrfState(grf,new_GrfState("\"<E>\"",50,0,0,0));
-	int j=2;
-	trans=automaton->states[0]->outgoing_transitions;
-	while (trans!=NULL) {
-		vector_int_add_if_absent(grf->states[0]->transitions,j++);
-		trans=trans->next;
-	}
-	/* We create the final state */
-	add_GrfState(grf,new_GrfState("\"\"",(width_max+100),0,maximum_rank,1));
-	/* Then, we save all the other grf states */
-	Ustring*  content=new_Ustring();
-	for (int i=0;i<n_states;i++) {
-		trans=automaton->states[i]->outgoing_transitions;
-		while (trans!=NULL) {
-			unichar* t=tags->value[trans->tag_number];
-			empty(content);
-			if (!u_strcmp(t,"\"")) {
-				/* If the box content is a double quote, we must protect it in a special
-				 * way since both \ and "  are special characters in grf files. */
-				u_sprintf(content,"\"\\\\\\\"\"");
-			} else if(!u_strcmp(t,"<")){
-				u_strcpy(content,"\"\\<\"");
-			} else if(!u_strcmp(t,"\\")){
-				u_strcpy(content,"\"\\\\\"");
-			} else if(!u_strcmp(t,"+")){
-				u_strcpy(content,"\"\\+\"");
-			} else if(!u_strcmp(t,"-")){
-				u_strcpy(content,"\"\\-\"");
-			} else if(!u_strcmp(t,":")){
-				u_strcpy(content,"\"\\:\"");
-			} else if(!u_strcmp(t,"/")){
-				u_strcpy(content,"\"\\/\"");
-			}	else {
-				/* Otherwise, we put the content between double quotes */
-				u_strcpy(content,"\"");
-				escape(t,content,P_DOUBLE_QUOTE);
-				u_strcatf(content,"\"");
-			}
-			int index=add_GrfState(grf,new_GrfState(content->str,pos_X[rank[i]],0,rank[i],grf->n_states));
-			/* Now that we have created the grf state, we set its outgoing transitions */
-			if (automaton->states[trans->state_number]->outgoing_transitions==NULL
-					|| is_final_state(automaton->states[trans->state_number])) {
-				/* If the current fst2 transition points to a final state,
-				 * we must put a transition for the current grf state to the
-				 * grf final state */
-				vector_int_add(grf->states[index]->transitions,1);
-			}
-			/* Then, we create transitions */
-			Transition* tmp=automaton->states[trans->state_number]->outgoing_transitions;
-			/* +2 because of the grf states 0 and 1 that are reserved */
-			if (tmp!=NULL) {
-				int k=2+n_transitions_before_state[trans->state_number];
-				while (tmp!=NULL) {
-					vector_int_add(grf->states[index]->transitions,k++);
-					tmp=tmp->next;
-				}
-			}
-			trans=trans->next;
-		}
-	}
-	free_Ustring(content);
-	free(n_transitions_before_state);
-	remove_duplicate_grf_states(grf);
-	/* And we prepare the grf so that it will be ready to be saved on disk */
-	prepare_grf_for_saving(grf,maximum_rank,NULL,fontsize);
-	return grf;
+        struct string_hash* tags,
+        int* rank,int maximum_rank,
+        int width_max,int* pos_X,int fontsize) {
+    Grf* grf=new_Grf(1);
+    int n_states=automaton->number_of_states;
+    int* n_transitions_before_state=get_n_transitions_before_state(automaton);
+    Transition* trans;
+    /* We create initial state and set its transitions. We start at 2 because
+     * 0 and 1 are respectively reserved for the initial and the final states. */
+    add_GrfState(grf,new_GrfState("\"<E>\"",50,0,0,0));
+    int j=2;
+    trans=automaton->states[0]->outgoing_transitions;
+    while (trans!=NULL) {
+        vector_int_add_if_absent(grf->states[0]->transitions,j++);
+        trans=trans->next;
+    }
+    /* We create the final state */
+    add_GrfState(grf,new_GrfState("\"\"",(width_max+100),0,maximum_rank,1));
+    /* Then, we save all the other grf states */
+    Ustring*  content=new_Ustring();
+    for (int i=0;i<n_states;i++) {
+        trans=automaton->states[i]->outgoing_transitions;
+        while (trans!=NULL) {
+            unichar* t=tags->value[trans->tag_number];
+            empty(content);
+            if (!u_strcmp(t,"\"")) {
+                /* If the box content is a double quote, we must protect it in a special
+                 * way since both \ and "  are special characters in grf files. */
+                u_sprintf(content,"\"\\\\\\\"\"");
+            } else if(!u_strcmp(t,"<")){
+                u_strcpy(content,"\"\\<\"");
+            } else if(!u_strcmp(t,"\\")){
+                u_strcpy(content,"\"\\\\\"");
+            } else if(!u_strcmp(t,"+")){
+                u_strcpy(content,"\"\\+\"");
+            } else if(!u_strcmp(t,"-")){
+                u_strcpy(content,"\"\\-\"");
+            } else if(!u_strcmp(t,":")){
+                u_strcpy(content,"\"\\:\"");
+            } else if(!u_strcmp(t,"/")){
+                u_strcpy(content,"\"\\/\"");
+            }   else {
+                /* Otherwise, we put the content between double quotes */
+                u_strcpy(content,"\"");
+                escape(t,content,P_DOUBLE_QUOTE);
+                u_strcatf(content,"\"");
+            }
+            int index=add_GrfState(grf,new_GrfState(content->str,pos_X[rank[i]],0,rank[i],grf->n_states));
+            /* Now that we have created the grf state, we set its outgoing transitions */
+            if (automaton->states[trans->state_number]->outgoing_transitions==NULL
+                    || is_final_state(automaton->states[trans->state_number])) {
+                /* If the current fst2 transition points to a final state,
+                 * we must put a transition for the current grf state to the
+                 * grf final state */
+                vector_int_add(grf->states[index]->transitions,1);
+            }
+            /* Then, we create transitions */
+            Transition* tmp=automaton->states[trans->state_number]->outgoing_transitions;
+            /* +2 because of the grf states 0 and 1 that are reserved */
+            if (tmp!=NULL) {
+                int k=2+n_transitions_before_state[trans->state_number];
+                while (tmp!=NULL) {
+                    vector_int_add(grf->states[index]->transitions,k++);
+                    tmp=tmp->next;
+                }
+            }
+            trans=trans->next;
+        }
+    }
+    free_Ustring(content);
+    free(n_transitions_before_state);
+    remove_duplicate_grf_states(grf);
+    /* And we prepare the grf so that it will be ready to be saved on disk */
+    prepare_grf_for_saving(grf,maximum_rank,NULL,fontsize);
+    return grf;
 }
 
 
@@ -486,30 +486,30 @@ Grf* transitions_to_grf_states(SingleGraph automaton,
  * Finally, we explore recursively all the states that have been updated.
  */
 void explore_states_for_ranks(int current_state,int initial_state,SingleGraph automaton,
-		int* rank,struct bit_array* modified,int* maximum_rank) {
-	Transition* trans=automaton->states[current_state]->outgoing_transitions;
-	int current_rank=rank[current_state-initial_state];
-	while (trans!=NULL) {
-		if (current_rank+1>rank[trans->state_number-initial_state]) {
-			/* If we must increase the rank of the destination state */
-			rank[trans->state_number-initial_state]=current_rank+1;
-			if ((current_rank+1)>(*maximum_rank)) {
-				(*maximum_rank)=current_rank+1;
-			}
-			set_value(modified,(trans->state_number)-initial_state,1);
-		}
-		trans=trans->next;
-	}
-	/* Then, we process all the states we have modified */
-	trans=automaton->states[current_state]->outgoing_transitions;
-	while (trans!=NULL) {
-		if (get_value(modified,trans->state_number-initial_state)) {
-			explore_states_for_ranks(trans->state_number,initial_state,automaton,rank,modified,maximum_rank);
-			/* After we have processed the state, we remove the modification mark */
-			set_value(modified,(trans->state_number)-initial_state,0);
-		}
-		trans=trans->next;
-	}
+        int* rank,struct bit_array* modified,int* maximum_rank) {
+    Transition* trans=automaton->states[current_state]->outgoing_transitions;
+    int current_rank=rank[current_state-initial_state];
+    while (trans!=NULL) {
+        if (current_rank+1>rank[trans->state_number-initial_state]) {
+            /* If we must increase the rank of the destination state */
+            rank[trans->state_number-initial_state]=current_rank+1;
+            if ((current_rank+1)>(*maximum_rank)) {
+                (*maximum_rank)=current_rank+1;
+            }
+            set_value(modified,(trans->state_number)-initial_state,1);
+        }
+        trans=trans->next;
+    }
+    /* Then, we process all the states we have modified */
+    trans=automaton->states[current_state]->outgoing_transitions;
+    while (trans!=NULL) {
+        if (get_value(modified,trans->state_number-initial_state)) {
+            explore_states_for_ranks(trans->state_number,initial_state,automaton,rank,modified,maximum_rank);
+            /* After we have processed the state, we remove the modification mark */
+            set_value(modified,(trans->state_number)-initial_state,0);
+        }
+        trans=trans->next;
+    }
 }
 
 
@@ -519,15 +519,15 @@ void explore_states_for_ranks(int current_state,int initial_state,SingleGraph au
  * maximum rank is returned.
  */
 int compute_state_ranks(SingleGraph automaton,int* rank) {
-	int n_states=automaton->number_of_states;
-	int maximum_rank=0;
-	for (int i=0;i<n_states;i++) {
-		rank[i]=0;
-	}
-	struct bit_array* modified=new_bit_array(n_states,ONE_BIT);
-	explore_states_for_ranks(0,0,automaton,rank,modified,&maximum_rank);
-	free_bit_array(modified);
-	return maximum_rank;
+    int n_states=automaton->number_of_states;
+    int maximum_rank=0;
+    for (int i=0;i<n_states;i++) {
+        rank[i]=0;
+    }
+    struct bit_array* modified=new_bit_array(n_states,ONE_BIT);
+    explore_states_for_ranks(0,0,automaton,rank,modified,&maximum_rank);
+    free_bit_array(modified);
+    return maximum_rank;
 }
 
 
@@ -535,26 +535,26 @@ int compute_state_ranks(SingleGraph automaton,int* rank) {
  * This is a raw approximation of the width of a tag.
  */
 int width_of_tag(unichar* tag) {
-	if (tag[0]!='{' || !u_strcmp(tag,"{S}")) {
-		/* Note that the {S} should not appear in a sentence automaton */
-		return u_strlen(tag);
-	}
-	/* If the tag is a tag token like {today,.ADV}, we take the maximum
-	 * of the lengths of the inflected form, the lemma and the codes */
-	struct dela_entry* entry=tokenize_tag_token(tag,1);
-	int width=u_strlen(entry->inflected);
-	int tmp=u_strlen(entry->lemma);
-	if (tmp>width) width=tmp;
-	tmp=u_strlen(entry->semantic_codes[0]);
-	for (int i=1;i<entry->n_semantic_codes;i++) {
-		tmp=tmp+1+u_strlen(entry->semantic_codes[i]);
-	}
-	for (int i=0;i<entry->n_inflectional_codes;i++) {
-		tmp=tmp+1+u_strlen(entry->inflectional_codes[i]);
-	}
-	if (tmp>width) width=tmp;
-	free_dela_entry(entry);
-	return width;
+    if (tag[0]!='{' || !u_strcmp(tag,"{S}")) {
+        /* Note that the {S} should not appear in a sentence automaton */
+        return u_strlen(tag);
+    }
+    /* If the tag is a tag token like {today,.ADV}, we take the maximum
+     * of the lengths of the inflected form, the lemma and the codes */
+    struct dela_entry* entry=tokenize_tag_token(tag,1);
+    int width=u_strlen(entry->inflected);
+    int tmp=u_strlen(entry->lemma);
+    if (tmp>width) width=tmp;
+    tmp=u_strlen(entry->semantic_codes[0]);
+    for (int i=1;i<entry->n_semantic_codes;i++) {
+        tmp=tmp+1+u_strlen(entry->semantic_codes[i]);
+    }
+    for (int i=0;i<entry->n_inflectional_codes;i++) {
+        tmp=tmp+1+u_strlen(entry->inflectional_codes[i]);
+    }
+    if (tmp>width) width=tmp;
+    free_dela_entry(entry);
+    return width;
 }
 
 
@@ -565,33 +565,33 @@ int width_of_tag(unichar* tag) {
  * The function returns the X position of the last rank boxes.
  */
 int get_max_width_for_ranks(Tfst* tfst,int* pos_X,int* rank,int maximum_rank,int fontsize) {
-	int n_states=tfst->automaton->number_of_states;
-	int i;
-	Transition* trans;
-	for (i=0;i<=maximum_rank;i++) {
-		pos_X[i]=0;
-	}
-	/* First, we compute the maximum width for the boxes of each rank */
-	for (i=0;i<n_states;i++) {
-		trans=tfst->automaton->states[i]->outgoing_transitions;
-		while (trans!=NULL) {
-			TfstTag* t=(TfstTag*)(tfst->tags->tab[trans->tag_number]);
-			int v=fontsize*(5+width_of_tag(t->content));
-			if (pos_X[rank[i]+1]<v) {
-				pos_X[rank[i]+1]=v;
-			}
-			trans=trans->next;
-		}
-	}
-	/* Now that we have the width for each rank, we compute the absolute X
-	 * for each rank. We arbitrary set a distance of 100 pixels between boxes
-	 * of consecutive ranks. */
-	int tmp=100;
-	for (i=0;i<=maximum_rank;i++) {
-		pos_X[i]=tmp+pos_X[i];
-		tmp=pos_X[i];
-	}
-	return pos_X[maximum_rank];
+    int n_states=tfst->automaton->number_of_states;
+    int i;
+    Transition* trans;
+    for (i=0;i<=maximum_rank;i++) {
+        pos_X[i]=0;
+    }
+    /* First, we compute the maximum width for the boxes of each rank */
+    for (i=0;i<n_states;i++) {
+        trans=tfst->automaton->states[i]->outgoing_transitions;
+        while (trans!=NULL) {
+            TfstTag* t=(TfstTag*)(tfst->tags->tab[trans->tag_number]);
+            int v=fontsize*(5+width_of_tag(t->content));
+            if (pos_X[rank[i]+1]<v) {
+                pos_X[rank[i]+1]=v;
+            }
+            trans=trans->next;
+        }
+    }
+    /* Now that we have the width for each rank, we compute the absolute X
+     * for each rank. We arbitrary set a distance of 100 pixels between boxes
+     * of consecutive ranks. */
+    int tmp=100;
+    for (i=0;i<=maximum_rank;i++) {
+        pos_X[i]=tmp+pos_X[i];
+        tmp=pos_X[i];
+    }
+    return pos_X[maximum_rank];
 }
 
 
@@ -602,34 +602,34 @@ int get_max_width_for_ranks(Tfst* tfst,int* pos_X,int* rank,int maximum_rank,int
  * The function returns the X position of the last rank boxes.
  */
 int get_max_width_for_ranks(SingleGraph automaton,struct string_hash* tags,
-		int* pos_X,int* rank,int maximum_rank,int fontsize) {
-	int n_states=automaton->number_of_states;
-	int i;
-	Transition* trans;
-	for (i=0;i<=maximum_rank;i++) {
-		pos_X[i]=0;
-	}
-	/* First, we compute the maximum width for the boxes of each rank */
-	for (i=0;i<n_states;i++) {
-		trans=automaton->states[i]->outgoing_transitions;
-		while (trans!=NULL) {
-			unichar* t=tags->value[trans->tag_number];
-			int v=fontsize*(5+width_of_tag(t));
-			if (pos_X[rank[i]+1]<v) {
-				pos_X[rank[i]+1]=v;
-			}
-			trans=trans->next;
-		}
-	}
-	/* Now that we have the width for each rank, we compute the absolute X
-	 * for each rank. We arbitrary set a distance of 100 pixels between boxes
-	 * of consecutive ranks. */
-	int tmp=100;
-	for (i=0;i<=maximum_rank;i++) {
-		pos_X[i]=tmp+pos_X[i];
-		tmp=pos_X[i];
-	}
-	return pos_X[maximum_rank];
+        int* pos_X,int* rank,int maximum_rank,int fontsize) {
+    int n_states=automaton->number_of_states;
+    int i;
+    Transition* trans;
+    for (i=0;i<=maximum_rank;i++) {
+        pos_X[i]=0;
+    }
+    /* First, we compute the maximum width for the boxes of each rank */
+    for (i=0;i<n_states;i++) {
+        trans=automaton->states[i]->outgoing_transitions;
+        while (trans!=NULL) {
+            unichar* t=tags->value[trans->tag_number];
+            int v=fontsize*(5+width_of_tag(t));
+            if (pos_X[rank[i]+1]<v) {
+                pos_X[rank[i]+1]=v;
+            }
+            trans=trans->next;
+        }
+    }
+    /* Now that we have the width for each rank, we compute the absolute X
+     * for each rank. We arbitrary set a distance of 100 pixels between boxes
+     * of consecutive ranks. */
+    int tmp=100;
+    for (i=0;i<=maximum_rank;i++) {
+        pos_X[i]=tmp+pos_X[i];
+        tmp=pos_X[i];
+    }
+    return pos_X[maximum_rank];
 }
 
 

--- a/Seq2Grf.cpp
+++ b/Seq2Grf.cpp
@@ -173,7 +173,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Seq2Grf,lopts_Seq2Grf,&i
       break;
     }
     case 'V': only_verify_arguments = true;
-      break;    
+      break;
     case 'h': {
       usage();
       return SUCCESS_RETURN_CODE;
@@ -489,9 +489,9 @@ while (EOF!=readline(line,f)) {
     }
   }
   if (first_on_this_line) {
-    if (seq->len!=0) { 
+    if (seq->len!=0) {
       u_strcat(seq,"\n");
-    }  
+    }
     first_on_this_line=0;
   }
   u_strcat(seq,line->str+line_start);

--- a/Seq2Grf.h
+++ b/Seq2Grf.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef Seq2GrfH
 #define Seq2GrfH
 

--- a/SingleGraph.cpp
+++ b/SingleGraph.cpp
@@ -37,7 +37,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1

--- a/SingleGraph.cpp
+++ b/SingleGraph.cpp
@@ -1060,8 +1060,8 @@ Transition* transition;
 typedef void (*free_list_int_func_t)(struct list_int*);
 free_list_int_func_t free_list_inst_func=free_list_int;
 struct hash_table* hash=new_hash_table((unsigned int (*)(const void*))hash_list_int,
-				(int (*)(const void*, const void*))equal_list_int,
-				(void (*)(void*))free_list_inst_func,NULL,NULL);
+                (int (*)(const void*, const void*))equal_list_int,
+                (void (*)(void*))free_list_inst_func,NULL,NULL);
 struct fifo* fifo=new_fifo();
 struct hash_table* transition_hash=new_hash_table();
 /* We start by creating the initial state of the new graph and inserting it
@@ -1261,7 +1261,7 @@ for (q=0;q<graph->number_of_states;q++) {
       old++;
    }
    if (oops==0) {
-	   fatal_error("Unexpected cyclic graph in topological_sort!\n");
+       fatal_error("Unexpected cyclic graph in topological_sort!\n");
    }
    renumber[old]=q;
    incoming[old]=-1;
@@ -1330,7 +1330,7 @@ for (Transition* t=graph->states[q1]->outgoing_transitions;t!=NULL;t=t->next) {
    number_of_paths[q1]=number_of_paths[q1]+number_of_paths[t->state_number];
    /* We use +1 because we must count the transition from q1 to t->state_number */
    if (min_path_length!=NULL &&
-		   (min_path_length[q1]==-1 || (min_path_length[t->state_number]+1)<min_path_length[q1])) {
+           (min_path_length[q1]==-1 || (min_path_length[t->state_number]+1)<min_path_length[q1])) {
       min_path_length[q1]=min_path_length[t->state_number]+1;
    }
    if (max_path_length!=NULL && (max_path_length[t->state_number]+1)>max_path_length[q1]) {
@@ -1476,7 +1476,7 @@ free_SingleGraph(B,NULL);
 
 void reverse_transition_lists(SingleGraph g) {
 for (int i=0;i<g->number_of_states;i++) {
-	g->states[i]->outgoing_transitions=reverse_list(g->states[i]->outgoing_transitions);
+    g->states[i]->outgoing_transitions=reverse_list(g->states[i]->outgoing_transitions);
 }
 }
 

--- a/Snt.cpp
+++ b/Snt.cpp
@@ -39,7 +39,7 @@ namespace unitex {
 struct snt_files* new_snt_files_from_path(const char* path) {
 struct snt_files* snt_files=(struct snt_files*)malloc(sizeof(struct snt_files));
 if (snt_files==NULL) {
-	fatal_alloc_error("new_snt_files_from_path");
+    fatal_alloc_error("new_snt_files_from_path");
 }
 strcpy(snt_files->path,path);
 new_file(path,"dlf",snt_files->dlf);

--- a/SortTxt.cpp
+++ b/SortTxt.cpp
@@ -285,18 +285,18 @@ int pseudo_main_SortTxt(const VersatileEncodingConfig* vec, int duplicates,
 }
 
 const char* optstring_SortTxt = ":ndr:o:l:tfVhk:q:";
-const struct option_TS lopts_SortTxt[] = { 
-  { "no_duplicates", no_argument_TS, NULL, 'n' }, 
-  { "duplicates", no_argument_TS, NULL, 'd' }, 
-  { "reverse", no_argument_TS, NULL, 'r' }, 
-  { "sort_order", required_argument_TS, NULL, 'o' }, 
-  { "line_info", required_argument_TS, NULL, 'l' }, 
-  { "thai", no_argument_TS, NULL, 't' }, 
+const struct option_TS lopts_SortTxt[] = {
+  { "no_duplicates", no_argument_TS, NULL, 'n' },
+  { "duplicates", no_argument_TS, NULL, 'd' },
+  { "reverse", no_argument_TS, NULL, 'r' },
+  { "sort_order", required_argument_TS, NULL, 'o' },
+  { "line_info", required_argument_TS, NULL, 'l' },
+  { "thai", no_argument_TS, NULL, 't' },
   { "factorize_inflectional_codes", no_argument_TS, NULL, 'f' },
-  { "input_encoding", required_argument_TS, NULL, 'k' }, 
+  { "input_encoding", required_argument_TS, NULL, 'k' },
   { "output_encoding", required_argument_TS, NULL, 'q' },
   { "only_verify_arguments",no_argument_TS,NULL,'V'},
-  {"help", no_argument_TS, NULL, 'h' }, { NULL, no_argument_TS, NULL, 0 } 
+  {"help", no_argument_TS, NULL, 'h' }, { NULL, no_argument_TS, NULL, 0 }
 };
 
 int main_SortTxt(int argc, char* const argv[]) {
@@ -353,7 +353,7 @@ int main_SortTxt(int argc, char* const argv[]) {
       inf->factorize_inflectional_codes = 1;
       break;
     case 'V': only_verify_arguments = true;
-      break;      
+      break;
     case 'h':
       usage();
       free_sort_infos(inf);
@@ -376,7 +376,7 @@ int main_SortTxt(int argc, char* const argv[]) {
       decode_writing_encoding_parameter(&(vec.encoding_output),
           &(vec.bom_output), options.vars()->optarg);
       break;
-    case ':': 
+    case ':':
         index == -1 ? error("Missing argument for option -%c\n", options.vars()->optopt) :
                       error("Missing argument for option --%s\n",lopts_SortTxt[index].name);
         free_sort_infos(inf);
@@ -393,7 +393,7 @@ int main_SortTxt(int argc, char* const argv[]) {
   if (options.vars()->optind != argc - 1) {
     error("Invalid arguments: rerun with --help\n");
     free_sort_infos(inf);
-    return USAGE_ERROR_CODE;    
+    return USAGE_ERROR_CODE;
   }
 
   if (only_verify_arguments) {
@@ -414,7 +414,7 @@ int main_SortTxt(int argc, char* const argv[]) {
   if (inf->f == NULL) {
     error("Cannot open file %s\n", argv[options.vars()->optind]);
     free_sort_infos(inf);
-    return DEFAULT_ERROR_CODE; 
+    return DEFAULT_ERROR_CODE;
   }
 
   inf->f_out = u_fopen(&vec, new_name, U_WRITE);
@@ -448,7 +448,7 @@ int main_SortTxt(int argc, char* const argv[]) {
   af_remove(argv[options.vars()->optind]);
   af_rename(new_name, argv[options.vars()->optind]);
   free_sort_infos(inf);
-  
+
   u_printf("Done.\n");
   return SUCCESS_RETURN_CODE;
 }

--- a/SortTxt.cpp
+++ b/SortTxt.cpp
@@ -976,7 +976,7 @@ struct couple* insert_string_thai(unichar* line, struct couple* couple,
     /* If we are at the end of the list, or if we have to insert */
     tmp = new_couple(line);
     if(tmp) {
-    	tmp->next = couple;
+        tmp->next = couple;
     }
     return tmp;
   }

--- a/SpellCheck.cpp
+++ b/SpellCheck.cpp
@@ -104,7 +104,7 @@ static void usage_scores() {
       "the score, the better the hypothesis. Default values are:\n"
       "--scores=%d",N_SPSubOp,N_SPSubOp,0xE9,default_scores[0]);
   for (int i=1;i<N_SPSubOp;i++) {
-  	u_printf(",%d",default_scores[i]);
+    u_printf(",%d",default_scores[i]);
   }
   u_printf("\n\n");
 }
@@ -137,8 +137,8 @@ const struct option_TS lopts_SpellCheck[]= {
 
 int main_SpellCheck(int argc,char* const argv[]) {
 if (argc==1) {
-	usage();
-	return SUCCESS_RETURN_CODE;
+    usage();
+    return SUCCESS_RETURN_CODE;
 }
 
 VersatileEncodingConfig vec=VEC_DEFAULT;
@@ -156,7 +156,7 @@ config.max_SP_SUPPR=1;
 config.max_SP_SWAP=1;
 config.max_SP_CHANGE=1;
 for (int i=0;i<N_SPSubOp;i++) {
-	config.score[i]=default_scores[i];
+    config.score[i]=default_scores[i];
 }
 config.min_length1=4;
 config.min_length2=6;
@@ -170,119 +170,119 @@ UnitexGetOpt options;
 while (EOF!=(val=options.parse_long(argc,argv,optstring_SpellCheck,lopts_SpellCheck,&index))) {
    switch(val) {
    case 's': {
-	   strcpy(snt,options.vars()->optarg);
-	   mode='s';
-	   break;
+       strcpy(snt,options.vars()->optarg);
+       mode='s';
+       break;
    }
    case 'f': {
-	   strcpy(txt,options.vars()->optarg);
-	   mode='f';
-	   break;
+       strcpy(txt,options.vars()->optarg);
+       mode='f';
+       break;
    }
    case 'o': {
-	   if (options.vars()->optarg!=NULL) {
-		   strcpy(output,options.vars()->optarg);
-	   }
-	   output_set=1;
-	   break;
+       if (options.vars()->optarg!=NULL) {
+           strcpy(output,options.vars()->optarg);
+       }
+       output_set=1;
+       break;
    }
    case 'I': {
-	   if (!strcmp(options.vars()->optarg,"D") || !strcmp(options.vars()->optarg,"M") || !strcmp(options.vars()->optarg,"U")) {
-		   config.input_op=options.vars()->optarg[0];
-	   } else {
+       if (!strcmp(options.vars()->optarg,"D") || !strcmp(options.vars()->optarg,"M") || !strcmp(options.vars()->optarg,"U")) {
+           config.input_op=options.vars()->optarg[0];
+       } else {
        error("Invalid argument %s for option --input-op: should in [DMU]\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 'O': {
-	   if (!strcmp(options.vars()->optarg,"O") || !strcmp(options.vars()->optarg,"A")) {
-		   output_op=options.vars()->optarg[0];
-	   } else {
-		   error("Invalid argument %s for option --output-op: should in [OA]\n",options.vars()->optarg);
+       if (!strcmp(options.vars()->optarg,"O") || !strcmp(options.vars()->optarg,"A")) {
+           output_op=options.vars()->optarg[0];
+       } else {
+           error("Invalid argument %s for option --output-op: should in [OA]\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 1: {
-	   config.keyboard=get_Keyboard(options.vars()->optarg);
-	   if (config.keyboard==NULL) {
-		   error("Invalid argument %s for option --keyboard:\nUse --show-keyboards to see possible values\n",options.vars()->optarg);
+       config.keyboard=get_Keyboard(options.vars()->optarg);
+       if (config.keyboard==NULL) {
+           error("Invalid argument %s for option --keyboard:\nUse --show-keyboards to see possible values\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 2: {
-	   print_available_keyboards(U_STDOUT);
-	   return SUCCESS_RETURN_CODE;
+       print_available_keyboards(U_STDOUT);
+       return SUCCESS_RETURN_CODE;
    }
    case 10: {
-	   if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_errors,&foo)) {
-		   error("Invalid argument %s for --max-errors: should be an integer >=0\n",options.vars()->optarg);
+       if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_errors,&foo)) {
+           error("Invalid argument %s for --max-errors: should be an integer >=0\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
        }
        break;
    }
    case 11: {
-	   if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_INSERT,&foo)) {
-		   error("Invalid argument %s for --max-insert: should be an integer >=0\n",options.vars()->optarg);
+       if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_INSERT,&foo)) {
+           error("Invalid argument %s for --max-insert: should be an integer >=0\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
        }
        break;
    }
    case 12: {
-	   if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_SUPPR,&foo)) {
-		   error("Invalid argument %s for --max-suppr: should be an integer >=0\n",options.vars()->optarg);
+       if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_SUPPR,&foo)) {
+           error("Invalid argument %s for --max-suppr: should be an integer >=0\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
        }
        break;
    }
    case 13: {
-	   if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_CHANGE,&foo)) {
-		   error("Invalid argument %s for --max-change: should be an integer >=0\n",options.vars()->optarg);
+       if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_CHANGE,&foo)) {
+           error("Invalid argument %s for --max-change: should be an integer >=0\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
        }
        break;
    }
    case 14: {
-	   if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_SWAP,&foo)) {
-		   error("Invalid argument %s for --max-swap: should be an integer >=0\n",options.vars()->optarg);
+       if (1!=sscanf(options.vars()->optarg,"%u%c",&config.max_SP_SWAP,&foo)) {
+           error("Invalid argument %s for --max-swap: should be an integer >=0\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
        }
        break;
    }
    case 20: {
-	   int* scores=config.score;
-	   if (N_SPSubOp!=sscanf(options.vars()->optarg,"%d,%d,%d,%d,%d,%d,%d,%d,%d%c",
-	   		scores,scores+1,scores+2,scores+3,scores+4,scores+5,
-	   		scores+6,scores+7,scores+8,&foo)) {
-		    error("Invalid argument %s for option --scores. See --help-scores\n",options.vars()->optarg);
+       int* scores=config.score;
+       if (N_SPSubOp!=sscanf(options.vars()->optarg,"%d,%d,%d,%d,%d,%d,%d,%d,%d%c",
+            scores,scores+1,scores+2,scores+3,scores+4,scores+5,
+            scores+6,scores+7,scores+8,&foo)) {
+            error("Invalid argument %s for option --scores. See --help-scores\n",options.vars()->optarg);
         return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 21: {
-	   usage_scores();
-	   return SUCCESS_RETURN_CODE;
+       usage_scores();
+       return SUCCESS_RETURN_CODE;
    }
    case 22: {
-	   if (3!=sscanf(options.vars()->optarg,"%u,%u,%u%c",
-	   		&config.min_length1,&config.min_length2,&config.min_length3,&foo)) {
-		    error("Invalid argument %s for option --min-lengths\n",options.vars()->optarg);
+       if (3!=sscanf(options.vars()->optarg,"%u,%u,%u%c",
+            &config.min_length1,&config.min_length2,&config.min_length3,&foo)) {
+            error("Invalid argument %s for option --min-lengths\n",options.vars()->optarg);
         return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 23: {
-	   if (!strcmp(options.vars()->optarg,"yes")) {
-		   config.allow_uppercase_initial=1;
-	   } else if (!strcmp(options.vars()->optarg,"no")) {
-		   config.allow_uppercase_initial=0;
-	   } else {
-		   error("Invalid argument %s for option --upper-initial\n",options.vars()->optarg);
+       if (!strcmp(options.vars()->optarg,"yes")) {
+           config.allow_uppercase_initial=1;
+       } else if (!strcmp(options.vars()->optarg,"no")) {
+           config.allow_uppercase_initial=0;
+       } else {
+           error("Invalid argument %s for option --upper-initial\n",options.vars()->optarg);
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
@@ -328,15 +328,15 @@ if (only_verify_arguments) {
 config.n_dics=argc-options.vars()->optind;
 config.dics=(Dictionary**)malloc(config.n_dics*sizeof(Dictionary*));
 if (config.dics==NULL) {
-	alloc_error("main_SpellCheck");
+    alloc_error("main_SpellCheck");
   return ALLOC_ERROR_CODE;
 }
 
 for (int i=0;i<config.n_dics;i++) {
-	config.dics[i]=new_Dictionary(&vec,argv[i+options.vars()->optind]);
-	if (config.dics[i]==NULL) {
-		error("Cannot load dictionary %s\n",argv[i+options.vars()->optind]);
-	}
+    config.dics[i]=new_Dictionary(&vec,argv[i+options.vars()->optind]);
+    if (config.dics[i]==NULL) {
+        error("Cannot load dictionary %s\n",argv[i+options.vars()->optind]);
+    }
 }
 
 config.out=U_STDOUT;
@@ -344,53 +344,53 @@ config.n_input_lines=0;
 config.n_output_lines=0;
 
 if (mode=='s') {
-	/* When working with a .snt, we actually want to work on its err file */
-	get_snt_path(snt,txt);
-	strcat(txt,"err");
-	/* the output must be dlf, and we note the number of lines in the existing
-	 * dlf file, if any */
-	get_snt_path(snt,output);
-	strcat(output,"dlf.n");
-	U_FILE* f=u_fopen(&vec,output,U_READ);
-	if (f!=NULL) {
-		u_fscanf(f,"%d",&(config.n_output_lines));
-		u_fclose(f);
-	}
-	get_snt_path(snt,output);
-	strcat(output,"dlf");
-	output_set=1;
-	/* and we force the values for -I and -O */
-	config.input_op='U';
-	output_op='A';
+    /* When working with a .snt, we actually want to work on its err file */
+    get_snt_path(snt,txt);
+    strcat(txt,"err");
+    /* the output must be dlf, and we note the number of lines in the existing
+     * dlf file, if any */
+    get_snt_path(snt,output);
+    strcat(output,"dlf.n");
+    U_FILE* f=u_fopen(&vec,output,U_READ);
+    if (f!=NULL) {
+        u_fscanf(f,"%d",&(config.n_output_lines));
+        u_fclose(f);
+    }
+    get_snt_path(snt,output);
+    strcat(output,"dlf");
+    output_set=1;
+    /* and we force the values for -I and -O */
+    config.input_op='U';
+    output_op='A';
 } else {
-	/* If mode=='f', we don't have anything to do since we already
-	 * defined the default output to stdout */
+    /* If mode=='f', we don't have anything to do since we already
+     * defined the default output to stdout */
 }
 
 if (output_set) {
-	if (output_op=='O') {
-		config.out=u_fopen(&vec,output,U_WRITE);
-	} else {
-		config.out=u_fopen(&vec,output,U_APPEND);
-	}
-	if (config.out==NULL) {
-		error("Cannot open output file %s\n",output);
+    if (output_op=='O') {
+        config.out=u_fopen(&vec,output,U_WRITE);
+    } else {
+        config.out=u_fopen(&vec,output,U_APPEND);
+    }
+    if (config.out==NULL) {
+        error("Cannot open output file %s\n",output);
     for (int i=0;i<config.n_dics;i++) {
       free_Dictionary(config.dics[i]);
     }
     free(config.dics);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 config.modified_input=NULL;
 char modified_input[FILENAME_MAX]="";
 if (config.input_op!='D') {
-	strcpy(modified_input,txt);
-	strcat(modified_input,".tmp");
-	config.modified_input=u_fopen(&vec,modified_input,U_WRITE);
-	if (config.modified_input==NULL) {
-		error("Cannot open tmp file %s\n",modified_input);
+    strcpy(modified_input,txt);
+    strcat(modified_input,".tmp");
+    config.modified_input=u_fopen(&vec,modified_input,U_WRITE);
+    if (config.modified_input==NULL) {
+        error("Cannot open tmp file %s\n",modified_input);
     if (config.out!=U_STDOUT) {
       u_fclose(config.out);
     }
@@ -399,12 +399,12 @@ if (config.input_op!='D') {
     }
     free(config.dics);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 
 config.in=u_fopen(&vec,txt,U_READ);
 if (config.in==NULL) {
-	error("Cannot open file %s\n",txt);
+    error("Cannot open file %s\n",txt);
   u_fclose(config.modified_input);
   if (config.out!=U_STDOUT) {
     u_fclose(config.out);
@@ -442,22 +442,22 @@ free(config.dics);
 
 /* Finally, we update the dlf.n and err.n files if mode=='s' */
 if (mode=='s') {
-	get_snt_path(snt,output);
-	strcat(output,"err.n");
-	U_FILE* f=u_fopen(&vec,output,U_WRITE);
-	if (f!=NULL) {
-		u_fprintf(f,"%d",config.n_input_lines);
-		u_fclose(f);
-	}
-	if (config.input_op!='D') {
-		get_snt_path(snt,output);
-		strcat(output,"dlf.n");
-		U_FILE* fw=u_fopen(&vec,output,U_WRITE);
-		if (fw!=NULL) {
-			u_fprintf(fw,"%d",config.n_output_lines);
-			u_fclose(fw);
-		}
-	}
+    get_snt_path(snt,output);
+    strcat(output,"err.n");
+    U_FILE* f=u_fopen(&vec,output,U_WRITE);
+    if (f!=NULL) {
+        u_fprintf(f,"%d",config.n_input_lines);
+        u_fclose(f);
+    }
+    if (config.input_op!='D') {
+        get_snt_path(snt,output);
+        strcat(output,"dlf.n");
+        U_FILE* fw=u_fopen(&vec,output,U_WRITE);
+        if (fw!=NULL) {
+            u_fprintf(fw,"%d",config.n_output_lines);
+            u_fclose(fw);
+        }
+    }
 }
 
 return SUCCESS_RETURN_CODE;

--- a/SpellCheck.cpp
+++ b/SpellCheck.cpp
@@ -297,12 +297,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_SpellCheck,lopts_SpellCh
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_SpellCheck[index].name);
-             return USAGE_ERROR_CODE;           
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;
@@ -317,7 +317,7 @@ if (options.vars()->optind==argc) {
 
 if (mode==0) {
   error("You must use either --snt or --file\n");
-  return USAGE_ERROR_CODE;  
+  return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
@@ -398,7 +398,7 @@ if (config.input_op!='D') {
       free_Dictionary(config.dics[i]);
     }
     free(config.dics);
-    return DEFAULT_ERROR_CODE;    
+    return DEFAULT_ERROR_CODE;
 	}
 }
 
@@ -408,7 +408,7 @@ if (config.in==NULL) {
   u_fclose(config.modified_input);
   if (config.out!=U_STDOUT) {
     u_fclose(config.out);
-  }  
+  }
   for (int i=0;i<config.n_dics;i++) {
     free_Dictionary(config.dics[i]);
   }

--- a/SpellChecking.cpp
+++ b/SpellChecking.cpp
@@ -33,28 +33,28 @@ int default_scores[N_SPSubOp]={5,50,5,50,10,10,10,20,50};
 
 
 typedef struct SPhypothesis {
-	unichar* entry;
-	int n_errors;
-	int n_insert;
-	int n_suppr;
-	int n_swap;
-	int n_change;
-	vector_int* pairs;
-	int score;
-	struct SPhypothesis* next;
+    unichar* entry;
+    int n_errors;
+    int n_insert;
+    int n_suppr;
+    int n_swap;
+    int n_change;
+    vector_int* pairs;
+    int score;
+    struct SPhypothesis* next;
 } SpellCheckHypothesis;
 
 
 static SpellCheckHypothesis* new_SpellCheckHypothesis(unichar* entry,int current_errors,
-		int current_SP_INSERT,int current_SP_SUPPR,int current_SP_SWAP,int current_SP_CHANGE,
-		vector_int* pairs,int score[],SpellCheckHypothesis* next);
+        int current_SP_INSERT,int current_SP_SUPPR,int current_SP_SWAP,int current_SP_CHANGE,
+        vector_int* pairs,int score[],SpellCheckHypothesis* next);
 static void free_SpellCheckHypothesis(SpellCheckHypothesis* h);
 static SpellCheckHypothesis* get_hypotheses(unichar* word,SpellCheckConfig* cfg);
 static void filter_hypotheses(SpellCheckHypothesis* *list);
 static void display_hypotheses(unichar* word,SpellCheckHypothesis* list,SpellCheckConfig* cfg);
 static void free_hypotheses(SpellCheckHypothesis* list);
 static void explore_dic(int offset,unichar* word,int pos_word,Dictionary* d,SpellCheckConfig* cfg,
-		Ustring* output,SpellCheckHypothesis* *list,int base,Ustring* inflected);
+        Ustring* output,SpellCheckHypothesis* *list,int base,Ustring* inflected);
 
 
 /**
@@ -67,14 +67,14 @@ cfg->inflected=new_Ustring(256);
 cfg->output=new_Ustring(256);
 cfg->pairs=new_vector_int(16);
 while (EOF!=readline(line,cfg->in)) {
-	if (line->str[0]=='\0') {
-		/* Ignoring empty lines */
-		continue;
-	}
-	SpellCheckHypothesis* list=get_hypotheses(line->str,cfg);
-	filter_hypotheses(&list);
-	display_hypotheses(line->str,list,cfg);
-	free_hypotheses(list);
+    if (line->str[0]=='\0') {
+        /* Ignoring empty lines */
+        continue;
+    }
+    SpellCheckHypothesis* list=get_hypotheses(line->str,cfg);
+    filter_hypotheses(&list);
+    display_hypotheses(line->str,list,cfg);
+    free_hypotheses(list);
 }
 free_vector_int(cfg->pairs);
 free_Ustring(line);
@@ -96,17 +96,17 @@ cfg->current_SP_CHANGE=0;
 SPhypothesis* list=NULL;
 int old_errors=cfg->max_errors;
 if (u_strlen(word)<cfg->min_length1) {
-	cfg->max_errors=0;
+    cfg->max_errors=0;
 } else if (u_strlen(word)<cfg->min_length2) {
-	if (cfg->max_errors>=1) cfg->max_errors=1;
+    if (cfg->max_errors>=1) cfg->max_errors=1;
 } else if (u_strlen(word)<cfg->min_length3) {
-	if (cfg->max_errors>=2) cfg->max_errors=2;
+    if (cfg->max_errors>=2) cfg->max_errors=2;
 }
 for (int i=0;i<cfg->n_dics;i++) {
-	empty(cfg->output);
-	empty(cfg->inflected);
-	cfg->pairs->nbelems=0;
-	explore_dic(cfg->dics[i]->initial_state_offset,word,0,cfg->dics[i],cfg,cfg->output,&list,0,cfg->inflected);
+    empty(cfg->output);
+    empty(cfg->inflected);
+    cfg->pairs->nbelems=0;
+    explore_dic(cfg->dics[i]->initial_state_offset,word,0,cfg->dics[i],cfg,cfg->output,&list,0,cfg->inflected);
 }
 cfg->max_errors=old_errors;
 return list;
@@ -117,20 +117,20 @@ return list;
  * Deals with the matches associated to the current word.
  */
 static void deal_with_matches(Dictionary* d,unichar* inflected,int inf_code,Ustring* output,
-		SpellCheckConfig* cfg,int base,SpellCheckHypothesis* *list) {
+        SpellCheckConfig* cfg,int base,SpellCheckHypothesis* *list) {
 struct list_ustring* inf_codes=NULL;
 int should_free=get_inf_codes(d,inf_code,output,&inf_codes,base);
 if (inf_codes==NULL) {
-	fatal_error("Internal error in deal_with_matches: no inf codes associated to %S (base=%d,output=%S)\n",
-			inflected,base,output->str);
+    fatal_error("Internal error in deal_with_matches: no inf codes associated to %S (base=%d,output=%S)\n",
+            inflected,base,output->str);
 }
 struct list_ustring* tmp=inf_codes;
 while (tmp!=NULL) {
-	uncompress_entry(inflected,tmp->string,cfg->tmp);
-	*list=new_SpellCheckHypothesis(cfg->tmp->str,cfg->current_errors,cfg->current_SP_INSERT,
-			cfg->current_SP_SUPPR,cfg->current_SP_SWAP,cfg->current_SP_CHANGE,cfg->pairs,
-			cfg->score,*list);
-	tmp=tmp->next;
+    uncompress_entry(inflected,tmp->string,cfg->tmp);
+    *list=new_SpellCheckHypothesis(cfg->tmp->str,cfg->current_errors,cfg->current_SP_INSERT,
+            cfg->current_SP_SUPPR,cfg->current_SP_SWAP,cfg->current_SP_CHANGE,cfg->pairs,
+            cfg->score,*list);
+    tmp=tmp->next;
 }
 if (should_free) free_list_ustring(inf_codes);
 }
@@ -149,12 +149,12 @@ if (c!=word[pos_word-1]) return 0;
 if (inflected->len==0 || (inflected->str[inflected->len-1]!=word[pos_word])) return 0;
 /* The previous operation must a SP_CHANGE_XXX one */
 if (cfg->pairs->nbelems==0 ||
-		!(cfg->pairs->tab[cfg->pairs->nbelems-2]==pos_word-1
-				&& (cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_DIACRITIC
-						|| cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_CASE
-						|| cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_KEYBOARD
-						|| cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_DEFAULT))) {
-	return 0;
+        !(cfg->pairs->tab[cfg->pairs->nbelems-2]==pos_word-1
+                && (cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_DIACRITIC
+                        || cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_CASE
+                        || cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_KEYBOARD
+                        || cfg->pairs->tab[cfg->pairs->nbelems-1]==SP_CHANGE_DEFAULT))) {
+    return 0;
 }
 return 1;
 }
@@ -164,7 +164,7 @@ return 1;
  * Explores the given dictionary to match the given word.
  */
 static void explore_dic(int offset,unichar* word,int pos_word,Dictionary* d,SpellCheckConfig* cfg,
-		Ustring* output,SpellCheckHypothesis* *list,int base,Ustring* inflected) {
+        Ustring* output,SpellCheckHypothesis* *list,int base,Ustring* inflected) {
 int original_offset=offset;
 int original_base=base;
 int final,n_transitions,inf_code;
@@ -172,137 +172,137 @@ int z=save_output(output);
 int size_pairs=cfg->pairs->nbelems;
 offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_code);
 if (final) {
-	if (word[pos_word]=='\0') {
-		/* If we have a match */
-		deal_with_matches(d,inflected->str,inf_code,output,cfg,base,list);
-	}
-	base=output->len;
+    if (word[pos_word]=='\0') {
+        /* If we have a match */
+        deal_with_matches(d,inflected->str,inf_code,output,cfg,base,list);
+    }
+    base=output->len;
 }
 /* If we are at the end of the token, then we stop */
 if (word[pos_word]=='\0') {
-	return;
+    return;
 }
 unsigned int l2=inflected->len;
 unichar c;
 int dest_offset;
 for (int i=0;i<n_transitions;i++) {
-	restore_output(z,output);
-	offset=read_dictionary_transition(d,offset,&c,&dest_offset,output);
-	/* For backup_output, see comment below */
-	int backup_output=save_output(output);
-	if (c==word[pos_word] || word[pos_word]==u_toupper(c)) {
-		u_strcat(inflected,c);
-		explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-	} else {
-		/* We deal with the SP_SWAP case, made of 2 SP_CHANGE_XXX */
-		if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_SWAP!=cfg->max_SP_SWAP
-				&& is_letter_swap(cfg,word,pos_word,inflected,c)) {
-			/* We don't modify the number of errors since we override an existing
-			 * SP_CHANGE_XXX one */
-			cfg->current_SP_SWAP++;
-			/* We override the previous change */
-			int a=cfg->pairs->tab[cfg->pairs->nbelems-2];
-			int b=cfg->pairs->tab[cfg->pairs->nbelems-1];
-			cfg->pairs->tab[cfg->pairs->nbelems-2]=pos_word-1;
-			cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_SWAP_DEFAULT;
-			u_strcat(inflected,c);
-			explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-			cfg->pairs->tab[cfg->pairs->nbelems-2]=a;
-			cfg->pairs->tab[cfg->pairs->nbelems-1]=b;
-			cfg->current_SP_SWAP--;
-		} else /* We deal with the SP_CHANGE case */
-		       if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_CHANGE!=cfg->max_SP_CHANGE
-				/* We want letters, not spaces or anything else */
-				&& is_letter(c,NULL)
-		        /* We do not allow the replacement of a lowercase letter by an uppercase
-		         * letter at the beginning of the word like Niserable, unless the whole word
-		         * is in uppercase or the letter is the same, module the case */
-		        && (cfg->allow_uppercase_initial || pos_word>0 || (!is_upper(word[0],NULL) || is_upper(word[1],NULL) || word[0]==u_toupper(c)))) {
-			cfg->current_errors++;
-			cfg->current_SP_CHANGE++;
-			/* Now we test all possible kinds of change */
-			vector_int_add(cfg->pairs,pos_word);
-			u_strcat(inflected,c);
-			/* We always add the default case */
-			vector_int_add(cfg->pairs,SP_CHANGE_DEFAULT);
-			int n_elem=cfg->pairs->nbelems;
-			explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-			/* Then we test the accent case */
-			if (u_deaccentuate(c)==u_deaccentuate(word[pos_word])) {
-				/* After a call to explore_dic, we must restore the output.
-				 * But, when dealing with SP_CHANGE_XXX ops, we must restore the
-				 * output including the output associated to the current transition,
-				 * which is why we don't use z (output before the current transition)
-				 * but backup_output */
-				restore_output(backup_output,output);
-			    cfg->pairs->nbelems=n_elem;
-			    cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_DIACRITIC;
-			    explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-			}
-			/* And the case variations */
-			if (u_tolower(c)==u_tolower(word[pos_word])) {
-			    restore_output(backup_output,output);
-			    cfg->pairs->nbelems=n_elem;
-				cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_CASE;
-				explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-			}
-			/* And finally the position on keyboard */
-			if (areCloseOnKeyboard(c,word[pos_word],cfg->keyboard)) {
-			    restore_output(backup_output,output);
-			    cfg->pairs->nbelems=n_elem;
-				cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_KEYBOARD;
-				explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
-			}
-			cfg->pairs->nbelems=size_pairs;
-			cfg->current_errors--;
-			cfg->current_SP_CHANGE--;
-			/* End of the SP_CHANGE case */
-		}
-	}
+    restore_output(z,output);
+    offset=read_dictionary_transition(d,offset,&c,&dest_offset,output);
+    /* For backup_output, see comment below */
+    int backup_output=save_output(output);
+    if (c==word[pos_word] || word[pos_word]==u_toupper(c)) {
+        u_strcat(inflected,c);
+        explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+    } else {
+        /* We deal with the SP_SWAP case, made of 2 SP_CHANGE_XXX */
+        if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_SWAP!=cfg->max_SP_SWAP
+                && is_letter_swap(cfg,word,pos_word,inflected,c)) {
+            /* We don't modify the number of errors since we override an existing
+             * SP_CHANGE_XXX one */
+            cfg->current_SP_SWAP++;
+            /* We override the previous change */
+            int a=cfg->pairs->tab[cfg->pairs->nbelems-2];
+            int b=cfg->pairs->tab[cfg->pairs->nbelems-1];
+            cfg->pairs->tab[cfg->pairs->nbelems-2]=pos_word-1;
+            cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_SWAP_DEFAULT;
+            u_strcat(inflected,c);
+            explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+            cfg->pairs->tab[cfg->pairs->nbelems-2]=a;
+            cfg->pairs->tab[cfg->pairs->nbelems-1]=b;
+            cfg->current_SP_SWAP--;
+        } else /* We deal with the SP_CHANGE case */
+               if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_CHANGE!=cfg->max_SP_CHANGE
+                /* We want letters, not spaces or anything else */
+                && is_letter(c,NULL)
+                /* We do not allow the replacement of a lowercase letter by an uppercase
+                 * letter at the beginning of the word like Niserable, unless the whole word
+                 * is in uppercase or the letter is the same, module the case */
+                && (cfg->allow_uppercase_initial || pos_word>0 || (!is_upper(word[0],NULL) || is_upper(word[1],NULL) || word[0]==u_toupper(c)))) {
+            cfg->current_errors++;
+            cfg->current_SP_CHANGE++;
+            /* Now we test all possible kinds of change */
+            vector_int_add(cfg->pairs,pos_word);
+            u_strcat(inflected,c);
+            /* We always add the default case */
+            vector_int_add(cfg->pairs,SP_CHANGE_DEFAULT);
+            int n_elem=cfg->pairs->nbelems;
+            explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+            /* Then we test the accent case */
+            if (u_deaccentuate(c)==u_deaccentuate(word[pos_word])) {
+                /* After a call to explore_dic, we must restore the output.
+                 * But, when dealing with SP_CHANGE_XXX ops, we must restore the
+                 * output including the output associated to the current transition,
+                 * which is why we don't use z (output before the current transition)
+                 * but backup_output */
+                restore_output(backup_output,output);
+                cfg->pairs->nbelems=n_elem;
+                cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_DIACRITIC;
+                explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+            }
+            /* And the case variations */
+            if (u_tolower(c)==u_tolower(word[pos_word])) {
+                restore_output(backup_output,output);
+                cfg->pairs->nbelems=n_elem;
+                cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_CASE;
+                explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+            }
+            /* And finally the position on keyboard */
+            if (areCloseOnKeyboard(c,word[pos_word],cfg->keyboard)) {
+                restore_output(backup_output,output);
+                cfg->pairs->nbelems=n_elem;
+                cfg->pairs->tab[cfg->pairs->nbelems-1]=SP_CHANGE_KEYBOARD;
+                explore_dic(dest_offset,word,pos_word+1,d,cfg,output,list,base,inflected);
+            }
+            cfg->pairs->nbelems=size_pairs;
+            cfg->current_errors--;
+            cfg->current_SP_CHANGE--;
+            /* End of the SP_CHANGE case */
+        }
+    }
     restore_output(backup_output,output);
-	truncate(inflected,l2);
-	/* Now we deal with the SP_SUPPR case */
-	if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_SUPPR!=cfg->max_SP_SUPPR
-		/* We want letters, not spaces or anything else */
-		&& is_letter(c,NULL)) {
-		cfg->current_errors++;
-		cfg->current_SP_SUPPR++;
-		vector_int_add(cfg->pairs,pos_word);
-		if (pos_word>=1 && c==word[pos_word-1]) {
-			vector_int_add(cfg->pairs,SP_SUPPR_DOUBLE);
-		} else {
-			vector_int_add(cfg->pairs,SP_SUPPR_DEFAULT);
-		}
-		u_strcat(inflected,c);
-		explore_dic(dest_offset,word,pos_word,d,cfg,output,list,original_base,inflected);
-		truncate(inflected,l2);
-		cfg->pairs->nbelems=size_pairs;
-		cfg->current_errors--;
-		cfg->current_SP_SUPPR--;
-	}
+    truncate(inflected,l2);
+    /* Now we deal with the SP_SUPPR case */
+    if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_SUPPR!=cfg->max_SP_SUPPR
+        /* We want letters, not spaces or anything else */
+        && is_letter(c,NULL)) {
+        cfg->current_errors++;
+        cfg->current_SP_SUPPR++;
+        vector_int_add(cfg->pairs,pos_word);
+        if (pos_word>=1 && c==word[pos_word-1]) {
+            vector_int_add(cfg->pairs,SP_SUPPR_DOUBLE);
+        } else {
+            vector_int_add(cfg->pairs,SP_SUPPR_DEFAULT);
+        }
+        u_strcat(inflected,c);
+        explore_dic(dest_offset,word,pos_word,d,cfg,output,list,original_base,inflected);
+        truncate(inflected,l2);
+        cfg->pairs->nbelems=size_pairs;
+        cfg->current_errors--;
+        cfg->current_SP_SUPPR--;
+    }
 }
 restore_output(z,output);
 /* Finally, we deal with the SP_INSERT case, by calling again the current
  * function with the same parameters, except pos_word that will be increased of 1 */
 if (cfg->current_errors!=cfg->max_errors && cfg->current_SP_INSERT!=cfg->max_SP_INSERT
-	/* We want letters, not spaces or anything else */
-	&& is_letter(word[pos_word],NULL)
-	/* We do not allow the insertion of a capital letter at the beginning of
-	 * the word like Astreet, unless the whole word is in uppercase like ASTREET */
+    /* We want letters, not spaces or anything else */
+    && is_letter(word[pos_word],NULL)
+    /* We do not allow the insertion of a capital letter at the beginning of
+     * the word like Astreet, unless the whole word is in uppercase like ASTREET */
     && (cfg->allow_uppercase_initial || pos_word>0 || (!is_upper(word[0],NULL) || is_upper(word[1],NULL)))) {
-	cfg->current_errors++;
-	cfg->current_SP_INSERT++;
-	vector_int_add(cfg->pairs,pos_word);
-	if (pos_word>=1 && word[pos_word]==word[pos_word-1]) {
-		vector_int_add(cfg->pairs,SP_INSERT_DOUBLE);
-	} else {
-		vector_int_add(cfg->pairs,SP_INSERT_DEFAULT);
-	}
-	explore_dic(original_offset,word,pos_word+1,d,cfg,output,list,original_base,inflected);
-	truncate(inflected,l2);
-	cfg->pairs->nbelems=size_pairs;
-	cfg->current_errors--;
-	cfg->current_SP_INSERT--;
+    cfg->current_errors++;
+    cfg->current_SP_INSERT++;
+    vector_int_add(cfg->pairs,pos_word);
+    if (pos_word>=1 && word[pos_word]==word[pos_word-1]) {
+        vector_int_add(cfg->pairs,SP_INSERT_DOUBLE);
+    } else {
+        vector_int_add(cfg->pairs,SP_INSERT_DEFAULT);
+    }
+    explore_dic(original_offset,word,pos_word+1,d,cfg,output,list,original_base,inflected);
+    truncate(inflected,l2);
+    cfg->pairs->nbelems=size_pairs;
+    cfg->current_errors--;
+    cfg->current_SP_INSERT--;
 }
 /* Finally, we restore the output as it was when we enter the function */
 restore_output(z,output);
@@ -315,10 +315,10 @@ restore_output(z,output);
 static SpellCheckHypothesis* remove_uninteresting_hypotheses(SpellCheckHypothesis* h,int n,int score) {
 if (h==NULL) return NULL;
 if (h->n_errors>n || h->score>score) {
-	/* We have to remove the current hypothesis */
-	SpellCheckHypothesis* tmp=h->next;
-	free_SpellCheckHypothesis(h);
-	return remove_uninteresting_hypotheses(tmp,n,score);
+    /* We have to remove the current hypothesis */
+    SpellCheckHypothesis* tmp=h->next;
+    free_SpellCheckHypothesis(h);
+    return remove_uninteresting_hypotheses(tmp,n,score);
 }
 h->next=remove_uninteresting_hypotheses(h->next,n,score);
 return h;
@@ -335,9 +335,9 @@ int min=(*list)->n_errors;
 int score_min=(*list)->score;
 SpellCheckHypothesis* tmp=(*list)->next;
 while (tmp!=NULL) {
-	if (tmp->n_errors<min) min=tmp->n_errors;
-	if (tmp->score<score_min) score_min=tmp->score;
-	tmp=tmp->next;
+    if (tmp->n_errors<min) min=tmp->n_errors;
+    if (tmp->score<score_min) score_min=tmp->score;
+    tmp=tmp->next;
 }
 /* Then, we remove all hypotheses involving more than 'min' errors,
  * or with a score greater than the minimum score */
@@ -353,30 +353,30 @@ static void display_hypotheses(unichar* word,SpellCheckHypothesis* list,SpellChe
 Ustring* line=new_Ustring(128);
 int printed=0;
 while (list!=NULL) {
-	printed=1;
-	struct dela_entry* entry=tokenize_DELAF_line(list->entry);
-	if (entry==NULL) {
-		fatal_error("Internal error in display_hypotheses; cannot tokenize entry:\n%S\n",list->entry);
-	}
-	unichar* inflected=entry->inflected;
-	entry->inflected=u_strdup(word);
-	entry->semantic_codes[entry->n_semantic_codes++]=u_strdup("SP_ERR");
-	u_sprintf(line,"SP_INF=%S",inflected);
-	entry->semantic_codes[entry->n_semantic_codes++]=u_strdup(line->str);
-	dela_entry_to_string(line,entry);
-	u_fprintf(cfg->out,"%S/score=%d\n",line->str,list->score);
-	free(inflected);
-	free_dela_entry(entry);
-	list=list->next;
+    printed=1;
+    struct dela_entry* entry=tokenize_DELAF_line(list->entry);
+    if (entry==NULL) {
+        fatal_error("Internal error in display_hypotheses; cannot tokenize entry:\n%S\n",list->entry);
+    }
+    unichar* inflected=entry->inflected;
+    entry->inflected=u_strdup(word);
+    entry->semantic_codes[entry->n_semantic_codes++]=u_strdup("SP_ERR");
+    u_sprintf(line,"SP_INF=%S",inflected);
+    entry->semantic_codes[entry->n_semantic_codes++]=u_strdup(line->str);
+    dela_entry_to_string(line,entry);
+    u_fprintf(cfg->out,"%S/score=%d\n",line->str,list->score);
+    free(inflected);
+    free_dela_entry(entry);
+    list=list->next;
 }
 free_Ustring(line);
 /* Now, we may have to print the word to the modified input file */
 if (cfg->input_op=='M') {
-	/* If we must keep matched words, then we print the word if it had matched */
-	if (printed) u_fprintf(cfg->modified_input,"%S\n",word);
+    /* If we must keep matched words, then we print the word if it had matched */
+    if (printed) u_fprintf(cfg->modified_input,"%S\n",word);
 } else if (cfg->input_op=='U') {
-	/* If we must keep unmatched words, then we print the word if it had matched */
-	if (!printed) u_fprintf(cfg->modified_input,"%S\n",word);
+    /* If we must keep unmatched words, then we print the word if it had matched */
+    if (!printed) u_fprintf(cfg->modified_input,"%S\n",word);
 }
 }
 
@@ -385,8 +385,8 @@ if (cfg->input_op=='M') {
  * Creates a new hypothesis.
  */
 SpellCheckHypothesis* new_SpellCheckHypothesis(unichar* entry,int current_errors,
-		int current_SP_INSERT,int current_SP_SUPPR,int current_SP_SWAP,int current_SP_CHANGE,
-		vector_int* pairs,int score[],SpellCheckHypothesis* next) {
+        int current_SP_INSERT,int current_SP_SUPPR,int current_SP_SWAP,int current_SP_CHANGE,
+        vector_int* pairs,int score[],SpellCheckHypothesis* next) {
 SpellCheckHypothesis* h=(SpellCheckHypothesis*)malloc(sizeof(SpellCheckHypothesis));
 h->entry=u_strdup(entry);
 h->n_errors=current_errors;
@@ -397,7 +397,7 @@ h->n_change=current_SP_CHANGE;
 h->pairs=vector_int_dup(pairs);
 h->score=0;
 for (int i=0;i<h->pairs->nbelems;i+=2) {
-	h->score=h->score+score[h->pairs->tab[i+1]];
+    h->score=h->score+score[h->pairs->tab[i+1]];
 }
 h->next=next;
 return h;
@@ -422,9 +422,9 @@ free(h);
 static void free_hypotheses(SpellCheckHypothesis* l) {
 SpellCheckHypothesis* tmp;
 while (l!=NULL) {
-	tmp=l;
-	l=l->next;
-	free_SpellCheckHypothesis(tmp);
+    tmp=l;
+    l=l->next;
+    free_SpellCheckHypothesis(tmp);
 }
 }
 

--- a/SpellChecking.h
+++ b/SpellChecking.h
@@ -38,10 +38,10 @@ namespace unitex {
  * Here are the four main kinds of tolerated errors.
  */
 typedef enum {
-	SP_INSERT, 	/* happy => hazppy */
-	SP_SUPPR,	/* happy => hapy */
-	SP_SWAP,	/* happy => hpapy */
-	SP_CHANGE	/* happy => hzppy */
+    SP_INSERT,  /* happy => hazppy */
+    SP_SUPPR,   /* happy => hapy */
+    SP_SWAP,    /* happy => hpapy */
+    SP_CHANGE   /* happy => hzppy */
 } SPBasicOp;
 
 
@@ -49,90 +49,90 @@ typedef enum {
  * Here are the subtypes of tolerated errors.
  */
 typedef enum {
-	/* Subtypes for SP_INSERT */
-	SP_INSERT_DOUBLE,	/* devil => devvil */
-	SP_INSERT_DEFAULT,	/* anything else */
-	/* Subtypes for SP_SUPPR */
-	SP_SUPPR_DOUBLE,	/* battle => batle */
-	SP_SUPPR_DEFAULT,	/* anything else */
-	/* There is not subtypes for SP_SWAP, but this declaration is
-	 * made to be consistent with other SPBasicOp values */
-	SP_SWAP_DEFAULT,
-	/* Subtypes for SP_CHANGE */
-	SP_CHANGE_DIACRITIC,	/* étaient => etaient */
-	SP_CHANGE_CASE,			/* London => london */
-	SP_CHANGE_KEYBOARD,		/* battle => bzttle (since z is close to a on the keyboard) */
-	SP_CHANGE_DEFAULT,		/* anything else */
+    /* Subtypes for SP_INSERT */
+    SP_INSERT_DOUBLE,   /* devil => devvil */
+    SP_INSERT_DEFAULT,  /* anything else */
+    /* Subtypes for SP_SUPPR */
+    SP_SUPPR_DOUBLE,    /* battle => batle */
+    SP_SUPPR_DEFAULT,   /* anything else */
+    /* There is not subtypes for SP_SWAP, but this declaration is
+     * made to be consistent with other SPBasicOp values */
+    SP_SWAP_DEFAULT,
+    /* Subtypes for SP_CHANGE */
+    SP_CHANGE_DIACRITIC,    /* étaient => etaient */
+    SP_CHANGE_CASE,         /* London => london */
+    SP_CHANGE_KEYBOARD,     /* battle => bzttle (since z is close to a on the keyboard) */
+    SP_CHANGE_DEFAULT,      /* anything else */
 
-	/* This last line is used to know the number of SPSubOp that have been defined */
-	N_SPSubOp
+    /* This last line is used to know the number of SPSubOp that have been defined */
+    N_SPSubOp
 } SPSubOp;
 
 
 typedef struct {
-	/* The file we read from words to check */
-	U_FILE* in;
-	/* The file where we print the analysis */
-	U_FILE* out;
-	/* Do we want to modify the input file ? (see SpellCheck usage for possible values) */
-	char input_op;
-	/* If we want to modify the input file, here is the tmp file pointer to use */
-	U_FILE* modified_input;
-	/* Number of lines printed in modified_input */
-	int n_input_lines;
-	/* Number of lines printed in out */
-	int n_output_lines;
-	/* The dictionaries to lookup in for spellchecking */
-	Dictionary** dics;
-	int n_dics;
-	/* The keyboard to use to test whether two letters are
-	 * geographically close or not */
-	Keyboard* keyboard;
+    /* The file we read from words to check */
+    U_FILE* in;
+    /* The file where we print the analysis */
+    U_FILE* out;
+    /* Do we want to modify the input file ? (see SpellCheck usage for possible values) */
+    char input_op;
+    /* If we want to modify the input file, here is the tmp file pointer to use */
+    U_FILE* modified_input;
+    /* Number of lines printed in modified_input */
+    int n_input_lines;
+    /* Number of lines printed in out */
+    int n_output_lines;
+    /* The dictionaries to lookup in for spellchecking */
+    Dictionary** dics;
+    int n_dics;
+    /* The keyboard to use to test whether two letters are
+     * geographically close or not */
+    Keyboard* keyboard;
 
-	/* Current and maximum number of errors tolerated in one word */
-	unsigned int current_errors;
-	unsigned int max_errors;
-	/* Current and maximum number of errors tolerated for each kind of error */
-	unsigned int current_SP_INSERT;
-	unsigned int current_SP_SUPPR;
-	unsigned int current_SP_SWAP;
-	unsigned int current_SP_CHANGE;
-	unsigned int max_SP_INSERT;
-	unsigned int max_SP_SUPPR;
-	unsigned int max_SP_SWAP;
-	unsigned int max_SP_CHANGE;
+    /* Current and maximum number of errors tolerated in one word */
+    unsigned int current_errors;
+    unsigned int max_errors;
+    /* Current and maximum number of errors tolerated for each kind of error */
+    unsigned int current_SP_INSERT;
+    unsigned int current_SP_SUPPR;
+    unsigned int current_SP_SWAP;
+    unsigned int current_SP_CHANGE;
+    unsigned int max_SP_INSERT;
+    unsigned int max_SP_SUPPR;
+    unsigned int max_SP_SWAP;
+    unsigned int max_SP_CHANGE;
 
-	/* Minimum word length required to tolerate 1, 2 or 3+ errors */
-	unsigned int min_length1;
-	unsigned int min_length2;
-	unsigned int min_length3;
+    /* Minimum word length required to tolerate 1, 2 or 3+ errors */
+    unsigned int min_length1;
+    unsigned int min_length2;
+    unsigned int min_length3;
 
-	/* This array associates a score to each kind of error.
-	 * The bigger the score, the more unlikely the error */
-	int score[N_SPSubOp];
+    /* This array associates a score to each kind of error.
+     * The bigger the score, the more unlikely the error */
+    int score[N_SPSubOp];
 
-	/* tmp strings, to avoid multiple allocations */
-	Ustring* tmp;
-	Ustring* inflected;
-	Ustring* output;
+    /* tmp strings, to avoid multiple allocations */
+    Ustring* tmp;
+    Ustring* inflected;
+    Ustring* output;
 
-	/* This vector must contain pairs of integer (pos,op), where
-	 * pos is the position of the event in the input word and op is the
-	 * value of the SPSubOp corresponding to the given event.
-	 * The meaning of pos is as follows:
-	 *
-	 * SP_INSERT_XXX: position of the extra char => pos=4 for happ(t)y
-	 * SP_SUPPR_XXX:  position in the input word of the missing char
-	 *                => pos=1 for h(a)pp
-	 *                => pos=3 for hpp(y) (if we already tolerated the suppression of 'a')
-	 * SP_SWAP_DEFAULT: position of the first swapped char => pos=1 for h(pa)py
-	 * SP_CHANGE_XXX: position of the modified char => pos=1 for h(z)ppy
-	 */
-	vector_int* pairs;
+    /* This vector must contain pairs of integer (pos,op), where
+     * pos is the position of the event in the input word and op is the
+     * value of the SPSubOp corresponding to the given event.
+     * The meaning of pos is as follows:
+     *
+     * SP_INSERT_XXX: position of the extra char => pos=4 for happ(t)y
+     * SP_SUPPR_XXX:  position in the input word of the missing char
+     *                => pos=1 for h(a)pp
+     *                => pos=3 for hpp(y) (if we already tolerated the suppression of 'a')
+     * SP_SWAP_DEFAULT: position of the first swapped char => pos=1 for h(pa)py
+     * SP_CHANGE_XXX: position of the modified char => pos=1 for h(z)ppy
+     */
+    vector_int* pairs;
 
-	/* Do we allow SP_INSERT or SP_CHANGE involving an uppercase as the first letter
-	 * of the word to analyze? */
-	int allow_uppercase_initial;
+    /* Do we allow SP_INSERT or SP_CHANGE involving an uppercase as the first letter
+     * of the word to analyze? */
+    int allow_uppercase_initial;
 } SpellCheckConfig;
 
 extern int default_scores[N_SPSubOp];

--- a/Stack_unichar.h
+++ b/Stack_unichar.h
@@ -58,12 +58,12 @@ static inline void resize(struct stack_unichar* stack,int minimum_new_size) {
 int new_size=stack->capacity;
 if (new_size==0) new_size=1;
 while (new_size<minimum_new_size) {
-	new_size=new_size*2;
+    new_size=new_size*2;
 }
 if (new_size==stack->capacity) return;
 stack->stack=(unichar*)realloc(stack->stack,new_size*sizeof(unichar));
 if (stack->stack==NULL) {
-	fatal_alloc_error("resize");
+    fatal_alloc_error("resize");
 }
 stack->capacity=new_size;
 }
@@ -73,7 +73,7 @@ if (stack==NULL) {
    fatal_error_NULL_push();
 }
 if (stack->stack_pointer==stack->capacity-1) {
-	resize(stack,stack->capacity+1);
+    resize(stack,stack->capacity+1);
 }
 stack->stack[++(stack->stack_pointer)]=c;
 }

--- a/Stats.cpp
+++ b/Stats.cpp
@@ -591,12 +591,12 @@ int build_counted_concord(match_list* matches, text_tokens* tokens, U_FILE* cod,
 
   // we initialize buffer to encompass 4096 tokens from starting position
   int get_buffer_return_value = get_buffer_around_token(cod,
-  	                                                    &buffer,
-  	                                                    0,
-  	                                                    0,
-  	                                                    STATS_BUFFER_LENGTH,
-  	                                                    &buff_start,
-  	                                                    &buff_end);
+                                                        &buffer,
+                                                        0,
+                                                        0,
+                                                        STATS_BUFFER_LENGTH,
+                                                        &buff_start,
+                                                        &buff_end);
   if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
     free(buffer);
     return get_buffer_return_value;
@@ -695,12 +695,12 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
 
   // we initialize buffer to encompass 4096 tokens from starting position
   int get_buffer_return_value = get_buffer_around_token(cod,
-  	                                                    &buffer,
-  	                                                    0,
-  	                                                    0,
-  	                                                    STATS_BUFFER_LENGTH,
-  	                                                    &buff_start,
-  	                                                    &buff_end);
+                                                        &buffer,
+                                                        0,
+                                                        0,
+                                                        STATS_BUFFER_LENGTH,
+                                                        &buff_start,
+                                                        &buff_end);
 
   if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
     free(buffer);
@@ -714,7 +714,7 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
 
   vector_int* allMatches        = new_vector_int();
   hash_table* countPerCollocate = new_hash_table(hash_token_as_int,
-  	                                             tokens_as_int_equal,
+                                                 tokens_as_int_equal,
                                                  free_token_as_int,
                                                  NULL,
                                                  copy_token_as_int);
@@ -733,16 +733,16 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
   // for all matches, we form list of token IDs and check it against hash table
   while(current_match != NULL) {
     currentMatchList = get_string_in_context_as_token_list(current_match,
-    	                                                     leftContext,
-    	                                                     rightContext,
-    	                                                     &buffer,
-    	                                                     &buff_start,
-    	                                                     &buff_end,
-    	                                                     codSize,
-    	                                                     tokens,
-    	                                                     cod,
-    	                                                     0,
-    	                                                     NULL);
+                                                             leftContext,
+                                                             rightContext,
+                                                             &buffer,
+                                                             &buff_start,
+                                                             &buff_end,
+                                                             codSize,
+                                                             tokens,
+                                                             cod,
+                                                             0,
+                                                             NULL);
 
     // now we don't just insert the whole match as we did in build_counted_concord, but
     // for each token in the left and right context we treat it as a possible entry to a hash
@@ -820,12 +820,12 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
 
   // now we count all collocates in corpus
   int count_collocates_return_value = count_collocates(cod,
-  	                                                   tokens,
-  	                                                   alphabet,
-  	                                                   caseSensitive,
-  	                                                   countPerCollocate,
-  	                                                   &collocateCountInCorpora,
-  	                                                   &corporaLength);
+                                                       tokens,
+                                                       alphabet,
+                                                       caseSensitive,
+                                                       countPerCollocate,
+                                                       &collocateCountInCorpora,
+                                                       &corporaLength);
 
   // return when count_collocates() fails
   if (count_collocates_return_value != SUCCESS_RETURN_CODE) {
@@ -895,12 +895,12 @@ int count_collocates(U_FILE* cod, text_tokens* tokens, Alphabet* alphabet, int c
   long bufferEnd;
 
   int get_buffer_return_value = get_buffer_around_token(cod,
-  	                                                    &buffer,
-  	                                                    0,
-  	                                                    0,
-  	                                                    STATS_BUFFER_LENGTH,
-  	                                                    &bufferStart,
-  	                                                    &bufferEnd);
+                                                        &buffer,
+                                                        0,
+                                                        0,
+                                                        STATS_BUFFER_LENGTH,
+                                                        &bufferStart,
+                                                        &bufferEnd);
 
   if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
     free(buffer);
@@ -908,10 +908,10 @@ int count_collocates(U_FILE* cod, text_tokens* tokens, Alphabet* alphabet, int c
   }
 
   hash_table* ret = new_hash_table(hash_token_as_int,
-  	                               tokens_as_int_equal,
-  	                               free_token_as_int,
-  	                               NULL,
-  	                               copy_token_as_int);
+                                   tokens_as_int_equal,
+                                   free_token_as_int,
+                                   NULL,
+                                   copy_token_as_int);
 
   *corpora_length = 0;
   int_CS_tag* currentKey = NULL;
@@ -922,12 +922,12 @@ int count_collocates(U_FILE* cod, text_tokens* tokens, Alphabet* alphabet, int c
   for (i = 0 ; i < codSize ; i++) {
     if (i < bufferStart || i > bufferEnd) {
       get_buffer_return_value = get_buffer_around_token(cod,
-      	                                                &buffer,
-      	                                                i,
-      	                                                0,
-      	                                                STATS_BUFFER_LENGTH,
-      	                                                &bufferStart,
-      	                                                &bufferEnd);
+                                                        &buffer,
+                                                        i,
+                                                        0,
+                                                        STATS_BUFFER_LENGTH,
+                                                        &bufferStart,
+                                                        &bufferEnd);
       if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
         free(buffer);
         return get_buffer_return_value;
@@ -1021,12 +1021,12 @@ vector_int* get_string_in_context_as_token_list(match_list* match, int leftConte
     if (startFrom < *bufferStart || startFrom > *bufferEnd) {
       // request new buffer
       get_buffer_return_value = get_buffer_around_token(source,
-      	                                                buffer,
-      	                                                startFrom,
-      	                                                STATS_BUFFER_LENGTH,
-      	                                                0,
-      	                                                bufferStart,
-      	                                                bufferEnd);
+                                                        buffer,
+                                                        startFrom,
+                                                        STATS_BUFFER_LENGTH,
+                                                        0,
+                                                        bufferStart,
+                                                        bufferEnd);
       if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
         return NULL;
       }
@@ -1049,12 +1049,12 @@ vector_int* get_string_in_context_as_token_list(match_list* match, int leftConte
     if (endAt > *bufferEnd || endAt < *bufferStart) {
       // request new buffer
        get_buffer_return_value = get_buffer_around_token(source,
-       	                                                 buffer,
-       	                                                 endAt,
-       	                                                 0,
-       	                                                 STATS_BUFFER_LENGTH,
-       	                                                 bufferStart,
-       	                                                 bufferEnd);
+                                                         buffer,
+                                                         endAt,
+                                                         0,
+                                                         STATS_BUFFER_LENGTH,
+                                                         bufferStart,
+                                                         bufferEnd);
       if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
         return NULL;
       }
@@ -1074,12 +1074,12 @@ vector_int* get_string_in_context_as_token_list(match_list* match, int leftConte
 
     if (i < *bufferStart || i > *bufferEnd) {
       int get_buffer_around_token_return_value = get_buffer_around_token(source,
-      	                                                    buffer,
-      	                                                    i,
-      	                                                    0,
-      	                                                    STATS_BUFFER_LENGTH,
-      	                                                    bufferStart,
-      	                                                    bufferEnd);
+                                                            buffer,
+                                                            i,
+                                                            0,
+                                                            STATS_BUFFER_LENGTH,
+                                                            bufferStart,
+                                                            bufferEnd);
       if(get_buffer_around_token_return_value != SUCCESS_RETURN_CODE) {
         return NULL;
       }

--- a/Stats.cpp
+++ b/Stats.cpp
@@ -161,7 +161,7 @@ const struct option_TS lopts_Stats[]= {
   {"input_encoding",required_argument_TS,NULL,'k'},
   {"output_encoding",required_argument_TS,NULL,'q'},
   {"only_verify_arguments",no_argument_TS,NULL,'V'},
-  {"help",no_argument_TS,NULL,'h'},      
+  {"help",no_argument_TS,NULL,'h'},
   {0, 0, 0, 0 }
  } ;
 
@@ -229,12 +229,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Stats,lopts_Stats,&index
             decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
             break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
-             return SUCCESS_RETURN_CODE;            
+             break;
+   case 'h': usage();
+             return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Stats[index].name);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;
@@ -262,12 +262,12 @@ strcat(tokens_txt,"tokens.txt");
 get_path(concord_ind,text_cod);
 strcat(text_cod,"text.cod");
 
-int return_value = concord_stats(output, 
+int return_value = concord_stats(output,
                                  mode,
                                  concord_ind,
                                  tokens_txt,
                                  text_cod,
-                                 alphabet, 
+                                 alphabet,
                                  &vec,
                                  leftContext,
                                  rightContext,
@@ -286,7 +286,7 @@ return return_value;
  * "space"-like and "regular" tokens to include.
  */
 int concord_stats(const char* outfilename,int mode, const char *concordfname, const char* tokens_path, const char* codname,
-                  const char* alphabetName, 
+                  const char* alphabetName,
                   const VersatileEncodingConfig* vec,
                   int leftContext, int rightContext, int caseSensitive) {
   U_FILE* concord = u_fopen(vec, concordfname, U_READ);
@@ -299,10 +299,10 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
 
   if (tokens == NULL) {
     error("Error in build_counted_concord, tokens cannot be loaded!");
-    
+
     match_list* current_match = matches;
     struct match_list* next_match = NULL;
-    
+
     while(current_match != NULL) {
       next_match = current_match->next;
       free_match_list_element(current_match);
@@ -310,7 +310,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
     }
 
     u_fclose(cod);
-    
+
     if (outfile != U_STDOUT) {
       u_fclose(outfile);
     }
@@ -327,7 +327,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
         free_text_tokens(tokens);
         match_list* current_match = matches;
         struct match_list* next_match = NULL;
-        
+
         while(current_match != NULL) {
           next_match = current_match->next;
           free_match_list_element(current_match);
@@ -335,10 +335,10 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
         }
 
         u_fclose(cod);
-        
+
         if (outfile != U_STDOUT) {
           u_fclose(outfile);
-        }      
+        }
         return DEFAULT_ERROR_CODE;
      }
   }
@@ -354,8 +354,8 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
     vector_ptr* allMatches     = NULL;
     hash_table* countsPerMatch = NULL;
 
-    counted_concord_return_value = build_counted_concord(matches, 
-                                                         tokens, 
+    counted_concord_return_value = build_counted_concord(matches,
+                                                         tokens,
                                                          cod,
                                                          alphabet,
                                                          leftContext,
@@ -378,7 +378,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
       }
 
       u_fclose(cod);
-      
+
       if (outfile != U_STDOUT) {
         u_fclose(outfile);
       }
@@ -388,7 +388,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
 
     // now we sort
     sort_matches_ptr(allMatches->tab, 0, allMatches->nbelems-1, swap_ptr, compare_ptr, countsPerMatch, NULL, -1);
-    
+
     // and then print
     for (i = 0; i < allMatches->nbelems ; i++) {
       hash_val = get_value(countsPerMatch, allMatches->tab[i], HT_DONT_INSERT);
@@ -405,7 +405,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
     vector_int* allMatches     = NULL;
     hash_table* countsPerMatch = NULL;
 
-    counted_collocates_return_value = build_counted_collocates(matches, 
+    counted_collocates_return_value = build_counted_collocates(matches,
                                                                tokens,
                                                                cod,
                                                                alphabet,
@@ -420,7 +420,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
     if(counted_concord_return_value != SUCCESS_RETURN_CODE) {
       free_alphabet(alphabet);
       free_text_tokens(tokens);
-      
+
       match_list* current_match     = matches;
       struct match_list* next_match = NULL;
 
@@ -431,7 +431,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
       }
 
       u_fclose(cod);
-      
+
       if (outfile != U_STDOUT) {
         u_fclose(outfile);
       }
@@ -482,7 +482,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
     if(counted_concord_return_value != SUCCESS_RETURN_CODE) {
       free_alphabet(alphabet);
       free_text_tokens(tokens);
-      
+
       match_list* current_match     = matches;
       struct match_list* next_match = NULL;
 
@@ -493,12 +493,12 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
       }
 
       u_fclose(cod);
-      
+
       if (outfile != U_STDOUT) {
         u_fclose(outfile);
       }
 
-      return counted_collocates_return_value;    	
+      return counted_collocates_return_value;
     }
 
     // now we sort
@@ -551,7 +551,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
 
   match_list* current_match     = matches;
   struct match_list* next_match = NULL;
-  
+
   while(current_match != NULL) {
     next_match = current_match->next;
     free_match_list_element(current_match);
@@ -559,7 +559,7 @@ int concord_stats(const char* outfilename,int mode, const char *concordfname, co
   }
 
   u_fclose(cod);
-  
+
   if (outfile != U_STDOUT) {
     u_fclose(outfile);
   }
@@ -590,12 +590,12 @@ int build_counted_concord(match_list* matches, text_tokens* tokens, U_FILE* cod,
   long buff_start, buff_end;
 
   // we initialize buffer to encompass 4096 tokens from starting position
-  int get_buffer_return_value = get_buffer_around_token(cod, 
-  	                                                    &buffer, 
-  	                                                    0, 
-  	                                                    0, 
-  	                                                    STATS_BUFFER_LENGTH, 
-  	                                                    &buff_start, 
+  int get_buffer_return_value = get_buffer_around_token(cod,
+  	                                                    &buffer,
+  	                                                    0,
+  	                                                    0,
+  	                                                    STATS_BUFFER_LENGTH,
+  	                                                    &buff_start,
   	                                                    &buff_end);
   if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
     free(buffer);
@@ -696,7 +696,7 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
   // we initialize buffer to encompass 4096 tokens from starting position
   int get_buffer_return_value = get_buffer_around_token(cod,
   	                                                    &buffer,
-  	                                                    0, 
+  	                                                    0,
   	                                                    0,
   	                                                    STATS_BUFFER_LENGTH,
   	                                                    &buff_start,
@@ -705,7 +705,7 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
   if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
     free(buffer);
     return get_buffer_return_value;
-  }  
+  }
 
   any* hash_val = NULL;
   int hash_ret;
@@ -713,10 +713,10 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
   int i;
 
   vector_int* allMatches        = new_vector_int();
-  hash_table* countPerCollocate = new_hash_table(hash_token_as_int, 
+  hash_table* countPerCollocate = new_hash_table(hash_token_as_int,
   	                                             tokens_as_int_equal,
                                                  free_token_as_int,
-                                                 NULL, 
+                                                 NULL,
                                                  copy_token_as_int);
   vector_int* currentMatchList;
   vector_int* tmpMatchList;
@@ -732,7 +732,7 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
 
   // for all matches, we form list of token IDs and check it against hash table
   while(current_match != NULL) {
-    currentMatchList = get_string_in_context_as_token_list(current_match, 
+    currentMatchList = get_string_in_context_as_token_list(current_match,
     	                                                     leftContext,
     	                                                     rightContext,
     	                                                     &buffer,
@@ -761,7 +761,7 @@ int build_counted_collocates(match_list* matches, text_tokens* tokens, U_FILE* c
         free_vector_int(allMatches, NULL);
         free(buffer);
         return ALLOC_ERROR_CODE;
-      }      
+      }
 
       hash_val = get_value(countPerCollocate, currentKey, HT_INSERT_IF_NEEDED, &hash_ret);
 
@@ -894,10 +894,10 @@ int count_collocates(U_FILE* cod, text_tokens* tokens, Alphabet* alphabet, int c
   long bufferStart;
   long bufferEnd;
 
-  int get_buffer_return_value = get_buffer_around_token(cod, 
-  	                                                    &buffer, 
-  	                                                    0, 
-  	                                                    0, 
+  int get_buffer_return_value = get_buffer_around_token(cod,
+  	                                                    &buffer,
+  	                                                    0,
+  	                                                    0,
   	                                                    STATS_BUFFER_LENGTH,
   	                                                    &bufferStart,
   	                                                    &bufferEnd);
@@ -907,9 +907,9 @@ int count_collocates(U_FILE* cod, text_tokens* tokens, Alphabet* alphabet, int c
     return get_buffer_return_value;
   }
 
-  hash_table* ret = new_hash_table(hash_token_as_int, 
+  hash_table* ret = new_hash_table(hash_token_as_int,
   	                               tokens_as_int_equal,
-  	                               free_token_as_int, 
+  	                               free_token_as_int,
   	                               NULL,
   	                               copy_token_as_int);
 
@@ -1057,7 +1057,7 @@ vector_int* get_string_in_context_as_token_list(match_list* match, int leftConte
        	                                                 bufferEnd);
       if(get_buffer_return_value != SUCCESS_RETURN_CODE) {
         return NULL;
-      }       
+      }
     }
 
     if (is_appropriate_token((*buffer)[endAt - *bufferStart], tokens)) {
@@ -1074,15 +1074,15 @@ vector_int* get_string_in_context_as_token_list(match_list* match, int leftConte
 
     if (i < *bufferStart || i > *bufferEnd) {
       int get_buffer_around_token_return_value = get_buffer_around_token(source,
-      	                                                    buffer, 
-      	                                                    i, 
-      	                                                    0, 
+      	                                                    buffer,
+      	                                                    i,
+      	                                                    0,
       	                                                    STATS_BUFFER_LENGTH,
       	                                                    bufferStart,
       	                                                    bufferEnd);
       if(get_buffer_around_token_return_value != SUCCESS_RETURN_CODE) {
         return NULL;
-      }      
+      }
     }
 
     vector_int_add(res, (*buffer)[i - *bufferStart]);
@@ -1436,7 +1436,7 @@ unsigned int hash_token_as_int(const void* t) {
   if (!(token->CStag)) {
     return jenkins_one_at_a_time_hash_string_uppercase(token->tokens->token[token->tokenID], u_strlen(token->tokens->token[token->tokenID]), token->alphabet);
   }
-  
+
   return token->tokenID;
 }
 

--- a/StringParsing.cpp
+++ b/StringParsing.cpp
@@ -86,15 +86,15 @@ const unichar STRING_EMPTY[] = { 0 };
 
 static inline int string_contains_unichar(const unichar* s,unichar c) {
 for (;;) {
-	if ((*(s)) == c) return 1;
-	if ((*(s)) == 0) return 0;
-	if ((*(s + 1)) == c) return 1;
-	if ((*(s + 1)) == 0) return 0;
-	if ((*(s + 2)) == c) return 1;
-	if ((*(s + 2)) == 0) return 0;
-	if ((*(s + 3)) == c) return 1;
-	if ((*(s + 3)) == 0) return 0;
-	s += 4;
+    if ((*(s)) == c) return 1;
+    if ((*(s)) == 0) return 0;
+    if ((*(s + 1)) == c) return 1;
+    if ((*(s + 1)) == 0) return 0;
+    if ((*(s + 2)) == c) return 1;
+    if ((*(s + 2)) == 0) return 0;
+    if ((*(s + 3)) == c) return 1;
+    if ((*(s + 3)) == 0) return 0;
+    s += 4;
 }
 }
 
@@ -328,7 +328,7 @@ for (int i=0;s[i]!='\0';i++) {
       u_strcat(result,PROTECTION_CHAR);
       u_strcat(result,s[i]);
    } else {
-	   u_strcat(result,s[i]);
+       u_strcat(result,s[i]);
    }
 }
 return result->len-n;
@@ -344,18 +344,18 @@ int unprotect(const unichar* s,unichar* result,const unichar* chars_to_unprotect
 chars_to_unprotect = (chars_to_unprotect == NULL) ? STRING_EMPTY : chars_to_unprotect;
 int j=0;
 for (int i=0;s[i]!='\0';i++) {
-	if (s[i]==PROTECTION_CHAR) {
-		if (s[i+1]=='\0') {
-			fatal_error("Unexpected %c at end of string in unprotect\n",PROTECTION_CHAR);
-		}
-		if (!string_contains_unichar(chars_to_unprotect,s[i+1])) {
-			result[j++]=PROTECTION_CHAR;
-		}
-		result[j++]=s[i+1];
-		i++;
-	} else {
-		result[j++]=s[i];
-	}
+    if (s[i]==PROTECTION_CHAR) {
+        if (s[i+1]=='\0') {
+            fatal_error("Unexpected %c at end of string in unprotect\n",PROTECTION_CHAR);
+        }
+        if (!string_contains_unichar(chars_to_unprotect,s[i+1])) {
+            result[j++]=PROTECTION_CHAR;
+        }
+        result[j++]=s[i+1];
+        i++;
+    } else {
+        result[j++]=s[i];
+    }
 }
 result[j]='\0';
 return j;
@@ -371,18 +371,18 @@ int unprotect(const unichar* s,Ustring* result,const unichar* chars_to_unprotect
 chars_to_unprotect = (chars_to_unprotect == NULL) ? STRING_EMPTY : chars_to_unprotect;
 int n=result->len;
 for (int i=0;s[i]!='\0';i++) {
-	if (s[i]==PROTECTION_CHAR) {
-		if (s[i+1]=='\0') {
-			fatal_error("Unexpected %c at end of string in unprotect\n",PROTECTION_CHAR);
-		}
-		if (!string_contains_unichar(chars_to_unprotect,s[i+1])) {
-			u_strcat(result,PROTECTION_CHAR);
-		}
-		u_strcat(result,s[i+1]);
-		i++;
-	} else {
-		u_strcat(result,s[i]);
-	}
+    if (s[i]==PROTECTION_CHAR) {
+        if (s[i+1]=='\0') {
+            fatal_error("Unexpected %c at end of string in unprotect\n",PROTECTION_CHAR);
+        }
+        if (!string_contains_unichar(chars_to_unprotect,s[i+1])) {
+            u_strcat(result,PROTECTION_CHAR);
+        }
+        u_strcat(result,s[i+1]);
+        i++;
+    } else {
+        u_strcat(result,s[i]);
+    }
 }
 return result->len-n;
 }

--- a/StringParsing.cpp
+++ b/StringParsing.cpp
@@ -65,21 +65,21 @@ const unichar P_COMMA_DOT_EQUAL_BACKSLASH[] = { ',', '.', '=', '\\', 0 };
 
 const unichar STRING_EMPTY[] = { 0 };
 /**
- * Parses the string 's' from the position '*ptr' until it finds '\0' 
+ * Parses the string 's' from the position '*ptr' until it finds '\0'
  * or a character that is in 'stop_chars'.
- * 'chars_to_keep_protected' is used to define which chars must keep their protection 
+ * 'chars_to_keep_protected' is used to define which chars must keep their protection
  * char. If it has the value NULL, it means that all protected chars must stay protected.
  * Note that forbidden chars and stop_chars will be taken into account if and only
  * if they are not protected. The intersection between 'stop_chars' and 'forbidden_chars'
  * is supposed to be empty. If not, 'stop_chars' is considered first.
- * If an error occurs, a \0 is put at the end of the result and the function 
+ * If an error occurs, a \0 is put at the end of the result and the function
  * returns an error code; otherwise, the substring obtained
  * is stored in 'result' and P_OK is returned.
  * If 's' is empty, the function returns P_EOS.
  * Note that '*ptr' is updated and points to the stop character (delimiter or '\0').
  * It is the responsability of the caller to increase the position if we are not
  * at the end of the input string.
- * 
+ *
  * Example: parse("E\=\mc\2 is a formula",result," ","m","2") will produce the
  *          result = "E=mc\2"
  */
@@ -143,7 +143,7 @@ return P_OK;
 
 
 /**
- * Parses the string 's' from '*ptr' until it finds '\0' or a character that is in 
+ * Parses the string 's' from '*ptr' until it finds '\0' or a character that is in
  * 'stop_chars'. '*ptr' is updated. All protected characters will be unprotected.
  * If an error occurs, it returns an error code; otherwise, the substring obtained
  * is stored in 'result' and P_OK is returned.
@@ -154,7 +154,7 @@ return parse_string(s,ptr,result,stop_chars,P_EMPTY,P_EMPTY);
 
 
 /**
- * Parses the string 's' from '*ptr' until it finds '\0' or a character that is in 
+ * Parses the string 's' from '*ptr' until it finds '\0' or a character that is in
  * 'stop_chars'. '*ptr' is updated. All protected characters will be unprotected.
  * If an error occurs, it returns an error code; otherwise, the substring obtained
  * is stored in 'result' and P_OK is returned.
@@ -283,16 +283,16 @@ return value;
 /**
  * This function copies 's' into 'result', escaping the chars in
  * 'chars_to_escape'. Protected chars are not taken into account.
- * 
+ *
  * Example: escape("E\=mc2",result,"2=") => result="E\=mc\2"
- * 
+ *
  * Note that the protection char will be escaped if and only if
  * it appears in 'chars_to_escape':
- * 
+ *
  * Example: escape("E\=mc2",result,"\") => result="E\\=mc2"
- * 
+ *
  * The function returns the length of 'result'.
- * 
+ *
  */
 int escape(const unichar* s,unichar* result,const unichar* chars_to_escape) {
 chars_to_escape = (chars_to_escape == NULL) ? STRING_EMPTY : chars_to_escape;

--- a/StringParsing.h
+++ b/StringParsing.h
@@ -31,7 +31,7 @@
 
 namespace unitex {
 
-/** 
+/**
  * Here are the error codes used for string parsing. Some of them like
  * P_UNEXPECTED_COMMENT are specially designed for errors in DELA lines.
  */

--- a/String_hash.cpp
+++ b/String_hash.cpp
@@ -402,7 +402,7 @@ while (EOF!=(line_length=u_fgets2(temp,f))) {
       else if (pos==0 && temp[pos]=='\0') {
          /* Empty line */
     	  continue;
-      }    
+      }
       else if (pos==0) {
          /* If the line starts with the separator */
          error("Line with empty key:\n<%S>\n",temp);
@@ -410,7 +410,7 @@ while (EOF!=(line_length=u_fgets2(temp,f))) {
       else if (pos>=line_length) {
         /* If the line doesn't have a separator */
         error("Line without separator:\n<%S>\n",temp);
-      }        
+      }
       else {
          /* We jump over the separator */
          pos++;

--- a/String_hash.cpp
+++ b/String_hash.cpp
@@ -205,66 +205,66 @@ int get_value_index_(const unichar* key,int pos,struct string_hash_tree_node* no
                     struct string_hash* hash,int insert_policy,const unichar* value) {
 
 for (;;) {
-	if (node==NULL) {
-	   fatal_error("NULL error in get_value_index\n");
-	}
-	if (key[pos]=='\0') {
-	   /* If we are at the end of the key */
-	   if (insert_policy==DONT_INSERT) {
-		  /* If we just consult the string_hash with no insert, we just
-		   * have to return the value_index of the node */
-		  return node->value_index;
-	   }
-	   if (node->value_index!=NO_VALUE_INDEX) {
-		  /* If the key already exists, we return its value index */
-		  return node->value_index;
-	   }
-	   /* Here, we have to build a new value index */
-	   if (hash->capacity==DONT_USE_VALUES) {
-		  /* If don't uses the 'value' array, there is no limitation */
-		  node->value_index=hash->size;
-		  (hash->size)++;
-	   } else {
-		 /* Otherwise: if there is a maximum capacity */
-		 if (hash->size==hash->capacity) {
-		   /* We check if we have reached the end of the 'value' array */
-		   if (hash->bound_policy==DONT_ENLARGE) {
-			 /* If we can't enlarge the 'value' array, we fail */
-			 fatal_error("Too much elements in a non extensible array in get_value_index\n");
-		   }
-		   /* If we can enlarge the 'value' array, we do it, doubling its capacity */
-		   hash->capacity=2*hash->capacity;
-		   hash->value=(unichar**)realloc(hash->value,sizeof(unichar*)*hash->capacity);
-		   if (hash->value==NULL) {
-			 fatal_alloc_error("get_value_index");
-		   }
-		 }
-		 node->value_index=hash->size;
-		 (hash->size)++;
-		 /* u_strdup is supposed to return NULL if 'value' is NULL */
-		 hash->value[node->value_index]=u_strdup(value);
-	   }
-	   return node->value_index;
-	}
+    if (node==NULL) {
+       fatal_error("NULL error in get_value_index\n");
+    }
+    if (key[pos]=='\0') {
+       /* If we are at the end of the key */
+       if (insert_policy==DONT_INSERT) {
+          /* If we just consult the string_hash with no insert, we just
+           * have to return the value_index of the node */
+          return node->value_index;
+       }
+       if (node->value_index!=NO_VALUE_INDEX) {
+          /* If the key already exists, we return its value index */
+          return node->value_index;
+       }
+       /* Here, we have to build a new value index */
+       if (hash->capacity==DONT_USE_VALUES) {
+          /* If don't uses the 'value' array, there is no limitation */
+          node->value_index=hash->size;
+          (hash->size)++;
+       } else {
+         /* Otherwise: if there is a maximum capacity */
+         if (hash->size==hash->capacity) {
+           /* We check if we have reached the end of the 'value' array */
+           if (hash->bound_policy==DONT_ENLARGE) {
+             /* If we can't enlarge the 'value' array, we fail */
+             fatal_error("Too much elements in a non extensible array in get_value_index\n");
+           }
+           /* If we can enlarge the 'value' array, we do it, doubling its capacity */
+           hash->capacity=2*hash->capacity;
+           hash->value=(unichar**)realloc(hash->value,sizeof(unichar*)*hash->capacity);
+           if (hash->value==NULL) {
+             fatal_alloc_error("get_value_index");
+           }
+         }
+         node->value_index=hash->size;
+         (hash->size)++;
+         /* u_strdup is supposed to return NULL if 'value' is NULL */
+         hash->value[node->value_index]=u_strdup(value);
+       }
+       return node->value_index;
+    }
 
-	/* If we are not at the end of the key, we look for the transition to follow */
-	struct string_hash_tree_transition* t=get_transition(key[pos],node->trans);
-	if (t==NULL) {
-	   /* If there is no suitable transition */
-	   if (insert_policy==DONT_INSERT) {
-		  /* If we just look, then we say that we have not found the key */
-		  return NO_VALUE_INDEX;
-	   }
-	   /* Otherwise, we create a transition */
-	   t=new_string_hash_tree_transition(hash);
-	   t->letter=key[pos];
-	   t->next=node->trans;
-	   t->node=new_string_hash_tree_node(hash);
-	   node->trans=t;
-	}
+    /* If we are not at the end of the key, we look for the transition to follow */
+    struct string_hash_tree_transition* t=get_transition(key[pos],node->trans);
+    if (t==NULL) {
+       /* If there is no suitable transition */
+       if (insert_policy==DONT_INSERT) {
+          /* If we just look, then we say that we have not found the key */
+          return NO_VALUE_INDEX;
+       }
+       /* Otherwise, we create a transition */
+       t=new_string_hash_tree_transition(hash);
+       t->letter=key[pos];
+       t->next=node->trans;
+       t->node=new_string_hash_tree_node(hash);
+       node->trans=t;
+    }
 
-	pos++;
-	node=t->node;
+    pos++;
+    node=t->node;
 }
 }
 
@@ -339,16 +339,16 @@ return hash;
 static void normalize_CR_LF(unichar* s) {
 int i=0,j=0;
 while (s[i]!='\0') {
-	if (s[i]=='\\') {
-		switch (s[i+1]) {
-		case '\0': fatal_error("Unexpected backslash at end of line in normalize_CR_LF\n");
-		case 'r': s[j++]=0x0D; i+=2; break;
-		case 'n': s[j++]=0x0A; i+=2; break;
-		default: s[j++]=s[i+1]; i+=2; break;
-		}
-	} else {
-		s[j++]=s[i++];
-	}
+    if (s[i]=='\\') {
+        switch (s[i+1]) {
+        case '\0': fatal_error("Unexpected backslash at end of line in normalize_CR_LF\n");
+        case 'r': s[j++]=0x0D; i+=2; break;
+        case 'n': s[j++]=0x0A; i+=2; break;
+        default: s[j++]=s[i+1]; i+=2; break;
+        }
+    } else {
+        s[j++]=s[i++];
+    }
 }
 s[j]='\0';
 }
@@ -401,7 +401,7 @@ while (EOF!=(line_length=u_fgets2(temp,f))) {
       }
       else if (pos==0 && temp[pos]=='\0') {
          /* Empty line */
-    	  continue;
+          continue;
       }
       else if (pos==0) {
          /* If the line starts with the separator */
@@ -418,12 +418,12 @@ while (EOF!=(line_length=u_fgets2(temp,f))) {
           * defined in the file */
          value[0]='\0';
          if(P_BACKSLASH_AT_END==parse_string(temp,&pos,value,P_EMPTY,P_EMPTY,to_keep_protected)) {
-        	 error("Backslash at end of line:\n<%S>\n",temp);
+             error("Backslash at end of line:\n<%S>\n",temp);
          }
          else {
             /* If we have a valid (key,value) pair, we insert it into the string_hash */
-        	normalize_CR_LF(value);
-        	normalize_CR_LF(key);
+            normalize_CR_LF(value);
+            normalize_CR_LF(key);
             get_value_index(key,hash,INSERT_IF_NEEDED,value);
          }
       }

--- a/Symbol.cpp
+++ b/Symbol.cpp
@@ -34,7 +34,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1
@@ -1386,21 +1386,21 @@ if (tag[0]=='<' && tag[1]!='\0') {
 
   /* special EXCLAM symbol */
 
-  if (*buf == '!' && buf[1] == 0) { 
+  if (*buf == '!' && buf[1] == 0) {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);
 #endif
-	  return new_symbol(S_EXCLAM,-1); 
+	  return new_symbol(S_EXCLAM,-1);
   }
 
 
   /* special EQUAL symbol */
 
-  if (*buf == '=' && buf[1] == 0) { 
+  if (*buf == '=' && buf[1] == 0) {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);
 #endif
-	  return new_symbol(S_EQUAL,-1); 
+	  return new_symbol(S_EQUAL,-1);
   }
 
 
@@ -1411,17 +1411,17 @@ if (tag[0]=='<' && tag[1]!='\0') {
 
   if (u_strchr(PUNC_TAB, *buf)) {
 
-    if (*buf == '\\' && (! buf[1] || buf[2])) { 
+    if (*buf == '\\' && (! buf[1] || buf[2])) {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
         free(buf);
 #endif
-		fatal_error("bad PUNC symbol '%S'\n", tag); 
+		fatal_error("bad PUNC symbol '%S'\n", tag);
 	}
-    if (buf[1] && buf[0] != '\\') { 
+    if (buf[1] && buf[0] != '\\') {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
         free(buf);
 #endif
-		fatal_error("bad symbol '%S' (PONC too long)\n", tag); 
+		fatal_error("bad symbol '%S' (PONC too long)\n", tag);
 	}
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);

--- a/Symbol.cpp
+++ b/Symbol.cpp
@@ -982,7 +982,7 @@ for (i=1;i<entry->n_semantic_codes;i++) {
    } else {
       if (get_value_index(entry->semantic_codes[i],language->unknown_codes,DONT_INSERT)==-1) {
          error("Unknown semantic value '%S', will not be taken into account\n",entry->semantic_codes[i]);
-	      get_value_index(entry->semantic_codes[i],language->unknown_codes,INSERT_IF_NEEDED,NULL);
+          get_value_index(entry->semantic_codes[i],language->unknown_codes,INSERT_IF_NEEDED,NULL);
       }
    }
 }
@@ -1007,7 +1007,7 @@ if (entry->n_inflectional_codes==0) {
 }
 model=symbol;
 if (model->next!=NULL) {
-	fatal_error("load_dic_entry: symbol list should not happen\n");
+    fatal_error("load_dic_entry: symbol list should not happen\n");
 }
 symbol=NULL;
 for (i=0;i<entry->n_inflectional_codes;i++) {
@@ -1250,7 +1250,7 @@ while (buffer[position]=='+' || buffer[position]=='!') {
       /* If we have to set a semantic feature */
       feature_info_t* info=POS_get_semantic_feature_infos(POS,tmp);
       if (info!=NULL) {
-	      symbol->feature[info->CATid]=info->val;
+          symbol->feature[info->CATid]=info->val;
       } else {
          if (get_value_index(tmp,language->unknown_codes,DONT_INSERT)==-1) {
             /* If we haven't already encountered this unknown code, we can print
@@ -1373,7 +1373,7 @@ if (tag[0]=='<' && tag[1]!='\0') {
    /* If we have a tag like <xxxx>, we test if it's a special symbol */
    if (!u_strcmp(tag,"<E>")) return new_symbol(S_EPSILON,-1);
    if (!u_strcmp(tag,"<.>")) {
-	   fatal_error("Invalid ELAG tag <.>\n");
+       fatal_error("Invalid ELAG tag <.>\n");
    }
    if (!u_strcmp(tag,"<def>")) return SYMBOL_DEF;
    if (!u_strcmp(tag,"<!>")) return new_symbol(S_EXCLAM,-1);
@@ -1390,7 +1390,7 @@ if (tag[0]=='<' && tag[1]!='\0') {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);
 #endif
-	  return new_symbol(S_EXCLAM,-1);
+      return new_symbol(S_EXCLAM,-1);
   }
 
 
@@ -1400,7 +1400,7 @@ if (tag[0]=='<' && tag[1]!='\0') {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);
 #endif
-	  return new_symbol(S_EQUAL,-1);
+      return new_symbol(S_EQUAL,-1);
   }
 
 
@@ -1415,14 +1415,14 @@ if (tag[0]=='<' && tag[1]!='\0') {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
         free(buf);
 #endif
-		fatal_error("bad PUNC symbol '%S'\n", tag);
-	}
+        fatal_error("bad PUNC symbol '%S'\n", tag);
+    }
     if (buf[1] && buf[0] != '\\') {
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
         free(buf);
 #endif
-		fatal_error("bad symbol '%S' (PONC too long)\n", tag);
-	}
+        fatal_error("bad symbol '%S' (PONC too long)\n", tag);
+    }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
       free(buf);
 #endif

--- a/SymbolAlphabet.h
+++ b/SymbolAlphabet.h
@@ -35,7 +35,7 @@ namespace unitex {
 
 /**
  * This library is used to manage an alphabet made of Elag symbols.
- * 
+ *
  */
 
 

--- a/Symbol_op.cpp
+++ b/Symbol_op.cpp
@@ -779,10 +779,10 @@ static symbol_t * minus_traits(const symbol_t * a, const symbol_t * b) {
 
       for (int v = -1; v < CAT->values->size; v++) { /* on ajoute pour chaque valeur fix�e != b->traits[idx] */
 
-	if (v == UNSPECIFIED || v == b->feature[idx]) { continue; }
+    if (v == UNSPECIFIED || v == b->feature[idx]) { continue; }
 
-	templat->feature[idx] = (char)v;
-	concat_symbols(end, dup_symbol(templat), & end);
+    templat->feature[idx] = (char)v;
+    concat_symbols(end, dup_symbol(templat), & end);
       }
 
       /* on fixe la valeur a b->traits[idx] et on continue */
@@ -1303,7 +1303,7 @@ return res.next;
 
 
 symbol_t * minus_symbol(language_t* language,const symbol_t * b) {
-	return LEXIC_minus_symbol(language,b);
+    return LEXIC_minus_symbol(language,b);
 }
 
 

--- a/SyncTool.h
+++ b/SyncTool.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/SyncToolDummy.cpp
+++ b/SyncToolDummy.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -101,7 +101,7 @@ UNITEX_FUNC SYNC_Mutex_OBJECT UNITEX_CALL SyncBuildMutex()
     SYNC_Mutex_OBJECT_INTERNAL* pMoi = (SYNC_Mutex_OBJECT_INTERNAL*)malloc(sizeof(SYNC_Mutex_OBJECT_INTERNAL));
     if (pMoi == NULL)
         return NULL;
-    
+
     return (SYNC_Mutex_OBJECT)pMoi;
 }
 

--- a/SyncToolDummy.cpp
+++ b/SyncToolDummy.cpp
@@ -66,9 +66,9 @@ UNITEX_FUNC unsigned int UNITEX_CALL SyncGetMSecElapsedNotDestructive(hTimeElaps
     time_t t_end;
     time(&t_end);
     iRet = (unsigned int)(difftime(t_end,pBegin->t_start) * 1000);
-	*/
-	clock_t endTime=clock();
-	iRet= (int)((((double)(endTime-(pBegin->startTime))) / CLOCKS_PER_SEC) * 1000);
+    */
+    clock_t endTime=clock();
+    iRet= (int)((((double)(endTime-(pBegin->startTime))) / CLOCKS_PER_SEC) * 1000);
     if (destructObject != 0)
       free(pBegin);
 

--- a/SyncToolPosix.cpp
+++ b/SyncToolPosix.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/SyncToolWin.cpp
+++ b/SyncToolWin.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/TEI2Txt.cpp
+++ b/TEI2Txt.cpp
@@ -123,7 +123,7 @@ if (only_verify_arguments) {
 
 if(output[0]=='\0') {
   remove_extension(argv[options.vars()->optind],output);
-	strcat(output,".txt");
+    strcat(output,".txt");
 }
 
 int return_value = tei2txt(argv[options.vars()->optind],output,&vec);
@@ -134,72 +134,72 @@ return return_value;
 static const char* body = "body";
 
 int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
-	void* html_ctx = init_HTML_character_context();
-	if (html_ctx == NULL) {
+    void* html_ctx = init_HTML_character_context();
+    if (html_ctx == NULL) {
     alloc_error("tei2txt");
     return ALLOC_ERROR_CODE;
   }
 
-	U_FILE* input = u_fopen(vec, fin, U_READ);
-	if (input == NULL) {
+    U_FILE* input = u_fopen(vec, fin, U_READ);
+    if (input == NULL) {
     error("Input file '%s' not found!\n", fin);
     free_HTML_character_context(html_ctx);
     return DEFAULT_ERROR_CODE;
   }
 
-	U_FILE* output = u_fopen(vec, fout, U_WRITE);
-	if (output == NULL) {
+    U_FILE* output = u_fopen(vec, fout, U_WRITE);
+    if (output == NULL) {
     error("Cannot open output file '%s'!\n", fout);
     u_fclose(input);
     free_HTML_character_context(html_ctx);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 
-	unichar buffer[5000];
+    unichar buffer[5000];
 
-	int i, j, k;
-	unichar c;
-	if((i = u_fgetc(input)) != EOF) {
-		c = (unichar)i;
+    int i, j, k;
+    unichar c;
+    if((i = u_fgetc(input)) != EOF) {
+        c = (unichar)i;
 
-		for (;;) {
-			while(c != '<' && (i = u_fgetc(input)) != EOF) {
-				c = (unichar)i;
+        for (;;) {
+            while(c != '<' && (i = u_fgetc(input)) != EOF) {
+                c = (unichar)i;
       }
 
-			j = 0;
-			while((i = u_fgetc(input)) != EOF && (c = (unichar)i) != ' '
+            j = 0;
+            while((i = u_fgetc(input)) != EOF && (c = (unichar)i) != ' '
                && (c = (unichar)i) != '\t' && (c = (unichar)i) != '\n'
                && (c = (unichar)i) != '>') {
-				buffer[j++] = c;
-			}
-			buffer[j] = '\0';
+                buffer[j++] = c;
+            }
+            buffer[j] = '\0';
          if (c!='>') {
             /* We do this because we can find <body ...> */
             while((i = u_fgetc(input)) != EOF && (c = (unichar)i) != '>') {}
          }
-			//u_printf("Current tag : <%S>\n", buffer);
+            //u_printf("Current tag : <%S>\n", buffer);
 
-			if(!u_strcmp(buffer, body)) {
+            if(!u_strcmp(buffer, body)) {
         break;
       } else {
         buffer[0] = '\0';
       }
-		}
-	} else {
+        }
+    } else {
     error("Empty TEI file %s\n", fin);
   }
 
-	char schars[11];
+    char schars[11];
 
   int first_sentence=1;
-	int current_state = 0;
+    int current_state = 0;
   int inside_sentence=0;
-	while ((i = u_fgetc(input)) != EOF) {
-		c = (unichar)i;
-		switch (current_state) {
-			case 0: {
-				if(c == '<') {
+    while ((i = u_fgetc(input)) != EOF) {
+        c = (unichar)i;
+        switch (current_state) {
+            case 0: {
+                if(c == '<') {
                current_state = 1;
                inside_sentence=0;
         } else if(c == '&') {
@@ -207,24 +207,24 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
         } else if (inside_sentence) {
           u_fputc(c, output);
         }
-				break;
-			}
-			case 1: {
-				if(c == 's' || c == 'S') {
+                break;
+            }
+            case 1: {
+                if(c == 's' || c == 'S') {
           current_state = 2;
-				} else {
-					while((i = u_fgetc(input)) != EOF) {
-						c = (unichar)i;
-						if(c == '>') {
+                } else {
+                    while((i = u_fgetc(input)) != EOF) {
+                        c = (unichar)i;
+                        if(c == '>') {
               break;
             }
-					}
-					current_state = 0;
-				}
-				break;
-			}
-			case 2: {
-				if(c == ' ' || c == '>') {
+                    }
+                    current_state = 0;
+                }
+                break;
+            }
+            case 2: {
+                if(c == ' ' || c == '>') {
           current_state = 0;
           inside_sentence=1;
           if (!first_sentence) {
@@ -233,56 +233,56 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
           } else {
              first_sentence=0;
           }
-				}
-				if(c != '>') {
-					while((i = u_fgetc(input)) != EOF) {
-						c = (unichar)i;
-						if(c == '>') {
+                }
+                if(c != '>') {
+                    while((i = u_fgetc(input)) != EOF) {
+                        c = (unichar)i;
+                        if(c == '>') {
               break;
             }
-					}
-				}
-				break;
-			}
-			case 3: {
-				j = 0;
-				while(c != ';' && (i = u_fgetc(input)) != EOF) {
-					//u_printf("Current S-character: %C\n", c);
-					schars[j++] = (char)c;
-					c = (unichar)i;
-				}
-				schars[j] = '\0';
-				//u_printf("Current S-chain: %S\n", schars);
+                    }
+                }
+                break;
+            }
+            case 3: {
+                j = 0;
+                while(c != ';' && (i = u_fgetc(input)) != EOF) {
+                    //u_printf("Current S-character: %C\n", c);
+                    schars[j++] = (char)c;
+                    c = (unichar)i;
+                }
+                schars[j] = '\0';
+                //u_printf("Current S-chain: %S\n", schars);
 
-				k = get_HTML_character(html_ctx,schars, 1);
-				switch (k) {
-					case UNKNOWN_CHARACTER: {
-						u_fputc('?', output);
-						break;
-					}
-					case MALFORMED_HTML_CODE: {
-						error("Malformed HTML character declaration &%s;\n", schars);
-						u_fputc('?', output);
-						break;
-					}
-					default: {
-						c = (unichar)k;
-						u_fputc(c, output);
-						break;
-					}
-				}
+                k = get_HTML_character(html_ctx,schars, 1);
+                switch (k) {
+                    case UNKNOWN_CHARACTER: {
+                        u_fputc('?', output);
+                        break;
+                    }
+                    case MALFORMED_HTML_CODE: {
+                        error("Malformed HTML character declaration &%s;\n", schars);
+                        u_fputc('?', output);
+                        break;
+                    }
+                    default: {
+                        c = (unichar)k;
+                        u_fputc(c, output);
+                        break;
+                    }
+                }
 
-				schars[0] = '\0';
-				current_state = 0;
-				break;
-			}
-		}
-	}
+                schars[0] = '\0';
+                current_state = 0;
+                break;
+            }
+        }
+    }
 
-	u_fclose(output);
-	u_fclose(input);
+    u_fclose(output);
+    u_fclose(input);
   free_HTML_character_context(html_ctx);
-	u_printf("Done.\n");
+    u_printf("Done.\n");
 
   return SUCCESS_RETURN_CODE;
 }

--- a/TEI2Txt.cpp
+++ b/TEI2Txt.cpp
@@ -103,10 +103,10 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_TEI2Txt,lopts_TEI2Txt,&i
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_TEI2Txt[index].name);
-             return USAGE_ERROR_CODE;               
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    }
    index=-1;
 }
@@ -135,17 +135,17 @@ static const char* body = "body";
 
 int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
 	void* html_ctx = init_HTML_character_context();
-	if (html_ctx == NULL) { 
+	if (html_ctx == NULL) {
     alloc_error("tei2txt");
     return ALLOC_ERROR_CODE;
-  }  
+  }
 
 	U_FILE* input = u_fopen(vec, fin, U_READ);
 	if (input == NULL) {
     error("Input file '%s' not found!\n", fin);
     free_HTML_character_context(html_ctx);
     return DEFAULT_ERROR_CODE;
-  } 
+  }
 
 	U_FILE* output = u_fopen(vec, fout, U_WRITE);
 	if (output == NULL) {
@@ -180,15 +180,15 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
          }
 			//u_printf("Current tag : <%S>\n", buffer);
 
-			if(!u_strcmp(buffer, body)) { 
+			if(!u_strcmp(buffer, body)) {
         break;
-      } else { 
+      } else {
         buffer[0] = '\0';
-      }  
+      }
 		}
-	} else { 
+	} else {
     error("Empty TEI file %s\n", fin);
-  }  
+  }
 
 	char schars[11];
 
@@ -204,9 +204,9 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
                inside_sentence=0;
         } else if(c == '&') {
           current_state = 3;
-        } else if (inside_sentence) { 
+        } else if (inside_sentence) {
           u_fputc(c, output);
-        }  
+        }
 				break;
 			}
 			case 1: {
@@ -217,7 +217,7 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
 						c = (unichar)i;
 						if(c == '>') {
               break;
-            }  
+            }
 					}
 					current_state = 0;
 				}
@@ -239,7 +239,7 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
 						c = (unichar)i;
 						if(c == '>') {
               break;
-            }  
+            }
 					}
 				}
 				break;
@@ -283,7 +283,7 @@ int tei2txt(char *fin, char *fout, const VersatileEncodingConfig* vec) {
 	u_fclose(input);
   free_HTML_character_context(html_ctx);
 	u_printf("Done.\n");
-  
+
   return SUCCESS_RETURN_CODE;
 }
 

--- a/TEI2Txt.h
+++ b/TEI2Txt.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef TEI2TxtH
 #define TEI2TxtH
 

--- a/Table2Grf.h
+++ b/Table2Grf.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef Table2GrfH
 #define Table2GrfH
 

--- a/TaggingProcess.cpp
+++ b/TaggingProcess.cpp
@@ -38,29 +38,29 @@ namespace unitex {
  */
 void compute_tag_code(struct dela_entry* tag,unichar* tag_code,int form_type){
 if(form_type == 0){
-	/* we use simple forms, we extract only the first semantic code */
-	unichar* tmp = u_strcpy(tag_code,tag->semantic_codes[0]);
-	for(int i=1;i<tag->n_semantic_codes;i++){
-		tmp = u_strcat(tmp,"+");
-		tmp = u_strcat(tmp,tag->semantic_codes[i]);
-	}
-	u_strcat(tmp,"\0");
+    /* we use simple forms, we extract only the first semantic code */
+    unichar* tmp = u_strcpy(tag_code,tag->semantic_codes[0]);
+    for(int i=1;i<tag->n_semantic_codes;i++){
+        tmp = u_strcat(tmp,"+");
+        tmp = u_strcat(tmp,tag->semantic_codes[i]);
+    }
+    u_strcat(tmp,"\0");
 }
 else{
-	/* we use compound forms, we extract the first semantic code
-	 * and possible inflectional codes */
-	unichar* tmp = u_strcpy(tag_code,tag->semantic_codes[0]);
-	for(int i=1;i<tag->n_semantic_codes;i++){
-		tmp = u_strcat(tmp,"+");
-		tmp = u_strcat(tmp,tag->semantic_codes[i]);
-	}
-	if(tag->n_inflectional_codes > 0){
-		tmp = u_strcat(tmp,":");
-		for(int i=0;i<tag->n_inflectional_codes;i++){
-			tmp = u_strcat(tmp,tag->inflectional_codes[i]);
-		}
-		tmp = u_strcat(tmp,"\0");
-	}
+    /* we use compound forms, we extract the first semantic code
+     * and possible inflectional codes */
+    unichar* tmp = u_strcpy(tag_code,tag->semantic_codes[0]);
+    for(int i=1;i<tag->n_semantic_codes;i++){
+        tmp = u_strcat(tmp,"+");
+        tmp = u_strcat(tmp,tag->semantic_codes[i]);
+    }
+    if(tag->n_inflectional_codes > 0){
+        tmp = u_strcat(tmp,":");
+        for(int i=0;i<tag->n_inflectional_codes;i++){
+            tmp = u_strcat(tmp,tag->inflectional_codes[i]);
+        }
+        tmp = u_strcat(tmp,"\0");
+    }
 }
 }
 
@@ -70,21 +70,21 @@ else{
 unichar* get_pos_unknown(const unichar* inflected){
 unichar* pos = (unichar*)malloc(DIC_LINE_SIZE*sizeof(unichar));
 if(pos == NULL){
-	fatal_alloc_error("get_pos_unknown");
+    fatal_alloc_error("get_pos_unknown");
 }
 if(u_are_digits(inflected) == 1 || u_is_word(inflected) == 1){
-	u_sprintf(pos,"N\0");//peut être séparer et faire suffix pour le word
+    u_sprintf(pos,"N\0");//peut être séparer et faire suffix pour le word
 }
 else{
 /* inflected is a punctuation, we have to identify if it's either a APOS like
  * "'" or a PONCT for all other punctuations */
-	unichar apos[2] = {'\'','\0'};
-	if(apos == inflected){
-		u_sprintf(pos,"APOS\0");
-	}
-	else{
-		u_sprintf(pos,"PONCT\0");
-	}
+    unichar apos[2] = {'\'','\0'};
+    if(apos == inflected){
+        u_sprintf(pos,"APOS\0");
+    }
+    else{
+        u_sprintf(pos,"PONCT\0");
+    }
 }
 return pos;
 }
@@ -96,7 +96,7 @@ return pos;
 int create_matrix_entry(const unichar* tag,struct matrix_entry** mx,int form_type,int tag_number,int state_number){
 *mx = (struct matrix_entry*)malloc(sizeof(struct matrix_entry));
 if(mx == NULL){
-	fatal_alloc_error("create_matrix_entry");
+    fatal_alloc_error("create_matrix_entry");
 }
 (*mx)->predecessor = -1;
 (*mx)->partial_prob = (double)0.0;
@@ -106,31 +106,31 @@ int verbose = 0;
 struct dela_entry* tmp = tokenize_DELAF_line(tag,1,&verbose);
 free_dela_entry(tmp);
 if(verbose == 0){
-	(*mx)->tag = tokenize_tag_token(tag,1);
-	(*mx)->tag_code = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
-	if((*mx)->tag_code == NULL){
-		fatal_alloc_error("create_matrix_entry");
-	}
-	compute_tag_code((*mx)->tag,(*mx)->tag_code,form_type);
+    (*mx)->tag = tokenize_tag_token(tag,1);
+    (*mx)->tag_code = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
+    if((*mx)->tag_code == NULL){
+        fatal_alloc_error("create_matrix_entry");
+    }
+    compute_tag_code((*mx)->tag,(*mx)->tag_code,form_type);
 }
 else {
-	/* we create a new inflected entry for unknown words (not present in lexicons).
-	 * POS of the entry is determined by a suffix way. */
-	unichar* code = get_pos_unknown(tag);
-	unichar* inflected = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag)+1));
-	if(inflected == NULL){
-		fatal_alloc_error("create_matrix_entry");
-	}
-	u_strcpy(inflected,tag);
-	(*mx)->tag = new_dela_entry(inflected,tag,code);
-	(*mx)->tag_code = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
-	if((*mx)->tag_code == NULL){
-		fatal_alloc_error("create_matrix_entry");
-	}
-	compute_tag_code((*mx)->tag,(*mx)->tag_code,form_type);
-	free(code);
-	free(inflected);
-	return -1;
+    /* we create a new inflected entry for unknown words (not present in lexicons).
+     * POS of the entry is determined by a suffix way. */
+    unichar* code = get_pos_unknown(tag);
+    unichar* inflected = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag)+1));
+    if(inflected == NULL){
+        fatal_alloc_error("create_matrix_entry");
+    }
+    u_strcpy(inflected,tag);
+    (*mx)->tag = new_dela_entry(inflected,tag,code);
+    (*mx)->tag_code = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
+    if((*mx)->tag_code == NULL){
+        fatal_alloc_error("create_matrix_entry");
+    }
+    compute_tag_code((*mx)->tag,(*mx)->tag_code,form_type);
+    free(code);
+    free(inflected);
+    return -1;
 }
 return 0;
 }
@@ -141,7 +141,7 @@ return 0;
 struct matrix_entry** allocate_matrix(int size){
 struct matrix_entry** matrix = (struct matrix_entry**)malloc(size*sizeof(struct matrix_entry));
 if(matrix == NULL){
-	fatal_alloc_error("allocate_matrix");
+    fatal_alloc_error("allocate_matrix");
 }
 return matrix;
 }
@@ -153,10 +153,10 @@ return matrix;
 struct matrix_entry** initialize_viterbi_matrix(SingleGraph automaton,int form_type){
 int nb_transitions = 0;
 for(int i=0;i<automaton->number_of_states;i++){
-	SingleGraphState state = automaton->states[i];
-	for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
-		nb_transitions++;
-	}
+    SingleGraphState state = automaton->states[i];
+    for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
+        nb_transitions++;
+    }
 }
 /* we allocate the matrix with a size of nb_transitions+2 because
  * we will add two entries "#" at start of this matrix representing
@@ -164,13 +164,13 @@ for(int i=0;i<automaton->number_of_states;i++){
 struct matrix_entry** matrix = allocate_matrix(nb_transitions+2);
 /* we add the two entries "#" */
 for(int i=0;i<2;i++){
-	unichar* token = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
-	if(token == NULL){
-		fatal_alloc_error("initialize_viterbi_matrix");
-	}
-	u_sprintf(token,"{#,#.#}");
-	create_matrix_entry(token,&matrix[i],form_type,-1,i);
-	free(token);
+    unichar* token = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
+    if(token == NULL){
+        fatal_alloc_error("initialize_viterbi_matrix");
+    }
+    u_sprintf(token,"{#,#.#}");
+    create_matrix_entry(token,&matrix[i],form_type,-1,i);
+    free(token);
 }
 /* the second # points on the first entry */
 matrix[1]->predecessor = 0;
@@ -181,32 +181,32 @@ return matrix;
  * Liberates memory used by a matrix_entry.
  */
 void free_matrix_entry(struct matrix_entry* entry){
-	free_dela_entry(entry->tag);
-	free(entry->tag_code);
-	free(entry);
+    free_dela_entry(entry->tag);
+    free(entry->tag_code);
+    free(entry);
 }
 
 /**
  * Liberates memory used by a viterbi matrix.
  */
 void free_viterbi_matrix(struct matrix_entry** matrix,int size){
-	for(int i=0;i<size;i++){
-		free_matrix_entry(matrix[i]);
-	}
-	free(matrix);
+    for(int i=0;i<size;i++){
+        free_matrix_entry(matrix[i]);
+    }
+    free(matrix);
 }
 
 /**
  * Return the index of the tag in matrix.
  */
 int search_matrix_predecessor(struct matrix_entry** matrix,unichar* tag,int start,
-		                      int tag_number,int state_number){
+                              int tag_number,int state_number){
 struct dela_entry* entry = tokenize_tag_token(tag,1);
 for(int i=start;i>=0;i--){
-	if(equal(entry,matrix[i]->tag) == 1 && matrix[i]->tag_number == tag_number && matrix[i]->state_number == state_number){
-		free_dela_entry(entry);
-		return i;
-	}
+    if(equal(entry,matrix[i]->tag) == 1 && matrix[i]->tag_number == tag_number && matrix[i]->state_number == state_number){
+        free_dela_entry(entry);
+        return i;
+    }
 }
 free_dela_entry(entry);
 return -1;
@@ -216,18 +216,18 @@ return -1;
  * Extracts INF_code of a given token in the dictionary.
  */
 void get_INF_code(Dictionary* d,const unichar* token,
-				  int case_sensitive,int index,int offset,
-				  const Alphabet* alphabet,int* inf_index,Ustring* ustr) {
+                  int case_sensitive,int index,int offset,
+                  const Alphabet* alphabet,int* inf_index,Ustring* ustr) {
 int final,n_transitions,inf_number;
 if (d->type!=BIN_CLASSIC) {
-	fatal_error("get_INF_code: unsupported dictionary type\n");
+    fatal_error("get_INF_code: unsupported dictionary type\n");
 }
 offset=read_dictionary_state(d,offset,&final,&n_transitions,&inf_number);
 if (token[index]=='\0') {
    /* If we are at end of the token */
    if (final) {
-	  /* If the node is final */
-	   *inf_index=inf_number;
+      /* If the node is final */
+       *inf_index=inf_number;
    }
    return;
 }
@@ -236,13 +236,13 @@ int adr;
 int z=save_output(ustr);
 for(int i=0;i<n_transitions;i++) {
    /* For each outgoing transition, we look if the transition character is
-	* compatible with the token's one */
-	offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
+    * compatible with the token's one */
+    offset=read_dictionary_transition(d,offset,&c,&adr,ustr);
    if(case_sensitive == 1 && c == token[index]){
-	   get_INF_code(d,token,case_sensitive,index+1,adr,alphabet,inf_index,ustr);
+       get_INF_code(d,token,case_sensitive,index+1,adr,alphabet,inf_index,ustr);
    }
    else if(case_sensitive == 0 && is_equal_ignore_case(token[index],c,alphabet)){
-	   get_INF_code(d,token,case_sensitive,index+1,adr,alphabet,inf_index,ustr);
+       get_INF_code(d,token,case_sensitive,index+1,adr,alphabet,inf_index,ustr);
    }
    restore_output(z,ustr);
 }
@@ -257,11 +257,11 @@ struct list_ustring* tmp=inf->codes[inf_index];
  * so we convert the string found into long value. */
 char* code = (char*)malloc(sizeof(char)*u_strlen(tmp->string));
 if(code == NULL){
-	fatal_alloc_error("get_inf_value");
+    fatal_alloc_error("get_inf_value");
 }
 unsigned int l=u_strlen(tmp->string);
 for(unsigned int i=0;i<l;i++){
-	code[i] = (char)tmp->string[i+1];
+    code[i] = (char)tmp->string[i+1];
 }
 /* conversion string to int value */
 long int value = strtol(code,NULL,10);
@@ -280,8 +280,8 @@ Ustring* ustr=new_Ustring();
 get_INF_code(d,sequence,1,0,d->initial_state_offset,alphabet,&inf_index,ustr);
 free_Ustring(ustr);
 if(inf_index == -1){
-	/* sequence is not in the dictionary */
-	return -1;
+    /* sequence is not in the dictionary */
+    return -1;
 }
 return get_inf_value(d->inf,inf_index);
 }
@@ -294,11 +294,11 @@ return get_inf_value(d->inf,inf_index);
 unichar* create_bigram_sequence(const unichar* first_token,const unichar* second_token,int tabulation){
 unichar* sequence = (unichar*)malloc(sizeof(unichar)*(2+u_strlen(first_token)+u_strlen(second_token)));
 if(sequence == NULL){
-	fatal_alloc_error("create_bigram_sequence");
+    fatal_alloc_error("create_bigram_sequence");
 }
 unichar* tmp = u_strcpy_sized(sequence,u_strlen(first_token)+1,first_token);
 if(tabulation == 1){
-	tmp = u_strcat(tmp,"\t");
+    tmp = u_strcat(tmp,"\t");
 }
 u_strcat(tmp,second_token);
 return sequence;
@@ -324,7 +324,7 @@ unichar* create_trigram_sequence(const unichar* first_token,const unichar* secon
 unichar* bigram = create_bigram_sequence(first_token,second_token,1);
 unichar* sequence = (unichar*)malloc(sizeof(unichar)*(2+u_strlen(bigram)+u_strlen(third_token)));
 if(sequence == NULL){
-	fatal_alloc_error("create_trigram_sequence");
+    fatal_alloc_error("create_trigram_sequence");
 }
 unichar* tmp = u_strcpy_sized(sequence,u_strlen(bigram)+1,bigram);
 free(bigram);
@@ -339,10 +339,10 @@ return sequence;
 unichar* u_strnsuffix(const unichar* s,int n){
 unichar* suffix = (unichar*)malloc(sizeof(unichar)*(n+1));
 if(suffix == NULL){
-	fatal_alloc_error("u_strnsuffix");
+    fatal_alloc_error("u_strnsuffix");
 }
 for(int i=0;i<=n;i++){
-	suffix[i] = s[(u_strlen(s)-n)+i];
+    suffix[i] = s[(u_strlen(s)-n)+i];
 }
 return suffix;
 }
@@ -353,7 +353,7 @@ return suffix;
  * This probability is a double value between 0 and 1.
  */
 double compute_emit_probability(Dictionary* d,const Alphabet* alphabet,
-		const unichar* tag,const unichar* inflected){
+        const unichar* tag,const unichar* inflected){
 const char prefix1[] = "word_";
 unichar* new_inflected = create_bigram_sequence(prefix1,inflected,0);
 unichar* sequence1 = create_bigram_sequence(tag,new_inflected,1);
@@ -362,31 +362,31 @@ long int N2 = get_sequence_integer(sequence1,d,alphabet);
 free(sequence1);
 free(new_inflected);
 if(N1 == -1){
-	/* current inflected token is unknown, we apply
-	 * a suffix-based algorithm to determine its part of speech tag*/
-	if(u_strlen(inflected) < 3){
-		/* the word is too short to be treated */
-		return 0;
-	}
-	int suffix_length = 4;
-	if(u_strlen(inflected) < 6){
-		suffix_length = u_strlen(inflected) - 2;
-	}
-	unichar* suffix = u_strnsuffix(inflected,suffix_length);
-	const char prefix2[] = "suff_";
-	unichar* seq_suff = create_bigram_sequence(prefix2,suffix,0);
-	N1 = get_sequence_integer(seq_suff,d,alphabet);
-	unichar* sequence2 = create_bigram_sequence(tag,seq_suff,1);
-	N2 = get_sequence_integer(sequence2,d,alphabet);
-	free(sequence2);
-	free(suffix);
-	free(seq_suff);
+    /* current inflected token is unknown, we apply
+     * a suffix-based algorithm to determine its part of speech tag*/
+    if(u_strlen(inflected) < 3){
+        /* the word is too short to be treated */
+        return 0;
+    }
+    int suffix_length = 4;
+    if(u_strlen(inflected) < 6){
+        suffix_length = u_strlen(inflected) - 2;
+    }
+    unichar* suffix = u_strnsuffix(inflected,suffix_length);
+    const char prefix2[] = "suff_";
+    unichar* seq_suff = create_bigram_sequence(prefix2,suffix,0);
+    N1 = get_sequence_integer(seq_suff,d,alphabet);
+    unichar* sequence2 = create_bigram_sequence(tag,seq_suff,1);
+    N2 = get_sequence_integer(sequence2,d,alphabet);
+    free(sequence2);
+    free(suffix);
+    free(seq_suff);
 }
 if(N1 == -1){
-	N1 = 0;
+    N1 = 0;
 }
 if(N2 == -1){
-	N2 = 0;
+    N2 = 0;
 }
 /* we compute the emit probability thanks to this smoothed formula */
 return (double)(((double)N2)/(1+((double)(N1))));
@@ -398,7 +398,7 @@ return (double)(((double)N2)/(1+((double)(N1))));
  * a double value between 0 and 1.
  */
 double compute_transition_probability(Dictionary* d,const Alphabet* alphabet,
-									 const unichar* ancestor,const unichar* predecessor,const unichar* current){
+                                     const unichar* ancestor,const unichar* predecessor,const unichar* current){
 unichar* tri_sequence = create_trigram_sequence(ancestor,predecessor,current);
 unichar* bi_sequence = create_bigram_sequence(ancestor,predecessor,1);
 long int C1 = get_sequence_integer(tri_sequence,d,alphabet);
@@ -406,10 +406,10 @@ long int C2 = get_sequence_integer(bi_sequence,d,alphabet);
 free(bi_sequence);
 free(tri_sequence);
 if(C1 == -1){
-	C1 = 0;
+    C1 = 0;
 }
 if(C2 == -1){
-	C2 = 1;
+    C2 = 1;
 }
 return (double)(((double)C1)/((double)(C2)));
 }
@@ -419,11 +419,11 @@ return (double)(((double)C1)/((double)(C2)));
  * If true, replace '-' by '_'.
  */
 void check_compound(unichar* inflected){
-	for(unsigned int i=0;i<u_strlen(inflected);i++){
-		if(inflected[i] == '-'){
-			inflected[i] = '_';
-		}
-	}
+    for(unsigned int i=0;i<u_strlen(inflected);i++){
+        if(inflected[i] == '-'){
+            inflected[i] = '_';
+        }
+    }
 }
 
 /**
@@ -431,53 +431,53 @@ void check_compound(unichar* inflected){
  * The system used here is BIO.
  */
 double compute_partial_probability_compounds(Dictionary* d,const Alphabet* alphabet,
-		  unichar* ancestor,unichar* predecessor,unichar* tag_code,unichar* inflected){
-	check_compound(inflected);
-	unichar* word = u_strchr(inflected,'_');
-	int old_value=0,nb_words=0;
-	double score = 0.0;
-	while(word != NULL) {
-		unichar* simple_word = u_strdup(inflected+old_value,u_strlen(inflected)-old_value-u_strlen(word));
-		unichar* new_tag_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag_code)+3));
-		unichar* tmp = u_strcpy_sized(new_tag_code,u_strlen(tag_code)+1,tag_code);
-		if(nb_words == 0){
-			u_strcat(tmp,"+B\0");
-		}
-		else{
-			u_strcat(tmp,"+I\0");
-		}
-		score += compute_emit_probability(d,alphabet,new_tag_code,simple_word);
-		score += compute_transition_probability(d,alphabet,ancestor,predecessor,new_tag_code);
-		nb_words+=1;
-		old_value += u_strlen(simple_word)+1;
-		word = u_strchr(inflected+old_value,'_');
-		if(nb_words>2){
-			free(ancestor);
-		}
-		ancestor = predecessor;
-		predecessor = new_tag_code;
-		free(simple_word);
-		if(word == NULL){
-			if(u_strlen(inflected)-old_value != 0){
-				word = inflected+old_value;
-				unichar* new_tag_code_2 = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag_code)+3));
-				unichar* tmp_2 = u_strcpy_sized(new_tag_code_2,u_strlen(tag_code)+1,tag_code);
-				u_strcat(tmp_2,"+I\0");
-				score += compute_emit_probability(d,alphabet,new_tag_code_2,word);
-				score += compute_transition_probability(d,alphabet,ancestor,predecessor,new_tag_code_2);
-				free(new_tag_code_2);
-			}
-			if(nb_words>=2){
-				free(ancestor);
-			}
-			if(nb_words>=1){
-				free(predecessor);
-			}
-			break;
-		}
-	}
-	free(inflected);
-	return score;
+          unichar* ancestor,unichar* predecessor,unichar* tag_code,unichar* inflected){
+    check_compound(inflected);
+    unichar* word = u_strchr(inflected,'_');
+    int old_value=0,nb_words=0;
+    double score = 0.0;
+    while(word != NULL) {
+        unichar* simple_word = u_strdup(inflected+old_value,u_strlen(inflected)-old_value-u_strlen(word));
+        unichar* new_tag_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag_code)+3));
+        unichar* tmp = u_strcpy_sized(new_tag_code,u_strlen(tag_code)+1,tag_code);
+        if(nb_words == 0){
+            u_strcat(tmp,"+B\0");
+        }
+        else{
+            u_strcat(tmp,"+I\0");
+        }
+        score += compute_emit_probability(d,alphabet,new_tag_code,simple_word);
+        score += compute_transition_probability(d,alphabet,ancestor,predecessor,new_tag_code);
+        nb_words+=1;
+        old_value += u_strlen(simple_word)+1;
+        word = u_strchr(inflected+old_value,'_');
+        if(nb_words>2){
+            free(ancestor);
+        }
+        ancestor = predecessor;
+        predecessor = new_tag_code;
+        free(simple_word);
+        if(word == NULL){
+            if(u_strlen(inflected)-old_value != 0){
+                word = inflected+old_value;
+                unichar* new_tag_code_2 = (unichar*)malloc(sizeof(unichar)*(u_strlen(tag_code)+3));
+                unichar* tmp_2 = u_strcpy_sized(new_tag_code_2,u_strlen(tag_code)+1,tag_code);
+                u_strcat(tmp_2,"+I\0");
+                score += compute_emit_probability(d,alphabet,new_tag_code_2,word);
+                score += compute_transition_probability(d,alphabet,ancestor,predecessor,new_tag_code_2);
+                free(new_tag_code_2);
+            }
+            if(nb_words>=2){
+                free(ancestor);
+            }
+            if(nb_words>=1){
+                free(predecessor);
+            }
+            break;
+        }
+    }
+    free(inflected);
+    return score;
 }
 
 /**
@@ -485,12 +485,12 @@ double compute_partial_probability_compounds(Dictionary* d,const Alphabet* alpha
  * This probability is the product of emit and transition probabilities.
  */
 double compute_partial_probability(Dictionary* d,const Alphabet* alphabet,
-								  struct matrix_entry* ancestor,struct matrix_entry* predecessor,
-								  struct matrix_entry* current){
+                                  struct matrix_entry* ancestor,struct matrix_entry* predecessor,
+                                  struct matrix_entry* current){
 unichar* inflected = compound_to_simple(current->tag->inflected);
 /* case : a transition tagged by a compound */
 if((u_strchr(inflected,'_') != NULL || (u_strchr(inflected,'-') != NULL && inflected[0]!='-'))&& u_strlen(inflected)>2){
-	return compute_partial_probability_compounds(d,alphabet,ancestor->tag_code,predecessor->tag_code,current->tag_code,inflected);
+    return compute_partial_probability_compounds(d,alphabet,ancestor->tag_code,predecessor->tag_code,current->tag_code,inflected);
 }
 double emit_prob = compute_emit_probability(d,alphabet,current->tag_code,inflected);
 double trans_prob = compute_transition_probability(d,alphabet,ancestor->tag_code,predecessor->tag_code,current->tag_code);
@@ -500,9 +500,9 @@ return emit_prob+trans_prob;
 
 int u_find_char(const unichar* s,unichar t){
 for(int i=u_strlen(s)-1;i>0;i--){
-	if(s[i]==t){
-		return i;
-	}
+    if(s[i]==t){
+        return i;
+    }
 }
 return -1;
 }
@@ -512,16 +512,16 @@ return -1;
  * is better than the previous best transition, we replace this one by the new.
  */
 void compute_best_probability(Dictionary* d,const Alphabet* alphabet,
-							  struct matrix_entry** matrix,int index_matrix,int indexI,int cover_span){
+                              struct matrix_entry** matrix,int index_matrix,int indexI,int cover_span){
 double score = cover_span==1?0:compute_partial_probability(d,alphabet,matrix[matrix[indexI]->predecessor],
-										  matrix[indexI],matrix[index_matrix])+matrix[indexI]->partial_prob;
+                                          matrix[indexI],matrix[index_matrix])+matrix[indexI]->partial_prob;
 if(score > 0 && u_find_char(matrix[index_matrix]->tag->inflected,'_') != -1){
-	score +=2;
+    score +=2;
 }
 /* best predecessor is saved for the current output transition*/
 if(score >= matrix[index_matrix]->partial_prob){
-	matrix[index_matrix]->predecessor = indexI;
-	matrix[index_matrix]->partial_prob = (float)score;
+    matrix[index_matrix]->predecessor = indexI;
+    matrix[index_matrix]->partial_prob = (float)score;
 }
 }
 
@@ -533,15 +533,15 @@ int* get_state_sequence(struct matrix_entry** matrix,int index){
 /* the sequence is just a table of matrix index */
 int* state_sequence = (int*)malloc(index*sizeof(int));
 if(state_sequence == NULL){
-	fatal_alloc_error("get_state_sequence");
+    fatal_alloc_error("get_state_sequence");
 }
 for(int i=index;;){
-	matrix_entry* me = matrix[i];
-	if(me->predecessor == -1){
-		break;
-	}
-	state_sequence[me->predecessor] = i;
-	i = me->predecessor;
+    matrix_entry* me = matrix[i];
+    if(me->predecessor == -1){
+        break;
+    }
+    state_sequence[me->predecessor] = i;
+    i = me->predecessor;
 }
 return state_sequence;
 }
@@ -553,9 +553,9 @@ return state_sequence;
 int is_compound_word(const unichar* token){
 unsigned int l=u_strlen(token);
 for(unsigned int i=0;i<l;i++){
-	if((token[i] == ' ') || (token[i] == '-')) {
-		return 1;
-	}
+    if((token[i] == ' ') || (token[i] == '-')) {
+        return 1;
+    }
 }
 return 0;
 }
@@ -567,12 +567,12 @@ return 0;
 unichar* compound_to_simple(const unichar* token){
 unichar* word = (unichar*)malloc(sizeof(unichar)*(u_strlen(token)+1));
 for(unsigned int i=0;i<=u_strlen(token);i++){
-	if(token[i] == ' '){
-		word[i] = '_';
-	}
-	else{
-		word[i] = token[i];
-	}
+    if(token[i] == ' '){
+        word[i] = '_';
+    }
+    else{
+        word[i] = token[i];
+    }
 }
 
 return word;
@@ -591,62 +591,62 @@ vector_ptr* new_tags = new_vector_ptr(index);
 /* the first tag token in the vector must be a Epsilon token <E> (by convention) */
 vector_ptr_add(new_tags,u_strdup("@<E>\n.\n"));
 if(index == 1){
-	/* sentence has been rejected by elag tagset.def, so we return the empty token */
-	free(state_sequence);
-	return new_tags;
+    /* sentence has been rejected by elag tagset.def, so we return the empty token */
+    free(state_sequence);
+    return new_tags;
 }
 /* trans_table is used to save indexes of best transitions */
 int* trans_table = (int*)malloc((index+1)*sizeof(int));
 for(int i=0;i<=index;i++){
-	trans_table[i] = -1;
+    trans_table[i] = -1;
 }
 SingleGraphState state = graph->states[get_initial_state(graph)];
 for(int i=state_sequence[1];i<=index;i=state_sequence[i]){
-	int next_state = -1;
-	Transition *first = new_Transition(-1,-1),*list = first;
-	for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
-		TfstTag* tag = (TfstTag*)tags->tab[transO->tag_number];
-		unichar* content = compound_to_simple(tag->content);
-		struct dela_entry* entry = tokenize_tag_token(content,1);
-		free(content);
-		if(((same_codes(entry,matrix[i]->tag) == 1 && form_type == 1) ||
-				(form_type == 0 && (u_strcmp(entry->semantic_codes[0],matrix[i]->tag->semantic_codes[0]) == 0))) &&
-				(u_strcmp(entry->inflected,matrix[i]->tag->inflected) == 0) &&
-				transO->tag_number == matrix[i]->tag_number){
-			/* this outgoing transition is the good one (best partial probability at this state) */
-			next_state = transO->state_number;
-			list->next = transO;
-			list = list->next;
-			if(trans_table[transO->tag_number] == -1){
-				/* we add a new tag in the tags table */
-				unichar* tmp = (unichar*)malloc(sizeof(unichar)*4096);
-				TfstTag_to_string(tag,tmp);
-				vector_ptr_add(new_tags,u_strdup(tmp));
-				free(tmp);
-				trans_table[transO->tag_number] = new_tags->nbelems-1;
-				transO->tag_number = new_tags->nbelems-1;
-			}
-			else{
-				transO->tag_number = trans_table[transO->tag_number];
-			}
-		}
-		else{
-			/* this transition is not the best at this state so we delete it */
-			list->next = transO->next;
-			free_Transition(transO);
-			transO = list;
-		}
-		free_dela_entry(entry);
-	}
-	state->outgoing_transitions = first->next;
-	free(first);
-	if(next_state == -1){
-		fatal_error("Invalid state value in do_backtracking\n");
-	}
-	state = graph->states[next_state];
-	if(is_final_state(state) == 1){
-		break;
-	}
+    int next_state = -1;
+    Transition *first = new_Transition(-1,-1),*list = first;
+    for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
+        TfstTag* tag = (TfstTag*)tags->tab[transO->tag_number];
+        unichar* content = compound_to_simple(tag->content);
+        struct dela_entry* entry = tokenize_tag_token(content,1);
+        free(content);
+        if(((same_codes(entry,matrix[i]->tag) == 1 && form_type == 1) ||
+                (form_type == 0 && (u_strcmp(entry->semantic_codes[0],matrix[i]->tag->semantic_codes[0]) == 0))) &&
+                (u_strcmp(entry->inflected,matrix[i]->tag->inflected) == 0) &&
+                transO->tag_number == matrix[i]->tag_number){
+            /* this outgoing transition is the good one (best partial probability at this state) */
+            next_state = transO->state_number;
+            list->next = transO;
+            list = list->next;
+            if(trans_table[transO->tag_number] == -1){
+                /* we add a new tag in the tags table */
+                unichar* tmp = (unichar*)malloc(sizeof(unichar)*4096);
+                TfstTag_to_string(tag,tmp);
+                vector_ptr_add(new_tags,u_strdup(tmp));
+                free(tmp);
+                trans_table[transO->tag_number] = new_tags->nbelems-1;
+                transO->tag_number = new_tags->nbelems-1;
+            }
+            else{
+                transO->tag_number = trans_table[transO->tag_number];
+            }
+        }
+        else{
+            /* this transition is not the best at this state so we delete it */
+            list->next = transO->next;
+            free_Transition(transO);
+            transO = list;
+        }
+        free_dela_entry(entry);
+    }
+    state->outgoing_transitions = first->next;
+    free(first);
+    if(next_state == -1){
+        fatal_error("Invalid state value in do_backtracking\n");
+    }
+    state = graph->states[next_state];
+    if(is_final_state(state) == 1){
+        break;
+    }
 }
 free(trans_table);
 free(state_sequence);
@@ -667,36 +667,36 @@ topological_sort(automaton,NULL);
 compute_reverse_transitions(automaton);
 struct matrix_entry** matrix = initialize_viterbi_matrix(automaton,form_type);
 for(int i=0;i<automaton->number_of_states;i++){
-	SingleGraphState state = automaton->states[i];
-	for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
-		TfstTag* tag = (TfstTag*)input_tfst->tags->tab[transO->tag_number];
-		unichar* content = compound_to_simple(tag->content);
-		int value = create_matrix_entry(content,&matrix[index_matrix],form_type,transO->tag_number,i);
-		free(content);
-		if(value == -1){
-			free(tag->content);
-			tag->content = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
-			if(tag->content == NULL){
-				fatal_alloc_error("do_viterbi");
-			}
-			build_tag(matrix[index_matrix]->tag,NULL,tag->content);
-		}
-		if(is_initial_state(state) != 0){
-			/* initial state has no incoming transitions so we
-			 * calculate probabilities in a separate process */
-			compute_best_probability(d,alphabet,matrix,index_matrix,1,0);
-		}
-		for(Transition* transI=state->reverted_incoming_transitions;transI!=NULL;transI=transI->next){
-			TfstTag* tagI = (TfstTag*)input_tfst->tags->tab[transI->tag_number];
-			unichar* content_2 = compound_to_simple(tagI->content);
-			int indexI = search_matrix_predecessor(matrix,content_2,index_matrix-1,
-						 transI->tag_number,transI->state_number);
-			free(content_2);
-			int cover_span = same_positions(&tagI->m,&tag->m);
-			compute_best_probability(d,alphabet,matrix,index_matrix,indexI,cover_span);
-		}
-		index_matrix++;
-	}
+    SingleGraphState state = automaton->states[i];
+    for(Transition* transO=state->outgoing_transitions;transO!=NULL;transO=transO->next){
+        TfstTag* tag = (TfstTag*)input_tfst->tags->tab[transO->tag_number];
+        unichar* content = compound_to_simple(tag->content);
+        int value = create_matrix_entry(content,&matrix[index_matrix],form_type,transO->tag_number,i);
+        free(content);
+        if(value == -1){
+            free(tag->content);
+            tag->content = (unichar*)malloc(sizeof(unichar)*DIC_LINE_SIZE);
+            if(tag->content == NULL){
+                fatal_alloc_error("do_viterbi");
+            }
+            build_tag(matrix[index_matrix]->tag,NULL,tag->content);
+        }
+        if(is_initial_state(state) != 0){
+            /* initial state has no incoming transitions so we
+             * calculate probabilities in a separate process */
+            compute_best_probability(d,alphabet,matrix,index_matrix,1,0);
+        }
+        for(Transition* transI=state->reverted_incoming_transitions;transI!=NULL;transI=transI->next){
+            TfstTag* tagI = (TfstTag*)input_tfst->tags->tab[transI->tag_number];
+            unichar* content_2 = compound_to_simple(tagI->content);
+            int indexI = search_matrix_predecessor(matrix,content_2,index_matrix-1,
+                         transI->tag_number,transI->state_number);
+            free(content_2);
+            int cover_span = same_positions(&tagI->m,&tag->m);
+            compute_best_probability(d,alphabet,matrix,index_matrix,indexI,cover_span);
+        }
+        index_matrix++;
+    }
 }
 /* we compute the backtracking part of the process to prune the automata */
 vector_ptr* new_tags = do_backtracking(matrix,index_matrix-1,automaton,input_tfst->tags,form_type);
@@ -715,7 +715,7 @@ unichar code_type[DIC_LINE_SIZE];
 u_sprintf(code_type,"CODE\tFEATURES");
 long int value = get_sequence_integer(code_type,d,alphabet);
 if(value == -1){
-	fatal_error("Bad value in get_form_type\n");
+    fatal_error("Bad value in get_form_type\n");
 }
 return (int)value;
 }
@@ -726,20 +726,20 @@ return (int)value;
  * obtain a linear path (the most probable path).
  */
 void do_tagging(Tfst* input_tfst,Tfst* result_tfst,Dictionary* d,
-				const Alphabet* alphabet,int form_type,
-				struct hash_table* form_frequencies){
+                const Alphabet* alphabet,int form_type,
+                struct hash_table* form_frequencies){
 /* we write the number of sentences in the result tfst file */
 u_fprintf(result_tfst->tfst,"%010d\n",input_tfst->N);
 /* for each sentence we compute Viterbi Path algorithm */
 for(int i=1;i<=input_tfst->N;i++){
-	load_sentence(input_tfst,i);
-	vector_ptr* new_tags = do_viterbi(d,alphabet,input_tfst,form_type);
-	save_current_sentence(input_tfst,result_tfst->tfst,result_tfst->tind,
-			(unichar**)new_tags->tab,new_tags->nbelems,form_frequencies);
-	free_vector_ptr(new_tags,free);
-	if(i%100 == 0){
-		u_printf("Sentence %d/%d...\r",i,input_tfst->N);
-	}
+    load_sentence(input_tfst,i);
+    vector_ptr* new_tags = do_viterbi(d,alphabet,input_tfst,form_type);
+    save_current_sentence(input_tfst,result_tfst->tfst,result_tfst->tind,
+            (unichar**)new_tags->tab,new_tags->nbelems,form_frequencies);
+    free_vector_ptr(new_tags,free);
+    if(i%100 == 0){
+        u_printf("Sentence %d/%d...\r",i,input_tfst->N);
+    }
 }
 u_printf("\n");
 }

--- a/TaggingProcess.h
+++ b/TaggingProcess.h
@@ -62,12 +62,12 @@ namespace unitex {
  * of the best predecessor).
  */
 struct matrix_entry {
-	struct dela_entry* tag;
-	unichar* tag_code;
-	int predecessor;
-	int tag_number;
-	int state_number;
-	float partial_prob;
+    struct dela_entry* tag;
+    unichar* tag_code;
+    int predecessor;
+    int tag_number;
+    int state_number;
+    float partial_prob;
 };
 
 void compute_tag_code(struct dela_entry*,unichar*,int);

--- a/Tagset.cpp
+++ b/Tagset.cpp
@@ -507,7 +507,7 @@ while (partid!=-1 && u_fgets(line,MAXBUF,f)>0) {
             case PART_NUM:
                fatal_error("No section specified. (line '%S')\n", line);
 
-            default:	fatal_error("While parsing POS section: what am i doing here?\n");
+            default:    fatal_error("While parsing POS section: what am i doing here?\n");
          }
          pos_section->parts[partid]=tokens_list_append(pos_section->parts[partid],toks);
          break;

--- a/TagsetNormTfst.h
+++ b/TagsetNormTfst.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef TagsetNormTfstH
 #define TagsetNormTfstH
 

--- a/Test_lib.cpp
+++ b/Test_lib.cpp
@@ -59,56 +59,56 @@ int retValue = 0;
 INSTALLLOGGER pInstallLogger = NULL;
 
 if (argc>=3) {
-	int skip_arg = 0;
-	if ((strcmp(argv[1], "{") == 0) && (strcmp(argv[2], "CreateLog") == 0))
-	{
-		for (int i = 2;i<argc;i++) {
-			if (strcmp(argv[i], "}") == 0) {
-				skip_arg = i;
-				break;
-			}
-		}
-	}
+    int skip_arg = 0;
+    if ((strcmp(argv[1], "{") == 0) && (strcmp(argv[2], "CreateLog") == 0))
+    {
+        for (int i = 2;i<argc;i++) {
+            if (strcmp(argv[i], "}") == 0) {
+                skip_arg = i;
+                break;
+            }
+        }
+    }
 
-	if (skip_arg == 0) {
-		pInstallLogger = BuildLogger();
-	}
-	else {
-		pInstallLogger = BuildLoggerFromArgs(skip_arg - 2, argv + 2);
-	}
-	argc -= skip_arg;
-	argv += skip_arg;
+    if (skip_arg == 0) {
+        pInstallLogger = BuildLogger();
+    }
+    else {
+        pInstallLogger = BuildLoggerFromArgs(skip_arg - 2, argv + 2);
+    }
+    argc -= skip_arg;
+    argv += skip_arg;
 }
 
 
 if (argc>1) {
   if (strcmp(argv[1],"RunLog")==0) {
     int ret_value = RunLog_run_main(argc-1,argv+1);
-	if (pInstallLogger != NULL) {
-		RemoveLoggerFromParamFile(pInstallLogger);
-	}
-	return ret_value;
+    if (pInstallLogger != NULL) {
+        RemoveLoggerFromParamFile(pInstallLogger);
+    }
+    return ret_value;
   }
   if (strcmp(argv[1],"UnitexTool")==0) {
-	int ret_value = UnitexTool_public_run(argc-1,argv+1,NULL,NULL);
-	if (pInstallLogger != NULL) {
-		RemoveLoggerFromParamFile(pInstallLogger);
-	}
-	return ret_value;
+    int ret_value = UnitexTool_public_run(argc-1,argv+1,NULL,NULL);
+    if (pInstallLogger != NULL) {
+        RemoveLoggerFromParamFile(pInstallLogger);
+    }
+    return ret_value;
   }
   if (strcmp(argv[1], "{") == 0) {
-	int ret_value = UnitexTool_public_run(argc, argv, NULL, NULL);
-	if (pInstallLogger != NULL) {
-		RemoveLoggerFromParamFile(pInstallLogger);
-	}
-	return ret_value;
+    int ret_value = UnitexTool_public_run(argc, argv, NULL, NULL);
+    if (pInstallLogger != NULL) {
+        RemoveLoggerFromParamFile(pInstallLogger);
+    }
+    return ret_value;
   }
   if (UnitexTool_public_GetToolInfo_byname(argv[1], NULL, NULL, NULL, NULL) != -1) {
-	int ret_value = UnitexTool_public_run(argc, argv, NULL, NULL);
-	if (pInstallLogger != NULL) {
-		RemoveLoggerFromParamFile(pInstallLogger);
-	}
-	return ret_value;
+    int ret_value = UnitexTool_public_run(argc, argv, NULL, NULL);
+    if (pInstallLogger != NULL) {
+        RemoveLoggerFromParamFile(pInstallLogger);
+    }
+    return ret_value;
   }
 }
 
@@ -122,7 +122,7 @@ if (CheckRegexLibInUnitex()) {
     puts("Regex Library is functionnal.");
 } else {
     puts("Regex Library is NOT functionnal.");
-	retValue = 1;
+    retValue = 1;
 }
 
 
@@ -160,7 +160,7 @@ RemoveUnitexFile(name);
 RemoveUnitexFile(grf);
 
 if (pInstallLogger != NULL) {
-	RemoveLoggerFromParamFile(pInstallLogger);
+    RemoveLoggerFromParamFile(pInstallLogger);
 }
 return retValue;
 }

--- a/Text_parsing.cpp
+++ b/Text_parsing.cpp
@@ -44,32 +44,32 @@ namespace unitex {
 
 static int binary_search(int, int*, int);
 static int find_compound_word(int, int, struct DLC_tree_info*,
-		struct locate_parameters*);
+        struct locate_parameters*);
 static unichar* get_token_sequence(struct locate_parameters*, int, int);
 void shift_variable_bounds(Variables*, int);
 static void add_match(int, unichar*, struct locate_parameters*, Abstract_allocator);
 static void real_add_match(struct match_list*, struct locate_parameters*, Abstract_allocator);
 static struct match_list* eliminate_longer_matches(struct match_list*, int, int,
-		unichar*, int*, struct locate_parameters*, Abstract_allocator);
+        unichar*, int*, struct locate_parameters*, Abstract_allocator);
 static struct match_list* eliminate_shorter_matches(struct match_list*, int, int,
-		unichar*, int*, struct locate_parameters*, Abstract_allocator);
+        unichar*, int*, struct locate_parameters*, Abstract_allocator);
 static struct match_list* save_matches(struct match_list*, int, U_FILE*,
-		struct locate_parameters*, Abstract_allocator);
+        struct locate_parameters*, Abstract_allocator);
 static inline int at_text_start(struct locate_parameters*,int);
 
 
 static long CalcPerfHalfHundred(long text_size, long matching_units) {
-	unsigned long text_size_calc_per_halfhundred = text_size;
-	unsigned long matching_units_per_halfhundred = (unsigned long)(matching_units);
-	unsigned long factor = 1;
-	while (text_size_calc_per_halfhundred / factor >= 21473) {
-	    factor *= 10;
-	}
+    unsigned long text_size_calc_per_halfhundred = text_size;
+    unsigned long matching_units_per_halfhundred = (unsigned long)(matching_units);
+    unsigned long factor = 1;
+    while (text_size_calc_per_halfhundred / factor >= 21473) {
+        factor *= 10;
+    }
 
-	long per_halfhundred=0;
-	if ((text_size_calc_per_halfhundred / factor) != 0)
-	{
-	    unsigned long multiplicator = 100000 ;
+    long per_halfhundred=0;
+    if ((text_size_calc_per_halfhundred / factor) != 0)
+    {
+        unsigned long multiplicator = 100000 ;
         unsigned long factor_matching_units = factor;
         while ((multiplicator > 1) && (factor_matching_units > 1)) {
           multiplicator /= 10;
@@ -77,9 +77,9 @@ static long CalcPerfHalfHundred(long text_size, long matching_units) {
         }
         if (factor_matching_units != 0)
             if ((text_size_calc_per_halfhundred / factor) != 0)
-	    per_halfhundred = (long)(((matching_units_per_halfhundred * multiplicator ) / factor_matching_units) / (text_size_calc_per_halfhundred / factor));
-	}
-	return per_halfhundred;
+        per_halfhundred = (long)(((matching_units_per_halfhundred * multiplicator ) / factor_matching_units) / (text_size_calc_per_halfhundred / factor));
+    }
+    return per_halfhundred;
 }
 
 /**
@@ -87,80 +87,80 @@ static long CalcPerfHalfHundred(long text_size, long matching_units) {
  * on the fly.
  */
 void launch_locate(U_FILE* out, long int text_size, U_FILE* info,
-		struct locate_parameters* p) {
-	p->token_error_ctx.n_errors = 0;
-	p->token_error_ctx.last_start = -1;
-	p->token_error_ctx.last_length = 0;
-	p->token_error_ctx.n_matches_at_token_pos__locate = 0;
-	p->token_error_ctx.n_matches_at_token_pos__morphological_locate = 0;
+        struct locate_parameters* p) {
+    p->token_error_ctx.n_errors = 0;
+    p->token_error_ctx.last_start = -1;
+    p->token_error_ctx.last_length = 0;
+    p->token_error_ctx.n_matches_at_token_pos__locate = 0;
+    p->token_error_ctx.n_matches_at_token_pos__morphological_locate = 0;
 
 
-	p->is_in_trace_state = 0;
-	if ((p->fnc_locate_trace_step != NULL))
-		p->is_in_trace_state = 1;
+    p->is_in_trace_state = 0;
+    if ((p->fnc_locate_trace_step != NULL))
+        p->is_in_trace_state = 1;
 
-	//fill_buffer(p->token_buffer, f);
-	OptimizedFst2State initial_state =
-			p->optimized_states[p->fst2->initial_states[1]];
-	p->current_origin = 0;
-	int n_read = 0;
-	int unite;
-	clock_t startTime = clock();
-	clock_t currentTime;
-	unsigned long total_count_step = 0;
+    //fill_buffer(p->token_buffer, f);
+    OptimizedFst2State initial_state =
+            p->optimized_states[p->fst2->initial_states[1]];
+    p->current_origin = 0;
+    int n_read = 0;
+    int unite;
+    clock_t startTime = clock();
+    clock_t currentTime;
+    unsigned long total_count_step = 0;
 
-	unite = (int)(((text_size / 100) > 1000) ? (text_size / 100) : 1000);
-	variable_backup_memory_reserve* backup_reserve =
-			create_variable_backup_memory_reserve(p->input_variables,1);
+    unite = (int)(((text_size / 100) > 1000) ? (text_size / 100) : 1000);
+    variable_backup_memory_reserve* backup_reserve =
+            create_variable_backup_memory_reserve(p->input_variables,1);
     p->backup_memory_reserve = backup_reserve;
-	int current_token;
-	while (p->current_origin < p->buffer_size &&
-			p->buffer[p->current_origin] < p->tokens->size &&
-			p->number_of_matches != p->search_limit) {
-		if (unite != 0) {
-			n_read = p->current_origin % unite;
-			if (n_read == 0 && ((currentTime = clock()) - startTime > DELAY)) {
-				startTime = currentTime;
-				u_printf("%2.2f%% done        \r", 100.0
-						* (float) (p->current_origin)
-						/ (float) text_size);
-			}
-		}
-		current_token = p->buffer[p->current_origin];
-		if (!(current_token == p->SPACE && p->space_policy
-				== DONT_START_WITH_SPACE) && !get_value(p->failfast,
-				current_token)) {
+    int current_token;
+    while (p->current_origin < p->buffer_size &&
+            p->buffer[p->current_origin] < p->tokens->size &&
+            p->number_of_matches != p->search_limit) {
+        if (unite != 0) {
+            n_read = p->current_origin % unite;
+            if (n_read == 0 && ((currentTime = clock()) - startTime > DELAY)) {
+                startTime = currentTime;
+                u_printf("%2.2f%% done        \r", 100.0
+                        * (float) (p->current_origin)
+                        / (float) text_size);
+            }
+        }
+        current_token = p->buffer[p->current_origin];
+        if (!(current_token == p->SPACE && p->space_policy
+                == DONT_START_WITH_SPACE) && !get_value(p->failfast,
+                current_token)) {
 
-			int cache_found = 0;
+            int cache_found = 0;
             if (p->useLocateCache)
                 cache_found =  consult_cache(p->buffer, p->current_origin,
-					p->buffer_size, p->match_cache,
-					p->cached_match_vector);
-			if (cache_found) {
-				/* If we have found matches in the cache, we use them */
-				for (int i=0;i<p->cached_match_vector->nbelems;i++) {
-					struct match_list* tmp=(struct match_list*)(p->cached_match_vector->tab[i]);
-					while (tmp!=NULL) {
-						/* We have to adjust the match coordinates */
-						int size=tmp->m.end_pos_in_token-tmp->m.start_pos_in_token;
-						tmp->m.start_pos_in_token=p->current_origin;
-						tmp->m.end_pos_in_token=tmp->m.start_pos_in_token+size;
-						real_add_match(tmp,p,p->al.prv_alloc_generic);
-						tmp=tmp->next;
-					}
-				}
-			} else {
-				/* Standard locate procedure */
-				p->stack_base = -1;
-				p->stack->stack_pointer = -1;
-				struct parsing_info* matches = NULL;
-				p->left_ctx_shift = 0;
-				p->left_ctx_base = 0;
+                    p->buffer_size, p->match_cache,
+                    p->cached_match_vector);
+            if (cache_found) {
+                /* If we have found matches in the cache, we use them */
+                for (int i=0;i<p->cached_match_vector->nbelems;i++) {
+                    struct match_list* tmp=(struct match_list*)(p->cached_match_vector->tab[i]);
+                    while (tmp!=NULL) {
+                        /* We have to adjust the match coordinates */
+                        int size=tmp->m.end_pos_in_token-tmp->m.start_pos_in_token;
+                        tmp->m.start_pos_in_token=p->current_origin;
+                        tmp->m.end_pos_in_token=tmp->m.start_pos_in_token+size;
+                        real_add_match(tmp,p,p->al.prv_alloc_generic);
+                        tmp=tmp->next;
+                    }
+                }
+            } else {
+                /* Standard locate procedure */
+                p->stack_base = -1;
+                p->stack->stack_pointer = -1;
+                struct parsing_info* matches = NULL;
+                p->left_ctx_shift = 0;
+                p->left_ctx_base = 0;
 
                 p->counting_step.count_call=0;
                 p->counting_step.count_cancel_trying=0;
-				p->last_tested_position = 0;
-				p->last_matched_position = -1;
+                p->last_tested_position = 0;
+                p->last_matched_position = -1;
                 p->graph_depth=0;
                 p->explore_depth=-1;
                 p->token_error_ctx.n_matches_at_token_pos__morphological_locate = 0;
@@ -171,113 +171,113 @@ void launch_locate(U_FILE* out, long int text_size, U_FILE* info,
                 p->no_fail_fast=0;
                 p->weight=-1;
                 int n_matches=0;
-				locate(/*0,*/ initial_state, 0,/* 0,*/ &matches, &n_matches, NULL, p);
+                locate(/*0,*/ initial_state, 0,/* 0,*/ &matches, &n_matches, NULL, p);
 
-				clean_allocator(p->al.pa.prv_alloc_vector_int_inside_token);
+                clean_allocator(p->al.pa.prv_alloc_vector_int_inside_token);
 
 
-				int count_call_real = p->counting_step.count_call;
-				count_call_real -= (p->is_in_trace_state == 0) ? (p->counting_step.count_cancel_trying) : (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
+                int count_call_real = p->counting_step.count_call;
+                count_call_real -= (p->is_in_trace_state == 0) ? (p->counting_step.count_cancel_trying) : (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
 
 
 //u_printf("token number %d : %d step\n",p->current_origin,count_call_real,p->tokens);
 
-				total_count_step += (unsigned long)count_call_real;
+                total_count_step += (unsigned long)count_call_real;
 
-				if ((p->max_count_call > 0)
-						&& (p->counting_step.count_call >= p->max_count_call)) {
-					error(
-							"Stop computing token %u after %u step computing with grammar %s.\n",
-							p->current_origin, p->counting_step.count_call, p->graph_filename);
-				} else if ((p->max_count_call_warning > 0) && (p->counting_step.count_call
-						>= p->max_count_call_warning)) {
-					error(
-							"Warning : computing token %u take %u step computing with grammar %s.\n",
-							p->current_origin, p->counting_step.count_call, p->graph_filename);
-				}
-				int can_cache_matches = 0;
-				p->last_tested_position=p->last_tested_position+p->current_origin;
-				if (p->last_matched_position == -1) {
-					if (p->last_tested_position == p->current_origin
-							&& !u_is_digit(p->tokens->value[current_token][0])
-							&& !p->no_fail_fast) {
-						/* We are in the fail fast case, nothing has been matched while
-						 * looking only at the first current token. That means that no match
-						 * could ever happen when this token is found in the text.
-						 *
-						 * NOTE: we add the digit test because if the fail came from
-						 * something like <NB><<....>>, then it may have failed on a token
-						 * because of the morphological filter, not because of the first
-						 * token itself */
-						set_value(p->failfast, current_token, 1);
-					}
-				} else {
-					if (p->last_tested_position <= p->last_matched_position
-							&& !at_text_start(p,0)) {
-						/* If there are matches that could never be longer, we
-						 * can cache them, BUT, we never cache a match that occurred
-						 * at the beginning of the text, since it may be a contextual
-						 * match depending on the {^} meta */
-						can_cache_matches = 1;
-					}
-				}
-				struct match_list* tmp;
-				while (p->match_cache_first != NULL) {
-					real_add_match(p->match_cache_first, p, p->al.prv_alloc_generic);
-					tmp = p->match_cache_first;
-					p->match_cache_first = p->match_cache_first->next;
-					if (can_cache_matches &&
-					      tmp->m.start_pos_in_token==p->current_origin) {
-						/* We have to test the start position, because a match obtained using a left
-						 * context could cause problems. We have to set tmp->next to NULL because
-						 * we just want to consider this single match */
-						tmp->next=NULL;
-						/* We have to cache the match using the longest possible context and not
-						 * only the end of the match. Imagine that the text contains the
-						 * sequence "...volley-ball..." with the matches "volley" and
-						 * "volley-ball". If we cache these two matches with their own ends,
-						 * then, if the text contains "volley ball meeting", we will find
-						 * "volley" in cache and skip longer matches like "volley ball".
-						 */
-						cache_match(tmp, p->buffer,
-								tmp->m.start_pos_in_token,
-								p->last_matched_position,
-								&(p->match_cache[current_token]), p->al.prv_alloc_generic);
-					} else {
-						free_match_list_element(tmp, p->al.prv_alloc_generic);
-					}
-				}
-				p->match_cache_last = NULL;
-				free_parsing_info(matches,&p->al.pa);
+                if ((p->max_count_call > 0)
+                        && (p->counting_step.count_call >= p->max_count_call)) {
+                    error(
+                            "Stop computing token %u after %u step computing with grammar %s.\n",
+                            p->current_origin, p->counting_step.count_call, p->graph_filename);
+                } else if ((p->max_count_call_warning > 0) && (p->counting_step.count_call
+                        >= p->max_count_call_warning)) {
+                    error(
+                            "Warning : computing token %u take %u step computing with grammar %s.\n",
+                            p->current_origin, p->counting_step.count_call, p->graph_filename);
+                }
+                int can_cache_matches = 0;
+                p->last_tested_position=p->last_tested_position+p->current_origin;
+                if (p->last_matched_position == -1) {
+                    if (p->last_tested_position == p->current_origin
+                            && !u_is_digit(p->tokens->value[current_token][0])
+                            && !p->no_fail_fast) {
+                        /* We are in the fail fast case, nothing has been matched while
+                         * looking only at the first current token. That means that no match
+                         * could ever happen when this token is found in the text.
+                         *
+                         * NOTE: we add the digit test because if the fail came from
+                         * something like <NB><<....>>, then it may have failed on a token
+                         * because of the morphological filter, not because of the first
+                         * token itself */
+                        set_value(p->failfast, current_token, 1);
+                    }
+                } else {
+                    if (p->last_tested_position <= p->last_matched_position
+                            && !at_text_start(p,0)) {
+                        /* If there are matches that could never be longer, we
+                         * can cache them, BUT, we never cache a match that occurred
+                         * at the beginning of the text, since it may be a contextual
+                         * match depending on the {^} meta */
+                        can_cache_matches = 1;
+                    }
+                }
+                struct match_list* tmp;
+                while (p->match_cache_first != NULL) {
+                    real_add_match(p->match_cache_first, p, p->al.prv_alloc_generic);
+                    tmp = p->match_cache_first;
+                    p->match_cache_first = p->match_cache_first->next;
+                    if (can_cache_matches &&
+                          tmp->m.start_pos_in_token==p->current_origin) {
+                        /* We have to test the start position, because a match obtained using a left
+                         * context could cause problems. We have to set tmp->next to NULL because
+                         * we just want to consider this single match */
+                        tmp->next=NULL;
+                        /* We have to cache the match using the longest possible context and not
+                         * only the end of the match. Imagine that the text contains the
+                         * sequence "...volley-ball..." with the matches "volley" and
+                         * "volley-ball". If we cache these two matches with their own ends,
+                         * then, if the text contains "volley ball meeting", we will find
+                         * "volley" in cache and skip longer matches like "volley ball".
+                         */
+                        cache_match(tmp, p->buffer,
+                                tmp->m.start_pos_in_token,
+                                p->last_matched_position,
+                                &(p->match_cache[current_token]), p->al.prv_alloc_generic);
+                    } else {
+                        free_match_list_element(tmp, p->al.prv_alloc_generic);
+                    }
+                }
+                p->match_cache_last = NULL;
+                free_parsing_info(matches,&p->al.pa);
                 if (p->dic_variables != NULL) {
                     clear_dic_variable_list(&(p->dic_variables));
                 }
-			}
-		}
-		reset_Variables(p->input_variables);
-		p->match_list = save_matches(p->match_list,p->current_origin, out, p, p->al.prv_alloc_generic);
-		(p->current_origin)++;
-	} /* End of the big while */
-	free_reserve(backup_reserve);
+            }
+        }
+        reset_Variables(p->input_variables);
+        p->match_list = save_matches(p->match_list,p->current_origin, out, p, p->al.prv_alloc_generic);
+        (p->current_origin)++;
+    } /* End of the big while */
+    free_reserve(backup_reserve);
     p->backup_memory_reserve = NULL;
 
-	p->match_list = save_matches(p->match_list,p->current_origin+1, out, p, p->al.prv_alloc_generic);
-	u_printf("100%% done      \n\n");
-	u_printf("%d match%s\n", p->number_of_matches,
-			(p->number_of_matches == 1) ? "" : "es");
-	if ((p->number_of_outputs != p->number_of_matches) && (p->number_of_outputs
-			!= 0))
-		u_printf("(%d output%s)\n", p->number_of_outputs, (p->number_of_outputs
-				== 1) ? "" : "s");
-	u_printf("%d recognized units\n", p->matching_units);
+    p->match_list = save_matches(p->match_list,p->current_origin+1, out, p, p->al.prv_alloc_generic);
+    u_printf("100%% done      \n\n");
+    u_printf("%d match%s\n", p->number_of_matches,
+            (p->number_of_matches == 1) ? "" : "es");
+    if ((p->number_of_outputs != p->number_of_matches) && (p->number_of_outputs
+            != 0))
+        u_printf("(%d output%s)\n", p->number_of_outputs, (p->number_of_outputs
+                == 1) ? "" : "s");
+    u_printf("%d recognized units\n", p->matching_units);
 
-	long per_halfhundred=CalcPerfHalfHundred(text_size,p->matching_units);
+    long per_halfhundred=CalcPerfHalfHundred(text_size,p->matching_units);
 
-	if (text_size != 0) {
-		u_printf("(%2.3f%% of the text is covered)\n", (float) (((float)per_halfhundred)
-				/ (float) 1000.0));
-	}
-	u_printf("%u exploration step\n",(unsigned int)total_count_step);
+    if (text_size != 0) {
+        u_printf("(%2.3f%% of the text is covered)\n", (float) (((float)per_halfhundred)
+                / (float) 1000.0));
+    }
+    u_printf("%u exploration step\n",(unsigned int)total_count_step);
 
     /*
     {
@@ -286,20 +286,20 @@ void launch_locate(U_FILE* out, long int text_size, U_FILE* info,
         puts(sz);
     }*/
 
-	if (info != NULL) {
-		u_fprintf(info, "%d match%s\n", p->number_of_matches,
-				(p->number_of_matches <= 1) ? "" : "es");
-		if ((p->number_of_outputs != p->number_of_matches)
-				&& (p->number_of_outputs != 0)) {
-			u_fprintf(info, "(%d output%s)\n", p->number_of_outputs,
-					(p->number_of_outputs <= 1) ? "" : "s");
-		}
-		u_fprintf(info, "%d recognized units\n", p->matching_units);
-		if (text_size != 0) {
-			u_fprintf(info, "(%2.3f%% of the text is covered)\n",
-					(float) (((float)per_halfhundred) / (float) 1000.0));
-		}
-	}
+    if (info != NULL) {
+        u_fprintf(info, "%d match%s\n", p->number_of_matches,
+                (p->number_of_matches <= 1) ? "" : "es");
+        if ((p->number_of_outputs != p->number_of_matches)
+                && (p->number_of_outputs != 0)) {
+            u_fprintf(info, "(%d output%s)\n", p->number_of_outputs,
+                    (p->number_of_outputs <= 1) ? "" : "s");
+        }
+        u_fprintf(info, "%d recognized units\n", p->matching_units);
+        if (text_size != 0) {
+            u_fprintf(info, "(%2.3f%% of the text is covered)\n",
+                    (float) (((float)per_halfhundred) / (float) 1000.0));
+        }
+    }
 }
 
 /**
@@ -309,48 +309,48 @@ void launch_locate(U_FILE* out, long int text_size, U_FILE* info,
  *  exit the programm by calling "fatal_error".
  */
 void error_at_token_pos(const char* message, int start, int length,
-		struct locate_parameters* p, const struct optimizedFst2State* current_state) {
-	//static int n_errors;
-	//static int last_start=-1;
-	//static int last_length;
-	int i;
-	if ((p->token_error_ctx.last_start) == start) {
-		/* The context was already printed */
-		return;
-	}
-	error("%s with grammar %s\n  ", message, p->graph_filename);
-	for (i = (start - 4); (i <= (start + 20)) && (i < p->buffer_size); i++) {
-		if (i < 0) {
-			continue;
-		}
-		if (i == start) {
-			error("<<HERE>>");
-		}
-		error("%S", p->tokens->value[p->buffer[i]]);
-		if (i == (start + length)) {
-			error("<<END>>");
-		}
-	}
-	if (i < (start + length)) {
-		error(" ...");
-	}
-	error(" graph name: [%S:%d:%d]\n", p->fst2->graph_names[current_state->graph_number],
-		current_state->pos_transition_in_fst2,current_state->pos_transition_in_graph);
-	(p->token_error_ctx.n_errors)++;
-	if (!p->debug && p->token_error_ctx.n_errors >= p->max_errors) {
-		/* In debug mode, we don't stop on such a problem */
-		error("Too many errors, giving up!\n");
-		p->is_in_cancel_state = 3;
-	}
-	p->token_error_ctx.last_start = start;
-	p->token_error_ctx.last_length = length;
+        struct locate_parameters* p, const struct optimizedFst2State* current_state) {
+    //static int n_errors;
+    //static int last_start=-1;
+    //static int last_length;
+    int i;
+    if ((p->token_error_ctx.last_start) == start) {
+        /* The context was already printed */
+        return;
+    }
+    error("%s with grammar %s\n  ", message, p->graph_filename);
+    for (i = (start - 4); (i <= (start + 20)) && (i < p->buffer_size); i++) {
+        if (i < 0) {
+            continue;
+        }
+        if (i == start) {
+            error("<<HERE>>");
+        }
+        error("%S", p->tokens->value[p->buffer[i]]);
+        if (i == (start + length)) {
+            error("<<END>>");
+        }
+    }
+    if (i < (start + length)) {
+        error(" ...");
+    }
+    error(" graph name: [%S:%d:%d]\n", p->fst2->graph_names[current_state->graph_number],
+        current_state->pos_transition_in_fst2,current_state->pos_transition_in_graph);
+    (p->token_error_ctx.n_errors)++;
+    if (!p->debug && p->token_error_ctx.n_errors >= p->max_errors) {
+        /* In debug mode, we don't stop on such a problem */
+        error("Too many errors, giving up!\n");
+        p->is_in_cancel_state = 3;
+    }
+    p->token_error_ctx.last_start = start;
+    p->token_error_ctx.last_length = length;
 }
 
 
 static inline void update_last_tested_position(struct locate_parameters* p, int pos) {
-	if (pos > p->last_tested_position) {
-		p->last_tested_position = pos;
-	}
+    if (pos > p->last_tested_position) {
+        p->last_tested_position = pos;
+    }
 }
 
 
@@ -371,7 +371,7 @@ return 0;
 
 static inline int at_text_start(struct locate_parameters* p,int pos) {
 int ret=pos == 0 && (p->current_origin == 0
-				|| (p->current_origin == 1 && p->buffer[0] == p->SPACE));
+                || (p->current_origin == 1 && p->buffer[0] == p->SPACE));
 return ret;
 }
 
@@ -392,889 +392,889 @@ struct list_context* ctx, /* information about the current context, if any */
 struct locate_parameters* p /* miscellaneous parameters needed by the function */
 ) {
 #ifdef REGEX_FACADE_ENGINE
-	int filter_number;
+    int filter_number;
 #endif
-	int pos2 = -1, ctrl = 0, end_of_compound;
-	int token, token2;
-	Transition* t1;
-	int stack_top = p->stack->stack_pointer;
-	int old_weight1=p->weight;
-	unichar* output;
-	int captured_chars;
+    int pos2 = -1, ctrl = 0, end_of_compound;
+    int token, token2;
+    Transition* t1;
+    int stack_top = p->stack->stack_pointer;
+    int old_weight1=p->weight;
+    unichar* output;
+    int captured_chars;
 
-	if ((p->counting_step.count_cancel_trying) == 0) {
+    if ((p->counting_step.count_cancel_trying) == 0) {
 
-		if (p->is_in_cancel_state != 0)
-			return;
+        if (p->is_in_cancel_state != 0)
+            return;
 
-		if (p->is_in_trace_state == 0) {
+        if (p->is_in_trace_state == 0) {
 
-			if ((p->max_count_call) > 0) {
-				if ((p->counting_step.count_call) >= (p->max_count_call)) {
-					p->counting_step.count_cancel_trying = 0;
-					p->is_in_cancel_state = 1;
-					return;
-				}
-			}
+            if ((p->max_count_call) > 0) {
+                if ((p->counting_step.count_call) >= (p->max_count_call)) {
+                    p->counting_step.count_cancel_trying = 0;
+                    p->is_in_cancel_state = 1;
+                    return;
+                }
+            }
 
-			p->counting_step.count_cancel_trying = COUNT_CANCEL_TRYING_INIT_CONST;
-			if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
-					+COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
-				p->counting_step.count_cancel_trying = (p->max_count_call) - (p->counting_step.count_call);
-			}
+            p->counting_step.count_cancel_trying = COUNT_CANCEL_TRYING_INIT_CONST;
+            if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
+                    +COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
+                p->counting_step.count_cancel_trying = (p->max_count_call) - (p->counting_step.count_call);
+            }
 
-			if (is_cancelling_requested() != 0) {
-				p->counting_step.count_cancel_trying = 0;
-				p->is_in_cancel_state = 2;
-				return;
-			}
-			(p->counting_step.count_call) += (p->counting_step.count_cancel_trying);
-		}
-		else
-		{
-			if ((p->fnc_locate_trace_step != NULL)) {
-				locate_trace_info* lti;
-				lti = (locate_trace_info*)malloc_cb(sizeof(locate_trace_info),p->al.prv_alloc_trace_info_allocator);
-				if (lti==NULL) {
-					fatal_alloc_error("locate");
-				}
-				lti->size_struct_locate_trace_info = (int)sizeof(locate_trace_info);
-				lti->is_on_morphlogical = 0;
+            if (is_cancelling_requested() != 0) {
+                p->counting_step.count_cancel_trying = 0;
+                p->is_in_cancel_state = 2;
+                return;
+            }
+            (p->counting_step.count_call) += (p->counting_step.count_cancel_trying);
+        }
+        else
+        {
+            if ((p->fnc_locate_trace_step != NULL)) {
+                locate_trace_info* lti;
+                lti = (locate_trace_info*)malloc_cb(sizeof(locate_trace_info),p->al.prv_alloc_trace_info_allocator);
+                if (lti==NULL) {
+                    fatal_alloc_error("locate");
+                }
+                lti->size_struct_locate_trace_info = (int)sizeof(locate_trace_info);
+                lti->is_on_morphlogical = 0;
 
-				lti->pos_in_tokens=pos;
+                lti->pos_in_tokens=pos;
 
-				lti->current_state=current_state;
+                lti->current_state=current_state;
 
-				lti->current_state_index=0;
-				lti->pos_in_chars=0;
+                lti->current_state_index=0;
+                lti->pos_in_chars=0;
 
-				lti->matches=matches;
-				lti->n_matches=(n_matches == NULL) ? (-1) : (*n_matches);
-				lti->ctx=ctx;
-				lti->p=p;
+                lti->matches=matches;
+                lti->n_matches=(n_matches == NULL) ? (-1) : (*n_matches);
+                lti->ctx=ctx;
+                lti->p=p;
 
-				lti->step_number=p->counting_step.count_call-p->counting_step_count_cancel_trying_real_in_debug_or_trace;
+                lti->step_number=p->counting_step.count_call-p->counting_step_count_cancel_trying_real_in_debug_or_trace;
 
-				lti->jamo=NULL;
-				lti->pos_in_jamo=0;
+                lti->jamo=NULL;
+                lti->pos_in_jamo=0;
 
-				p->is_in_cancel_state = (*(p->fnc_locate_trace_step))(lti,p->private_param_locate_trace);
-				free_cb(lti,p->al.prv_alloc_trace_info_allocator);
-			}
+                p->is_in_cancel_state = (*(p->fnc_locate_trace_step))(lti,p->private_param_locate_trace);
+                free_cb(lti,p->al.prv_alloc_trace_info_allocator);
+            }
 
-			if ((p->counting_step_count_cancel_trying_real_in_debug_or_trace) == 0) {
-				if ((p->max_count_call) > 0) {
-					if ((p->counting_step.count_call) >= (p->max_count_call)) {
-						p->counting_step.count_cancel_trying = 0;
-						p->is_in_cancel_state = 1;
-						return;
-					}
-				}
+            if ((p->counting_step_count_cancel_trying_real_in_debug_or_trace) == 0) {
+                if ((p->max_count_call) > 0) {
+                    if ((p->counting_step.count_call) >= (p->max_count_call)) {
+                        p->counting_step.count_cancel_trying = 0;
+                        p->is_in_cancel_state = 1;
+                        return;
+                    }
+                }
 
-				p->counting_step_count_cancel_trying_real_in_debug_or_trace = COUNT_CANCEL_TRYING_INIT_CONST;
-				if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
-						+COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
-					p->counting_step_count_cancel_trying_real_in_debug_or_trace = (p->max_count_call) - (p->counting_step.count_call);
-				}
+                p->counting_step_count_cancel_trying_real_in_debug_or_trace = COUNT_CANCEL_TRYING_INIT_CONST;
+                if (((p->max_count_call) > 0) && (((p->counting_step.count_call)
+                        +COUNT_CANCEL_TRYING_INIT_CONST) > (p->max_count_call))) {
+                    p->counting_step_count_cancel_trying_real_in_debug_or_trace = (p->max_count_call) - (p->counting_step.count_call);
+                }
 
-				if (is_cancelling_requested() != 0) {
-					p->counting_step.count_cancel_trying = 0;
-					p->is_in_cancel_state = 2;
-					return;
-				}
-				(p->counting_step.count_call) += (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
-			}
+                if (is_cancelling_requested() != 0) {
+                    p->counting_step.count_cancel_trying = 0;
+                    p->is_in_cancel_state = 2;
+                    return;
+                }
+                (p->counting_step.count_call) += (p->counting_step_count_cancel_trying_real_in_debug_or_trace);
+            }
 
-			p->counting_step_count_cancel_trying_real_in_debug_or_trace --;
-			//  prepare now to be at 0 after the "--" (we don't want another test for performance */
-			(p->counting_step.count_cancel_trying)++;
-		}
-	}
-	(p->counting_step.count_cancel_trying)--;
+            p->counting_step_count_cancel_trying_real_in_debug_or_trace --;
+            //  prepare now to be at 0 after the "--" (we don't want another test for performance */
+            (p->counting_step.count_cancel_trying)++;
+        }
+    }
+    (p->counting_step.count_cancel_trying)--;
 
-	/* The following static variable holds the number of matches at
-	 * one position in text. */
-	//static int n_matches_at_token_pos;
+    /* The following static variable holds the number of matches at
+     * one position in text. */
+    //static int n_matches_at_token_pos;
 
 
-	p->explore_depth ++ ;
+    p->explore_depth ++ ;
 
 /*
-	if (p->explore_depth == 0) {
-		// We reset if this is first call to 'locate' from a given position in the text
-		p->p_token_error_ctx->n_matches_at_token_pos__morphological_locate = 0;
-	}
+    if (p->explore_depth == 0) {
+        // We reset if this is first call to 'locate' from a given position in the text
+        p->p_token_error_ctx->n_matches_at_token_pos__morphological_locate = 0;
+    }
 */
 
 
-	if ((p->explore_depth) > p->stack_max) {
-		/* If there are too much recursive calls */
-		error_at_token_pos("\nMaximal stack size reached!\n"
-			"(There may be longer matches not recognized!)", p->current_origin,
-			pos, p, current_state);
-		p->explore_depth -- ;
-		return;
-	}
-	if ((p->token_error_ctx.n_matches_at_token_pos__morphological_locate)
-			> p->max_matches_at_token_pos) {
-		/* If there are too much matches from the current origin in the text */
-		error_at_token_pos(
-				"\nToo many (ambiguous) matches starting from one position in text!",
-				p->current_origin, pos, p, current_state);
-		p->explore_depth -- ;
-		return;
-	}
-	if (current_state->control & 1) {
-		/* If we are in a final state... */
-		if (ctx != NULL) {
-			/* If we have reached the final state of a graph while
-			 * looking for a context, it's an error because every
-			 * opened context must be closed before the end of the graph. */
-			fatal_error("ERROR: unclosed context in graph \"%S\"\n",
-					p->fst2->graph_names[current_state->graph_number]);
-		}
-		/* In we are in the top level graph, we have a match */
-		if ((p->graph_depth) == 0) {
-			(p->token_error_ctx.n_matches_at_token_pos__morphological_locate)++;
-			if (p->output_policy == IGNORE_OUTPUTS) {
-				if (pos > 0) {
-					add_match(pos + p->current_origin-1,NULL, p, p->al.prv_alloc_generic);
-				} else {
-					add_match(pos + p->current_origin,NULL, p, p->al.prv_alloc_generic);
-				}
-			} else {
-				p->stack->stack[stack_top + 1] = '\0';
-				if (pos > 0) {
-					add_match(pos + p->current_origin-1,
-							p->stack->stack + p->left_ctx_base, p, p->al.prv_alloc_generic);
-				} else {
-					add_match(pos + p->current_origin,
-							p->stack->stack + p->left_ctx_base, p, p->al.prv_alloc_generic);
-				}
-			}
-		} else {
-			/* If we are in a subgraph */
-			if (*n_matches >= p->max_matches_per_subgraph) {
-				/* If there are too much matches, we suspect an error in the grammar
-				 * like an infinite recursion */
-				error_at_token_pos(
-						"\nMaximal number of matches per subgraph reached!!",
-						p->current_origin, pos, p, current_state);
-				p->explore_depth -- ;
-				return;
-			} else {
-				/* If everything is fine, we add this match to the match list of the
-				 * current graph level */
-				(*n_matches)++;
-				p->stack->stack[stack_top + 1] = '\0';
-				if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-					(*matches) = insert_if_different(pos, -1, -1, (*matches),
-							p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables,p->dic_variables, p->left_ctx_shift,
-							p->left_ctx_base, NULL, -1, NULL, p->weight,&p->al.pa);
-				} else {
-					(*matches) = insert_if_absent(pos, -1, -1, (*matches),
-							p->stack->stack_pointer,
-							&(p->stack->stack[p->stack_base + 1]),
-							p->input_variables, p->output_variables,p->dic_variables, p->left_ctx_shift,
-							p->left_ctx_base, NULL, -1, NULL, p->weight,&p->al.pa);
-				}
-			}
-		}
-	}
-	int end_of_text = pos + p->current_origin == p->buffer_size;
-	/* The same, but tolerant if there is a remaining space */
-	int end_of_text2 = pos + p->current_origin + 1 == p->buffer_size
-			&& p->buffer[pos + p->current_origin] == p->SPACE;
+    if ((p->explore_depth) > p->stack_max) {
+        /* If there are too much recursive calls */
+        error_at_token_pos("\nMaximal stack size reached!\n"
+            "(There may be longer matches not recognized!)", p->current_origin,
+            pos, p, current_state);
+        p->explore_depth -- ;
+        return;
+    }
+    if ((p->token_error_ctx.n_matches_at_token_pos__morphological_locate)
+            > p->max_matches_at_token_pos) {
+        /* If there are too much matches from the current origin in the text */
+        error_at_token_pos(
+                "\nToo many (ambiguous) matches starting from one position in text!",
+                p->current_origin, pos, p, current_state);
+        p->explore_depth -- ;
+        return;
+    }
+    if (current_state->control & 1) {
+        /* If we are in a final state... */
+        if (ctx != NULL) {
+            /* If we have reached the final state of a graph while
+             * looking for a context, it's an error because every
+             * opened context must be closed before the end of the graph. */
+            fatal_error("ERROR: unclosed context in graph \"%S\"\n",
+                    p->fst2->graph_names[current_state->graph_number]);
+        }
+        /* In we are in the top level graph, we have a match */
+        if ((p->graph_depth) == 0) {
+            (p->token_error_ctx.n_matches_at_token_pos__morphological_locate)++;
+            if (p->output_policy == IGNORE_OUTPUTS) {
+                if (pos > 0) {
+                    add_match(pos + p->current_origin-1,NULL, p, p->al.prv_alloc_generic);
+                } else {
+                    add_match(pos + p->current_origin,NULL, p, p->al.prv_alloc_generic);
+                }
+            } else {
+                p->stack->stack[stack_top + 1] = '\0';
+                if (pos > 0) {
+                    add_match(pos + p->current_origin-1,
+                            p->stack->stack + p->left_ctx_base, p, p->al.prv_alloc_generic);
+                } else {
+                    add_match(pos + p->current_origin,
+                            p->stack->stack + p->left_ctx_base, p, p->al.prv_alloc_generic);
+                }
+            }
+        } else {
+            /* If we are in a subgraph */
+            if (*n_matches >= p->max_matches_per_subgraph) {
+                /* If there are too much matches, we suspect an error in the grammar
+                 * like an infinite recursion */
+                error_at_token_pos(
+                        "\nMaximal number of matches per subgraph reached!!",
+                        p->current_origin, pos, p, current_state);
+                p->explore_depth -- ;
+                return;
+            } else {
+                /* If everything is fine, we add this match to the match list of the
+                 * current graph level */
+                (*n_matches)++;
+                p->stack->stack[stack_top + 1] = '\0';
+                if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+                    (*matches) = insert_if_different(pos, -1, -1, (*matches),
+                            p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables,p->dic_variables, p->left_ctx_shift,
+                            p->left_ctx_base, NULL, -1, NULL, p->weight,&p->al.pa);
+                } else {
+                    (*matches) = insert_if_absent(pos, -1, -1, (*matches),
+                            p->stack->stack_pointer,
+                            &(p->stack->stack[p->stack_base + 1]),
+                            p->input_variables, p->output_variables,p->dic_variables, p->left_ctx_shift,
+                            p->left_ctx_base, NULL, -1, NULL, p->weight,&p->al.pa);
+                }
+            }
+        }
+    }
+    int end_of_text = pos + p->current_origin == p->buffer_size;
+    /* The same, but tolerant if there is a remaining space */
+    int end_of_text2 = pos + p->current_origin + 1 == p->buffer_size
+            && p->buffer[pos + p->current_origin] == p->SPACE;
 
-	/* If we have reached the end of the token buffer, we indicate it by setting
-	 * the current tokens to -1 */
-	if ((((pos + p->current_origin) >= p->buffer_size)) || (pos==-1)) {
-		token = -1;
-		token2 = -1;
-	} else {
-		token = p->buffer[pos + p->current_origin];
-		if (token == p->SPACE) {
-			pos2 = pos + 1;
-		}
-		/* Now, we deal with the SPACE, if any. To do that, we use several variables:
-		 * pos: current position in the token buffer, relative to the current origin
-		 * pos2: position of the first non-space token from 'pos'.
-		 * token2: token at pos2  or -1 if 'pos2' is outside the token buffer */
-		else {
-			pos2 = pos;
-		}
-		if ((pos2 + p->current_origin) >= p->buffer_size) {
-			token2 = -1;
-		} else {
-			token2 = p->buffer[pos2 + p->current_origin];
-		}
-	}
+    /* If we have reached the end of the token buffer, we indicate it by setting
+     * the current tokens to -1 */
+    if ((((pos + p->current_origin) >= p->buffer_size)) || (pos==-1)) {
+        token = -1;
+        token2 = -1;
+    } else {
+        token = p->buffer[pos + p->current_origin];
+        if (token == p->SPACE) {
+            pos2 = pos + 1;
+        }
+        /* Now, we deal with the SPACE, if any. To do that, we use several variables:
+         * pos: current position in the token buffer, relative to the current origin
+         * pos2: position of the first non-space token from 'pos'.
+         * token2: token at pos2  or -1 if 'pos2' is outside the token buffer */
+        else {
+            pos2 = pos;
+        }
+        if ((pos2 + p->current_origin) >= p->buffer_size) {
+            token2 = -1;
+        } else {
+            token2 = p->buffer[pos2 + p->current_origin];
+        }
+    }
 
-	/**
-	 * SUBGRAPHS
-	 */
-	struct opt_graph_call* graph_call_list = current_state->graph_calls;
-	if (graph_call_list != NULL) {
-		/* If there are subgraphs, we process them */
+    /**
+     * SUBGRAPHS
+     */
+    struct opt_graph_call* graph_call_list = current_state->graph_calls;
+    if (graph_call_list != NULL) {
+        /* If there are subgraphs, we process them */
 
-		int* save_previous_ptr_var = NULL;
-		//int create_new_reserve_done = 0;
+        int* save_previous_ptr_var = NULL;
+        //int create_new_reserve_done = 0;
         variable_backup_memory_reserve* reserve_previous = NULL;
 
-		struct dic_variable* dic_variables_backup = NULL;
-		int old_StackBase = p->stack_base;
-		OutputVariablesBackup* output_var_backup=NULL;
-		int old_weight2=p->weight;
-		if (p->output_policy != IGNORE_OUTPUTS) {
-			/* For better performance when ignoring outputs */
+        struct dic_variable* dic_variables_backup = NULL;
+        int old_StackBase = p->stack_base;
+        OutputVariablesBackup* output_var_backup=NULL;
+        int old_weight2=p->weight;
+        if (p->output_policy != IGNORE_OUTPUTS) {
+            /* For better performance when ignoring outputs */
 
-			if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
-					p->backup_memory_reserve) == 0) {
-				reserve_previous=p->backup_memory_reserve;
-				p->backup_memory_reserve = create_variable_backup_memory_reserve(
-						p->input_variables,0);
-				//create_new_reserve_done = 1;
-			}
+            if (is_enough_memory_in_reserve_for_transduction_variable_set(p->input_variables,
+                    p->backup_memory_reserve) == 0) {
+                reserve_previous=p->backup_memory_reserve;
+                p->backup_memory_reserve = create_variable_backup_memory_reserve(
+                        p->input_variables,0);
+                //create_new_reserve_done = 1;
+            }
 
-			create_variable_backup_using_reserve(p->input_variables,
-					p->backup_memory_reserve);
-			dic_variables_backup = p->dic_variables;
-			if (p->nb_output_variables != 0) {
-			    output_var_backup = create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
-			}
-		}
+            create_variable_backup_using_reserve(p->input_variables,
+                    p->backup_memory_reserve);
+            dic_variables_backup = p->dic_variables;
+            if (p->nb_output_variables != 0) {
+                output_var_backup = create_output_variable_backup(p->output_variables,p->al.pa.prv_alloc_backup_growing_recycle);
+            }
+        }
 
-		do {
-			/* For each graph call, we look all the reachable states */
-			t1 = graph_call_list->transition;
-			while (t1 != NULL) {
-				/* We reset some parameters before exploring the subgraph */
-				struct parsing_info* L = NULL;
-				p->stack_base = p->stack->stack_pointer;
-				p->dic_variables = NULL;
-				if (dic_variables_backup != NULL) {
-				    p->dic_variables = clone_dic_variable_list(dic_variables_backup);
-				}
-				if (p->nb_output_variables != 0) {
-				    install_output_variable_backup(p->output_variables,output_var_backup);
-				}
+        do {
+            /* For each graph call, we look all the reachable states */
+            t1 = graph_call_list->transition;
+            while (t1 != NULL) {
+                /* We reset some parameters before exploring the subgraph */
+                struct parsing_info* L = NULL;
+                p->stack_base = p->stack->stack_pointer;
+                p->dic_variables = NULL;
+                if (dic_variables_backup != NULL) {
+                    p->dic_variables = clone_dic_variable_list(dic_variables_backup);
+                }
+                if (p->nb_output_variables != 0) {
+                    install_output_variable_backup(p->output_variables,output_var_backup);
+                }
 
-				p->graph_depth ++ ;
-				p->weight=-1;
-				int n_matches_in_subgraph=0;
-				locate(/*graph_depth + 1,*/ /* Exploration of the subgraph */
-				       p->optimized_states[p->fst2->initial_states[graph_call_list->graph_number]],
-				       pos, &L, &n_matches_in_subgraph, NULL, /* ctx is set to NULL because the end of a context must occur in the
-						 * same graph than its beginning */
-				       p);
-				p->graph_depth -- ;
+                p->graph_depth ++ ;
+                p->weight=-1;
+                int n_matches_in_subgraph=0;
+                locate(/*graph_depth + 1,*/ /* Exploration of the subgraph */
+                       p->optimized_states[p->fst2->initial_states[graph_call_list->graph_number]],
+                       pos, &L, &n_matches_in_subgraph, NULL, /* ctx is set to NULL because the end of a context must occur in the
+                         * same graph than its beginning */
+                       p);
+                p->graph_depth -- ;
 
-				p->stack_base = old_StackBase;
-				if (p->dic_variables != NULL) {
-				    clear_dic_variable_list(&(p->dic_variables));
-				}
-				if (L != NULL) {
-					struct parsing_info* L_first = L;
-					/* If there is at least one match, we process the match list */
-					do {
-						/* We restore the settings that we had at the end of the subgraph exploration */
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							u_strcpy(&(p->stack->stack[stack_top + 1]),
-									L->stack);
-							p->stack->stack_pointer = L->stack_pointer;
+                p->stack_base = old_StackBase;
+                if (p->dic_variables != NULL) {
+                    clear_dic_variable_list(&(p->dic_variables));
+                }
+                if (L != NULL) {
+                    struct parsing_info* L_first = L;
+                    /* If there is at least one match, we process the match list */
+                    do {
+                        /* We restore the settings that we had at the end of the subgraph exploration */
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            u_strcpy(&(p->stack->stack[stack_top + 1]),
+                                    L->stack);
+                            p->stack->stack_pointer = L->stack_pointer;
 
-							if (save_previous_ptr_var == NULL && ctx==NULL) {
-								save_previous_ptr_var
-										= install_variable_backup_preserving(
-												p->input_variables, p->backup_memory_reserve,
-												L->input_variable_backup);
-							} else {
-								install_variable_backup(p->input_variables,
-										L->input_variable_backup);
-							}
+                            if (save_previous_ptr_var == NULL && ctx==NULL) {
+                                save_previous_ptr_var
+                                        = install_variable_backup_preserving(
+                                                p->input_variables, p->backup_memory_reserve,
+                                                L->input_variable_backup);
+                            } else {
+                                install_variable_backup(p->input_variables,
+                                        L->input_variable_backup);
+                            }
 
-							p->dic_variables = NULL;
-							if (L->dic_variable_backup != NULL) {
-							    p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
-							}
+                            p->dic_variables = NULL;
+                            if (L->dic_variable_backup != NULL) {
+                                p->dic_variables = clone_dic_variable_list(L->dic_variable_backup);
+                            }
 
-							if (p->nb_output_variables != 0) {
-							    install_output_variable_backup(p->output_variables,L->output_variable_backup);
-							}
-						}
-						/* And we continue the exploration */
-						int old_left_ctx_shift = p->left_ctx_shift;
-						int old_left_ctx_base = p->left_ctx_base;
-						p->left_ctx_shift = L->left_ctx_shift;
-						p->left_ctx_base = L->left_ctx_base;
+                            if (p->nb_output_variables != 0) {
+                                install_output_variable_backup(p->output_variables,L->output_variable_backup);
+                            }
+                        }
+                        /* And we continue the exploration */
+                        int old_left_ctx_shift = p->left_ctx_shift;
+                        int old_left_ctx_base = p->left_ctx_base;
+                        p->left_ctx_shift = L->left_ctx_shift;
+                        p->left_ctx_base = L->left_ctx_base;
 
 //variable_backup_memory_reserve* reserve_new=p->backup_memory_reserve;
 //p->backup_memory_reserve=reserve_previous;
 
-						p->weight=old_weight2;
-						locate(/*graph_depth,*/
-								p->optimized_states[t1->state_number],
-								L->pos_in_tokens, matches, n_matches,
-								ctx, p);
+                        p->weight=old_weight2;
+                        locate(/*graph_depth,*/
+                                p->optimized_states[t1->state_number],
+                                L->pos_in_tokens, matches, n_matches,
+                                ctx, p);
 
 //p->backup_memory_reserve=reserve_new;
 
-						p->left_ctx_shift = old_left_ctx_shift;
-						p->left_ctx_base = old_left_ctx_base;
-						p->stack->stack_pointer = stack_top;
-						if (p->dic_variables != NULL) {
-						    clear_dic_variable_list(&(p->dic_variables));
-						}
-						if (p->graph_depth == 0 && ctx==NULL) {
-							/* If we are at the top graph level, we restore the variables */
-							if (p->output_policy != IGNORE_OUTPUTS) {
-								if (save_previous_ptr_var != NULL) {
-									restore_variable_array(p->input_variables,
-											p->backup_memory_reserve, save_previous_ptr_var);
-									save_previous_ptr_var = NULL;
-								}
-							}
-						}
-						L = L->next;
-					} while (L != NULL);
-					free_parsing_info(L_first, &p->al.pa); //  free all subgraph matches
-				}
-				/* As free_parsing_info has freed p->dic_variables, we must restore it */
-				t1 = t1->next;
-			} /* end of while (t!=NULL) */
-		} while ((graph_call_list = graph_call_list->next) != NULL);
-		/* Finally, we have to restore the stack and other backup stuff */
-		p->weight=old_weight2;
-		p->stack->stack_pointer = stack_top;
-		p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
-		if (p->output_policy != IGNORE_OUTPUTS) { /* For better performance (see above) */
-			if (save_previous_ptr_var != NULL) {
-				restore_variable_array(p->input_variables, p->backup_memory_reserve,
-						save_previous_ptr_var);
-				save_previous_ptr_var = NULL;
-			}
+                        p->left_ctx_shift = old_left_ctx_shift;
+                        p->left_ctx_base = old_left_ctx_base;
+                        p->stack->stack_pointer = stack_top;
+                        if (p->dic_variables != NULL) {
+                            clear_dic_variable_list(&(p->dic_variables));
+                        }
+                        if (p->graph_depth == 0 && ctx==NULL) {
+                            /* If we are at the top graph level, we restore the variables */
+                            if (p->output_policy != IGNORE_OUTPUTS) {
+                                if (save_previous_ptr_var != NULL) {
+                                    restore_variable_array(p->input_variables,
+                                            p->backup_memory_reserve, save_previous_ptr_var);
+                                    save_previous_ptr_var = NULL;
+                                }
+                            }
+                        }
+                        L = L->next;
+                    } while (L != NULL);
+                    free_parsing_info(L_first, &p->al.pa); //  free all subgraph matches
+                }
+                /* As free_parsing_info has freed p->dic_variables, we must restore it */
+                t1 = t1->next;
+            } /* end of while (t!=NULL) */
+        } while ((graph_call_list = graph_call_list->next) != NULL);
+        /* Finally, we have to restore the stack and other backup stuff */
+        p->weight=old_weight2;
+        p->stack->stack_pointer = stack_top;
+        p->stack_base = old_StackBase; /* May be changed by recursive subgraph calls */
+        if (p->output_policy != IGNORE_OUTPUTS) { /* For better performance (see above) */
+            if (save_previous_ptr_var != NULL) {
+                restore_variable_array(p->input_variables, p->backup_memory_reserve,
+                        save_previous_ptr_var);
+                save_previous_ptr_var = NULL;
+            }
 
-			int reserve_freeable = free_variable_backup_using_reserve(
-							p->backup_memory_reserve);
-			if (reserve_previous != NULL) {
-					if (reserve_freeable == 0) {
-						fatal_error("incoherent reserve free result\n");
-					}
-					free_reserve(p->backup_memory_reserve);
-					p->backup_memory_reserve = reserve_previous;
-			}
+            int reserve_freeable = free_variable_backup_using_reserve(
+                            p->backup_memory_reserve);
+            if (reserve_previous != NULL) {
+                    if (reserve_freeable == 0) {
+                        fatal_error("incoherent reserve free result\n");
+                    }
+                    free_reserve(p->backup_memory_reserve);
+                    p->backup_memory_reserve = reserve_previous;
+            }
 
-			if (p->nb_output_variables != 0) {
-			    install_output_variable_backup(p->output_variables,output_var_backup);
-			    free_output_variable_backup(output_var_backup,p->al.pa.prv_alloc_backup_growing_recycle);
-			}
-		}
-		p->dic_variables = dic_variables_backup;
-	} /* End of processing subgraphs */
+            if (p->nb_output_variables != 0) {
+                install_output_variable_backup(p->output_variables,output_var_backup);
+                free_output_variable_backup(output_var_backup,p->al.pa.prv_alloc_backup_growing_recycle);
+            }
+        }
+        p->dic_variables = dic_variables_backup;
+    } /* End of processing subgraphs */
 
-	/**
-	 * METAS
-	 */
-	struct opt_meta* meta_list = current_state->metas;
-	if (meta_list != NULL) {
-		/* We cache the control bytes of the pos2 token. The pos token has not interest,
-		 * because it is 1) a space or 2) equal to the pos2 one. */
-		if (token2 != -1)
-			ctrl = p->token_control[token2];
-		else
-			ctrl = 0;
-	}
-	while (meta_list != NULL) {
-		/* We process all the meta of the list */
-		t1 = meta_list->transition;
-		while (t1 != NULL) {
-			/* We cache the output of the current tag, as well as values indicating if the
-			 * current pos2 tokens matches the tag's morphological filter, if any. */
-			output = p->tags[t1->tag_number]->output;
-			/* If there is no morphological filter, we act as if there was a matching one, except
-			 * if we are at the end of the token buffer. With this trick, the morphofilter test
-			 * will avoid overpassing the end of the token buffer. */
-			int morpho_filter_OK = (token2 != -1) ? 1 : 0;
+    /**
+     * METAS
+     */
+    struct opt_meta* meta_list = current_state->metas;
+    if (meta_list != NULL) {
+        /* We cache the control bytes of the pos2 token. The pos token has not interest,
+         * because it is 1) a space or 2) equal to the pos2 one. */
+        if (token2 != -1)
+            ctrl = p->token_control[token2];
+        else
+            ctrl = 0;
+    }
+    while (meta_list != NULL) {
+        /* We process all the meta of the list */
+        t1 = meta_list->transition;
+        while (t1 != NULL) {
+            /* We cache the output of the current tag, as well as values indicating if the
+             * current pos2 tokens matches the tag's morphological filter, if any. */
+            output = p->tags[t1->tag_number]->output;
+            /* If there is no morphological filter, we act as if there was a matching one, except
+             * if we are at the end of the token buffer. With this trick, the morphofilter test
+             * will avoid overpassing the end of the token buffer. */
+            int morpho_filter_OK = (token2 != -1) ? 1 : 0;
 #ifdef REGEX_FACADE_ENGINE
-			filter_number = p->tags[t1->tag_number]->filter_number;
-			if (token2 != -1) {
-				morpho_filter_OK = (filter_number == -1 || token_match_filter(
-						p->filter_match_index, token2, filter_number));
-			}
+            filter_number = p->tags[t1->tag_number]->filter_number;
+            if (token2 != -1) {
+                morpho_filter_OK = (filter_number == -1 || token_match_filter(
+                        p->filter_match_index, token2, filter_number));
+            }
 #endif
-			int negation = meta_list->negation;
-			/* We use these variables to deal with match cases:
-			 * the matching sequence is in the range [start;end[
-			 * start=end means that the transition matches but that no token is read in the text,
-			 * which is the case, for instance, with epsilon transitions. start=-1 means that the
-			 * transition does not match. 'end' is the position for the next call
-			 * to 'locate'. */
-			int start = -1;
-			int end = -1;
-			switch (meta_list->meta) {
+            int negation = meta_list->negation;
+            /* We use these variables to deal with match cases:
+             * the matching sequence is in the range [start;end[
+             * start=end means that the transition matches but that no token is read in the text,
+             * which is the case, for instance, with epsilon transitions. start=-1 means that the
+             * transition does not match. 'end' is the position for the next call
+             * to 'locate'. */
+            int start = -1;
+            int end = -1;
+            switch (meta_list->meta) {
 
-			case META_SHARP:
-				if (token == -1 || token != p->SPACE) {
-					/* # can match only if there is no space at the current position or
-					 * if we are at the end of the token buffer. */
-					start = pos;
-					end = pos;
-				}
-				if (token != -1) {
-					/* We don't update the position if # has matched because of the
-					 * end of the buffer */
-					update_last_tested_position(p, pos);
-				}
-				break;
+            case META_SHARP:
+                if (token == -1 || token != p->SPACE) {
+                    /* # can match only if there is no space at the current position or
+                     * if we are at the end of the token buffer. */
+                    start = pos;
+                    end = pos;
+                }
+                if (token != -1) {
+                    /* We don't update the position if # has matched because of the
+                     * end of the buffer */
+                    update_last_tested_position(p, pos);
+                }
+                break;
 
-			case META_SPACE:
-				if (token != -1 && token == p->SPACE) {
-					/* The space meta can match only if there is a space at the current position.
-					 * Note that we don't compare token and p->SPACE since p->SPACE can be -1 if
-					 * the text contains no space. */
-					start = pos;
-					end = pos + 1;
-				}
-				update_last_tested_position(p, pos);
-				break;
+            case META_SPACE:
+                if (token != -1 && token == p->SPACE) {
+                    /* The space meta can match only if there is a space at the current position.
+                     * Note that we don't compare token and p->SPACE since p->SPACE can be -1 if
+                     * the text contains no space. */
+                    start = pos;
+                    end = pos + 1;
+                }
+                update_last_tested_position(p, pos);
+                break;
 
-			case META_EPSILON:
-				/* We can always match the empty word */
-				start = pos;
-				end = pos;
-				break;
+            case META_EPSILON:
+                /* We can always match the empty word */
+                start = pos;
+                end = pos;
+                break;
 
-			case META_TEXT_START:
-				/* We can match if and only if we are at the beginning of the text */
-				p->no_fail_fast=1;
-				if (at_text_start(p,pos)) {
-					start = pos;
-					end = pos;
-				}
-				break;
+            case META_TEXT_START:
+                /* We can match if and only if we are at the beginning of the text */
+                p->no_fail_fast=1;
+                if (at_text_start(p,pos)) {
+                    start = pos;
+                    end = pos;
+                }
+                break;
 
-			case META_TEXT_END:
-				p->no_fail_fast=1;
-				if (end_of_text || end_of_text2) {
-					start = pos;
-					end = pos;
-				}
-				break;
+            case META_TEXT_END:
+                p->no_fail_fast=1;
+                if (end_of_text || end_of_text2) {
+                    start = pos;
+                    end = pos;
+                }
+                break;
 
-			case META_WORD:
-			case META_MOT:
-				update_last_tested_position(p, pos2);
-				if (!morpho_filter_OK || token2 == p->SENTENCE || token2
-						== p->STOP) {
-					/* <MOT>, <WORD> and <!MOT> must NEVER match {S} and {STOP}! */
-					break;
-				}
-				if ((p->space_policy == START_WITH_SPACE) && (token2
-						== p->SPACE) && negation) {
-					/* If we want to catch a space with <!MOT> */
-					start = pos;
-					end = pos + 1;
-				} else if (XOR(negation, ctrl & MOT_TOKEN_BIT_MASK)) {
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+            case META_WORD:
+            case META_MOT:
+                update_last_tested_position(p, pos2);
+                if (!morpho_filter_OK || token2 == p->SENTENCE || token2
+                        == p->STOP) {
+                    /* <MOT>, <WORD> and <!MOT> must NEVER match {S} and {STOP}! */
+                    break;
+                }
+                if ((p->space_policy == START_WITH_SPACE) && (token2
+                        == p->SPACE) && negation) {
+                    /* If we want to catch a space with <!MOT> */
+                    start = pos;
+                    end = pos + 1;
+                } else if (XOR(negation, ctrl & MOT_TOKEN_BIT_MASK)) {
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
-			case META_DIC:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (!negation) {
-					/* If there is no negation on DIC, we can look for a compound word */
-					end_of_compound = find_compound_word(pos2,
-							COMPOUND_WORD_PATTERN, p->DLC_tree, p);
-					if (end_of_compound != -1) {
-						/* If we find one, we must test if it matches the morphological filter, if any */
-						int OK = 1;
+            case META_DIC:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (!negation) {
+                    /* If there is no negation on DIC, we can look for a compound word */
+                    end_of_compound = find_compound_word(pos2,
+                            COMPOUND_WORD_PATTERN, p->DLC_tree, p);
+                    if (end_of_compound != -1) {
+                        /* If we find one, we must test if it matches the morphological filter, if any */
+                        int OK = 1;
 #ifdef REGEX_FACADE_ENGINE
-						if (filter_number == -1)
-							OK = 1;
-						else {
-							unichar* sequence = get_token_sequence(p,
-									pos2 + p->current_origin,
-									end_of_compound + p->current_origin);
-							OK = string_match_filter(p->filters, sequence,
-								filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
-						}
+                        if (filter_number == -1)
+                            OK = 1;
+                        else {
+                            unichar* sequence = get_token_sequence(p,
+                                    pos2 + p->current_origin,
+                                    end_of_compound + p->current_origin);
+                            OK = string_match_filter(p->filters, sequence,
+                                filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
+                        }
 #endif
-						if (OK) {
-							/* <DIC> can match two things: a sequence of tokens or a single token
-							 * As we don't want to process lists of [start,end[ ranges, we
-							 * directly handle here the case of a token sequence. */
-							if (p->output_policy == MERGE_OUTPUTS && pos2!=pos) {
-								push_input_char(p->stack, ' ',
-										p->protect_dic_chars);
-							}
-							captured_chars=0;
-							if (p->output_policy != IGNORE_OUTPUTS) {
-								if (!deal_with_output(output,p,&captured_chars)) {
-									break;
-								}
-							}
-							if (p->output_policy == MERGE_OUTPUTS) {
-								for (int x = pos2; x <= end_of_compound; x++) {
-									push_input_string(p->stack,
-											p->tokens->value[p->buffer[x
-													+ p->current_origin]],
-											p->protect_dic_chars);
-								}
-							}
-							locate(/*graph_depth,*/
-									p->optimized_states[t1->state_number],
-									end_of_compound + 1, matches,
-									n_matches, ctx, p);
-							p->stack->stack_pointer = stack_top;
-							p->weight=old_weight1;
-							if (p->nb_output_variables != 0) {
-							    remove_chars_from_output_variables(p->output_variables,captured_chars);
-							}
-						}
-					}
-					/* Now, we look for a simple word */
-					if ((ctrl & DIC_TOKEN_BIT_MASK) && morpho_filter_OK) {
-						start = pos2;
-						end = pos2 + 1;
-					}
-					break;
-				}
-				/* We have the meta <!DIC> */
-				if ((ctrl & NOT_DIC_TOKEN_BIT_MASK) && morpho_filter_OK) {
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+                        if (OK) {
+                            /* <DIC> can match two things: a sequence of tokens or a single token
+                             * As we don't want to process lists of [start,end[ ranges, we
+                             * directly handle here the case of a token sequence. */
+                            if (p->output_policy == MERGE_OUTPUTS && pos2!=pos) {
+                                push_input_char(p->stack, ' ',
+                                        p->protect_dic_chars);
+                            }
+                            captured_chars=0;
+                            if (p->output_policy != IGNORE_OUTPUTS) {
+                                if (!deal_with_output(output,p,&captured_chars)) {
+                                    break;
+                                }
+                            }
+                            if (p->output_policy == MERGE_OUTPUTS) {
+                                for (int x = pos2; x <= end_of_compound; x++) {
+                                    push_input_string(p->stack,
+                                            p->tokens->value[p->buffer[x
+                                                    + p->current_origin]],
+                                            p->protect_dic_chars);
+                                }
+                            }
+                            locate(/*graph_depth,*/
+                                    p->optimized_states[t1->state_number],
+                                    end_of_compound + 1, matches,
+                                    n_matches, ctx, p);
+                            p->stack->stack_pointer = stack_top;
+                            p->weight=old_weight1;
+                            if (p->nb_output_variables != 0) {
+                                remove_chars_from_output_variables(p->output_variables,captured_chars);
+                            }
+                        }
+                    }
+                    /* Now, we look for a simple word */
+                    if ((ctrl & DIC_TOKEN_BIT_MASK) && morpho_filter_OK) {
+                        start = pos2;
+                        end = pos2 + 1;
+                    }
+                    break;
+                }
+                /* We have the meta <!DIC> */
+                if ((ctrl & NOT_DIC_TOKEN_BIT_MASK) && morpho_filter_OK) {
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
-			case META_SDIC:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (morpho_filter_OK && (ctrl & DIC_TOKEN_BIT_MASK) && !(ctrl
-						& CDIC_TOKEN_BIT_MASK)) {
-					/* We match only simple words */
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+            case META_SDIC:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (morpho_filter_OK && (ctrl & DIC_TOKEN_BIT_MASK) && !(ctrl
+                        & CDIC_TOKEN_BIT_MASK)) {
+                    /* We match only simple words */
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
-			case META_CDIC:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				end_of_compound = find_compound_word(pos2,
-						COMPOUND_WORD_PATTERN, p->DLC_tree, p);
-				if (end_of_compound != -1) {
-					/* If we find a compound word */
-					int OK = 1;
+            case META_CDIC:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                end_of_compound = find_compound_word(pos2,
+                        COMPOUND_WORD_PATTERN, p->DLC_tree, p);
+                if (end_of_compound != -1) {
+                    /* If we find a compound word */
+                    int OK = 1;
 #ifdef REGEX_FACADE_ENGINE
-					if (filter_number == -1)
-						OK = 1;
-					else {
-						unichar* sequence = get_token_sequence(p,
-								pos2 + p->current_origin,
-								end_of_compound + p->current_origin);
-						OK = string_match_filter(p->filters, sequence,
-							filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
-					}
+                    if (filter_number == -1)
+                        OK = 1;
+                    else {
+                        unichar* sequence = get_token_sequence(p,
+                                pos2 + p->current_origin,
+                                end_of_compound + p->current_origin);
+                        OK = string_match_filter(p->filters, sequence,
+                            filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
+                    }
 #endif
-					if (OK) {
-						/* <CDIC> can match two things: a sequence of tokens or a compound
-						 * tag token like "{black-eyed,.A}". As we don't want to process lists
-						 * of [start,end[ ranges, we directly handle here the case of a
-						 * token sequence. */
-						if (p->output_policy == MERGE_OUTPUTS && pos2!=pos) {
-							push_input_char(p->stack, ' ', p->protect_dic_chars);
-						}
-						captured_chars=0;
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(output,p,&captured_chars)) {
-								break;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							for (int x = pos2; x <= end_of_compound; x++) {
-								push_input_string(p->stack,
-										p->tokens->value[p->buffer[x
-												+ p->current_origin]],
-										p->protect_dic_chars);
-							}
-						}
-						locate(/*graph_depth,*/
-								p->optimized_states[t1->state_number],
-								end_of_compound + 1, matches,
-								n_matches, ctx, p);
-						p->weight=old_weight1;
-						if (p->nb_output_variables != 0) {
-						    remove_chars_from_output_variables(p->output_variables,captured_chars);
-						}
-						p->stack->stack_pointer = stack_top;
-					}
-				}
-				/* Anyway, we could have a tag compound word like {aujourd'hui,.ADV} */
-				if (morpho_filter_OK && (ctrl & CDIC_TOKEN_BIT_MASK)) {
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+                    if (OK) {
+                        /* <CDIC> can match two things: a sequence of tokens or a compound
+                         * tag token like "{black-eyed,.A}". As we don't want to process lists
+                         * of [start,end[ ranges, we directly handle here the case of a
+                         * token sequence. */
+                        if (p->output_policy == MERGE_OUTPUTS && pos2!=pos) {
+                            push_input_char(p->stack, ' ', p->protect_dic_chars);
+                        }
+                        captured_chars=0;
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(output,p,&captured_chars)) {
+                                break;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            for (int x = pos2; x <= end_of_compound; x++) {
+                                push_input_string(p->stack,
+                                        p->tokens->value[p->buffer[x
+                                                + p->current_origin]],
+                                        p->protect_dic_chars);
+                            }
+                        }
+                        locate(/*graph_depth,*/
+                                p->optimized_states[t1->state_number],
+                                end_of_compound + 1, matches,
+                                n_matches, ctx, p);
+                        p->weight=old_weight1;
+                        if (p->nb_output_variables != 0) {
+                            remove_chars_from_output_variables(p->output_variables,captured_chars);
+                        }
+                        p->stack->stack_pointer = stack_top;
+                    }
+                }
+                /* Anyway, we could have a tag compound word like {aujourd'hui,.ADV} */
+                if (morpho_filter_OK && (ctrl & CDIC_TOKEN_BIT_MASK)) {
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
-			case META_TDIC:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (morpho_filter_OK && (ctrl & TDIC_TOKEN_BIT_MASK)) {
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+            case META_TDIC:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (morpho_filter_OK && (ctrl & TDIC_TOKEN_BIT_MASK)) {
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
                             case META_UPPER: case META_MAJ:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (!morpho_filter_OK)
-					break;
-				if (!negation) {
-					if (ctrl & MAJ_TOKEN_BIT_MASK) {
-						start = pos2;
-						end = pos2 + 1;
-					}
-					break;
-				}
-				if (!(ctrl & MAJ_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
-					/* If we have <!MAJ>, the matching token must be matched by <MOT> */
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (!morpho_filter_OK)
+                    break;
+                if (!negation) {
+                    if (ctrl & MAJ_TOKEN_BIT_MASK) {
+                        start = pos2;
+                        end = pos2 + 1;
+                    }
+                    break;
+                }
+                if (!(ctrl & MAJ_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
+                    /* If we have <!MAJ>, the matching token must be matched by <MOT> */
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
                         case META_LOWER: case META_MIN:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (!morpho_filter_OK)
-					break;
-				if (!negation) {
-					if (ctrl & MIN_TOKEN_BIT_MASK) {
-						start = pos2;
-						end = pos2 + 1;
-					}
-					break;
-				}
-				if (!(ctrl & MIN_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
-					/* If we have <!MIN>, the matching token must be matched by <MOT> */
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (!morpho_filter_OK)
+                    break;
+                if (!negation) {
+                    if (ctrl & MIN_TOKEN_BIT_MASK) {
+                        start = pos2;
+                        end = pos2 + 1;
+                    }
+                    break;
+                }
+                if (!(ctrl & MIN_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
+                    /* If we have <!MIN>, the matching token must be matched by <MOT> */
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
                         case META_FIRST: case META_PRE:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				if (!morpho_filter_OK)
-					break;
-				if (!negation) {
-					if (ctrl & PRE_TOKEN_BIT_MASK) {
-						start = pos2;
-						end = pos2 + 1;
-					}
-					break;
-				}
-				if (!(ctrl & PRE_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
-					/* If we have <!PRE>, the matching token must be matched by <MOT> */
-					start = pos2;
-					end = pos2 + 1;
-				}
-				break;
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                if (!morpho_filter_OK)
+                    break;
+                if (!negation) {
+                    if (ctrl & PRE_TOKEN_BIT_MASK) {
+                        start = pos2;
+                        end = pos2 + 1;
+                    }
+                    break;
+                }
+                if (!(ctrl & PRE_TOKEN_BIT_MASK) && (ctrl & MOT_TOKEN_BIT_MASK)) {
+                    /* If we have <!PRE>, the matching token must be matched by <MOT> */
+                    start = pos2;
+                    end = pos2 + 1;
+                }
+                break;
 
-			case META_NB:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP) {
-					break;
-				}
-				{ /* This block avoids visibility problem about 'z' */
+            case META_NB:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP) {
+                    break;
+                }
+                { /* This block avoids visibility problem about 'z' */
 
 
-					// local_is_not_a_digit_token return 1 if s is a digit sequence, 0 else
-					if (!(pos2 + p->current_origin < p->buffer_size
-							&& (local_is_not_a_digit_token(p->tokens->value[p->buffer[pos2
-									+ p->current_origin]]) == 0) )) {
-						break;
-					}
-
-					/* If we have found a contiguous digit sequence */
-
-					int z = pos2+1;
-					int pos_limit = p->buffer_size - p->current_origin;
-
-					int next_pos_add = 0;
-					while (z  < pos_limit
-							&& ((next_pos_add = local_is_not_a_digit_token(p->tokens->value[p->buffer[z
-									+ p->current_origin]])) == 0)) {
-						z++;
-					}
-
-					// If we have stopped because of the end of the buffer, next_pos_add = 0
-					// If we have stopped because of a non matching token, next_pos_add = 1
-					start = pos2;
-					end = z;
-
-#ifdef REGEX_FACADE_ENGINE
-					if (filter_number == -1) {
-						update_last_tested_position(p,z+next_pos_add);
-						break;
+                    // local_is_not_a_digit_token return 1 if s is a digit sequence, 0 else
+                    if (!(pos2 + p->current_origin < p->buffer_size
+                            && (local_is_not_a_digit_token(p->tokens->value[p->buffer[pos2
+                                    + p->current_origin]]) == 0) )) {
+                        break;
                     }
 
-					int OK = 1;
-					unichar* sequence = get_token_sequence(p,
-							start + p->current_origin,
-							end-1 + p->current_origin);
-					OK = string_match_filter(p->filters, sequence,
-						filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
-					if (!OK) {
-						start=-1;
-						break;
-					}
+                    /* If we have found a contiguous digit sequence */
+
+                    int z = pos2+1;
+                    int pos_limit = p->buffer_size - p->current_origin;
+
+                    int next_pos_add = 0;
+                    while (z  < pos_limit
+                            && ((next_pos_add = local_is_not_a_digit_token(p->tokens->value[p->buffer[z
+                                    + p->current_origin]])) == 0)) {
+                        z++;
+                    }
+
+                    // If we have stopped because of the end of the buffer, next_pos_add = 0
+                    // If we have stopped because of a non matching token, next_pos_add = 1
+                    start = pos2;
+                    end = z;
+
+#ifdef REGEX_FACADE_ENGINE
+                    if (filter_number == -1) {
+                        update_last_tested_position(p,z+next_pos_add);
+                        break;
+                    }
+
+                    int OK = 1;
+                    unichar* sequence = get_token_sequence(p,
+                            start + p->current_origin,
+                            end-1 + p->current_origin);
+                    OK = string_match_filter(p->filters, sequence,
+                        filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
+                    if (!OK) {
+                        start=-1;
+                        break;
+                    }
 #endif
-					update_last_tested_position(p,z+next_pos_add);
-				}
-				break;
-
-			case META_TOKEN:
-				if (token2 == -1)
-					break;
-				update_last_tested_position(p, pos2);
-				if (token2 == p->STOP || !morpho_filter_OK) {
-					/* The {STOP} tag must NEVER be matched by any pattern */
-					break;
-				}
-				start = pos2;
-				end = pos2 + 1;
-				break;
-
-			case META_BEGIN_MORPHO:
-				if (token2 == -1)
-					break;
-				if (token2 == p->STOP) {
-					/* The {STOP} tag must NEVER be matched by any pattern */
-					break;
-				}
-				if (p->output_policy == MERGE_OUTPUTS) {
-					if (pos2 != pos)
-						push_input_char(p->stack, ' ', p->protect_dic_chars);
-				}
-				/* we don't know if enter_morphological_mode will modify variable
-				 so we increment the dirty flag, without any associated decrement, to be sure
-				 having no problem */
-				inc_dirty(p->backup_memory_reserve);
-				enter_morphological_mode(/*graph_depth,*/ t1->state_number, pos2,
-						matches, n_matches, ctx, p);
-				p->stack->stack_pointer = stack_top;
-				break;
-
-			case META_END_MORPHO:
-				/* Should not happen */
-				fatal_error("Unexpected morphological mode end tag $>\n");
-				break;
-
-			// avoid ‘META_LETTER’ and ‘META_LETTRE’ not handled in switch warning
-			case META_LETTER:
-			case META_LETTRE:
-			  // do nothing
-			  break;
-
-			case META_LEFT_CONTEXT:
-				int current_shift = p->left_ctx_shift;
-				if (p->space_policy == START_WITH_SPACE) {
-					p->left_ctx_shift = pos;
-				} else {
-					p->left_ctx_shift = pos2;
-				}
-				int old_left_ctx_stack_base = p->left_ctx_base;
-				p->left_ctx_base = p->stack->stack_pointer + 1;
-				/*int* var_backup=NULL;
-				 if (p->output_policy!=IGNORE_OUTPUTS) {
-				 var_backup=create_variable_backup(p->variables);
-				 shift_variable_bounds(p->variables,real_origin-p->current_origin);
-				 }*/
-				locate(/*graph_depth,*/ p->optimized_states[t1->state_number], pos2,
-						matches, n_matches, ctx, p);
-				/*if (p->output_policy!=IGNORE_OUTPUTS) {
-				 install_variable_backup(p->variables,var_backup);
-				 free_variable_backup(var_backup);
-				 }*/
-				p->weight=old_weight1;
-				p->left_ctx_shift = current_shift;
-				p->left_ctx_base = old_left_ctx_stack_base;
-				p->stack->stack_pointer = stack_top;
-				break;
-			} /* End of the switch */
-
-			if (start != -1) {
-				/* If the transition has matched */
-				if (p->output_policy == MERGE_OUTPUTS && start == pos2 && pos2!=pos) {
-					push_input_char(p->stack, ' ', p->protect_dic_chars);
-				}
-				captured_chars=0;
-				if (p->output_policy != IGNORE_OUTPUTS) {
-					/* We process its output */
-					if (!deal_with_output(output,p,&captured_chars)) {
-						goto next;
-					}
-				}
-				if (p->output_policy == MERGE_OUTPUTS) {
-					/* Then, if we are in merge mode, we push the tokens that have
-					 * been read to the output */
-					for (int y = start; y < end; y++) {
-						push_input_string(p->stack,
-								p->tokens->value[p->buffer[y
-										+ p->current_origin]],
-								p->protect_dic_chars);
-					}
-				}
-				/* Then, we continue the exploration of the grammar */
-				locate(/*graph_depth,*/ p->optimized_states[t1->state_number], end,
-						matches, n_matches, ctx, p);
-				/* Once we have finished, we restore the stack */
-				p->weight=old_weight1;
-				p->stack->stack_pointer = stack_top;
-				if (p->nb_output_variables != 0) {
-				  remove_chars_from_output_variables(p->output_variables,captured_chars);
+                    update_last_tested_position(p,z+next_pos_add);
                 }
-			}
-			next: t1 = t1->next;
-		}
-		meta_list = meta_list->next;
-	}
+                break;
+
+            case META_TOKEN:
+                if (token2 == -1)
+                    break;
+                update_last_tested_position(p, pos2);
+                if (token2 == p->STOP || !morpho_filter_OK) {
+                    /* The {STOP} tag must NEVER be matched by any pattern */
+                    break;
+                }
+                start = pos2;
+                end = pos2 + 1;
+                break;
+
+            case META_BEGIN_MORPHO:
+                if (token2 == -1)
+                    break;
+                if (token2 == p->STOP) {
+                    /* The {STOP} tag must NEVER be matched by any pattern */
+                    break;
+                }
+                if (p->output_policy == MERGE_OUTPUTS) {
+                    if (pos2 != pos)
+                        push_input_char(p->stack, ' ', p->protect_dic_chars);
+                }
+                /* we don't know if enter_morphological_mode will modify variable
+                 so we increment the dirty flag, without any associated decrement, to be sure
+                 having no problem */
+                inc_dirty(p->backup_memory_reserve);
+                enter_morphological_mode(/*graph_depth,*/ t1->state_number, pos2,
+                        matches, n_matches, ctx, p);
+                p->stack->stack_pointer = stack_top;
+                break;
+
+            case META_END_MORPHO:
+                /* Should not happen */
+                fatal_error("Unexpected morphological mode end tag $>\n");
+                break;
+
+            // avoid ‘META_LETTER’ and ‘META_LETTRE’ not handled in switch warning
+            case META_LETTER:
+            case META_LETTRE:
+              // do nothing
+              break;
+
+            case META_LEFT_CONTEXT:
+                int current_shift = p->left_ctx_shift;
+                if (p->space_policy == START_WITH_SPACE) {
+                    p->left_ctx_shift = pos;
+                } else {
+                    p->left_ctx_shift = pos2;
+                }
+                int old_left_ctx_stack_base = p->left_ctx_base;
+                p->left_ctx_base = p->stack->stack_pointer + 1;
+                /*int* var_backup=NULL;
+                 if (p->output_policy!=IGNORE_OUTPUTS) {
+                 var_backup=create_variable_backup(p->variables);
+                 shift_variable_bounds(p->variables,real_origin-p->current_origin);
+                 }*/
+                locate(/*graph_depth,*/ p->optimized_states[t1->state_number], pos2,
+                        matches, n_matches, ctx, p);
+                /*if (p->output_policy!=IGNORE_OUTPUTS) {
+                 install_variable_backup(p->variables,var_backup);
+                 free_variable_backup(var_backup);
+                 }*/
+                p->weight=old_weight1;
+                p->left_ctx_shift = current_shift;
+                p->left_ctx_base = old_left_ctx_stack_base;
+                p->stack->stack_pointer = stack_top;
+                break;
+            } /* End of the switch */
+
+            if (start != -1) {
+                /* If the transition has matched */
+                if (p->output_policy == MERGE_OUTPUTS && start == pos2 && pos2!=pos) {
+                    push_input_char(p->stack, ' ', p->protect_dic_chars);
+                }
+                captured_chars=0;
+                if (p->output_policy != IGNORE_OUTPUTS) {
+                    /* We process its output */
+                    if (!deal_with_output(output,p,&captured_chars)) {
+                        goto next;
+                    }
+                }
+                if (p->output_policy == MERGE_OUTPUTS) {
+                    /* Then, if we are in merge mode, we push the tokens that have
+                     * been read to the output */
+                    for (int y = start; y < end; y++) {
+                        push_input_string(p->stack,
+                                p->tokens->value[p->buffer[y
+                                        + p->current_origin]],
+                                p->protect_dic_chars);
+                    }
+                }
+                /* Then, we continue the exploration of the grammar */
+                locate(/*graph_depth,*/ p->optimized_states[t1->state_number], end,
+                        matches, n_matches, ctx, p);
+                /* Once we have finished, we restore the stack */
+                p->weight=old_weight1;
+                p->stack->stack_pointer = stack_top;
+                if (p->nb_output_variables != 0) {
+                  remove_chars_from_output_variables(p->output_variables,captured_chars);
+                }
+            }
+            next: t1 = t1->next;
+        }
+        meta_list = meta_list->next;
+    }
 
 /**
  * OUTPUT VARIABLE STARTS
@@ -1283,438 +1283,438 @@ struct opt_variable* output_variable_list = current_state->output_variable_start
 Ustring* recycle_Ustring=NULL;
 while (output_variable_list != NULL) {
 
-	if (recycle_Ustring==NULL) {
-		recycle_Ustring=new_Ustring();
-	}
-	else {
-		empty(recycle_Ustring);
-	}
-	swap_output_variable_content(p->output_variables, output_variable_list->variable_number, recycle_Ustring);
+    if (recycle_Ustring==NULL) {
+        recycle_Ustring=new_Ustring();
+    }
+    else {
+        empty(recycle_Ustring);
+    }
+    swap_output_variable_content(p->output_variables, output_variable_list->variable_number, recycle_Ustring);
 
-	set_output_variable_pending(p->output_variables,output_variable_list->variable_number);
-	locate(/*graph_depth,*/
-			p->optimized_states[output_variable_list->transition->state_number],
-			pos, matches, n_matches, ctx, p);
-	p->weight=old_weight1;
-	unset_output_variable_pending(p->output_variables,output_variable_list->variable_number);
+    set_output_variable_pending(p->output_variables,output_variable_list->variable_number);
+    locate(/*graph_depth,*/
+            p->optimized_states[output_variable_list->transition->state_number],
+            pos, matches, n_matches, ctx, p);
+    p->weight=old_weight1;
+    unset_output_variable_pending(p->output_variables,output_variable_list->variable_number);
 
-	swap_output_variable_content(p->output_variables, output_variable_list->variable_number, recycle_Ustring);
+    swap_output_variable_content(p->output_variables, output_variable_list->variable_number, recycle_Ustring);
 
-	p->stack->stack_pointer = stack_top;
-	output_variable_list=output_variable_list->next;
+    p->stack->stack_pointer = stack_top;
+    output_variable_list=output_variable_list->next;
 }
 if (recycle_Ustring!=NULL) {
-	free_Ustring(recycle_Ustring);
-	recycle_Ustring=NULL;
+    free_Ustring(recycle_Ustring);
+    recycle_Ustring=NULL;
 }
 /**
  * OUTPUT VARIABLE ENDS
  */
 output_variable_list = current_state->output_variable_ends;
 while (output_variable_list != NULL) {
-	unset_output_variable_pending(p->output_variables,output_variable_list->variable_number);
-	locate(/*graph_depth,*/
-			p->optimized_states[output_variable_list->transition->state_number],
-			pos, matches, n_matches, ctx, p);
-	p->weight=old_weight1;
-	set_output_variable_pending(p->output_variables,output_variable_list->variable_number);
-	p->stack->stack_pointer = stack_top;
-	output_variable_list=output_variable_list->next;
+    unset_output_variable_pending(p->output_variables,output_variable_list->variable_number);
+    locate(/*graph_depth,*/
+            p->optimized_states[output_variable_list->transition->state_number],
+            pos, matches, n_matches, ctx, p);
+    p->weight=old_weight1;
+    set_output_variable_pending(p->output_variables,output_variable_list->variable_number);
+    p->stack->stack_pointer = stack_top;
+    output_variable_list=output_variable_list->next;
 }
 
-	/**
-	 * VARIABLE STARTS
-	 */
-	struct opt_variable* variable_list = current_state->input_variable_starts;
-	/* We don't start variables after the end of the buffer */
-	if (token2!=-1) while (variable_list != NULL) {
-		inc_dirty(p->backup_memory_reserve);
-		int old_in_token = get_variable_start(p->input_variables,
-				variable_list->variable_number);
-		int old_in_char = get_variable_start_in_chars(p->input_variables,
-						variable_list->variable_number);
-		set_variable_start(p->input_variables, variable_list->variable_number, pos2);
-		set_variable_start_in_chars(p->input_variables, variable_list->variable_number, 0);
-		locate(/*graph_depth,*/
-				p->optimized_states[variable_list->transition->state_number],
-				pos, matches, n_matches, ctx, p);
-		p->weight=old_weight1;
-		p->stack->stack_pointer = stack_top;
-		if (ctx == NULL) {
-			/* We do not restore previous value if we are inside a context, in order
-			 * to allow extracting things from contexts (see the
-			 * "the cat is white" example in Unitex manual). */
-			set_variable_start(p->input_variables, variable_list->variable_number,
-					old_in_token);
-			set_variable_start_in_chars(p->input_variables, variable_list->variable_number,
-								old_in_char);
-			dec_dirty(p->backup_memory_reserve);
-			// restore dirty
-		}
-		variable_list = variable_list->next;
-	}
+    /**
+     * VARIABLE STARTS
+     */
+    struct opt_variable* variable_list = current_state->input_variable_starts;
+    /* We don't start variables after the end of the buffer */
+    if (token2!=-1) while (variable_list != NULL) {
+        inc_dirty(p->backup_memory_reserve);
+        int old_in_token = get_variable_start(p->input_variables,
+                variable_list->variable_number);
+        int old_in_char = get_variable_start_in_chars(p->input_variables,
+                        variable_list->variable_number);
+        set_variable_start(p->input_variables, variable_list->variable_number, pos2);
+        set_variable_start_in_chars(p->input_variables, variable_list->variable_number, 0);
+        locate(/*graph_depth,*/
+                p->optimized_states[variable_list->transition->state_number],
+                pos, matches, n_matches, ctx, p);
+        p->weight=old_weight1;
+        p->stack->stack_pointer = stack_top;
+        if (ctx == NULL) {
+            /* We do not restore previous value if we are inside a context, in order
+             * to allow extracting things from contexts (see the
+             * "the cat is white" example in Unitex manual). */
+            set_variable_start(p->input_variables, variable_list->variable_number,
+                    old_in_token);
+            set_variable_start_in_chars(p->input_variables, variable_list->variable_number,
+                                old_in_char);
+            dec_dirty(p->backup_memory_reserve);
+            // restore dirty
+        }
+        variable_list = variable_list->next;
+    }
 
-	/**
-	 * VARIABLE ENDS
-	 */
-	variable_list = current_state->input_variable_ends;
-	int end=(token!=-1)?pos:(p->buffer_size-p->current_origin);
-	while (variable_list != NULL) {
-		inc_dirty(p->backup_memory_reserve);
-		int old_in_token =
-				get_variable_end(p->input_variables, variable_list->variable_number);
-		int old_in_char =
-						get_variable_end_in_chars(p->input_variables, variable_list->variable_number);
-		set_variable_end(p->input_variables, variable_list->variable_number, /*pos*/end);
-		set_variable_end_in_chars(p->input_variables, variable_list->variable_number,-1);
-		locate(/*graph_depth,*/
-				p->optimized_states[variable_list->transition->state_number],
-				pos, matches, n_matches, ctx, p);
-		p->weight=old_weight1;
-		p->stack->stack_pointer = stack_top;
-		if (ctx == NULL) {
-			/* We do not restore previous value if we are inside a context, in order
-			 * to allow extracting things from contexts (see the
-			 * "the cat is white" example in Unitex manual). */
-			set_variable_end(p->input_variables, variable_list->variable_number, old_in_token);
-			set_variable_end_in_chars(p->input_variables, variable_list->variable_number, old_in_char);
-			dec_dirty(p->backup_memory_reserve);
-		}
-		variable_list = variable_list->next;
-	}
+    /**
+     * VARIABLE ENDS
+     */
+    variable_list = current_state->input_variable_ends;
+    int end=(token!=-1)?pos:(p->buffer_size-p->current_origin);
+    while (variable_list != NULL) {
+        inc_dirty(p->backup_memory_reserve);
+        int old_in_token =
+                get_variable_end(p->input_variables, variable_list->variable_number);
+        int old_in_char =
+                        get_variable_end_in_chars(p->input_variables, variable_list->variable_number);
+        set_variable_end(p->input_variables, variable_list->variable_number, /*pos*/end);
+        set_variable_end_in_chars(p->input_variables, variable_list->variable_number,-1);
+        locate(/*graph_depth,*/
+                p->optimized_states[variable_list->transition->state_number],
+                pos, matches, n_matches, ctx, p);
+        p->weight=old_weight1;
+        p->stack->stack_pointer = stack_top;
+        if (ctx == NULL) {
+            /* We do not restore previous value if we are inside a context, in order
+             * to allow extracting things from contexts (see the
+             * "the cat is white" example in Unitex manual). */
+            set_variable_end(p->input_variables, variable_list->variable_number, old_in_token);
+            set_variable_end_in_chars(p->input_variables, variable_list->variable_number, old_in_char);
+            dec_dirty(p->backup_memory_reserve);
+        }
+        variable_list = variable_list->next;
+    }
 
-	/**
-	 * CONTEXTS
-	 */
-	struct opt_contexts* contexts = current_state->contexts;
-	if (contexts != NULL) {
-		Transition* t2;
-		for (int n_ctxt = 0; n_ctxt < contexts->size_positive; n_ctxt = n_ctxt
-				+ 2) {
-			t2 = contexts->positive_mark[n_ctxt];
-			if (t2==NULL) {
-				/* The optimization may have nulled transitions in this array */
-				continue;
-			}
-			/* We look for a positive context from the current position */
-			struct list_context* c = new_list_context(0, ctx, p->al.prv_alloc_context);
-			locate(/*graph_depth,*/ p->optimized_states[t2->state_number], pos,
-					NULL, 0, c, p);
-			p->weight=old_weight1;
-			/* Note that there is no match to free since matches cannot be built within a context */
-			p->stack->stack_pointer = stack_top;
-			p->stack->stack[stack_top+1]='\0';
-			if (c->n) {
-				/* If the context has matched, then we can explore all the paths
-				 * that starts from the context end */
-				Transition* states = contexts->positive_mark[n_ctxt + 1];
-				unichar* backup=NULL;
-				if (p->debug) {
-					/* In debug mode, we copy the debug output
-					 * obtained while exploring the context,
-					 * but we remove the input part in order
-					 * not to produce an invalid concordance
-					 */
-					backup=u_strdup(p->stack->stack);
-					u_strcat(p->stack->stack,c->output+stack_top+1);
-					int pos3=u_strlen(p->stack->stack);
-					p->stack->stack_pointer=pos3-1;
-				}
-				while (states != NULL) {
-					locate(/*graph_depth,*/
-							p->optimized_states[states->state_number], pos,
-							matches, n_matches, ctx, p);
-					p->weight=old_weight1;
-					p->stack->stack_pointer = stack_top;
-					states = states->next;
-				}
-				if (p->debug) {
-					u_strcpy(p->stack->stack,backup);
-					free(backup);
-				}
-			}
-			free_list_context(c, p->al.prv_alloc_context);
-		}
-		for (int n_ctxt = 0; n_ctxt < contexts->size_negative; n_ctxt = n_ctxt
-				+ 2) {
-			t2 = contexts->negative_mark[n_ctxt];
-			/* We look for a negative context from the current position */
-			struct list_context* c = new_list_context(0, ctx, p->al.prv_alloc_context);
-			locate(/*graph_depth,*/ p->optimized_states[t2->state_number], pos,
-					NULL, 0, c, p);
-			p->weight=old_weight1;
-			/* Note that there is no matches to free since matches cannot be built within a context */
-			p->stack->stack_pointer = stack_top;
-			if (!c->n) {
-				/* If the context has not matched, then we can explore all the paths
-				 * that starts from the context end */
-				Transition* states = contexts->negative_mark[n_ctxt + 1];
-				while (states != NULL) {
-					locate(/*graph_depth,*/
-							p->optimized_states[states->state_number], pos,
-							matches, n_matches, ctx, p);
-					p->weight=old_weight1;
-					p->stack->stack_pointer = stack_top;
-					states = states->next;
-				}
-			}
-			/* We just want to free the cell we created */
-			free_list_context(c, p->al.prv_alloc_context);
-		}
-		if ((t2 = contexts->end_mark) != NULL) {
-			/* If we have a closing context mark */
-			if (ctx == NULL) {
-				/* If there was no current opened context, it's an error */
-				error(
-						"ERROR: unexpected closing context mark in graph \"%S\"\n",
-						p->fst2->graph_names[current_state->graph_number]);
-				p->explore_depth -- ;
-				return;
-			}
-			/* Otherwise, we just indicate that we have found a context closing mark,
-			 * and we return */
-			ctx->n = 1;
-			if (ctx->output==NULL) {
-				p->stack->stack[p->stack->stack_pointer+1]='\0';
-				set_list_context_output(ctx,p->stack->stack);
-			}
-			p->explore_depth -- ;
-			return;
-		}
-	}
+    /**
+     * CONTEXTS
+     */
+    struct opt_contexts* contexts = current_state->contexts;
+    if (contexts != NULL) {
+        Transition* t2;
+        for (int n_ctxt = 0; n_ctxt < contexts->size_positive; n_ctxt = n_ctxt
+                + 2) {
+            t2 = contexts->positive_mark[n_ctxt];
+            if (t2==NULL) {
+                /* The optimization may have nulled transitions in this array */
+                continue;
+            }
+            /* We look for a positive context from the current position */
+            struct list_context* c = new_list_context(0, ctx, p->al.prv_alloc_context);
+            locate(/*graph_depth,*/ p->optimized_states[t2->state_number], pos,
+                    NULL, 0, c, p);
+            p->weight=old_weight1;
+            /* Note that there is no match to free since matches cannot be built within a context */
+            p->stack->stack_pointer = stack_top;
+            p->stack->stack[stack_top+1]='\0';
+            if (c->n) {
+                /* If the context has matched, then we can explore all the paths
+                 * that starts from the context end */
+                Transition* states = contexts->positive_mark[n_ctxt + 1];
+                unichar* backup=NULL;
+                if (p->debug) {
+                    /* In debug mode, we copy the debug output
+                     * obtained while exploring the context,
+                     * but we remove the input part in order
+                     * not to produce an invalid concordance
+                     */
+                    backup=u_strdup(p->stack->stack);
+                    u_strcat(p->stack->stack,c->output+stack_top+1);
+                    int pos3=u_strlen(p->stack->stack);
+                    p->stack->stack_pointer=pos3-1;
+                }
+                while (states != NULL) {
+                    locate(/*graph_depth,*/
+                            p->optimized_states[states->state_number], pos,
+                            matches, n_matches, ctx, p);
+                    p->weight=old_weight1;
+                    p->stack->stack_pointer = stack_top;
+                    states = states->next;
+                }
+                if (p->debug) {
+                    u_strcpy(p->stack->stack,backup);
+                    free(backup);
+                }
+            }
+            free_list_context(c, p->al.prv_alloc_context);
+        }
+        for (int n_ctxt = 0; n_ctxt < contexts->size_negative; n_ctxt = n_ctxt
+                + 2) {
+            t2 = contexts->negative_mark[n_ctxt];
+            /* We look for a negative context from the current position */
+            struct list_context* c = new_list_context(0, ctx, p->al.prv_alloc_context);
+            locate(/*graph_depth,*/ p->optimized_states[t2->state_number], pos,
+                    NULL, 0, c, p);
+            p->weight=old_weight1;
+            /* Note that there is no matches to free since matches cannot be built within a context */
+            p->stack->stack_pointer = stack_top;
+            if (!c->n) {
+                /* If the context has not matched, then we can explore all the paths
+                 * that starts from the context end */
+                Transition* states = contexts->negative_mark[n_ctxt + 1];
+                while (states != NULL) {
+                    locate(/*graph_depth,*/
+                            p->optimized_states[states->state_number], pos,
+                            matches, n_matches, ctx, p);
+                    p->weight=old_weight1;
+                    p->stack->stack_pointer = stack_top;
+                    states = states->next;
+                }
+            }
+            /* We just want to free the cell we created */
+            free_list_context(c, p->al.prv_alloc_context);
+        }
+        if ((t2 = contexts->end_mark) != NULL) {
+            /* If we have a closing context mark */
+            if (ctx == NULL) {
+                /* If there was no current opened context, it's an error */
+                error(
+                        "ERROR: unexpected closing context mark in graph \"%S\"\n",
+                        p->fst2->graph_names[current_state->graph_number]);
+                p->explore_depth -- ;
+                return;
+            }
+            /* Otherwise, we just indicate that we have found a context closing mark,
+             * and we return */
+            ctx->n = 1;
+            if (ctx->output==NULL) {
+                p->stack->stack[p->stack->stack_pointer+1]='\0';
+                set_list_context_output(ctx,p->stack->stack);
+            }
+            p->explore_depth -- ;
+            return;
+        }
+    }
 
-	/**
-	 * Now that we have finished with meta symbols, there can be no chance to advance
-	 * in the grammar if we are at the end of the token buffer.
-	 */
-	if (token2 == -1) {
-		p->explore_depth -- ;
-		return;
-	}
+    /**
+     * Now that we have finished with meta symbols, there can be no chance to advance
+     * in the grammar if we are at the end of the token buffer.
+     */
+    if (token2 == -1) {
+        p->explore_depth -- ;
+        return;
+    }
 
-	/**
-	 * COMPOUND WORD PATTERNS:
-	 * here, we deal with patterns that can only match compound sequences
-	 */
-	struct opt_pattern* pattern_list = current_state->compound_patterns;
-	while (pattern_list != NULL) {
-		t1 = pattern_list->transition;
-		while (t1 != NULL) {
+    /**
+     * COMPOUND WORD PATTERNS:
+     * here, we deal with patterns that can only match compound sequences
+     */
+    struct opt_pattern* pattern_list = current_state->compound_patterns;
+    while (pattern_list != NULL) {
+        t1 = pattern_list->transition;
+        while (t1 != NULL) {
 #ifdef REGEX_FACADE_ENGINE
-			filter_number = p->tags[t1->tag_number]->filter_number;
+            filter_number = p->tags[t1->tag_number]->filter_number;
 #endif
-			output = p->tags[t1->tag_number]->output;
-			end_of_compound = find_compound_word(pos2,
-					pattern_list->pattern_number, p->DLC_tree, p);
-			if (end_of_compound != -1 && !(pattern_list->negation)) {
-				int OK = 1;
+            output = p->tags[t1->tag_number]->output;
+            end_of_compound = find_compound_word(pos2,
+                    pattern_list->pattern_number, p->DLC_tree, p);
+            if (end_of_compound != -1 && !(pattern_list->negation)) {
+                int OK = 1;
 #ifdef REGEX_FACADE_ENGINE
-				if (filter_number == -1)
-					OK = 1;
-				else {
-					unichar* sequence = get_token_sequence(p,
-							pos2 + p->current_origin,
-							end_of_compound + p->current_origin);
-					OK = string_match_filter(p->filters, sequence,
-						filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
-				}
+                if (filter_number == -1)
+                    OK = 1;
+                else {
+                    unichar* sequence = get_token_sequence(p,
+                            pos2 + p->current_origin,
+                            end_of_compound + p->current_origin);
+                    OK = string_match_filter(p->filters, sequence,
+                        filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
+                }
 #endif
-				if (OK) {
-					if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
-						push_input_char(p->stack, ' ', p->protect_dic_chars);
-					}
-					captured_chars=0;
-					if (p->output_policy != IGNORE_OUTPUTS) {
-						if (!deal_with_output(output,p,&captured_chars)) {
-							goto next4;
-						}
-					}
-					if (p->output_policy == MERGE_OUTPUTS) {
-						for (int x = pos2; x <= end_of_compound; x++) {
-							push_input_string(p->stack,
-									p->tokens->value[p->buffer[x
-											+ p->current_origin]],
-									p->protect_dic_chars);
-						}
-					}
-					locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
-							end_of_compound + 1, matches, n_matches,
-							ctx, p);
-					p->weight=old_weight1;
-					p->stack->stack_pointer = stack_top;
-					remove_chars_from_output_variables(p->output_variables,captured_chars);
-				}
-			}
-			next4: t1 = t1->next;
-		}
-		pattern_list = pattern_list->next;
-	}
+                if (OK) {
+                    if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
+                        push_input_char(p->stack, ' ', p->protect_dic_chars);
+                    }
+                    captured_chars=0;
+                    if (p->output_policy != IGNORE_OUTPUTS) {
+                        if (!deal_with_output(output,p,&captured_chars)) {
+                            goto next4;
+                        }
+                    }
+                    if (p->output_policy == MERGE_OUTPUTS) {
+                        for (int x = pos2; x <= end_of_compound; x++) {
+                            push_input_string(p->stack,
+                                    p->tokens->value[p->buffer[x
+                                            + p->current_origin]],
+                                    p->protect_dic_chars);
+                        }
+                    }
+                    locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
+                            end_of_compound + 1, matches, n_matches,
+                            ctx, p);
+                    p->weight=old_weight1;
+                    p->stack->stack_pointer = stack_top;
+                    remove_chars_from_output_variables(p->output_variables,captured_chars);
+                }
+            }
+            next4: t1 = t1->next;
+        }
+        pattern_list = pattern_list->next;
+    }
 
-	/**
-	 * SIMPLE WORD PATTERNS:
-	 * here, we deal with patterns that can match both simple and
-	 * compound words, like "<N>".
-	 */
-	pattern_list = current_state->patterns;
-	while (pattern_list != NULL) {
-		t1 = pattern_list->transition;
-		while (t1 != NULL) {
+    /**
+     * SIMPLE WORD PATTERNS:
+     * here, we deal with patterns that can match both simple and
+     * compound words, like "<N>".
+     */
+    pattern_list = current_state->patterns;
+    while (pattern_list != NULL) {
+        t1 = pattern_list->transition;
+        while (t1 != NULL) {
 #ifdef REGEX_FACADE_ENGINE
-			filter_number = p->tags[t1->tag_number]->filter_number;
+            filter_number = p->tags[t1->tag_number]->filter_number;
 #endif
-			output = p->tags[t1->tag_number]->output;
-			/* We try to match a compound word */
-			end_of_compound = find_compound_word(pos2,
-					pattern_list->pattern_number, p->DLC_tree, p);
-			if (end_of_compound != -1 && !(pattern_list->negation)) {
-				int OK = 1;
+            output = p->tags[t1->tag_number]->output;
+            /* We try to match a compound word */
+            end_of_compound = find_compound_word(pos2,
+                    pattern_list->pattern_number, p->DLC_tree, p);
+            if (end_of_compound != -1 && !(pattern_list->negation)) {
+                int OK = 1;
 #ifdef REGEX_FACADE_ENGINE
-				if (filter_number == -1)
-					OK = 1;
-				else {
-					unichar* sequence = get_token_sequence(p,
-							pos2 + p->current_origin,
-							end_of_compound + p->current_origin);
-					OK = string_match_filter(p->filters, sequence,
-							filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
-				}
+                if (filter_number == -1)
+                    OK = 1;
+                else {
+                    unichar* sequence = get_token_sequence(p,
+                            pos2 + p->current_origin,
+                            end_of_compound + p->current_origin);
+                    OK = string_match_filter(p->filters, sequence,
+                            filter_number, p->recyclable_wchart_buffer, SIZE_RECYCLABLE_WCHAR_T_BUFFER);
+                }
 #endif
-				if (OK) {
-					if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
-						push_input_char(p->stack, ' ', p->protect_dic_chars);
-					}
-					captured_chars=0;
-					if (p->output_policy != IGNORE_OUTPUTS) {
-						if (!deal_with_output(output,p,&captured_chars)) {
-							goto next6;
-						}
-					}
-					if (p->output_policy == MERGE_OUTPUTS) {
-						for (int x = pos2; x <= end_of_compound; x++) {
-							push_input_string(p->stack,
-									p->tokens->value[p->buffer[x
-											+ p->current_origin]],
-									p->protect_dic_chars);
-						}
-					}
-					locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
-							end_of_compound + 1, matches, n_matches,
-							ctx, p);
-					p->weight=old_weight1;
-					p->stack->stack_pointer = stack_top;
-					remove_chars_from_output_variables(p->output_variables,captured_chars);
-				}
-				/* This useless empty block is just here to enable the declaration of the next6 label */
-				next6: {
-				}
-			}
-			/* And now, we look for simple words */
-			int OK = 1;
-			update_last_tested_position(p, pos2);
+                if (OK) {
+                    if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
+                        push_input_char(p->stack, ' ', p->protect_dic_chars);
+                    }
+                    captured_chars=0;
+                    if (p->output_policy != IGNORE_OUTPUTS) {
+                        if (!deal_with_output(output,p,&captured_chars)) {
+                            goto next6;
+                        }
+                    }
+                    if (p->output_policy == MERGE_OUTPUTS) {
+                        for (int x = pos2; x <= end_of_compound; x++) {
+                            push_input_string(p->stack,
+                                    p->tokens->value[p->buffer[x
+                                            + p->current_origin]],
+                                    p->protect_dic_chars);
+                        }
+                    }
+                    locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
+                            end_of_compound + 1, matches, n_matches,
+                            ctx, p);
+                    p->weight=old_weight1;
+                    p->stack->stack_pointer = stack_top;
+                    remove_chars_from_output_variables(p->output_variables,captured_chars);
+                }
+                /* This useless empty block is just here to enable the declaration of the next6 label */
+                next6: {
+                }
+            }
+            /* And now, we look for simple words */
+            int OK = 1;
+            update_last_tested_position(p, pos2);
 #ifdef REGEX_FACADE_ENGINE
-			OK = (filter_number == -1 || token_match_filter(
-					p->filter_match_index, token2, filter_number));
+            OK = (filter_number == -1 || token_match_filter(
+                    p->filter_match_index, token2, filter_number));
 #endif
-			if (OK) {
-				if (p->matching_patterns[token2] != NULL) {
-					if (XOR(get_value(p->matching_patterns[token2],
-							pattern_list->pattern_number),
-							pattern_list->negation)) {
-						if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
-							push_input_char(p->stack, ' ', p->protect_dic_chars);
-						}
-						captured_chars=0;
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(output,p,&captured_chars)) {
-								goto next2;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							push_input_string(p->stack,
-									p->tokens->value[token2],
-									p->protect_dic_chars);
-						}
-						locate(/*graph_depth,*/
-								p->optimized_states[t1->state_number], pos2 + 1,
-								matches, n_matches, ctx, p);
-						p->weight=old_weight1;
-						p->stack->stack_pointer = stack_top;
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-					}
-				} else {
-					/* If the token matches no pattern, then it can match a pattern negation
-					 * like <!V> */
-					if (pattern_list->negation && (p->token_control[token2]
-							& MOT_TOKEN_BIT_MASK)) {
-						if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
-							push_input_char(p->stack, ' ', p->protect_dic_chars);
-						}
-						captured_chars=0;
-						if (p->output_policy != IGNORE_OUTPUTS) {
-							if (!deal_with_output(output,p,&captured_chars)) {
-								goto next2;
-							}
-						}
-						if (p->output_policy == MERGE_OUTPUTS) {
-							push_input_string(p->stack,
-									p->tokens->value[token2],
-									p->protect_dic_chars);
-						}
-						locate(/*graph_depth,*/
-								p->optimized_states[t1->state_number], pos2 + 1,
-								matches, n_matches, ctx, p);
-						p->weight=old_weight1;
-						p->stack->stack_pointer = stack_top;
-						remove_chars_from_output_variables(p->output_variables,captured_chars);
-					}
-				}
-			}
-			next2: t1 = t1->next;
-		}
-		pattern_list = pattern_list->next;
-	}
+            if (OK) {
+                if (p->matching_patterns[token2] != NULL) {
+                    if (XOR(get_value(p->matching_patterns[token2],
+                            pattern_list->pattern_number),
+                            pattern_list->negation)) {
+                        if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
+                            push_input_char(p->stack, ' ', p->protect_dic_chars);
+                        }
+                        captured_chars=0;
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(output,p,&captured_chars)) {
+                                goto next2;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            push_input_string(p->stack,
+                                    p->tokens->value[token2],
+                                    p->protect_dic_chars);
+                        }
+                        locate(/*graph_depth,*/
+                                p->optimized_states[t1->state_number], pos2 + 1,
+                                matches, n_matches, ctx, p);
+                        p->weight=old_weight1;
+                        p->stack->stack_pointer = stack_top;
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                    }
+                } else {
+                    /* If the token matches no pattern, then it can match a pattern negation
+                     * like <!V> */
+                    if (pattern_list->negation && (p->token_control[token2]
+                            & MOT_TOKEN_BIT_MASK)) {
+                        if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
+                            push_input_char(p->stack, ' ', p->protect_dic_chars);
+                        }
+                        captured_chars=0;
+                        if (p->output_policy != IGNORE_OUTPUTS) {
+                            if (!deal_with_output(output,p,&captured_chars)) {
+                                goto next2;
+                            }
+                        }
+                        if (p->output_policy == MERGE_OUTPUTS) {
+                            push_input_string(p->stack,
+                                    p->tokens->value[token2],
+                                    p->protect_dic_chars);
+                        }
+                        locate(/*graph_depth,*/
+                                p->optimized_states[t1->state_number], pos2 + 1,
+                                matches, n_matches, ctx, p);
+                        p->weight=old_weight1;
+                        p->stack->stack_pointer = stack_top;
+                        remove_chars_from_output_variables(p->output_variables,captured_chars);
+                    }
+                }
+            }
+            next2: t1 = t1->next;
+        }
+        pattern_list = pattern_list->next;
+    }
 
-	/**
-	 * TOKENS
-	 */
-	if (current_state->number_of_tokens != 0) {
-		update_last_tested_position(p, pos2);
-		int n = binary_search(token2, current_state->tokens,
-				current_state->number_of_tokens);
-		if (n != -1) {
-			t1 = current_state->token_transitions[n];
-			while (t1 != NULL) {
+    /**
+     * TOKENS
+     */
+    if (current_state->number_of_tokens != 0) {
+        update_last_tested_position(p, pos2);
+        int n = binary_search(token2, current_state->tokens,
+                current_state->number_of_tokens);
+        if (n != -1) {
+            t1 = current_state->token_transitions[n];
+            while (t1 != NULL) {
 #ifdef REGEX_FACADE_ENGINE
-				filter_number = p->tags[t1->tag_number]->filter_number;
-				if (filter_number == -1 || token_match_filter(
-						p->filter_match_index, token2, filter_number))
+                filter_number = p->tags[t1->tag_number]->filter_number;
+                if (filter_number == -1 || token_match_filter(
+                        p->filter_match_index, token2, filter_number))
 #endif
-				{
-					output = p->tags[t1->tag_number]->output;
-					if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
-						push_input_char(p->stack, ' ', p->protect_dic_chars);
-					}
-					captured_chars=0;
-					if (p->output_policy != IGNORE_OUTPUTS) {
-						if (!deal_with_output(output,p,&captured_chars)) {
-							goto next3;
-						}
-					}
-					if (p->output_policy == MERGE_OUTPUTS) {
-						push_input_string(p->stack, p->tokens->value[token2],
-								p->protect_dic_chars);
-					}
-					locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
-							pos2 + 1, matches, n_matches, ctx, p);
-					p->weight=old_weight1;
-					p->stack->stack_pointer = stack_top;
-					remove_chars_from_output_variables(p->output_variables,captured_chars);
-				}
-				next3: t1 = t1->next;
-			}
-		}
-	}
-	p->explore_depth -- ;
+                {
+                    output = p->tags[t1->tag_number]->output;
+                    if (p->output_policy == MERGE_OUTPUTS && pos2 != pos) {
+                        push_input_char(p->stack, ' ', p->protect_dic_chars);
+                    }
+                    captured_chars=0;
+                    if (p->output_policy != IGNORE_OUTPUTS) {
+                        if (!deal_with_output(output,p,&captured_chars)) {
+                            goto next3;
+                        }
+                    }
+                    if (p->output_policy == MERGE_OUTPUTS) {
+                        push_input_string(p->stack, p->tokens->value[token2],
+                                p->protect_dic_chars);
+                    }
+                    locate(/*graph_depth,*/ p->optimized_states[t1->state_number],
+                            pos2 + 1, matches, n_matches, ctx, p);
+                    p->weight=old_weight1;
+                    p->stack->stack_pointer = stack_top;
+                    remove_chars_from_output_variables(p->output_variables,captured_chars);
+                }
+                next3: t1 = t1->next;
+            }
+        }
+    }
+    p->explore_depth -- ;
 }
 
 
@@ -1722,26 +1722,26 @@ while (output_variable_list != NULL) {
  * Looks for 'a' in the given array. Returns its position or -1 if not found.
  */
 static int binary_search(int a, int* t, int n) {
-	register int start, middle;
-	if (n == 0 || t == NULL)
-		return -1;
-	if (a < t[0])
-		return -1;
-	if (a > t[n - 1])
-		return -1;
-	n = n - 1;
-	start = 0;
-	while (start <= n) {
-		middle = ((start + n) >> 1); // like /2, but faster (depends on compiler)
-		if (t[middle] == a)
-			return middle;
-		if (t[middle] < a) {
-			start = middle + 1;
-		} else {
-			n = middle - 1;
-		}
-	}
-	return -1;
+    register int start, middle;
+    if (n == 0 || t == NULL)
+        return -1;
+    if (a < t[0])
+        return -1;
+    if (a > t[n - 1])
+        return -1;
+    n = n - 1;
+    start = 0;
+    while (start <= n) {
+        middle = ((start + n) >> 1); // like /2, but faster (depends on compiler)
+        if (t[middle] == a)
+            return middle;
+        if (t[middle] < a) {
+            start = middle + 1;
+        } else {
+            n = middle - 1;
+        }
+    }
+    return -1;
 }
 
 /**
@@ -1750,46 +1750,46 @@ static int binary_search(int a, int* t, int n) {
  * of the last token of the compound word, or -1 if no compound word is found.
  */
 static int find_longest_compound_word(int pos, struct DLC_tree_node* node,
-		int pattern_number, struct locate_parameters* p) {
-	if (node == NULL) {
-		fatal_error("NULL node in find_longest_compound_word\n");
-	}
-	update_last_tested_position(p, pos);
-	int current_token = p->buffer[pos + p->current_origin];
-	int position_max;
-	if (-1 != binary_search(pattern_number, node->array_of_patterns,
-			node->number_of_patterns))
-		position_max = pos - 1;
-	else
-		position_max = -1;
-	if (pos + p->current_origin == p->buffer_size)
-		return position_max;
-	/* As the 'node->destination_tokens' array may contain duplicates, we look for
-	 * one, and then we look before and after it, in order to examine all the
-	 * duplicates. */
-	int position = binary_search(current_token, node->destination_tokens,
-			node->number_of_transitions);
-	if (position == -1)
-		return position_max;
-	/* We look after it... */
-	for (int i = position; i < node->number_of_transitions && current_token
-			== node->destination_tokens[i]; i++) {
-		/* If we can follow a transition tagged with the good token */
-		int m = find_longest_compound_word(pos + 1, node->destination_nodes[i],
-				pattern_number, p);
-		if (m > position_max)
-			position_max = m;
-	}
-	/* ...and before it */
-	for (int i = position - 1; i >= 0 && current_token
-			== node->destination_tokens[i]; i--) {
-		/* If we can follow a transition tagged with the good token */
-		int m = find_longest_compound_word(pos + 1, node->destination_nodes[i],
-				pattern_number, p);
-		if (m > position_max)
-			position_max = m;
-	}
-	return position_max;
+        int pattern_number, struct locate_parameters* p) {
+    if (node == NULL) {
+        fatal_error("NULL node in find_longest_compound_word\n");
+    }
+    update_last_tested_position(p, pos);
+    int current_token = p->buffer[pos + p->current_origin];
+    int position_max;
+    if (-1 != binary_search(pattern_number, node->array_of_patterns,
+            node->number_of_patterns))
+        position_max = pos - 1;
+    else
+        position_max = -1;
+    if (pos + p->current_origin == p->buffer_size)
+        return position_max;
+    /* As the 'node->destination_tokens' array may contain duplicates, we look for
+     * one, and then we look before and after it, in order to examine all the
+     * duplicates. */
+    int position = binary_search(current_token, node->destination_tokens,
+            node->number_of_transitions);
+    if (position == -1)
+        return position_max;
+    /* We look after it... */
+    for (int i = position; i < node->number_of_transitions && current_token
+            == node->destination_tokens[i]; i++) {
+        /* If we can follow a transition tagged with the good token */
+        int m = find_longest_compound_word(pos + 1, node->destination_nodes[i],
+                pattern_number, p);
+        if (m > position_max)
+            position_max = m;
+    }
+    /* ...and before it */
+    for (int i = position - 1; i >= 0 && current_token
+            == node->destination_tokens[i]; i--) {
+        /* If we can follow a transition tagged with the good token */
+        int m = find_longest_compound_word(pos + 1, node->destination_nodes[i],
+                pattern_number, p);
+        if (m > position_max)
+            position_max = m;
+    }
+    return position_max;
 }
 
 /**
@@ -1799,8 +1799,8 @@ static int find_longest_compound_word(int pos, struct DLC_tree_node* node,
  * of another, the function considers the longest one.
  */
 static int find_compound_word(int pos, int pattern_number,
-		struct DLC_tree_info* DLC_tree, struct locate_parameters* p) {
-	return find_longest_compound_word(pos, DLC_tree->root, pattern_number, p);
+        struct DLC_tree_info* DLC_tree, struct locate_parameters* p) {
+    return find_longest_compound_word(pos, DLC_tree->root, pattern_number, p);
 }
 
 
@@ -1808,40 +1808,40 @@ static int find_compound_word(int pos, int pattern_number,
  * Returns a string corresponding to the tokens in the range [start;end].
  */
 static unichar* get_token_sequence(struct locate_parameters*p,
-		int start, int end) {
-	unichar* recyclable_buffer = p->recyclable_unichar_buffer;
-	unichar* recyclable_buffer_limit = recyclable_buffer + p->size_recyclable_unichar_buffer ;
-	unichar* fill_recyclable_buffer = recyclable_buffer;
-	const int* token_array = p->buffer;
-	const struct string_hash* tokens = p->tokens;
-	int i;
+        int start, int end) {
+    unichar* recyclable_buffer = p->recyclable_unichar_buffer;
+    unichar* recyclable_buffer_limit = recyclable_buffer + p->size_recyclable_unichar_buffer ;
+    unichar* fill_recyclable_buffer = recyclable_buffer;
+    const int* token_array = p->buffer;
+    const struct string_hash* tokens = p->tokens;
+    int i;
 
-	for (i = start; i <= end; i++) {
-		const unichar* current_string = tokens->value[token_array[i]];
-		unichar c;
-		do
-		{
-			c=*(current_string++);
+    for (i = start; i <= end; i++) {
+        const unichar* current_string = tokens->value[token_array[i]];
+        unichar c;
+        do
+        {
+            c=*(current_string++);
 
-			if (fill_recyclable_buffer == recyclable_buffer_limit)
+            if (fill_recyclable_buffer == recyclable_buffer_limit)
             {
-				// we have reached the end of the recyclable buffer
-				// we enlarge (*2) the size of recyclable buffer and try again with the new buffer
-				p->size_recyclable_unichar_buffer *= 2;
-				free(p->recyclable_unichar_buffer);
-				p->recyclable_unichar_buffer=(unichar*)malloc(sizeof(unichar) * (p->size_recyclable_unichar_buffer));
-				if (p->recyclable_unichar_buffer==NULL) {
-					fatal_alloc_error("get_token_sequence");
-				}
-				return get_token_sequence(p,start,end);
+                // we have reached the end of the recyclable buffer
+                // we enlarge (*2) the size of recyclable buffer and try again with the new buffer
+                p->size_recyclable_unichar_buffer *= 2;
+                free(p->recyclable_unichar_buffer);
+                p->recyclable_unichar_buffer=(unichar*)malloc(sizeof(unichar) * (p->size_recyclable_unichar_buffer));
+                if (p->recyclable_unichar_buffer==NULL) {
+                    fatal_alloc_error("get_token_sequence");
+                }
+                return get_token_sequence(p,start,end);
             }
 
-			*(fill_recyclable_buffer++) = c;
-		} while (c != '\0');
-		// next writting in buffer must overwrite the end of string
-		fill_recyclable_buffer--;
-	}
-	return recyclable_buffer;
+            *(fill_recyclable_buffer++) = c;
+        } while (c != '\0');
+        // next writting in buffer must overwrite the end of string
+        fill_recyclable_buffer--;
+    }
+    return recyclable_buffer;
 }
 
 
@@ -1851,8 +1851,8 @@ static unichar* get_token_sequence(struct locate_parameters*p,
  * all have the same weight.
  */
 void remove_matches_with_lesser_weights(int weight,struct match_list* *match_cache_first,
-										struct match_list* *match_cache_last,
-										Abstract_allocator prv_alloc) {
+                                        struct match_list* *match_cache_last,
+                                        Abstract_allocator prv_alloc) {
 if (*match_cache_first==NULL || (*match_cache_first)->weight>=weight) return;
 /* If the new weight is bigger, we must free the whole match list */
 free_match_list(*match_cache_first,prv_alloc);
@@ -1865,30 +1865,30 @@ free_match_list(*match_cache_first,prv_alloc);
  * Stores the given match in a list. All matches will be processed later.
  */
 static void add_match(int end, unichar* output, struct locate_parameters* p, Abstract_allocator prv_alloc) {
-	if (end > p->last_matched_position) {
-		p->last_matched_position = end;
-	}
-	int start = p->current_origin + p->left_ctx_shift;
-	unichar* z=output;
-	if (p->debug && p->left_ctx_base!=0) {
-		/* In debug mode, we always use the whole output. It will be
-		 * the match writing operation into the concordance index that
-		 * will rebuild the actual output parsing the full debug one */
-		z=p->stack->stack;
-	}
-	remove_matches_with_lesser_weights(p->weight,&(p->match_cache_first),&(p->match_cache_last),prv_alloc);
-	if (p->match_cache_first!=NULL && p->match_cache_first->weight>p->weight) {
-		/* If we have to ignore this match because its weight is lesser
-		 * than the weight of the existing matches */
-		return;
-	}
-	struct match_list* m = new_match(start, end, z, p->weight, NULL, prv_alloc);
-	if (p->match_cache_first == NULL) {
-		p->match_cache_first = p->match_cache_last = m;
-		return;
-	}
-	p->match_cache_last->next = m;
-	p->match_cache_last = m;
+    if (end > p->last_matched_position) {
+        p->last_matched_position = end;
+    }
+    int start = p->current_origin + p->left_ctx_shift;
+    unichar* z=output;
+    if (p->debug && p->left_ctx_base!=0) {
+        /* In debug mode, we always use the whole output. It will be
+         * the match writing operation into the concordance index that
+         * will rebuild the actual output parsing the full debug one */
+        z=p->stack->stack;
+    }
+    remove_matches_with_lesser_weights(p->weight,&(p->match_cache_first),&(p->match_cache_last),prv_alloc);
+    if (p->match_cache_first!=NULL && p->match_cache_first->weight>p->weight) {
+        /* If we have to ignore this match because its weight is lesser
+         * than the weight of the existing matches */
+        return;
+    }
+    struct match_list* m = new_match(start, end, z, p->weight, NULL, prv_alloc);
+    if (p->match_cache_first == NULL) {
+        p->match_cache_first = p->match_cache_last = m;
+        return;
+    }
+    p->match_cache_last->next = m;
+    p->match_cache_last = m;
 }
 
 
@@ -1898,47 +1898,47 @@ int end = m->m.end_pos_in_token;
 unichar* output = m->output;
 struct match_list* *L=&(p->match_list);
 while (*L != NULL) {
-	if ((*L)->m.start_pos_in_token == start
-		&& (*L)->m.end_pos_in_token == end
-		&& (p->ambiguous_output_policy != ALLOW_AMBIGUOUS_OUTPUTS || !u_strcmp((*L)->output, output))) {
-		/* The match is already there, nothing to do */
-		if (p->ambiguous_output_policy!=ALLOW_AMBIGUOUS_OUTPUTS && u_strcmp((*L)->output, output)) {
-			/* If ambiguous outputs are forbidden, we emit an error message */
-			error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",(*L)->output,output);
-		}
-		return;
-	}
-	if (start<(*L)->m.start_pos_in_token ||
-			(start==(*L)->m.start_pos_in_token && end<(*L)->m.end_pos_in_token)) {
-		/* We have to insert at the current position */
-		(*L)=new_match(start, end, output, -1, *L, prv_alloc);
-		return;
-	}
-	L = &((*L)->next);
+    if ((*L)->m.start_pos_in_token == start
+        && (*L)->m.end_pos_in_token == end
+        && (p->ambiguous_output_policy != ALLOW_AMBIGUOUS_OUTPUTS || !u_strcmp((*L)->output, output))) {
+        /* The match is already there, nothing to do */
+        if (p->ambiguous_output_policy!=ALLOW_AMBIGUOUS_OUTPUTS && u_strcmp((*L)->output, output)) {
+            /* If ambiguous outputs are forbidden, we emit an error message */
+            error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",(*L)->output,output);
+        }
+        return;
+    }
+    if (start<(*L)->m.start_pos_in_token ||
+            (start==(*L)->m.start_pos_in_token && end<(*L)->m.end_pos_in_token)) {
+        /* We have to insert at the current position */
+        (*L)=new_match(start, end, output, -1, *L, prv_alloc);
+        return;
+    }
+    L = &((*L)->next);
 }
 /* End of list? We add the match */
 (*L) = new_match(start, end, output, -1, NULL, prv_alloc);
 }
 
 static struct match_list* filter_on_weight_matches_with_same_start(struct match_list* l,int start,
-			int weight,int *dont_add_new_match,Abstract_allocator prv_alloc) {
+            int weight,int *dont_add_new_match,Abstract_allocator prv_alloc) {
 if (l==NULL) return NULL;
 if (l->m.start_pos_in_token==start) {
-	/* We have a match with the same start */
-	if (l->weight>weight) {
-		/* There is at least one match with a bigger weight, we must remove
-		 * the new match */
-		*dont_add_new_match=1;
-		return l;
-	}
-	if (l->weight<weight) {
-		/* The current match must be discarded */
-		struct match_list* tmp=l->next;
-		free_match_list_element(l,prv_alloc);
-		return filter_on_weight_matches_with_same_start(tmp,start,weight,dont_add_new_match,prv_alloc);
-	}
-	/* If both matches have the same weight, we do nothing but exploring the
-	 * remaining list */
+    /* We have a match with the same start */
+    if (l->weight>weight) {
+        /* There is at least one match with a bigger weight, we must remove
+         * the new match */
+        *dont_add_new_match=1;
+        return l;
+    }
+    if (l->weight<weight) {
+        /* The current match must be discarded */
+        struct match_list* tmp=l->next;
+        free_match_list_element(l,prv_alloc);
+        return filter_on_weight_matches_with_same_start(tmp,start,weight,dont_add_new_match,prv_alloc);
+    }
+    /* If both matches have the same weight, we do nothing but exploring the
+     * remaining list */
 }
 l->next=filter_on_weight_matches_with_same_start(l->next,start,weight,dont_add_new_match,prv_alloc);
 return l;
@@ -1953,62 +1953,62 @@ return l;
  * # Changed to allow different outputs in merge/replace
  * mode when the grammar is an ambiguous transducer (S.N.) */
 static void real_add_match(struct match_list* m, struct locate_parameters* p, Abstract_allocator prv_alloc) {
-	int start = m->m.start_pos_in_token;
-	int end = m->m.end_pos_in_token;
-	unichar* output = m->output;
-	int weight=m->weight;
-	int dont_add_match;
-	/* When we a conflict between two weighted paths, one with a left context and
-	 * not the other, the two matches are processed at different times in this function,
-	 * so their weights have not been compared yet. To address this issue, we always
-	 * filter the existing match list when adding a new match according the following
-	 * rule: if there is a match starting at the same position than the new one,
-	 * then we filter them according to their weights */
-	dont_add_match=0;
-	p->match_list=filter_on_weight_matches_with_same_start(p->match_list,start,
-			weight,&dont_add_match,prv_alloc);
-	if (dont_add_match) {
-		/* There is already a match better than the new one, so we are done */
-		return;
-	}
-	if (p->match_list == NULL) {
-		/* If the match list was empty, we always can put the match in the list */
-		p->match_list = new_match(start, end, output, weight, NULL, prv_alloc);
-		return;
-	}
-	switch (p->match_policy) {
-	case LONGEST_MATCHES:
-		/* We put the new match at the beginning of the list, but before, we
-		 * test if the match we want to add may not be discarded because of
-		 * a longest match that would already be in the list. By the way,
-		 * we eliminate matches that are shorter than this one, if any. */
-		dont_add_match = 0;
-		p->match_list = eliminate_shorter_matches(p->match_list, start, end,
-				output, &dont_add_match, p, prv_alloc);
-		if (!dont_add_match) {
-			p->match_list = new_match(start, end, output, weight, p->match_list, prv_alloc);
-		}
-		break;
+    int start = m->m.start_pos_in_token;
+    int end = m->m.end_pos_in_token;
+    unichar* output = m->output;
+    int weight=m->weight;
+    int dont_add_match;
+    /* When we a conflict between two weighted paths, one with a left context and
+     * not the other, the two matches are processed at different times in this function,
+     * so their weights have not been compared yet. To address this issue, we always
+     * filter the existing match list when adding a new match according the following
+     * rule: if there is a match starting at the same position than the new one,
+     * then we filter them according to their weights */
+    dont_add_match=0;
+    p->match_list=filter_on_weight_matches_with_same_start(p->match_list,start,
+            weight,&dont_add_match,prv_alloc);
+    if (dont_add_match) {
+        /* There is already a match better than the new one, so we are done */
+        return;
+    }
+    if (p->match_list == NULL) {
+        /* If the match list was empty, we always can put the match in the list */
+        p->match_list = new_match(start, end, output, weight, NULL, prv_alloc);
+        return;
+    }
+    switch (p->match_policy) {
+    case LONGEST_MATCHES:
+        /* We put the new match at the beginning of the list, but before, we
+         * test if the match we want to add may not be discarded because of
+         * a longest match that would already be in the list. By the way,
+         * we eliminate matches that are shorter than this one, if any. */
+        dont_add_match = 0;
+        p->match_list = eliminate_shorter_matches(p->match_list, start, end,
+                output, &dont_add_match, p, prv_alloc);
+        if (!dont_add_match) {
+            p->match_list = new_match(start, end, output, weight, p->match_list, prv_alloc);
+        }
+        break;
 
-	case ALL_MATCHES:
-		/* We unify identical matches, i.e. matches with same range (start and end),
-		 * taking the output into account if ambiguous outputs are allowed. */
-		insert_in_all_matches_mode(m,p,prv_alloc);
-		return;
+    case ALL_MATCHES:
+        /* We unify identical matches, i.e. matches with same range (start and end),
+         * taking the output into account if ambiguous outputs are allowed. */
+        insert_in_all_matches_mode(m,p,prv_alloc);
+        return;
 
-	case SHORTEST_MATCHES:
-		/* We put the new match at the beginning of the list, but before, we
-		 * test if the match we want to add may not be discarded because of
-		 * a shortest match that would already be in the list. By the way,
-		 * we eliminate matches that are longer than this one, if any. */
-		dont_add_match = 0;
-		p->match_list = eliminate_longer_matches(p->match_list, start, end,
-				output, &dont_add_match, p, prv_alloc);
-		if (!dont_add_match) {
-			p->match_list = new_match(start, end, output, weight, p->match_list, prv_alloc);
-		}
-		break;
-	}
+    case SHORTEST_MATCHES:
+        /* We put the new match at the beginning of the list, but before, we
+         * test if the match we want to add may not be discarded because of
+         * a shortest match that would already be in the list. By the way,
+         * we eliminate matches that are longer than this one, if any. */
+        dont_add_match = 0;
+        p->match_list = eliminate_longer_matches(p->match_list, start, end,
+                output, &dont_add_match, p, prv_alloc);
+        if (!dont_add_match) {
+            p->match_list = new_match(start, end, output, weight, p->match_list, prv_alloc);
+        }
+        break;
+    }
 }
 
 /**
@@ -2025,60 +2025,60 @@ static void real_add_match(struct match_list* m, struct locate_parameters* p, Ab
  *       funtion is called.
  */
 static struct match_list* eliminate_longer_matches(struct match_list *ptr, int start,
-		int end, unichar* output, int *dont_add_match,
-		struct locate_parameters* p, Abstract_allocator prv_alloc) {
-	struct match_list *l;
-	if (ptr == NULL)
-		return NULL;
-	if (ptr->m.start_pos_in_token==start
-		&& ptr->m.end_pos_in_token==end
-		&& u_strcmp(ptr->output, output)) {
-		if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-			/* In the case of ambiguous transductions producing different outputs,
-			 * we accept matches with same range */
-			ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
-					dont_add_match, p, prv_alloc);
-			return ptr;
-		} else {
-			/* If we don't allow ambiguous outputs, we have to print an error message */
-			error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",ptr->output,output);
-		}
-	}
-	if (start >= ptr->m.start_pos_in_token && end <= ptr->m.end_pos_in_token) {
-		/* If the new match is shorter (or of equal length) than the current one
-		 * in the list, we replace the match in the list by the new one */
-		if (*dont_add_match) {
-			/* If we have already noticed that the match mustn't be added
-			 * to the list, we delete the current list element */
-			l = ptr->next;
-			free_match_list_element(ptr, prv_alloc);
-			return eliminate_longer_matches(l, start, end, output,
-					dont_add_match, p, prv_alloc);
-		}
-		/* If the new match is shorter than the current one in the list, then we
-		 * update the current one with the value of the new match. */
-		ptr->m.start_pos_in_token = start;
-		ptr->m.end_pos_in_token = end;
-		if (ptr->output != NULL)
-			free_cb(ptr->output,prv_alloc);
-		ptr->output = u_strdup(output,prv_alloc);
-		/* We note that the match does not need anymore to be added */
-		(*dont_add_match) = 1;
-		ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
-				dont_add_match, p, prv_alloc);
-		return ptr;
-	}
-	if (start <= ptr->m.start_pos_in_token && end >= ptr->m.end_pos_in_token) {
-		/* The new match is longer than the one in list => we
-		 * skip the new match */
-		(*dont_add_match) = 1;
-		return ptr;
-	}
-	/* If we have disjunct ranges or overlapping ranges without inclusion,
-	 * we examine recursively the rest of the list */
-	ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
-			dont_add_match, p, prv_alloc);
-	return ptr;
+        int end, unichar* output, int *dont_add_match,
+        struct locate_parameters* p, Abstract_allocator prv_alloc) {
+    struct match_list *l;
+    if (ptr == NULL)
+        return NULL;
+    if (ptr->m.start_pos_in_token==start
+        && ptr->m.end_pos_in_token==end
+        && u_strcmp(ptr->output, output)) {
+        if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+            /* In the case of ambiguous transductions producing different outputs,
+             * we accept matches with same range */
+            ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
+                    dont_add_match, p, prv_alloc);
+            return ptr;
+        } else {
+            /* If we don't allow ambiguous outputs, we have to print an error message */
+            error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",ptr->output,output);
+        }
+    }
+    if (start >= ptr->m.start_pos_in_token && end <= ptr->m.end_pos_in_token) {
+        /* If the new match is shorter (or of equal length) than the current one
+         * in the list, we replace the match in the list by the new one */
+        if (*dont_add_match) {
+            /* If we have already noticed that the match mustn't be added
+             * to the list, we delete the current list element */
+            l = ptr->next;
+            free_match_list_element(ptr, prv_alloc);
+            return eliminate_longer_matches(l, start, end, output,
+                    dont_add_match, p, prv_alloc);
+        }
+        /* If the new match is shorter than the current one in the list, then we
+         * update the current one with the value of the new match. */
+        ptr->m.start_pos_in_token = start;
+        ptr->m.end_pos_in_token = end;
+        if (ptr->output != NULL)
+            free_cb(ptr->output,prv_alloc);
+        ptr->output = u_strdup(output,prv_alloc);
+        /* We note that the match does not need anymore to be added */
+        (*dont_add_match) = 1;
+        ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
+                dont_add_match, p, prv_alloc);
+        return ptr;
+    }
+    if (start <= ptr->m.start_pos_in_token && end >= ptr->m.end_pos_in_token) {
+        /* The new match is longer than the one in list => we
+         * skip the new match */
+        (*dont_add_match) = 1;
+        return ptr;
+    }
+    /* If we have disjunct ranges or overlapping ranges without inclusion,
+     * we examine recursively the rest of the list */
+    ptr->next = eliminate_longer_matches(ptr->next, start, end, output,
+            dont_add_match, p, prv_alloc);
+    return ptr;
 }
 
 
@@ -2086,60 +2086,60 @@ static struct match_list* eliminate_longer_matches(struct match_list *ptr, int s
  * Does the same as eliminate_longer_matches, but with shorter matches.
  */
 static struct match_list* eliminate_shorter_matches(struct match_list *ptr, int start,
-		int end, unichar* output, int *dont_add_match,
-		struct locate_parameters* p, Abstract_allocator prv_alloc) {
-	struct match_list *l;
-	if (ptr == NULL)
-		return NULL;
-	if (ptr->m.start_pos_in_token==start
-		&& ptr->m.end_pos_in_token==end
-		&& u_strcmp(ptr->output, output)) {
-		if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-			/* In the case of ambiguous transductions producing different outputs,
-			 * we accept matches with same range */
-			ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
-					dont_add_match, p, prv_alloc);
-			return ptr;
-		} else {
-			/* If we don't allow ambiguous outputs, we have to print an error message */
-			error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",ptr->output,output);
-		}
-	}
-	if (start <= ptr->m.start_pos_in_token && end >= ptr->m.end_pos_in_token) {
-		/* If the new match is longer (or of equal length) than the current one
-		 * in the list, we replace the match in the list by the new one */
-		if (*dont_add_match) {
-			/* If we have already noticed that the match mustn't be added
-			 * to the list, we delete the current list element */
-			l = ptr->next;
-			free_match_list_element(ptr, prv_alloc);
-			return eliminate_shorter_matches(l, start, end, output,
-					dont_add_match, p, prv_alloc);
-		}
-		/* If the new match is longer than the current one in the list, then we
-		 * update the current one with the value of the new match. */
-		ptr->m.start_pos_in_token = start;
-		ptr->m.end_pos_in_token = end;
-		if (ptr->output != NULL)
-			free_cb(ptr->output,prv_alloc);
-		ptr->output = u_strdup(output,prv_alloc);
-		/* We note that the match does not need anymore to be added */
-		(*dont_add_match) = 1;
-		ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
-				dont_add_match, p, prv_alloc);
-		return ptr;
-	}
-	if (start >= ptr->m.start_pos_in_token && end <= ptr->m.end_pos_in_token) {
-		/* The new match is shorter than the one in list => we
-		 * skip the new match */
-		(*dont_add_match) = 1;
-		return ptr;
-	}
-	/* If we have disjunct ranges or overlapping ranges without inclusion,
-	 * we examine recursively the rest of the list */
-	ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
-			dont_add_match, p, prv_alloc);
-	return ptr;
+        int end, unichar* output, int *dont_add_match,
+        struct locate_parameters* p, Abstract_allocator prv_alloc) {
+    struct match_list *l;
+    if (ptr == NULL)
+        return NULL;
+    if (ptr->m.start_pos_in_token==start
+        && ptr->m.end_pos_in_token==end
+        && u_strcmp(ptr->output, output)) {
+        if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+            /* In the case of ambiguous transductions producing different outputs,
+             * we accept matches with same range */
+            ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
+                    dont_add_match, p, prv_alloc);
+            return ptr;
+        } else {
+            /* If we don't allow ambiguous outputs, we have to print an error message */
+            error("Unexpected ambiguous outputs:\n<%S>\n<%S>\n",ptr->output,output);
+        }
+    }
+    if (start <= ptr->m.start_pos_in_token && end >= ptr->m.end_pos_in_token) {
+        /* If the new match is longer (or of equal length) than the current one
+         * in the list, we replace the match in the list by the new one */
+        if (*dont_add_match) {
+            /* If we have already noticed that the match mustn't be added
+             * to the list, we delete the current list element */
+            l = ptr->next;
+            free_match_list_element(ptr, prv_alloc);
+            return eliminate_shorter_matches(l, start, end, output,
+                    dont_add_match, p, prv_alloc);
+        }
+        /* If the new match is longer than the current one in the list, then we
+         * update the current one with the value of the new match. */
+        ptr->m.start_pos_in_token = start;
+        ptr->m.end_pos_in_token = end;
+        if (ptr->output != NULL)
+            free_cb(ptr->output,prv_alloc);
+        ptr->output = u_strdup(output,prv_alloc);
+        /* We note that the match does not need anymore to be added */
+        (*dont_add_match) = 1;
+        ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
+                dont_add_match, p, prv_alloc);
+        return ptr;
+    }
+    if (start >= ptr->m.start_pos_in_token && end <= ptr->m.end_pos_in_token) {
+        /* The new match is shorter than the one in list => we
+         * skip the new match */
+        (*dont_add_match) = 1;
+        return ptr;
+    }
+    /* If we have disjunct ranges or overlapping ranges without inclusion,
+     * we examine recursively the rest of the list */
+    ptr->next = eliminate_shorter_matches(ptr->next, start, end, output,
+            dont_add_match, p, prv_alloc);
+    return ptr;
 }
 
 
@@ -2156,144 +2156,144 @@ static struct match_list* eliminate_shorter_matches(struct match_list *ptr, int 
  * left-most stehen am Anfang der Liste
  */
 static struct match_list* save_matches(struct match_list* l, int current_position,
-		U_FILE* f, struct locate_parameters* p, Abstract_allocator prv_alloc) {
+        U_FILE* f, struct locate_parameters* p, Abstract_allocator prv_alloc) {
 struct match_list* ptr;
 
 if (l == NULL)
-	return NULL;
-	if (l->m.end_pos_in_token < current_position) {
-		/* we can save the match (necessary for SHORTEST_MATCHES: there
-		 * may be no shorter match) */
+    return NULL;
+    if (l->m.end_pos_in_token < current_position) {
+        /* we can save the match (necessary for SHORTEST_MATCHES: there
+         * may be no shorter match) */
 
-		/* We save the match according to the new concord.ind format
-		 * that takes into account 3 kinds of information:
-		 *   1) offset in token
-		 *   2) offset in char inside the token
-		 *   3) offset in logical letter inside the current char (for Korean) */
-		u_fprintf(f, "%d.0.0 %d.%d.0", l->m.start_pos_in_token,
-				l->m.end_pos_in_token, u_strlen(
-						p->tokens->value[p->buffer[l->m.end_pos_in_token]]) - 1);
-		if (l->output != NULL) {
-			/* If there is an output */
-			if (!p->debug) {
-				/* Normal mode */
-				u_fprintf(f, " %S", l->output);
-			} else {
-				/* In debug mode, we save the normal (non debug) mode output,
-				 * before the debug one */
-				u_fprintf(f, " ");
-				save_real_output_from_debug(f,p->real_output_policy,l->output);
-				u_fputs(l->output,f);
-			}
-		}
-		u_fprintf(f, "\n");
-		if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
-			(p->number_of_outputs)++;
-			/* If we allow different outputs for ambiguous transducers,
-			 * we have to distinguish between matches and outputs
-			 * The algorithm is based on the following considerations:
-			 *  - l has all matches with same starting point in one block,
-			 *    because they are inserted in one turn (Locate runs from left
-			 *    to right through the text)
-			 *  - since we consider only matches right from actual position,
-			 *    matches with same range (start and end position) always follow consecutively.
-			 *  - the start and end positions of the last printed match are stored in the
-			 *    Locate parameters
-			 *  - if the range differs (start and/or end position are different),
-			 *    a new match is counted
-			 */
-			if (!(p->start_position_last_printed_match
-					== l->m.start_pos_in_token
-					&& p->end_position_last_printed_match
-							== l->m.end_pos_in_token)) {
-				(p->number_of_matches)++;
-			}
-		} else {
-			/* If we don't allow ambiguous outputs, we count the matches */
-			(p->number_of_matches)++;
-		}
-		// To count the number of matched tokens this won't work:
-		//  p->matching_units=p->matching_units+(l->end+1)-(l->start);
-		// or you get outputs like:
-		//  1647 matches
-		//  4101 recognized units
-		//  (221.916% of the text is covered)
-		// because of overlapping matches or the option "All matches" is choosed.
-		// For options "Shortest" and "Longest matches", the last start and end
-		// position are sufficient to calculate the correct coverage.
-		// For all matches this is not the case. Suppose you have the matches at token pos:
-		//  0 1 2 3 4 5
-		//  XXX
-		//    YYY
-		//  ZZZZZ
-		// The resulting concord.ind file will look like (for sort ordering see above)
-		//   0 1 X
-		//   1 2 Y
-		//   0 2 Z
-		// So when processing match Z we don't know, that token 0 has been already counted.
-		// I guess a bit array is needed to count correctly.
-		// But since for "Longest matches" only Z, and for "Shortest" only X and Y are
-		// accepted, and the option "All matches" is rarely used, I (S.N.) propose:
-		if (p->end_position_last_printed_match != current_position - 1) {
-			// initial (non-recursive) call of function:
-			// then check if match is out of range of previous matches
-			if (p->end_position_last_printed_match < l->m.start_pos_in_token) { // out of range
-				p->matching_units += (l->m.end_pos_in_token + 1)
-						- (l->m.start_pos_in_token);
-			} else {
-				p->matching_units += (l->m.end_pos_in_token + 1)
-						- (p->end_position_last_printed_match + 1);
-			}
-		}
-		// else:
-		//  recursive call, i.e. end position of match was already counted:
-		//  for "longest" and "shortest" matches all is done, for option "all"
-		//  it is possible that a token won't be counted (in the above example,
-		//  when there is no match X), this will lead to an incorrect displayed
-		//  coverage, lower than correct.
-		else {
-			// this may make the coverage greater than correct:
-			if (p->start_position_last_printed_match > l->m.start_pos_in_token) {
-				p->matching_units += p->start_position_last_printed_match
-						- (l->m.start_pos_in_token);
-			}
-		}
-		p->start_position_last_printed_match = l->m.start_pos_in_token;
-		p->end_position_last_printed_match = l->m.end_pos_in_token;
-		if (p->number_of_matches == p->search_limit) {
-			/* If we have reached the search limitation, we free the remaining
-			 * matches and return */
-			while (l != NULL) {
-				ptr = l;
-				l = l->next;
-				free_match_list_element(ptr, prv_alloc);
-			}
-			return NULL;
-		}
-		ptr = l->next;
-		free_match_list_element(l, prv_alloc);
-		return save_matches(ptr, current_position, f, p, prv_alloc);
-	}
-	l->next = save_matches(l->next, current_position, f, p, prv_alloc);
-	return l;
+        /* We save the match according to the new concord.ind format
+         * that takes into account 3 kinds of information:
+         *   1) offset in token
+         *   2) offset in char inside the token
+         *   3) offset in logical letter inside the current char (for Korean) */
+        u_fprintf(f, "%d.0.0 %d.%d.0", l->m.start_pos_in_token,
+                l->m.end_pos_in_token, u_strlen(
+                        p->tokens->value[p->buffer[l->m.end_pos_in_token]]) - 1);
+        if (l->output != NULL) {
+            /* If there is an output */
+            if (!p->debug) {
+                /* Normal mode */
+                u_fprintf(f, " %S", l->output);
+            } else {
+                /* In debug mode, we save the normal (non debug) mode output,
+                 * before the debug one */
+                u_fprintf(f, " ");
+                save_real_output_from_debug(f,p->real_output_policy,l->output);
+                u_fputs(l->output,f);
+            }
+        }
+        u_fprintf(f, "\n");
+        if (p->ambiguous_output_policy == ALLOW_AMBIGUOUS_OUTPUTS) {
+            (p->number_of_outputs)++;
+            /* If we allow different outputs for ambiguous transducers,
+             * we have to distinguish between matches and outputs
+             * The algorithm is based on the following considerations:
+             *  - l has all matches with same starting point in one block,
+             *    because they are inserted in one turn (Locate runs from left
+             *    to right through the text)
+             *  - since we consider only matches right from actual position,
+             *    matches with same range (start and end position) always follow consecutively.
+             *  - the start and end positions of the last printed match are stored in the
+             *    Locate parameters
+             *  - if the range differs (start and/or end position are different),
+             *    a new match is counted
+             */
+            if (!(p->start_position_last_printed_match
+                    == l->m.start_pos_in_token
+                    && p->end_position_last_printed_match
+                            == l->m.end_pos_in_token)) {
+                (p->number_of_matches)++;
+            }
+        } else {
+            /* If we don't allow ambiguous outputs, we count the matches */
+            (p->number_of_matches)++;
+        }
+        // To count the number of matched tokens this won't work:
+        //  p->matching_units=p->matching_units+(l->end+1)-(l->start);
+        // or you get outputs like:
+        //  1647 matches
+        //  4101 recognized units
+        //  (221.916% of the text is covered)
+        // because of overlapping matches or the option "All matches" is choosed.
+        // For options "Shortest" and "Longest matches", the last start and end
+        // position are sufficient to calculate the correct coverage.
+        // For all matches this is not the case. Suppose you have the matches at token pos:
+        //  0 1 2 3 4 5
+        //  XXX
+        //    YYY
+        //  ZZZZZ
+        // The resulting concord.ind file will look like (for sort ordering see above)
+        //   0 1 X
+        //   1 2 Y
+        //   0 2 Z
+        // So when processing match Z we don't know, that token 0 has been already counted.
+        // I guess a bit array is needed to count correctly.
+        // But since for "Longest matches" only Z, and for "Shortest" only X and Y are
+        // accepted, and the option "All matches" is rarely used, I (S.N.) propose:
+        if (p->end_position_last_printed_match != current_position - 1) {
+            // initial (non-recursive) call of function:
+            // then check if match is out of range of previous matches
+            if (p->end_position_last_printed_match < l->m.start_pos_in_token) { // out of range
+                p->matching_units += (l->m.end_pos_in_token + 1)
+                        - (l->m.start_pos_in_token);
+            } else {
+                p->matching_units += (l->m.end_pos_in_token + 1)
+                        - (p->end_position_last_printed_match + 1);
+            }
+        }
+        // else:
+        //  recursive call, i.e. end position of match was already counted:
+        //  for "longest" and "shortest" matches all is done, for option "all"
+        //  it is possible that a token won't be counted (in the above example,
+        //  when there is no match X), this will lead to an incorrect displayed
+        //  coverage, lower than correct.
+        else {
+            // this may make the coverage greater than correct:
+            if (p->start_position_last_printed_match > l->m.start_pos_in_token) {
+                p->matching_units += p->start_position_last_printed_match
+                        - (l->m.start_pos_in_token);
+            }
+        }
+        p->start_position_last_printed_match = l->m.start_pos_in_token;
+        p->end_position_last_printed_match = l->m.end_pos_in_token;
+        if (p->number_of_matches == p->search_limit) {
+            /* If we have reached the search limitation, we free the remaining
+             * matches and return */
+            while (l != NULL) {
+                ptr = l;
+                l = l->next;
+                free_match_list_element(ptr, prv_alloc);
+            }
+            return NULL;
+        }
+        ptr = l->next;
+        free_match_list_element(l, prv_alloc);
+        return save_matches(ptr, current_position, f, p, prv_alloc);
+    }
+    l->next = save_matches(l->next, current_position, f, p, prv_alloc);
+    return l;
 }
 
 /**
  * Apply the given shift to all variable bounds in the given variable set.
  */
 void shift_variable_bounds(Variables* v, int shift) {
-	if (v == NULL) {
-		return;
-	}
-	int l = v->variable_index->size;
-	for (int i = 0; i < l; i++) {
-		if (v->variables[i].start_in_tokens != UNDEF_VAR_BOUND) {
-			v->variables[i].start_in_tokens += shift;
-		}
-		if (v->variables[i].end_in_tokens != UNDEF_VAR_BOUND) {
-			v->variables[i].end_in_tokens += shift;
-		}
-	}
+    if (v == NULL) {
+        return;
+    }
+    int l = v->variable_index->size;
+    for (int i = 0; i < l; i++) {
+        if (v->variables[i].start_in_tokens != UNDEF_VAR_BOUND) {
+            v->variables[i].start_in_tokens += shift;
+        }
+        if (v->variables[i].end_in_tokens != UNDEF_VAR_BOUND) {
+            v->variables[i].end_in_tokens += shift;
+        }
+    }
 }
 
 } // namespace unitex

--- a/Text_parsing.cpp
+++ b/Text_parsing.cpp
@@ -1122,7 +1122,7 @@ struct locate_parameters* p /* miscellaneous parameters needed by the function *
 					break;
 				}
 				{ /* This block avoids visibility problem about 'z' */
-                    
+
 
 					// local_is_not_a_digit_token return 1 if s is a digit sequence, 0 else
 					if (!(pos2 + p->current_origin < p->buffer_size
@@ -1134,7 +1134,7 @@ struct locate_parameters* p /* miscellaneous parameters needed by the function *
 					/* If we have found a contiguous digit sequence */
 
 					int z = pos2+1;
-					int pos_limit = p->buffer_size - p->current_origin; 
+					int pos_limit = p->buffer_size - p->current_origin;
 
 					int next_pos_add = 0;
 					while (z  < pos_limit
@@ -1282,7 +1282,7 @@ struct locate_parameters* p /* miscellaneous parameters needed by the function *
 struct opt_variable* output_variable_list = current_state->output_variable_starts;
 Ustring* recycle_Ustring=NULL;
 while (output_variable_list != NULL) {
-	
+
 	if (recycle_Ustring==NULL) {
 		recycle_Ustring=new_Ustring();
 	}

--- a/Text_parsing.h
+++ b/Text_parsing.h
@@ -74,7 +74,7 @@ void locate(/*int,*/OptimizedFst2State,int,/*int,*/struct parsing_info**,int*,st
  * The logical XOR.
  */
 static inline int XOR(int a, int b) {
-	return (a && !b) || (!a && b);
+    return (a && !b) || (!a && b);
 }
 
 } // namespace unitex

--- a/Text_tokens.cpp
+++ b/Text_tokens.cpp
@@ -114,7 +114,7 @@ while (EOF!=readline(tmp,f)) {
   i++;
   if (i>*NUMBER_OF_TEXT_TOKENS) {
      fatal_error("Inconsistency in file %s between header (%d) and actual number of lines\n"
-    		     "Last token loaded=%S\n",nom,*NUMBER_OF_TEXT_TOKENS,tmp);
+                 "Last token loaded=%S\n",nom,*NUMBER_OF_TEXT_TOKENS,tmp);
   }
 }
 free_Ustring(tmp);

--- a/Text_tokens.h
+++ b/Text_tokens.h
@@ -39,7 +39,7 @@
 namespace unitex {
 
 /*
- * This is the structure that holds 
+ * This is the structure that holds
  *  - The strings that each token represent (unichar **token)
  *  - The biggest token id                  (int N)
  *  - The token id of the sentence marker   (int SENTENCE_MARKER)

--- a/Tfst.cpp
+++ b/Tfst.cpp
@@ -119,11 +119,11 @@ tfst->current_sentence=NO_SENTENCE_LOADED;
 free(tfst->text);
 tfst->text=NULL;
 if (tfst->token_content!=NULL) {
-	for (int i=0;i<tfst->tokens->nbelems;i++) {
-		free(tfst->token_content[i]);
-	}
-	free(tfst->token_content);
-	tfst->token_content=NULL;
+    for (int i=0;i<tfst->tokens->nbelems;i++) {
+        free(tfst->token_content[i]);
+    }
+    free(tfst->token_content);
+    tfst->token_content=NULL;
 }
 free_vector_int(tfst->tokens);
 tfst->tokens=NULL;
@@ -383,7 +383,7 @@ if (4!=fwrite(t,1,4,tind)) {
  * WARNING: if tags are provided, they are supposed to be \n terminated !
  */
 void save_current_sentence(Tfst* tfst,U_FILE* out_tfst,U_FILE* out_tind,unichar** tags,int n_tags,
-							struct hash_table* form_frequencies) {
+                            struct hash_table* form_frequencies) {
 if (tfst==NULL) {
    fatal_error("NULL tfst in save_current_sentence\n");
 }
@@ -408,11 +408,11 @@ if (tags==NULL && tfst->tags->nbelems==0) {
 
 /* We compute form frequencies */
 if (form_frequencies!=NULL) {
-	if (tags!=NULL) {
-	   compute_form_frequencies(tfst->automaton,tags,n_tags,form_frequencies);
-	} else {
-	   compute_form_frequencies(tfst->automaton,(TfstTag**)(tfst->tags->tab),form_frequencies);
-	}
+    if (tags!=NULL) {
+       compute_form_frequencies(tfst->automaton,tags,n_tags,form_frequencies);
+    } else {
+       compute_form_frequencies(tfst->automaton,(TfstTag**)(tfst->tags->tab),form_frequencies);
+    }
 }
 
 /* First, we update the offset index in the .tind file */
@@ -451,7 +451,7 @@ u_fprintf(out_tfst,"f\n");
 if (tags!=NULL) {
    /* If there is a tag array, we use it */
    for (int i=0;i<n_tags;i++) {
-	   u_fputs(tags[i],out_tfst);
+       u_fputs(tags[i],out_tfst);
    }
 } else {
    for (int i=0;i<tfst->tags->nbelems;i++) {
@@ -504,24 +504,24 @@ fatal_error("Invalid tag type %d in TfstTag_to_string\n",t->type);
  */
 void compute_token_contents(Tfst* t) {
 if (t==NULL) {
-	fatal_error("NULL error in compute_token_contents\n");
+    fatal_error("NULL error in compute_token_contents\n");
 }
 if (t->current_sentence==NO_SENTENCE_LOADED) {
-	fatal_error("Cannot compute token contents when no sentence is loaded\n");
+    fatal_error("Cannot compute token contents when no sentence is loaded\n");
 }
 t->token_content=(unichar**)malloc(t->token_sizes->nbelems*sizeof(unichar*));
 if (t->token_content==NULL) {
-	fatal_alloc_error("compute_token_contents");
+    fatal_alloc_error("compute_token_contents");
 }
 unichar tmp[4096];
 int j,pos=0;
 for (int i=0;i<t->token_sizes->nbelems;i++) {
-	for (j=0;j<t->token_sizes->tab[i];j++) {
-		tmp[j]=t->text[pos];
-		pos++;
-	}
-	tmp[j]='\0';
-	t->token_content[i]=u_strdup(tmp);
+    for (j=0;j<t->token_sizes->tab[i];j++) {
+        tmp[j]=t->text[pos];
+        pos++;
+    }
+    tmp[j]='\0';
+    t->token_content[i]=u_strdup(tmp);
 }
 }
 

--- a/Tfst.h
+++ b/Tfst.h
@@ -107,19 +107,19 @@ typedef struct {
 
    /* The boundings of the sentence area covered by the tag */
    /* Special information for Korean transitions
-    * 
-    * In a Korean word, a character represents a syllable, which may contains several 
+    *
+    * In a Korean word, a character represents a syllable, which may contains several
     * logical letters. Note that these information must always be set to values
     * between 0 and MAX_LETTERS, where MAX_LETTERS is the maximum number of logical
     * letters in the last syllabic character of the input of the transition.
     * For instance, let us assume that (abc) stands for one syllabic character made of
     * 3 logical letters a, b and c. Then, for the following input:
-    * 
+    *
     *    {(fg)(fda) (zegd)(ddz),.XXX}
-    * 
+    *
     * we would have end_pos_letter=2, because the 'z' of '(ddz)' is the third logical letter.
-    * In the same way, let us assume that the initial '(fg)' is actually the end of a syllable 
-    * in the text like '(afg)'. In that case, we would have start_pos_letter=1, because 'f' is 
+    * In the same way, let us assume that the initial '(fg)' is actually the end of a syllable
+    * in the text like '(afg)'. In that case, we would have start_pos_letter=1, because 'f' is
     * the second logical letter of '(afg)'.
     */
    Match m;
@@ -130,7 +130,7 @@ Tfst* open_text_automaton(const VersatileEncodingConfig*,const char* tfst);
 void close_text_automaton(Tfst* tfst);
 void load_sentence(Tfst* tfst,int n);
 void save_current_sentence(Tfst* tfst,U_FILE* out_tfst,U_FILE* tind,unichar** tags,int n_tags,
-							struct hash_table* form_frequencies);
+                            struct hash_table* form_frequencies);
 
 TfstTag* new_TfstTag(TfstTagType);
 void free_TfstTag(TfstTag*);

--- a/Tfst2Grf.cpp
+++ b/Tfst2Grf.cpp
@@ -108,7 +108,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
    case 'o': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty output name pattern\n");
                 free(fontname);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              output=strdup(options.vars()->optarg);
              if (output==NULL) {
@@ -120,7 +120,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
    case 'f': if (options.vars()->optarg[0]=='\0') {
                 error("You must specify a non empty font name\n");
                 free(output);
-                return USAGE_ERROR_CODE; 
+                return USAGE_ERROR_CODE;
              }
              fontname=strdup(options.vars()->optarg);
              if (fontname==NULL) {
@@ -134,7 +134,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
                 error("Invalid font size: %s\n",options.vars()->optarg);
                 free(fontname);
                 free(output);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              break;
    case 'k': if (options.vars()->optarg[0]=='\0') {
@@ -154,7 +154,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': usage();
              free(fontname);
              free(output);
@@ -162,12 +162,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Tfst2Grf[index].name);
              free(fontname);
-             free(output);                         
+             free(output);
              return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              free(fontname);
-             free(output); 
+             free(output);
              return USAGE_ERROR_CODE;
    }
    index=-1;
@@ -176,21 +176,21 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Grf,lopts_Tfst2Grf,
 if (SENTENCE==-1) {
   error("You must specify a sentence number\n");
   free(fontname);
-  free(output); 
-  return USAGE_ERROR_CODE;   
+  free(output);
+  return USAGE_ERROR_CODE;
 }
 
 if (options.vars()->optind!=argc-1) {
   error("Invalid arguments: rerun with --help\n");
   free(fontname);
-  free(output); 
+  free(output);
   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
-  // freeing all allocated memory 
+  // freeing all allocated memory
   free(fontname);
-  free(output);   
+  free(output);
   return SUCCESS_RETURN_CODE;
 }
 
@@ -223,8 +223,8 @@ if (fontname==NULL) {
    fontname=strdup("Times New Roman");
    if (fontname==NULL) {
       alloc_error("main_Tfst2Grf");
-      free(output); 
-      return ALLOC_ERROR_CODE;      
+      free(output);
+      return ALLOC_ERROR_CODE;
    }
 }
 
@@ -232,7 +232,7 @@ U_FILE* f=u_fopen(&vec,grf_name,U_WRITE);
 if (f==NULL) {
    error("Cannot open file %s\n",grf_name);
    free(fontname);
-   free(output); 
+   free(output);
    return DEFAULT_ERROR_CODE;
 }
 
@@ -241,7 +241,7 @@ if (txt==NULL) {
    error("Cannot open file %s\n",txt_name);
    u_fclose(f);
    free(fontname);
-   free(output); 
+   free(output);
    return DEFAULT_ERROR_CODE;
 }
 
@@ -251,7 +251,7 @@ if (tok==NULL) {
    u_fclose(f);
    u_fclose(txt);
    free(fontname);
-   free(output); 
+   free(output);
    return DEFAULT_ERROR_CODE;
 }
 
@@ -269,7 +269,7 @@ if (start==NULL) {
    u_fclose(tok);
    u_fclose(f);
    free(fontname);
-   free(output); 
+   free(output);
    return DEFAULT_ERROR_CODE;
 }
 

--- a/Tfst2Grf.h
+++ b/Tfst2Grf.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef Tfst2GrfH
 #define Tfst2GrfH
 

--- a/Tfst2Unambig.cpp
+++ b/Tfst2Unambig.cpp
@@ -89,7 +89,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Unambig,lopts_Tfst2
              output=strdup(options.vars()->optarg);
              if (output==NULL) {
                 alloc_error("main_Tfst2Unambig");
-                return ALLOC_ERROR_CODE;                
+                return ALLOC_ERROR_CODE;
              }
              break;
    case 'k': if (options.vars()->optarg[0]=='\0') {
@@ -102,14 +102,14 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tfst2Unambig,lopts_Tfst2
    case 'q': if (options.vars()->optarg[0]=='\0') {
                 error("Empty output_encoding argument\n");
                 free(output);
-                return USAGE_ERROR_CODE;                
+                return USAGE_ERROR_CODE;
              }
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
              break;
    case 'h': usage();
-             free(output); 
+             free(output);
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Tfst2Unambig[index].name);
@@ -133,7 +133,7 @@ if (options.vars()->optind!=argc-1) {
 if (output==NULL) {
    error("You must specify an output text file\n");
    free(output);
-   return USAGE_ERROR_CODE;   
+   return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {

--- a/Tfst2Unambig.h
+++ b/Tfst2Unambig.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef Tfst2UnambigH
 #define Tfst2UnambigH
 

--- a/TfstStats.cpp
+++ b/TfstStats.cpp
@@ -29,7 +29,7 @@
 
 namespace unitex {
 
-/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it 
+/* see http://en.wikipedia.org/wiki/Variable_Length_Array . MSVC did not support it
    see http://msdn.microsoft.com/en-us/library/zb1574zs(VS.80).aspx */
 #if defined(_MSC_VER) && (!(defined(NO_C99_VARIABLE_LENGTH_ARRAY)))
 #define NO_C99_VARIABLE_LENGTH_ARRAY 1

--- a/TfstStats.cpp
+++ b/TfstStats.cpp
@@ -38,7 +38,7 @@ namespace unitex {
 
 static void compute_form_frequencies(SingleGraph g,void** tags,int tfst_tags,struct hash_table* hash);
 static int explore_for_form_frequencies(SingleGraph g,int state,char* factorizing,double freq,
-									void** tags,int tfst_tags,struct hash_table* form_frequencies);
+                                    void** tags,int tfst_tags,struct hash_table* form_frequencies);
 
 /**
  * Computes the form frequencies for the given sentence automaton as follows:
@@ -49,7 +49,7 @@ static int explore_for_form_frequencies(SingleGraph g,int state,char* factorizin
  * 'hash' is supposed to be a hash table associating double values to strings.
  */
 void compute_form_frequencies(SingleGraph g,TfstTag** tags,
-								struct hash_table* form_frequencies) {
+                                struct hash_table* form_frequencies) {
   compute_form_frequencies(g,(void**)tags,1,form_frequencies);
 }
 
@@ -66,40 +66,40 @@ void compute_form_frequencies(SingleGraph g,TfstTag** tags,
  * that only contains the tag contents.
  */
 void compute_form_frequencies(SingleGraph g,const unichar* const* string_tags,int n_string_tags,
-								struct hash_table* form_frequencies) {
+                                struct hash_table* form_frequencies) {
 unichar** tags=(unichar**)calloc(n_string_tags,sizeof(unichar*));
 if (tags==NULL) {
-	fatal_alloc_error("compute_form_frequencies");
+    fatal_alloc_error("compute_form_frequencies");
 }
 
 Ustring* foo=new_Ustring(64);
 tags[0]=u_strdup("<E>");
 
 for (int i=1;i<n_string_tags;i++) {
-	const unichar* s=string_tags[i];
-	int n_at=0;
-	/* We look for the second '@' */
-	while ((*s)!='\0' && n_at!=2) {
-		if ((*s)=='@') n_at++;
-		s++;
-	}
-	if ((*s)=='\0') {
-		fatal_error("Invalid tfst tag %S in compute_form_frequencies\n",string_tags[i]);
-	}
-	empty(foo);
-	while ((*s)!='\0' && (*s)!='\n') {
-		u_strcat(foo,(*s));
-		s++;
-	}
-	if ((*s)=='\0') {
-		fatal_error("Invalid tfst tag %S in compute_form_frequencies\n",string_tags[i]);
-	}
-	tags[i]=u_strdup(foo->str);
+    const unichar* s=string_tags[i];
+    int n_at=0;
+    /* We look for the second '@' */
+    while ((*s)!='\0' && n_at!=2) {
+        if ((*s)=='@') n_at++;
+        s++;
+    }
+    if ((*s)=='\0') {
+        fatal_error("Invalid tfst tag %S in compute_form_frequencies\n",string_tags[i]);
+    }
+    empty(foo);
+    while ((*s)!='\0' && (*s)!='\n') {
+        u_strcat(foo,(*s));
+        s++;
+    }
+    if ((*s)=='\0') {
+        fatal_error("Invalid tfst tag %S in compute_form_frequencies\n",string_tags[i]);
+    }
+    tags[i]=u_strdup(foo->str);
 }
 free_Ustring(foo);
 compute_form_frequencies(g,(void**)tags,0,form_frequencies);
 for (int i=0;i<n_string_tags;i++) {
-	free(tags[i]);
+    free(tags[i]);
 }
 free(tags);
 }
@@ -180,9 +180,9 @@ while (q2<g->number_of_states-1) {
  * can explore the subautomata between factorizing states in order to compute
  * form frequencies */
 for (int i=0;i<g->number_of_states;i++) {
-	if (factorizing[i]) {
-		explore_for_form_frequencies(g,i,factorizing,(double)(1./number_of_paths[i]),tags,tfst_tags,form_frequencies);
-	}
+    if (factorizing[i]) {
+        explore_for_form_frequencies(g,i,factorizing,(double)(1./number_of_paths[i]),tags,tfst_tags,form_frequencies);
+    }
 }
 #ifdef NO_C99_VARIABLE_LENGTH_ARRAY
 free(direct);
@@ -197,31 +197,31 @@ free(number_of_paths);
  * transition we go through, we add 'freq' to its tag frequency.
  */
 static int explore_for_form_frequencies(SingleGraph g,int state,char* factorizing,double freq,
-									void** tags,int tfst_tags,struct hash_table* form_frequencies) {
+                                    void** tags,int tfst_tags,struct hash_table* form_frequencies) {
 Transition* t=g->states[state]->outgoing_transitions;
 int n=0,foo;
 while (t!=NULL) {
-	int ret;
-	unichar* content;
-	if (tfst_tags) {
-		TfstTag* tmp=(TfstTag*)(tags[t->tag_number]);
-		content=tmp->content;
-	} else {
-		content=(unichar*)(tags[t->tag_number]);
-	}
-	struct any* value=get_value(form_frequencies,content,HT_INSERT_IF_NEEDED,&ret);
-	if (ret!=HT_KEY_ALREADY_THERE) {
-		value->_double=0;
-	}
-	if (!factorizing[t->state_number]) {
-		foo=explore_for_form_frequencies(g,t->state_number,factorizing,freq,tags,tfst_tags,form_frequencies);
-		n=n+foo;
-		value->_double=value->_double+freq*foo;
-	} else {
-		value->_double=value->_double+freq;
-		n++;
-	}
-	t=t->next;
+    int ret;
+    unichar* content;
+    if (tfst_tags) {
+        TfstTag* tmp=(TfstTag*)(tags[t->tag_number]);
+        content=tmp->content;
+    } else {
+        content=(unichar*)(tags[t->tag_number]);
+    }
+    struct any* value=get_value(form_frequencies,content,HT_INSERT_IF_NEEDED,&ret);
+    if (ret!=HT_KEY_ALREADY_THERE) {
+        value->_double=0;
+    }
+    if (!factorizing[t->state_number]) {
+        foo=explore_for_form_frequencies(g,t->state_number,factorizing,freq,tags,tfst_tags,form_frequencies);
+        n=n+foo;
+        value->_double=value->_double+freq*foo;
+    } else {
+        value->_double=value->_double+freq;
+        n++;
+    }
+    t=t->next;
 }
 return n;
 }
@@ -233,11 +233,11 @@ static const double cte_double_b = (double)atof("0.66666\x00\nb");
 
 static inline int compare_freq_then_name(double freq_a,  const unichar * name_a, double freq_b,const unichar* name_b)
 {
-	if ((freq_a*cte_double_a) < (freq_b*cte_double_b))
-		return -1;
-	if ((freq_a*cte_double_a) > (freq_b*cte_double_b))
-		return 1;
-	return -u_strcmp(name_a, name_b);
+    if ((freq_a*cte_double_a) < (freq_b*cte_double_b))
+        return -1;
+    if ((freq_a*cte_double_a) > (freq_b*cte_double_b))
+        return 1;
+    return -u_strcmp(name_a, name_b);
 }
 
 static int partition_for_quicksort_by_frequence(int m, int n,vector_ptr* tags,vector_double* freq) {
@@ -332,18 +332,18 @@ vector_ptr* tags=new_vector_ptr(4096);
 vector_double* freq=new_vector_double(4096);
 /* First, we build vectors from the hash table content */
 for (unsigned int i=0;i<form_frequencies->capacity;i++) {
-	struct hash_list* l=form_frequencies->table[i];
-	while (l!=NULL) {
-		vector_ptr_add(tags,l->ptr_key);
-		vector_double_add(freq,l->value._double);
-		l=l->next;
-	}
+    struct hash_list* l=form_frequencies->table[i];
+    while (l!=NULL) {
+        vector_ptr_add(tags,l->ptr_key);
+        vector_double_add(freq,l->value._double);
+        l=l->next;
+    }
 }
 if (by_freq!=NULL) {
-	sort_and_save_by_freq(by_freq,tags,freq);
+    sort_and_save_by_freq(by_freq,tags,freq);
 }
 if (by_alph!=NULL) {
-	sort_and_save_by_alph(by_alph,tags,freq);
+    sort_and_save_by_alph(by_alph,tags,freq);
 }
 free_vector_ptr(tags,NULL);
 free_vector_double(freq);

--- a/TfstStats.h
+++ b/TfstStats.h
@@ -40,9 +40,9 @@
 namespace unitex {
 
 void compute_form_frequencies(SingleGraph g,const unichar* const* string_tags,int n_string_tags,
-								struct hash_table* hash);
+                                struct hash_table* hash);
 void compute_form_frequencies(SingleGraph g,TfstTag** tags,
-								struct hash_table* hash);
+                                struct hash_table* hash);
 void sort_and_save_tfst_stats(struct hash_table* form_frequencies,U_FILE* by_freq,U_FILE* by_alph);
 
 } // namespace unitex

--- a/TfstTag.cpp
+++ b/TfstTag.cpp
@@ -103,7 +103,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_TfstTag,lopts_TfstTag,&i
              break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_TfstTag[index].name);
@@ -233,7 +233,7 @@ return SUCCESS_RETURN_CODE;
  * The match list is freed by this function.
  */
 static int process(Tfst* in,Tfst* out,struct match_list* matches) {
-int process_matches_return_value = SUCCESS_RETURN_CODE; 
+int process_matches_return_value = SUCCESS_RETURN_CODE;
 u_fprintf(out->tfst,"%010d\n",out->N);
 for (int i=1;i<=in->N;i++) {
 	load_sentence(in,i);

--- a/TfstTag.cpp
+++ b/TfstTag.cpp
@@ -132,7 +132,7 @@ if (only_verify_arguments) {
 
 U_FILE* f=u_fopen(&vec,ind,U_READ);
 if (f==NULL) {
-	error("Cannot load ind file %s\n",ind);
+    error("Cannot load ind file %s\n",ind);
   return DEFAULT_ERROR_CODE;
 }
 
@@ -140,7 +140,7 @@ unichar header;
 struct match_list* matches=load_match_list(f,NULL,&header);
 u_fclose(f);
 if (header!='X') {
-	error("Invalid ind file %s\n",ind);
+    error("Invalid ind file %s\n",ind);
   return DEFAULT_ERROR_CODE;
 }
 
@@ -152,23 +152,23 @@ strcat(in_tind,".tind");
 char out_tfst[FILENAME_MAX];
 char out_tind[FILENAME_MAX];
 if (output[0]!='\0') {
-	strcpy(out_tfst,output);
-	remove_extension(output,out_tind);
-	strcat(out_tind,".tind");
+    strcpy(out_tfst,output);
+    remove_extension(output,out_tind);
+    strcat(out_tind,".tind");
 } else {
-	strcpy(out_tfst,"tmp__.tfst");
-	strcpy(out_tind,"tmp__.tind");
+    strcpy(out_tfst,"tmp__.tfst");
+    strcpy(out_tind,"tmp__.tind");
 }
 
 U_FILE* f_out_tfst=u_fopen(&vec,out_tfst,U_WRITE);
 if (f_out_tfst==NULL) {
-	error("Cannot create %s\n",out_tfst);
+    error("Cannot create %s\n",out_tfst);
   return DEFAULT_ERROR_CODE;
 }
 
 U_FILE* f_out_tind=u_fopen(&vec,out_tind,U_WRITE);
 if (f_out_tind==NULL) {
-	error("Cannot create %s\n",out_tind);
+    error("Cannot create %s\n",out_tind);
   u_fclose(f_out_tfst);
   return DEFAULT_ERROR_CODE;
 }
@@ -181,11 +181,11 @@ int return_value = process(input_tfst,output_tfst,matches);
 close_text_automaton(input_tfst);
 close_text_automaton(output_tfst);
 if (output[0]=='\0') {
-	/* If we wanted to replace the given text automaton, we do it now */
-	::remove(in_tfst);
-	::remove(in_tind);
-	::rename(out_tfst,in_tfst);
-	::rename(out_tind,in_tind);
+    /* If we wanted to replace the given text automaton, we do it now */
+    ::remove(in_tfst);
+    ::remove(in_tind);
+    ::rename(out_tfst,in_tfst);
+    ::rename(out_tind,in_tind);
 }
 
 u_printf("Done.\n");
@@ -196,34 +196,34 @@ static int process_matches(Tfst* in,struct match_list* *matches) {
 int sentence,start,end,pos;
 int epsilon=0;
 while (*matches!=NULL) {
-	if ((*matches)->output==NULL) {
-		error("Unexpected NULL output in process_matches\n");
+    if ((*matches)->output==NULL) {
+        error("Unexpected NULL output in process_matches\n");
     return DEFAULT_ERROR_CODE;
-	}
-	if (3!=u_sscanf((*matches)->output,"%d %d %d:%n",&sentence,&start,&end,&pos)) {
-		error("Invalid tagging output in process_matches:\n_%S_\n",(*matches)->output);
+    }
+    if (3!=u_sscanf((*matches)->output,"%d %d %d:%n",&sentence,&start,&end,&pos)) {
+        error("Invalid tagging output in process_matches:\n_%S_\n",(*matches)->output);
     return DEFAULT_ERROR_CODE;
-	}
-	if (sentence!=in->current_sentence) break;
-	unichar* s=(*matches)->output+pos;
-	struct match_list* tmp=(*matches);
-	if (!u_strcmp(s,"<E>")) {
-		/* We add an epsilon transition */
-		add_outgoing_transition(in->automaton->states[start],0,end);
-		epsilon=1;
-	} else {
-		/* We have to create a new tag */
-		TfstTag* tag=new_TfstTag(T_STD);
-		tag->content=u_strdup(s);
-		tag->m=tmp->m;
-		int index=vector_ptr_add(in->tags,tag);
-		add_outgoing_transition(in->automaton->states[start],index,end);
-	}
-	(*matches)=(*matches)->next;
-	free_match_list_element(tmp);
+    }
+    if (sentence!=in->current_sentence) break;
+    unichar* s=(*matches)->output+pos;
+    struct match_list* tmp=(*matches);
+    if (!u_strcmp(s,"<E>")) {
+        /* We add an epsilon transition */
+        add_outgoing_transition(in->automaton->states[start],0,end);
+        epsilon=1;
+    } else {
+        /* We have to create a new tag */
+        TfstTag* tag=new_TfstTag(T_STD);
+        tag->content=u_strdup(s);
+        tag->m=tmp->m;
+        int index=vector_ptr_add(in->tags,tag);
+        add_outgoing_transition(in->automaton->states[start],index,end);
+    }
+    (*matches)=(*matches)->next;
+    free_match_list_element(tmp);
 }
 if (epsilon) {
-	remove_epsilon_transitions(in->automaton,0);
+    remove_epsilon_transitions(in->automaton,0);
 }
 return SUCCESS_RETURN_CODE;
 }
@@ -236,15 +236,15 @@ static int process(Tfst* in,Tfst* out,struct match_list* matches) {
 int process_matches_return_value = SUCCESS_RETURN_CODE;
 u_fprintf(out->tfst,"%010d\n",out->N);
 for (int i=1;i<=in->N;i++) {
-	load_sentence(in,i);
-	/* We reverse transitions to have an identical output if the sentence is
-	 * not modified */
-	reverse_transition_lists(in->automaton);
-	process_matches_return_value = process_matches(in,&matches);
+    load_sentence(in,i);
+    /* We reverse transitions to have an identical output if the sentence is
+     * not modified */
+    reverse_transition_lists(in->automaton);
+    process_matches_return_value = process_matches(in,&matches);
   if(process_matches_return_value != SUCCESS_RETURN_CODE) {
     return process_matches_return_value;
   }
-	save_current_sentence(in,out->tfst,out->tind,NULL,0,NULL);
+    save_current_sentence(in,out->tfst,out->tind,NULL,0,NULL);
 }
 return SUCCESS_RETURN_CODE;
 }

--- a/TfstTag.h
+++ b/TfstTag.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef TfstTagH
 #define TfstTagH
 

--- a/Token.h
+++ b/Token.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef TokenH
 #define TokenH
 

--- a/Tokenization.cpp
+++ b/Tokenization.cpp
@@ -31,7 +31,7 @@ namespace unitex {
 
 /**
  * This function takes a text sequence and returns the list of its tokens.
- * 'mode' defines if the tokenization must be done character by character 
+ * 'mode' defines if the tokenization must be done character by character
  * or word by word. In that last case, a word is defined as a contiguous
  * sequence letters and the letters are defined by the given alphabet.
  */
@@ -122,7 +122,7 @@ return 0;
 /**
  * Returns 1 if the given sequence can be considered as a simple word;
  * 0 otherwise.
- * 
+ *
  * NOTE: with such a definition, a single char that is not a letter is not a simple word
  */
 int is_a_simple_word(const unichar* sequence,TokenizationPolicy tokenization_policy,const Alphabet* alphabet) {

--- a/Tokenization.h
+++ b/Tokenization.h
@@ -24,7 +24,7 @@
 
 /**
  * This library provides functions for tokenizing text.
- * 
+ *
  */
 
 #include "Unicode.h"

--- a/Tokenize.cpp
+++ b/Tokenize.cpp
@@ -198,7 +198,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tokenize,lopts_Tokenize,
              strcpy(out_offsets,options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
+             break;
    case 'h': usage();
              free(buffer_filename);
              return SUCCESS_RETURN_CODE;
@@ -217,7 +217,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Tokenize,lopts_Tokenize,
 if (options.vars()->optind!=argc-1) {
   error("Invalid arguments: rerun with --help\n");
   free(buffer_filename);
-  return USAGE_ERROR_CODE;   
+  return USAGE_ERROR_CODE;
 }
 
 if (only_verify_arguments) {
@@ -259,7 +259,7 @@ text=u_fopen(&vec,argv[options.vars()->optind],U_READ);
 if (text==NULL) {
   error("Cannot open text file %s\n",argv[options.vars()->optind]);
   free(buffer_filename);
-  return DEFAULT_ERROR_CODE;   
+  return DEFAULT_ERROR_CODE;
 }
 
 if (alphabet[0]!='\0') {
@@ -277,7 +277,7 @@ if (out==NULL) {
    error("Cannot create file %s\n",text_cod);
    free_alphabet(alph);
    u_fclose(text);
-   free(buffer_filename); 
+   free(buffer_filename);
    return DEFAULT_ERROR_CODE;
 }
 
@@ -287,7 +287,7 @@ if (enter==NULL) {
    u_fclose(out);
    free_alphabet(alph);
    u_fclose(text);
-   free(buffer_filename); 
+   free(buffer_filename);
    return DEFAULT_ERROR_CODE;
 }
 
@@ -299,7 +299,7 @@ if (out_offsets[0]!='\0') {
     u_fclose(out);
     free_alphabet(alph);
     u_fclose(text);
-    free(buffer_filename); 
+    free(buffer_filename);
     return DEFAULT_ERROR_CODE;
 	}
 	/* We deal with offsets only if the program is expected to produce some */
@@ -312,7 +312,7 @@ if (out_offsets[0]!='\0') {
       u_fclose(out);
       free_alphabet(alph);
       u_fclose(text);
-      free(buffer_filename); 
+      free(buffer_filename);
       return DEFAULT_ERROR_CODE;
 		}
 	} else {
@@ -346,9 +346,9 @@ if (token_file[0]!='\0') {
    u_fclose(out);
    free_alphabet(alph);
    u_fclose(text);
-   free(buffer_filename); 
+   free(buffer_filename);
    return DEFAULT_ERROR_CODE;
-  } 
+  }
 }
 
 output=u_fopen(&vec,tokens_txt,U_WRITE);
@@ -365,7 +365,7 @@ if (output==NULL) {
    u_fclose(out);
    free_alphabet(alph);
    u_fclose(text);
-   free(buffer_filename); 
+   free(buffer_filename);
    return DEFAULT_ERROR_CODE;
 }
 u_fprintf(output,"0000000000\n");
@@ -390,13 +390,13 @@ if (!save_snt_offsets(snt_offsets,snt_offsets_pos)) {
   free_vector_int(n_occur);
   free_vector_ptr(tokens,free);
   free_vector_offset(v_in_offsets);
-  u_fclose(f_out_offsets);  
+  u_fclose(f_out_offsets);
   u_fclose(enter);
   u_fclose(out);
   free_alphabet(alph);
   u_fclose(text);
-  free(buffer_filename); 
-  return DEFAULT_ERROR_CODE;  
+  free(buffer_filename);
+  return DEFAULT_ERROR_CODE;
 }
 
 u_fclose(output);

--- a/Tokenize.cpp
+++ b/Tokenize.cpp
@@ -50,8 +50,8 @@ static void sort_and_save_by_frequence(U_FILE*,vector_ptr*,vector_int*);
 static void sort_and_save_by_alph_order(U_FILE*,vector_ptr*,vector_int*);
 static void compute_statistics(U_FILE*,vector_ptr*,Alphabet*,int,int,int,int);
 static int tokenization(U_FILE*,U_FILE*,U_FILE*,Alphabet*,vector_ptr*,struct hash_table*,vector_int*,
-		vector_int*,vector_int*,
-		   int*,int*,int*,int*,U_FILE*,vector_offset*,int);
+        vector_int*,vector_int*,
+           int*,int*,int*,int*,U_FILE*,vector_offset*,int);
 static void save_new_line_positions(U_FILE*,vector_int*);
 static int load_token_file(char* filename, const VersatileEncodingConfig*,vector_ptr* tokens,struct hash_table* hashtable,vector_int* n_occur);
 
@@ -133,7 +133,7 @@ size_t step_filename_buffer = (((FILENAME_MAX / 0x10) + 1) * 0x10);
 char* buffer_filename = (char*)malloc(step_filename_buffer * 8);
 
 if (buffer_filename == NULL) {
-	alloc_error("main_Tokenize");
+    alloc_error("main_Tokenize");
   return ALLOC_ERROR_CODE;
 }
 
@@ -292,21 +292,21 @@ if (enter==NULL) {
 }
 
 if (out_offsets[0]!='\0') {
-	f_out_offsets=u_fopen(&vec,out_offsets,U_WRITE);
-	if (f_out_offsets==NULL) {
-		error("Cannot create file %s\n",out_offsets);
+    f_out_offsets=u_fopen(&vec,out_offsets,U_WRITE);
+    if (f_out_offsets==NULL) {
+        error("Cannot create file %s\n",out_offsets);
     u_fclose(enter);
     u_fclose(out);
     free_alphabet(alph);
     u_fclose(text);
     free(buffer_filename);
     return DEFAULT_ERROR_CODE;
-	}
-	/* We deal with offsets only if the program is expected to produce some */
-	if (in_offsets[0]!='\0') {
-		v_in_offsets=load_offsets(&vec,in_offsets);
-		if (v_in_offsets==NULL) {
-			error("Cannot load offset file %s\n",in_offsets);
+    }
+    /* We deal with offsets only if the program is expected to produce some */
+    if (in_offsets[0]!='\0') {
+        v_in_offsets=load_offsets(&vec,in_offsets);
+        if (v_in_offsets==NULL) {
+            error("Cannot load offset file %s\n",in_offsets);
       u_fclose(f_out_offsets);
       u_fclose(enter);
       u_fclose(out);
@@ -314,12 +314,12 @@ if (out_offsets[0]!='\0') {
       u_fclose(text);
       free(buffer_filename);
       return DEFAULT_ERROR_CODE;
-		}
-	} else {
-		/* If there is no input offset file, we create an empty offset vector
-		 * in order to avoid testing whether the vector is NULL or not */
-		v_in_offsets=new_vector_offset(1);
-	}
+        }
+    } else {
+        /* If there is no input offset file, we create an empty offset vector
+         * in order to avoid testing whether the vector is NULL or not */
+        v_in_offsets=new_vector_offset(1);
+    }
 }
 
 vector_ptr* tokens=new_vector_ptr(4096);
@@ -382,7 +382,7 @@ int result_tokenization = tokenization(text,out,output,alph,tokens,hashtable,n_o
 u_printf((result_tokenization == 0) ? "\nDone.\n" : "\nTokenization error.\n");
 save_new_line_positions(enter,n_enter_pos);
 if (!save_snt_offsets(snt_offsets,snt_offsets_pos)) {
-	error("Cannot save snt offsets in file %s\n",snt_offsets_pos);
+    error("Cannot save snt offsets in file %s\n",snt_offsets_pos);
   u_fclose(output);
   free_hash_table(hashtable);
   free_vector_int(snt_offsets);
@@ -507,80 +507,80 @@ u_fprintf(f,"%d %d %d <%S>\n",n,start,end,s);
 
 
 static int save_token_offset(U_FILE* f,const unichar* s,int n,int start,int end,const vector_offset* v, int *index,
-		int *shift) {
+        int *shift) {
 if (f==NULL) return 0;
 for (;;) {
 if (*index==v->nbelems) {
-	/* If there is no more offsets to take into account, we just save the token */
-	save(f,s,n,start+*shift,end+*shift);
-	return 0;
+    /* If there is no more offsets to take into account, we just save the token */
+    save(f,s,n,start+*shift,end+*shift);
+    return 0;
 }
 Offsets x=v->tab[*index];
 Overlap o=overlap(x.new_start,x.new_end,start,end);
 switch (o) {
 case A_BEFORE_B: {
-	error("A_BEFORE_B: ");
-	error("shift=%d  token=<%S> start=%d end=%d    cur_offset[%d]=%d;%d => %d;%d\n",
-			*shift,s,start,end,*index,x.old_start,x.old_end,x.new_start,x.new_end);
-	error("Unexpected A_BEFORE_B in save_token_offset\n");
-	return 1;
+    error("A_BEFORE_B: ");
+    error("shift=%d  token=<%S> start=%d end=%d    cur_offset[%d]=%d;%d => %d;%d\n",
+            *shift,s,start,end,*index,x.old_start,x.old_end,x.new_start,x.new_end);
+    error("Unexpected A_BEFORE_B in save_token_offset\n");
+    return 1;
 }
 case A_AFTER_B: {
-	//error("A_AFTER_B:\n");
-	save(f,s,n,start+*shift,end+*shift);
-	return 0;
+    //error("A_AFTER_B:\n");
+    save(f,s,n,start+*shift,end+*shift);
+    return 0;
 }
 case A_EQUALS_B: {
-	//error("A_EQUALS_B:\n");
-	save(f,s,n,x.old_start,x.old_end);
-	(*index)++;
-	(*shift)=x.old_end-end;
-	return 0;
+    //error("A_EQUALS_B:\n");
+    save(f,s,n,x.old_start,x.old_end);
+    (*index)++;
+    (*shift)=x.old_end-end;
+    return 0;
 }
 case A_BEFORE_B_OVERLAP: {
-	//error("A_BEFORE_B_OVERLAP:\n");
-	int j;
-	for (j=(*index)+1;j<v->nbelems && B_INCLUDES_A==overlap(v->tab[j].new_start,v->tab[j].new_end,start,end);j++) {}
-	j--;
-	int delta_end=end-v->tab[j].new_end;
-	int old_end=v->tab[j].old_end+delta_end;
-	save(f,s,n,x.old_start,old_end);
-	(*index)=j+1;
-	(*shift)=v->tab[j].old_end-end+delta_end;
-	return 0;
+    //error("A_BEFORE_B_OVERLAP:\n");
+    int j;
+    for (j=(*index)+1;j<v->nbelems && B_INCLUDES_A==overlap(v->tab[j].new_start,v->tab[j].new_end,start,end);j++) {}
+    j--;
+    int delta_end=end-v->tab[j].new_end;
+    int old_end=v->tab[j].old_end+delta_end;
+    save(f,s,n,x.old_start,old_end);
+    (*index)=j+1;
+    (*shift)=v->tab[j].old_end-end+delta_end;
+    return 0;
 }
 case A_AFTER_B_OVERLAP: {
-	//error("A_AFTER_B_OVERLAP:\n");
-	int delta=start-x.new_start;
-	save(f,s,n,x.old_start+delta,x.old_end);
-	return 0;
+    //error("A_AFTER_B_OVERLAP:\n");
+    int delta=start-x.new_start;
+    save(f,s,n,x.old_start+delta,x.old_end);
+    return 0;
 }
 case A_INCLUDES_B: {
-	//error("A_INCLUDES_B:\n");
-	save(f,s,n,x.old_start,x.old_end);
-	if (x.new_end==end) {
-		(*index)++;
-	}
-	(*shift)=x.old_end-end;
-	return 0;
+    //error("A_INCLUDES_B:\n");
+    save(f,s,n,x.old_start,x.old_end);
+    if (x.new_end==end) {
+        (*index)++;
+    }
+    (*shift)=x.old_end-end;
+    return 0;
 }
 case B_INCLUDES_A: {
-	//error("B_INCLUDES_A:\n");
-	int delta_start=start-x.new_start;
-	int old_start=x.old_start+delta_start;
-	int j;
-	Overlap tmp;
-	for (j=(*index)+1;j<v->nbelems &&
-		(B_INCLUDES_A==(tmp=overlap(v->tab[j].new_start,v->tab[j].new_end,start,end))
-			|| A_EQUALS_B==tmp
-			|| A_AFTER_B_OVERLAP==tmp);j++) {}
-	j--;
-	int delta_end=end-v->tab[j].new_end;
-	int old_end=v->tab[j].old_end+delta_end;
-	save(f,s,n,old_start,old_end);
-	(*index)=j+1;
-	(*shift)=v->tab[j].old_end-end+delta_end;
-	return 0;
+    //error("B_INCLUDES_A:\n");
+    int delta_start=start-x.new_start;
+    int old_start=x.old_start+delta_start;
+    int j;
+    Overlap tmp;
+    for (j=(*index)+1;j<v->nbelems &&
+        (B_INCLUDES_A==(tmp=overlap(v->tab[j].new_start,v->tab[j].new_end,start,end))
+            || A_EQUALS_B==tmp
+            || A_AFTER_B_OVERLAP==tmp);j++) {}
+    j--;
+    int delta_end=end-v->tab[j].new_end;
+    int old_end=v->tab[j].old_end+delta_end;
+    save(f,s,n,old_start,old_end);
+    (*index)=j+1;
+    (*shift)=v->tab[j].old_end-end+delta_end;
+    return 0;
 }
 }
 }
@@ -590,72 +590,72 @@ case B_INCLUDES_A: {
 #define TOKENIZE_WRITE_BUFFER_SIZE 0x80
 static void fast_fwrite_raw_flush(U_FILE* f, unsigned char*out_buffer, unsigned int* pos_out_buffer)
 {
-	if ((*pos_out_buffer) > 0)
-		fwrite(out_buffer, 4, *pos_out_buffer, f);
-	*pos_out_buffer = 0;
+    if ((*pos_out_buffer) > 0)
+        fwrite(out_buffer, 4, *pos_out_buffer, f);
+    *pos_out_buffer = 0;
 }
 
 static inline void fast_fwrite_raw(U_FILE* f, int n, unsigned char*out_buffer, unsigned int* pos_out_buffer, unsigned int size_out_buffer)
 {
-	if ((*pos_out_buffer) == size_out_buffer) {
-		fast_fwrite_raw_flush(f, out_buffer, pos_out_buffer);
-	}
-	*((int*)(out_buffer + ((*pos_out_buffer) * 4))) = n;
-	(*pos_out_buffer)++;
+    if ((*pos_out_buffer) == size_out_buffer) {
+        fast_fwrite_raw_flush(f, out_buffer, pos_out_buffer);
+    }
+    *((int*)(out_buffer + ((*pos_out_buffer) * 4))) = n;
+    (*pos_out_buffer)++;
 }
 
 #define TOKENIZE_GET_BUFFER_SIZE 0x200
 
 static inline int fast_u_fgetc_raw(U_FILE* f, unichar*buffer,unsigned int* pos_in_buffer, unsigned int* filled_in_buffer)
 {
-	for (;;)
-	{
-		if ((*pos_in_buffer) < (*filled_in_buffer))
-		{
-			int c = (int)*(buffer + (*pos_in_buffer));
-			(*pos_in_buffer)++;
-			return c;
-		}
+    for (;;)
+    {
+        if ((*pos_in_buffer) < (*filled_in_buffer))
+        {
+            int c = (int)*(buffer + (*pos_in_buffer));
+            (*pos_in_buffer)++;
+            return c;
+        }
 
-		*filled_in_buffer = 0;
-		*pos_in_buffer = 0;
-		int res = u_fget_unichars_raw(buffer, TOKENIZE_GET_BUFFER_SIZE, f);
-		if (res == 0)
-			return EOF;
-		if (res < 0)
-			return res;
-		*filled_in_buffer = res;
-	}
+        *filled_in_buffer = 0;
+        *pos_in_buffer = 0;
+        int res = u_fget_unichars_raw(buffer, TOKENIZE_GET_BUFFER_SIZE, f);
+        if (res == 0)
+            return EOF;
+        if (res < 0)
+            return res;
+        *filled_in_buffer = res;
+    }
 }
 
 static int enlarge_token_buffer_as_needed(unichar** token_buffer, size_t *buffer_size, size_t size_needed)
 {
-	if (size_needed <= (*buffer_size)) {
-		return SUCCESS_RETURN_CODE;
+    if (size_needed <= (*buffer_size)) {
+        return SUCCESS_RETURN_CODE;
   }
 
-	size_t buffer_new_size = *buffer_size;
-	while (size_needed > buffer_new_size) {
-		buffer_new_size *= 2;
+    size_t buffer_new_size = *buffer_size;
+    while (size_needed > buffer_new_size) {
+        buffer_new_size *= 2;
   }
 
-	unichar* new_token_buffer = (unichar*)realloc((void*)*token_buffer, buffer_new_size*sizeof(unichar));
-	if (new_token_buffer == NULL) {
-		alloc_error("enlarge_token_buffer_as_needed");
+    unichar* new_token_buffer = (unichar*)realloc((void*)*token_buffer, buffer_new_size*sizeof(unichar));
+    if (new_token_buffer == NULL) {
+        alloc_error("enlarge_token_buffer_as_needed");
     return ALLOC_ERROR_CODE;
-	}
+    }
 
-	*token_buffer = new_token_buffer;
-	*buffer_size = buffer_new_size;
+    *token_buffer = new_token_buffer;
+    *buffer_size = buffer_new_size;
 
   return SUCCESS_RETURN_CODE;
 }
 
 static inline int enlarge_token_buffer_if_needed(unichar** token_buffer, size_t *buffer_size, size_t size_needed) {
-	if (size_needed <= (*buffer_size)) {
-		return SUCCESS_RETURN_CODE;
+    if (size_needed <= (*buffer_size)) {
+        return SUCCESS_RETURN_CODE;
   }
-	return enlarge_token_buffer_as_needed(token_buffer, buffer_size, size_needed);
+    return enlarge_token_buffer_as_needed(token_buffer, buffer_size, size_needed);
 }
 
 #define TOKENIZE_ORIGINAL_TOKEN_BUFFER_SIZE 0x400
@@ -702,7 +702,7 @@ while ((c!=EOF) && (result == 0)) {
       ENTER=0;
       if (c==0x0d || c==0x0a) ENTER=1;
       // if the char is a separator, we jump all the separators
-	  while ((c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) == ' ' || c == 0x0d || c == 0x0a || c == '\t') {
+      while ((c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) == ' ' || c == 0x0d || c == 0x0a || c == '\t') {
         if (c==0x0d || c==0x0a) ENTER=1;
         COUNT++;
       }
@@ -710,9 +710,9 @@ while ((c!=EOF) && (result == 0)) {
       token_buffer[1]='\0';
       n=get_token_number(token_buffer,tokens,hashtable,n_occur);
       if (COUNT-current_pos!=1) {
-    	  /* If there is a shift with the .snt file */
-    	  add_snt_offsets(snt_offsets,*TOKENS_TOTAL,snt_offsets_shift,snt_offsets_shift+(COUNT-current_pos-1));
-    	  snt_offsets_shift+=(COUNT-current_pos-1);
+          /* If there is a shift with the .snt file */
+          add_snt_offsets(snt_offsets,*TOKENS_TOTAL,snt_offsets_shift,snt_offsets_shift+(COUNT-current_pos-1));
+          snt_offsets_shift+=(COUNT-current_pos-1);
       }
       result=save_token_offset(f_out_offsets,token_buffer,n,current_pos,COUNT,v_in_offsets,&offset_index,&shift);
       /* If there is a \n, we note it */
@@ -720,22 +720,22 @@ while ((c!=EOF) && (result == 0)) {
          vector_int_add(n_enter_pos,*TOKENS_TOTAL);
       }
       (*TOKENS_TOTAL)++;
-	  fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
+      fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
    }
    else if (c=='{') {
      token_buffer[0]='{';
      int z=1;
      bool protected_char = false; // Cassys add
-	 while ((((c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) != '}' && c
-					!= '{' && c != '\n') || protected_char)) {
-			protected_char = false; // Cassys add
-			if (c == '\\') { // Cassys add
-				protected_char = true; // Cassys add
-			} // Cassys add
-			enlarge_token_buffer_if_needed(&token_buffer, &token_buffer_size, z+2);
-			token_buffer[z++] = (unichar) c;
-			COUNT++;
-	}
+     while ((((c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) != '}' && c
+                    != '{' && c != '\n') || protected_char)) {
+            protected_char = false; // Cassys add
+            if (c == '\\') { // Cassys add
+                protected_char = true; // Cassys add
+            } // Cassys add
+            enlarge_token_buffer_if_needed(&token_buffer, &token_buffer_size, z+2);
+            token_buffer[z++] = (unichar) c;
+            COUNT++;
+    }
 
      if (c!='}') {
         // if the tag has no ending }
@@ -769,8 +769,8 @@ while ((c!=EOF) && (result == 0)) {
      COUNT++;
      result=save_token_offset(f_out_offsets,token_buffer,n,current_pos,COUNT,v_in_offsets,&offset_index,&shift);
      (*TOKENS_TOTAL)++;
-	 fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
-	 c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer);
+     fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
+     c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer);
    }
    else {
       token_buffer[0]=(unichar)c;
@@ -780,14 +780,14 @@ while ((c!=EOF) && (result == 0)) {
          if (is_letter(token_buffer[0],alph)) (*WORDS_TOTAL)++;
          n=get_token_number(token_buffer,tokens,hashtable,n_occur);
          result=save_token_offset(f_out_offsets,token_buffer,n,current_pos,COUNT,v_in_offsets,&offset_index,
-        		 &shift);
+                 &shift);
          (*TOKENS_TOTAL)++;
          if (c>='0' && c<='9') (*DIGITS_TOTAL)++;
-		 fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
-		 c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer);
+         fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
+         c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer);
       }
       else {
-		  while (EOF != (c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) && is_letter((unichar)c, alph)) {
+          while (EOF != (c = fast_u_fgetc_raw(f_read, read_buffer, &pos_in_buffer, &filled_in_buffer)) && is_letter((unichar)c, alph)) {
            enlarge_token_buffer_if_needed(&token_buffer, &token_buffer_size, n + 2);
            token_buffer[n++]=(unichar)c;
            COUNT++;
@@ -796,10 +796,10 @@ while ((c!=EOF) && (result == 0)) {
          token_buffer[n]='\0';
          n=get_token_number(token_buffer,tokens,hashtable,n_occur);
          result=save_token_offset(f_out_offsets,token_buffer,n,current_pos,COUNT,v_in_offsets,&offset_index,
-        		 &shift);
+                 &shift);
          (*TOKENS_TOTAL)++;
          (*WORDS_TOTAL)++;
-		 fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
+         fast_fwrite_raw(coded_text, n, write_buffer, &pos_out_buffer, TOKENIZE_WRITE_BUFFER_SIZE);
       }
    }
 }
@@ -912,7 +912,7 @@ for (int i=0;i<tokens->nbelems;i++) {
 
 
 static void compute_statistics(U_FILE *f,vector_ptr* tokens,Alphabet* alph,
-		                int SENTENCES,int TOKENS_TOTAL,int WORDS_TOTAL,int DIGITS_TOTAL) {
+                        int SENTENCES,int TOKENS_TOTAL,int WORDS_TOTAL,int DIGITS_TOTAL) {
 int DIFFERENT_DIGITS=0;
 int DIFFERENT_WORDS=0;
 for (int i=0;i<tokens->nbelems;i++) {
@@ -923,8 +923,8 @@ for (int i=0;i<tokens->nbelems;i++) {
    if (is_letter(foo[0],alph)) DIFFERENT_WORDS++;
 }
 u_fprintf(f,"%d sentence delimiter%s, %d (%d diff) token%s, %d (%d) simple form%s, %d (%d) digit%s\n",
-		SENTENCES,(SENTENCES>1)?"s":"",TOKENS_TOTAL,tokens->nbelems,(TOKENS_TOTAL>1)?"s":"",WORDS_TOTAL,
-		DIFFERENT_WORDS,(WORDS_TOTAL>1)?"s":"",DIGITS_TOTAL,DIFFERENT_DIGITS,(DIGITS_TOTAL>1)?"s":"");
+        SENTENCES,(SENTENCES>1)?"s":"",TOKENS_TOTAL,tokens->nbelems,(TOKENS_TOTAL>1)?"s":"",WORDS_TOTAL,
+        DIFFERENT_WORDS,(WORDS_TOTAL>1)?"s":"",DIGITS_TOTAL,DIFFERENT_DIGITS,(DIGITS_TOTAL>1)?"s":"");
 }
 
 

--- a/Tokenize.h
+++ b/Tokenize.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef TokenizeH
 #define TokenizeH
 

--- a/TrainingProcess.cpp
+++ b/TrainingProcess.cpp
@@ -36,9 +36,9 @@ namespace unitex {
  * Indicates that those cannot be used like other dictionaries.
  */
 void create_disclaimer(const VersatileEncodingConfig* vec,const char* file){
-	U_FILE* disclaimer = u_fopen(vec,file,U_WRITE);
-	u_fprintf(disclaimer,"This file contains statistics gathered from a tagged corpus.\nIt cannot be used like other .bin dictionaries but only in input of Tagger program.\n\nContact : unitex@univ-mlv.fr");
-	u_fclose(disclaimer);
+    U_FILE* disclaimer = u_fopen(vec,file,U_WRITE);
+    u_fprintf(disclaimer,"This file contains statistics gathered from a tagged corpus.\nIt cannot be used like other .bin dictionaries but only in input of Tagger program.\n\nContact : unitex@univ-mlv.fr");
+    u_fclose(disclaimer);
 }
 
 /**
@@ -59,7 +59,7 @@ free(entry);
 void push_corpus_entry(struct corpus_entry* entry,struct corpus_entry** context){
 free_corpus_entry(context[0]);
 for(int i=0;i<MAX_CONTEXT-1;i++){
-	context[i] = context[i+1];
+    context[i] = context[i+1];
 }
 context[MAX_CONTEXT-1] = entry;
 }
@@ -70,16 +70,16 @@ context[MAX_CONTEXT-1] = entry;
 struct corpus_entry* new_corpus_entry(const unichar* line){
 struct corpus_entry* entry = (corpus_entry*)malloc(sizeof(corpus_entry));
 if(entry == NULL){
-	fatal_alloc_error("compute_corpus_entry");
+    fatal_alloc_error("compute_corpus_entry");
 }
 /* we fill corpus entry with information extracted from the corpus line*/
 int pos = u_strrchr(line,'/');
 if(pos == -1){
-	fatal_error("Wrong format for line %S\n",line);
+    fatal_error("Wrong format for line %S\n",line);
 }
 entry->word = (unichar*)malloc(sizeof(unichar)*(pos+1));
 if(entry->word == NULL){
-	fatal_alloc_error("compute_corpus_entry");
+    fatal_alloc_error("compute_corpus_entry");
 }
 unichar* tmp = u_strcpy_sized(entry->word,pos+1,line);
 u_strcat(tmp,"\0");
@@ -87,32 +87,32 @@ u_strcat(tmp,"\0");
 int code_pos = u_strrchr(line,':');
 /* there are no morphological codes associated to this entry */
 if(code_pos == -1){
-	entry->pos_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(line)-pos));
-	if(entry->pos_code == NULL){
-		fatal_alloc_error("new_corpus_entry");
-	}
-	u_strcpy(entry->pos_code,&line[pos+1]);
-	entry->overall_codes = u_strdup(entry->pos_code);
+    entry->pos_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(line)-pos));
+    if(entry->pos_code == NULL){
+        fatal_alloc_error("new_corpus_entry");
+    }
+    u_strcpy(entry->pos_code,&line[pos+1]);
+    entry->overall_codes = u_strdup(entry->pos_code);
 }
 else{
-	entry->pos_code = (unichar*)malloc(sizeof(unichar)*(code_pos-pos));
-	if(entry->pos_code == NULL){
-		fatal_alloc_error("new_corpus_entry");
-	}
-	entry->overall_codes = (unichar*)malloc(sizeof(unichar)*(u_strlen(line)-pos));
-	if(entry->overall_codes == NULL){
-		fatal_alloc_error("new_corpus_entry");
-	}
-	unichar* tmp2 = u_strcpy_sized(entry->pos_code,code_pos-pos,&line[pos+1]);
-	u_strcat(tmp2,"\0");
-	u_strcpy(entry->overall_codes,&line[pos+1]);
+    entry->pos_code = (unichar*)malloc(sizeof(unichar)*(code_pos-pos));
+    if(entry->pos_code == NULL){
+        fatal_alloc_error("new_corpus_entry");
+    }
+    entry->overall_codes = (unichar*)malloc(sizeof(unichar)*(u_strlen(line)-pos));
+    if(entry->overall_codes == NULL){
+        fatal_alloc_error("new_corpus_entry");
+    }
+    unichar* tmp2 = u_strcpy_sized(entry->pos_code,code_pos-pos,&line[pos+1]);
+    u_strcat(tmp2,"\0");
+    u_strcpy(entry->overall_codes,&line[pos+1]);
 }
 /* if the token is not annotated in the corpus, we put "UNK" */
 if(u_strlen(entry->pos_code) == 0){
-	free(entry->pos_code);
-	free(entry->overall_codes);
-	entry->pos_code = u_strdup("UNK");
-	entry->overall_codes = u_strdup("UNK");
+    free(entry->pos_code);
+    free(entry->overall_codes);
+    entry->pos_code = u_strdup("UNK");
+    entry->overall_codes = u_strdup("UNK");
 }
 return entry;
 }
@@ -123,7 +123,7 @@ return entry;
  */
 int check_corpus_entry(const unichar* line){
 if(u_strrchr(line,'/') == -1 || line[0] == '{')
-	return 1;
+    return 1;
 return 0;
 }
 
@@ -132,10 +132,10 @@ return 0;
  */
 void free_context_matrix(struct corpus_entry** context){
 for(int i=0;i<MAX_CONTEXT;i++){
-	if(context[i]!=NULL){
-		free_corpus_entry(context[i]);
-		context[i] = NULL;
-	}
+    if(context[i]!=NULL){
+        free_corpus_entry(context[i]);
+        context[i] = NULL;
+    }
 }
 free(context);
 }
@@ -145,12 +145,12 @@ free(context);
  */
 void initialize_context_matrix(struct corpus_entry** context){
 for(int i=0;i<MAX_CONTEXT;i++){
-	if(context[i] != NULL){
-		free_corpus_entry(context[i]);
-	}
-	unichar* str = u_strdup("#/#");
-	context[i] = new_corpus_entry(str);
-	free(str);
+    if(context[i] != NULL){
+        free_corpus_entry(context[i]);
+    }
+    unichar* str = u_strdup("#/#");
+    context[i] = new_corpus_entry(str);
+    free(str);
 }
 }
 
@@ -160,10 +160,10 @@ for(int i=0;i<MAX_CONTEXT;i++){
 struct corpus_entry** new_context_matrix(){
 struct corpus_entry** matrix = (struct corpus_entry**)malloc(sizeof(struct corpus_entry)*MAX_CONTEXT);
 if(matrix == NULL){
-	fatal_alloc_error("new_context_matrix");
+    fatal_alloc_error("new_context_matrix");
 }
 for(int i=0;i<MAX_CONTEXT;i++){
-	matrix[i] = NULL;
+    matrix[i] = NULL;
 }
 return matrix;
 }
@@ -174,10 +174,10 @@ return matrix;
 void add_key_table(const unichar* key,struct string_hash_ptr* table){
 void* value = get_value(key,table);
 if(value != NULL){
-	table->value[get_value_index(key,table)] = (void*)(((char*)value)+1);
+    table->value[get_value_index(key,table)] = (void*)(((char*)value)+1);
 }
 else{
-	get_value_index(key,table,INSERT_IF_NEEDED,(void*)1);
+    get_value_index(key,table,INSERT_IF_NEEDED,(void*)1);
 }
 }
 
@@ -199,21 +199,21 @@ free(str);
 unichar* compute_contextual_entries(struct corpus_entry** context,int start_index,int mode){
 unichar* line = NULL;
 if(mode == INFLECTED_FORMS){
-	line = u_strdup(context[start_index]->overall_codes);
+    line = u_strdup(context[start_index]->overall_codes);
 }
 else if(mode == RAW_FORMS){
-	line = u_strdup(context[start_index]->pos_code);
+    line = u_strdup(context[start_index]->pos_code);
 }
 unichar* tmp = NULL;
 for(int i=start_index+1;i<MAX_CONTEXT;i++){
-	if (mode == RAW_FORMS){
-		tmp = create_bigram_sequence(line,context[i]->pos_code,1);
-	}
-	else if(mode == INFLECTED_FORMS){
-		tmp = create_bigram_sequence(line,context[i]->overall_codes,1);
-	}
-	free(line);
-	line = tmp;
+    if (mode == RAW_FORMS){
+        tmp = create_bigram_sequence(line,context[i]->pos_code,1);
+    }
+    else if(mode == INFLECTED_FORMS){
+        tmp = create_bigram_sequence(line,context[i]->overall_codes,1);
+    }
+    free(line);
+    line = tmp;
 }
 return line;
 }
@@ -222,41 +222,41 @@ return line;
  * Computes lexical and contextual entries to put into the file containing statistics.
  */
 void add_statistics(struct corpus_entry** context,struct string_hash_ptr* rforms_table,
-		            struct string_hash_ptr* iforms_table){
+                    struct string_hash_ptr* iforms_table){
 char prefix[] = "word_";
 /* we first raise the number of time current word occurs in the corpus (unigrams) */
 struct corpus_entry* current = context[MAX_CONTEXT-1];
 unichar* word = create_bigram_sequence(prefix,current->word,0);
 if(rforms_table != NULL){
-	add_key_table(word,rforms_table);
+    add_key_table(word,rforms_table);
 }
 if(iforms_table != NULL){
-	add_key_table(word,iforms_table);
+    add_key_table(word,iforms_table);
 }
 /* then we compute line for bigrams (tag,word), bigrams (tag(i-1),tag(i))
  * and trigrams (tag(i-2),tag(i-1),tag(i)) */
 unichar* line = NULL;
 if(rforms_table != NULL){
-	line = create_bigram_sequence(current->pos_code,word,1);
-	add_key_table(line,rforms_table);
-	free(line);
-	line = compute_contextual_entries(context,1,RAW_FORMS);
-	add_key_table(line,rforms_table);
-	free(line);
-	line = compute_contextual_entries(context,0,RAW_FORMS);
-	add_key_table(line,rforms_table);
-	free(line);
+    line = create_bigram_sequence(current->pos_code,word,1);
+    add_key_table(line,rforms_table);
+    free(line);
+    line = compute_contextual_entries(context,1,RAW_FORMS);
+    add_key_table(line,rforms_table);
+    free(line);
+    line = compute_contextual_entries(context,0,RAW_FORMS);
+    add_key_table(line,rforms_table);
+    free(line);
 }
 if(iforms_table != NULL){
-	line = create_bigram_sequence(current->overall_codes,word,1);
-	add_key_table(line,iforms_table);
-	free(line);
-	line = compute_contextual_entries(context,1,INFLECTED_FORMS);
-	add_key_table(line,iforms_table);
-	free(line);
-	line = compute_contextual_entries(context,0,INFLECTED_FORMS);
-	add_key_table(line,iforms_table);
-	free(line);
+    line = create_bigram_sequence(current->overall_codes,word,1);
+    add_key_table(line,iforms_table);
+    free(line);
+    line = compute_contextual_entries(context,1,INFLECTED_FORMS);
+    add_key_table(line,iforms_table);
+    free(line);
+    line = compute_contextual_entries(context,0,INFLECTED_FORMS);
+    add_key_table(line,iforms_table);
+    free(line);
 }
 free(word);
 }
@@ -266,69 +266,69 @@ free(word);
  */
 void write_keys_values(struct string_hash_ptr* table,struct string_hash_tree_node* node,const unichar* str,U_FILE* file){
 if(node->value_index != NO_VALUE_INDEX){
-	u_fprintf(file,"%S,.%d\n",str,table->value[node->value_index]);
+    u_fprintf(file,"%S,.%d\n",str,table->value[node->value_index]);
 }
 for(struct string_hash_tree_transition* trans=node->trans;trans!=NULL;trans=trans->next){
-	unichar* new_str = (unichar*)malloc(DIC_LINE_SIZE);
-	u_sprintf(new_str,"%S%C",str,trans->letter);
-	write_keys_values(table,trans->node,new_str,file);
-	free(new_str);
+    unichar* new_str = (unichar*)malloc(DIC_LINE_SIZE);
+    u_sprintf(new_str,"%S%C",str,trans->letter);
+    write_keys_values(table,trans->node,new_str,file);
+    free(new_str);
 }
 }
 
 corpus_entry* new_simple_word_entry(const unichar* word,corpus_entry* entry,int start){
-	corpus_entry* wentry = (corpus_entry*)malloc(sizeof(corpus_entry));
-	wentry->word = u_strdup(word);
-	wentry->pos_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(entry->pos_code)+3));
-	wentry->overall_codes = (unichar*)malloc(sizeof(unichar)*(u_strlen(entry->overall_codes)+3));
-	unichar* tmp = u_strcpy_sized(wentry->pos_code,u_strlen(entry->pos_code)+1,entry->pos_code);
-	unichar* tmp2 = u_strcpy_sized(wentry->overall_codes,u_strlen(entry->overall_codes)+1,entry->overall_codes);
-	if(start == 0){
-		u_strcat(tmp,"+I\0");
-		u_strcat(tmp2,"+I\0");
-	}
-	else {
-		u_strcat(tmp,"+B\0");
-		u_strcat(tmp2,"+B\0");
-	}
-	return wentry;
+    corpus_entry* wentry = (corpus_entry*)malloc(sizeof(corpus_entry));
+    wentry->word = u_strdup(word);
+    wentry->pos_code = (unichar*)malloc(sizeof(unichar)*(u_strlen(entry->pos_code)+3));
+    wentry->overall_codes = (unichar*)malloc(sizeof(unichar)*(u_strlen(entry->overall_codes)+3));
+    unichar* tmp = u_strcpy_sized(wentry->pos_code,u_strlen(entry->pos_code)+1,entry->pos_code);
+    unichar* tmp2 = u_strcpy_sized(wentry->overall_codes,u_strlen(entry->overall_codes)+1,entry->overall_codes);
+    if(start == 0){
+        u_strcat(tmp,"+I\0");
+        u_strcat(tmp2,"+I\0");
+    }
+    else {
+        u_strcat(tmp,"+B\0");
+        u_strcat(tmp2,"+B\0");
+    }
+    return wentry;
 }
 
 /**
  * Extract simple words contained into compound words.
  */
 corpus_entry** extract_simple_words(corpus_entry* entry){
-	corpus_entry** words = (corpus_entry**)malloc(sizeof(corpus_entry)*100);
-	words[0] = NULL;
-	unichar* word = u_strchr(entry->word,'_');
-	int old_value=0,nb_words=0;
-	while(word != NULL) {
-		unichar* simple_word = u_strdup(entry->word+old_value,u_strlen(entry->word)-old_value-u_strlen(word));
-		if(simple_word[0] != '-'){
-			if(nb_words > 0){
-				words[nb_words] = new_simple_word_entry(simple_word,entry,0);
-			}
-			else{
-				words[nb_words] = new_simple_word_entry(simple_word,entry,1);
-			}
-		}
-		else{
-			nb_words -= 1;
-		}
-		nb_words+=1;
-		old_value += u_strlen(simple_word)+1;
-		word = u_strchr(entry->word+old_value,'_');
-		free(simple_word);
-		if(word == NULL){
-			if(u_strlen(entry->word)-old_value != 0){
-				word = entry->word+old_value;
-				words[nb_words] = new_simple_word_entry(word,entry,0);
-				words[nb_words+1] = NULL;
-			}
-			break;
-		}
-	}
-	return words;
+    corpus_entry** words = (corpus_entry**)malloc(sizeof(corpus_entry)*100);
+    words[0] = NULL;
+    unichar* word = u_strchr(entry->word,'_');
+    int old_value=0,nb_words=0;
+    while(word != NULL) {
+        unichar* simple_word = u_strdup(entry->word+old_value,u_strlen(entry->word)-old_value-u_strlen(word));
+        if(simple_word[0] != '-'){
+            if(nb_words > 0){
+                words[nb_words] = new_simple_word_entry(simple_word,entry,0);
+            }
+            else{
+                words[nb_words] = new_simple_word_entry(simple_word,entry,1);
+            }
+        }
+        else{
+            nb_words -= 1;
+        }
+        nb_words+=1;
+        old_value += u_strlen(simple_word)+1;
+        word = u_strchr(entry->word+old_value,'_');
+        free(simple_word);
+        if(word == NULL){
+            if(u_strlen(entry->word)-old_value != 0){
+                word = entry->word+old_value;
+                words[nb_words] = new_simple_word_entry(word,entry,0);
+                words[nb_words+1] = NULL;
+            }
+            break;
+        }
+    }
+    return words;
 }
 
 /**
@@ -338,10 +338,10 @@ void do_training(U_FILE* input_text,U_FILE* rforms_file,U_FILE* iforms_file){
 /* these two hash tables are respectively for simple and compound entries */
 struct string_hash_ptr* rforms_table = NULL, *iforms_table = NULL;
 if(rforms_file != NULL){
-	rforms_table = new_string_hash_ptr(200000);
+    rforms_table = new_string_hash_ptr(200000);
 }
 if(iforms_file != NULL){
-	iforms_table = new_string_hash_ptr(200000);
+    iforms_table = new_string_hash_ptr(200000);
 }
 
 
@@ -355,99 +355,99 @@ unichar line[MAX_TAGGED_CORPUS_LINE];
 /* check the format of the corpus */
 long previous_file_position = ftell(input_text);
 if(u_fgets(line,input_text) == EOF){
-	fatal_error("File is empty");
+    fatal_error("File is empty");
 }
 fseek(input_text,previous_file_position,SEEK_SET);
 
 int format_corpus = check_corpus_entry(line);
 
 if(format_corpus == 0){
-	// the corpus is in the Tagger format, one word per line where line=word/tag
-	while(u_fgets(line,input_text) !=EOF){
-		if(u_strlen(line) == 0){
-			initialize_context_matrix(context);
-		}
-		else{
-			corpus_entry* entry = new_corpus_entry(line);
-			if(u_strchr(line,'_')!=NULL && line[0]!='_'){
-				corpus_entry** entries = extract_simple_words(entry);
-				free_corpus_entry(entry);
-				for(int i=0;entries[i]!=NULL;i++){
-					push_corpus_entry(entries[i],context);
-					add_statistics(context,rforms_table,iforms_table);
-				}
-				free(entries);
-			}
-			else {
-				push_corpus_entry(entry,context);
-				add_statistics(context,rforms_table,iforms_table);
-			}
-		}
-	}
+    // the corpus is in the Tagger format, one word per line where line=word/tag
+    while(u_fgets(line,input_text) !=EOF){
+        if(u_strlen(line) == 0){
+            initialize_context_matrix(context);
+        }
+        else{
+            corpus_entry* entry = new_corpus_entry(line);
+            if(u_strchr(line,'_')!=NULL && line[0]!='_'){
+                corpus_entry** entries = extract_simple_words(entry);
+                free_corpus_entry(entry);
+                for(int i=0;entries[i]!=NULL;i++){
+                    push_corpus_entry(entries[i],context);
+                    add_statistics(context,rforms_table,iforms_table);
+                }
+                free(entries);
+            }
+            else {
+                push_corpus_entry(entry,context);
+                add_statistics(context,rforms_table,iforms_table);
+            }
+        }
+    }
 }
 else {
-	// the corpus is in the Unitex tagged format, one sentence per line where token={word,lemma.tag}
-	unichar *tmp,*s = (unichar*)malloc(sizeof(unichar)*(MAX_TAGGED_CORPUS_LINE));
-	int current_len,len;
-	unsigned int i;
-	while(u_fgets(line,input_text) != EOF){
-		current_len = 0, len = 0;
-		/* extract each token of the sentence */
-		for (;;) {
-			len = 1+u_strlen(line+current_len)-u_strlen(u_strchr(line+current_len,'}'));
-			tmp = u_strcpy_sized(s,len-1,line+current_len+1);
-			u_strcat(tmp,"\0");
-			if(u_strcmp(s,"S") == 0)
-				break;
+    // the corpus is in the Unitex tagged format, one sentence per line where token={word,lemma.tag}
+    unichar *tmp,*s = (unichar*)malloc(sizeof(unichar)*(MAX_TAGGED_CORPUS_LINE));
+    int current_len,len;
+    unsigned int i;
+    while(u_fgets(line,input_text) != EOF){
+        current_len = 0, len = 0;
+        /* extract each token of the sentence */
+        for (;;) {
+            len = 1+u_strlen(line+current_len)-u_strlen(u_strchr(line+current_len,'}'));
+            tmp = u_strcpy_sized(s,len-1,line+current_len+1);
+            u_strcat(tmp,"\0");
+            if(u_strcmp(s,"S") == 0)
+                break;
 
-			//particular case: '\},\}.PONCT'
-			if(line[current_len+2] == '}'){
-				int start = current_len+3;
-				do{
-					tmp = u_strchr(line+start,'}');
-					start += 1+u_strlen(line+start)-u_strlen(tmp);
-				}
-				while(*(tmp+1) != ' ');
-				tmp = u_strcpy_sized(s,start-current_len-1,line+current_len+1);
-				u_strcat(tmp,"\0");
-				len += start-current_len-3;
-			}
+            //particular case: '\},\}.PONCT'
+            if(line[current_len+2] == '}'){
+                int start = current_len+3;
+                do{
+                    tmp = u_strchr(line+start,'}');
+                    start += 1+u_strlen(line+start)-u_strlen(tmp);
+                }
+                while(*(tmp+1) != ' ');
+                tmp = u_strcpy_sized(s,start-current_len-1,line+current_len+1);
+                u_strcat(tmp,"\0");
+                len += start-current_len-3;
+            }
 
-			/* format the {XX.YY} into standard tagger format, XX/YY */
-			unichar* newline = (unichar*)malloc(sizeof(unichar)*(8096));
-			if(u_strchr(s,',')[1] == ','){
-				u_strcpy(newline,",");
-			}
-			else
-				u_strcpy_sized(newline,1+u_strlen(s)-u_strlen(u_strchr(s,',')),s);
-			u_sprintf(newline,"%S/%S\0",newline,s+u_strrchr(s,'.')+1);
-			for(i=0;i<u_strlen(newline);i++){
-				if(newline[i] == ' ')
-					newline[i] = '_';
-			}
+            /* format the {XX.YY} into standard tagger format, XX/YY */
+            unichar* newline = (unichar*)malloc(sizeof(unichar)*(8096));
+            if(u_strchr(s,',')[1] == ','){
+                u_strcpy(newline,",");
+            }
+            else
+                u_strcpy_sized(newline,1+u_strlen(s)-u_strlen(u_strchr(s,',')),s);
+            u_sprintf(newline,"%S/%S\0",newline,s+u_strrchr(s,'.')+1);
+            for(i=0;i<u_strlen(newline);i++){
+                if(newline[i] == ' ')
+                    newline[i] = '_';
+            }
 
-			//create corpus entry
-			corpus_entry* entry = new_corpus_entry(newline);
-			if(u_strchr(newline,'_') != NULL && newline[0] != '_'){
-				corpus_entry** entries = extract_simple_words(entry);
-				free_corpus_entry(entry);
-				for(int j=0;entries[j]!=NULL;j++){
-					push_corpus_entry(entries[j],context);
-					add_statistics(context,rforms_table,iforms_table);
-				}
-				free(entries);
-			}
-			else {
-				push_corpus_entry(entry,context);
-				add_statistics(context,rforms_table,iforms_table);
-			}
+            //create corpus entry
+            corpus_entry* entry = new_corpus_entry(newline);
+            if(u_strchr(newline,'_') != NULL && newline[0] != '_'){
+                corpus_entry** entries = extract_simple_words(entry);
+                free_corpus_entry(entry);
+                for(int j=0;entries[j]!=NULL;j++){
+                    push_corpus_entry(entries[j],context);
+                    add_statistics(context,rforms_table,iforms_table);
+                }
+                free(entries);
+            }
+            else {
+                push_corpus_entry(entry,context);
+                add_statistics(context,rforms_table,iforms_table);
+            }
 
-			free(newline);
-			current_len += len+1;
-		}
-		initialize_context_matrix(context);
-	}
-	free(s);
+            free(newline);
+            current_len += len+1;
+        }
+        initialize_context_matrix(context);
+    }
+    free(s);
 }
 free_context_matrix(context);
 /* we fill dictionary files with pairs (tuple,value) and then
@@ -455,14 +455,14 @@ free_context_matrix(context);
  * specify whether the dictionary contains inflected or raw form tuples*/
 unichar* str = u_strdup("");
 if(rforms_table != NULL){
-	write_keys_values(rforms_table,rforms_table->hash->root,str,rforms_file);
-	u_fprintf(rforms_file,"%s,.%d\n","CODE\tFEATURES",0);
-	free_string_hash_ptr(rforms_table,NULL);
+    write_keys_values(rforms_table,rforms_table->hash->root,str,rforms_file);
+    u_fprintf(rforms_file,"%s,.%d\n","CODE\tFEATURES",0);
+    free_string_hash_ptr(rforms_table,NULL);
 }
 if(iforms_table != NULL){
-	write_keys_values(iforms_table,iforms_table->hash->root,str,iforms_file);
-	u_fprintf(iforms_file,"%s,.%d\n","CODE\tFEATURES",1);
-	free_string_hash_ptr(iforms_table,NULL);
+    write_keys_values(iforms_table,iforms_table->hash->root,str,iforms_file);
+    u_fprintf(iforms_file,"%s,.%d\n","CODE\tFEATURES",1);
+    free_string_hash_ptr(iforms_table,NULL);
 }
 free(str);
 }

--- a/TrainingProcess.h
+++ b/TrainingProcess.h
@@ -50,9 +50,9 @@ namespace unitex {
 #define MAX_TAGGED_CORPUS_LINE 20000
 
 struct corpus_entry{
-	unichar* word;
-	unichar* pos_code;
-	unichar* overall_codes;
+    unichar* word;
+    unichar* pos_code;
+    unichar* overall_codes;
 };
 
 void create_disclaimer(const VersatileEncodingConfig* vec,const char* file);

--- a/TrainingTagger.cpp
+++ b/TrainingTagger.cpp
@@ -109,16 +109,16 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_TrainingTagger,lopts_Tra
              strcpy(output,options.vars()->optarg);
              break;
    case 'b': binaries = 1;
-			 break;
+             break;
    case 'n': binaries = 0;
-			 break;
+             break;
    case 'a': break;
    case 'c': i_forms = 0;
-			 break;
+             break;
    case 'm': r_forms = 0;
-   			 break;
+             break;
    case 'S': semitic=1;
-   			 break;
+             break;
    case 'k': if (options.vars()->optarg[0]=='\0') {
                error("Empty input_encoding argument\n");
                return USAGE_ERROR_CODE;
@@ -169,19 +169,19 @@ if(output[0]=='\0'){
 char path[FILENAME_MAX],filename[FILENAME_MAX];
 get_path(text,path);
 if(strlen(path) == 0){
-	strcpy(path,".");
+    strcpy(path,".");
 }
 /* we create files which will contain statistics extracted from the tagged corpus */
 U_FILE* rforms_file = NULL, *iforms_file = NULL;
 if(r_forms == 1){
-	sprintf(filename,"%s_data_cat.dic",output);
-	new_file(path,filename,raw_forms);
-	rforms_file=u_fopen(&vec,raw_forms,U_WRITE);
+    sprintf(filename,"%s_data_cat.dic",output);
+    new_file(path,filename,raw_forms);
+    rforms_file=u_fopen(&vec,raw_forms,U_WRITE);
 }
 if(i_forms == 1){
-	sprintf(filename,"%s_data_morph.dic",output);
-	new_file(path,filename,inflected_forms);
-	iforms_file=u_fopen(&vec,inflected_forms,U_WRITE);
+    sprintf(filename,"%s_data_morph.dic",output);
+    new_file(path,filename,inflected_forms);
+    iforms_file=u_fopen(&vec,inflected_forms,U_WRITE);
 }
 
 u_printf("Gathering statistics from tagged corpus...\n");
@@ -191,31 +191,31 @@ do_training(input_text,rforms_file,iforms_file);
 u_fclose(input_text);
 char disclaimer[FILENAME_MAX];
 if(rforms_file != NULL){
-	u_fclose(rforms_file);
-	pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,raw_forms,0);
-	strcpy(disclaimer,raw_forms);
-	remove_extension(disclaimer);
-	strcat(disclaimer,".txt");
-	create_disclaimer(&vec,disclaimer);
+    u_fclose(rforms_file);
+    pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,raw_forms,0);
+    strcpy(disclaimer,raw_forms);
+    remove_extension(disclaimer);
+    strcat(disclaimer,".txt");
+    create_disclaimer(&vec,disclaimer);
 }
 if(iforms_file != NULL){
-	u_fclose(iforms_file);
-	pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,inflected_forms,0);
-	strcpy(disclaimer,inflected_forms);
-	remove_extension(disclaimer);
-	strcat(disclaimer,".txt");
-	create_disclaimer(&vec,disclaimer);
+    u_fclose(iforms_file);
+    pseudo_main_SortTxt(&vec,0,0,NULL,NULL,0,inflected_forms,0);
+    strcpy(disclaimer,inflected_forms);
+    remove_extension(disclaimer);
+    strcat(disclaimer,".txt");
+    create_disclaimer(&vec,disclaimer);
 }
 
 /* we compress dictionaries if option is specified by user (output is ".bin") */
 if(binaries == 1){
 /* simple forms dictionary */
 if(r_forms == 1){
-	pseudo_main_Compress(&vec,0,semitic,raw_forms,1);
+    pseudo_main_Compress(&vec,0,semitic,raw_forms,1);
 }
 /* compound forms dictionary */
 if(i_forms == 1){
-	pseudo_main_Compress(&vec,0,semitic,inflected_forms,1);
+    pseudo_main_Compress(&vec,0,semitic,inflected_forms,1);
 }
 }
 

--- a/TrainingTagger.cpp
+++ b/TrainingTagger.cpp
@@ -157,7 +157,7 @@ if (only_verify_arguments) {
 
 strcpy(text,argv[options.vars()->optind]);
 U_FILE* input_text=u_fopen(&vec,text,U_READ);
-if (input_text==NULL) {   
+if (input_text==NULL) {
   error("cannot open file %s\n",text);
   return DEFAULT_ERROR_CODE;
 }

--- a/TransductionStack.cpp
+++ b/TransductionStack.cpp
@@ -52,9 +52,9 @@ return ((c>='A' && c<='Z') || (c>='a' && c<='z') || (c>='0' && c<='9') || c=='_'
  */
 void push_input_char(struct stack_unichar* s,unichar c,int protect_dic_chars) {
 if (protect_dic_chars && (c==',' || c=='.')) {
-	/* We want to protect dots and commas because the Locate program can be used
-	 * by Dico to generate dictionary entries */
-	push(s,'\\');
+    /* We want to protect dots and commas because the Locate program can be used
+     * by Dico to generate dictionary entries */
+    push(s,'\\');
 }
 push(s,c);
 }
@@ -114,12 +114,12 @@ push_input_string(stack,s,0);
  *
  */
 int process_output(unichar* s,struct locate_parameters* p,struct stack_unichar* stack,
-		int capture_in_debug_mode) {
+        int capture_in_debug_mode) {
 int old_stack_pointer=stack->stack_pointer;
 int i1=0;
 if (capture_in_debug_mode) {
-	/* If we have a capture in debug mode, we must skip the initial char #1 */
-	i1++;
+    /* If we have a capture in debug mode, we must skip the initial char #1 */
+    i1++;
 }
 if (s==NULL) {
    /* We do nothing if there is no output */
@@ -130,7 +130,7 @@ for (;;) {
     /* First, we push all chars before '\0' or '$' */
     int char_to_push_count=0;
     while ((s[i1+char_to_push_count]!='\0') && (s[i1+char_to_push_count]!='$')
-    		&& (s[i1+char_to_push_count]!=DEBUG_INFO_COORD_MARK)) {
+            && (s[i1+char_to_push_count]!=DEBUG_INFO_COORD_MARK)) {
         char_to_push_count++;
     }
     if (char_to_push_count!=0) {
@@ -142,13 +142,13 @@ for (;;) {
         return 1;
     }
     if (s[i1]==DEBUG_INFO_COORD_MARK) {
-    	/* If we have found the debug mark indicating the end of the real output,
-    	 * we rawly copy the end of the output without interpreting it,
-    	 * or return if we were in capture mode */
-    	if (capture_in_debug_mode) return 1;
-    	char_to_push_count=u_strlen(s+i1);
-    	push_array(stack,&s[i1],char_to_push_count);
-    	return 1;
+        /* If we have found the debug mark indicating the end of the real output,
+         * we rawly copy the end of the output without interpreting it,
+         * or return if we were in capture mode */
+        if (capture_in_debug_mode) return 1;
+        char_to_push_count=u_strlen(s+i1);
+        push_array(stack,&s[i1],char_to_push_count);
+        return 1;
     }
     /* Now we are sure to have s[i1]=='$' */
     {
@@ -156,17 +156,17 @@ for (;;) {
       unichar name[MAX_TRANSDUCTION_VAR_LENGTH];
       int l=0;
       if (s[i1+1]=='{') {
-    	  /* If we have a weight of the form ${n}$ */
-    	  int weight;
-    	  unichar foo1,foo2;
-    	  int ret=u_sscanf(s+i1+2,"%d%C%C%n",&weight,&foo1,&foo2,&l);
-    	  int ok=ret==3 && weight>=0 && foo1=='}' && foo2=='$';
-    	  if (!ok) {
-  	          fatal_error("Output error: invalid weight definition %S\n",s+i1);
-   	      }
-    	  i1+=l+2;
-    	  p->weight=weight;
-    	  continue;
+          /* If we have a weight of the form ${n}$ */
+          int weight;
+          unichar foo1,foo2;
+          int ret=u_sscanf(s+i1+2,"%d%C%C%n",&weight,&foo1,&foo2,&l);
+          int ok=ret==3 && weight>=0 && foo1=='}' && foo2=='$';
+          if (!ok) {
+              fatal_error("Output error: invalid weight definition %S\n",s+i1);
+          }
+          i1+=l+2;
+          p->weight=weight;
+          continue;
       }
       i1++;
       while (is_variable_char(s[i1]) && l<MAX_TRANSDUCTION_VAR_LENGTH) {
@@ -211,93 +211,93 @@ for (;;) {
          }
          i1++;
          if (u_starts_with(field,"EQUAL=")) {
-        	 int n=compare_variables(name,field+6,p,1); // strlen("EQUAL=") == 6
-        	 if (n==VAR_CMP_EQUAL) {
-        		 continue;
-        	 }
-        	 if (n==VAR_CMP_DIFF) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-        	    case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-        	    case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-        	                                  * so we consider it to be equivalent to backtrack */
-        	    case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        	 }
+             int n=compare_variables(name,field+6,p,1); // strlen("EQUAL=") == 6
+             if (n==VAR_CMP_EQUAL) {
+                 continue;
+             }
+             if (n==VAR_CMP_DIFF) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+             }
          } else if (u_starts_with(field,"EQUALcC=")) {
-        	 int n=compare_variables(name,field+8,p,0); // strlen("EQUALcC=") == 8
-        	 if (n==VAR_CMP_EQUAL) {
-        		 continue;
-        	 }
-        	 if (n==VAR_CMP_DIFF) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-        	    case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-        	    case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-        	                                  * so we consider it to be equivalent to backtrack */
-        	    case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        	 }
+             int n=compare_variables(name,field+8,p,0); // strlen("EQUALcC=") == 8
+             if (n==VAR_CMP_EQUAL) {
+                 continue;
+             }
+             if (n==VAR_CMP_DIFF) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+             }
          } else if (u_starts_with(field,"UNEQUAL=")) {
-        	 int n=compare_variables(name,field+8,p,1); // strlen("UNEQUAL=") == 8
-        	 if (n==VAR_CMP_DIFF) continue;
-        	 if (n==VAR_CMP_EQUAL) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-        	    case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-        	    case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-        	                                  * so we consider it to be equivalent to backtrack */
-        	    case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        	 }
+             int n=compare_variables(name,field+8,p,1); // strlen("UNEQUAL=") == 8
+             if (n==VAR_CMP_DIFF) continue;
+             if (n==VAR_CMP_EQUAL) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+             }
          } else if (u_starts_with(field,"UNEQUALcC=")) {
-        	 int n=compare_variables(name,field+10,p,0); // strlen("UNEQUALcC=") == 10
-        	 if (n==VAR_CMP_DIFF) continue;
-        	 if (n==VAR_CMP_EQUAL) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-        	    case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-        	    case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-        	                                  * so we consider it to be equivalent to backtrack */
-        	    case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        	 }
+             int n=compare_variables(name,field+10,p,0); // strlen("UNEQUALcC=") == 10
+             if (n==VAR_CMP_DIFF) continue;
+             if (n==VAR_CMP_EQUAL) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+             }
          } else if (u_starts_with(field,"SUBSTR.")) {
-        	 int n=compare_variables_substr(name,field+7,p,0); // strlen("UNEQUALcC=") == 10
-        	 if (n==VAR_CMP_EQUAL) continue;
-        	 if (n==VAR_CMP_DIFF) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-        	    case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-        	    case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-											  * so we consider it to be equivalent to backtrack */
-     	        case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        	 }
+             int n=compare_variables_substr(name,field+7,p,0); // strlen("UNEQUALcC=") == 10
+             if (n==VAR_CMP_EQUAL) continue;
+             if (n==VAR_CMP_DIFF) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+             }
          } else if (u_starts_with(field,"NOT_SUBSTR.")) {
-        	 int n=compare_variables_substr(name,field+11,p,0); // strlen("UNEQUALcC=") == 10
-        	 if (n==VAR_CMP_DIFF) continue;
-        	 if (n==VAR_CMP_EQUAL) {
-        		 stack->stack_pointer=old_stack_pointer;
-        		 return 0;
-        	 }
-        	 /* n==VAR_CMP_ERROR means an error while accessing variables */
-        	 switch (p->variable_error_policy) {
-				case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
-				case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
-											  * so we consider it to be equivalent to backtrack */
-				case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-     	 }
+             int n=compare_variables_substr(name,field+11,p,0); // strlen("UNEQUALcC=") == 10
+             if (n==VAR_CMP_DIFF) continue;
+             if (n==VAR_CMP_EQUAL) {
+                 stack->stack_pointer=old_stack_pointer;
+                 return 0;
+             }
+             /* n==VAR_CMP_ERROR means an error while accessing variables */
+             switch (p->variable_error_policy) {
+                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: empty field: $%S.$\n",name); break;
+                case IGNORE_VARIABLE_ERRORS: /* This mode is not relevant for variable comparison,
+                                              * so we consider it to be equivalent to backtrack */
+                case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+         }
       }
 
 
@@ -305,19 +305,19 @@ for (;;) {
              /* Case of a variable like $a$ that can be either a normal one or an output one */
              struct transduction_variable* v=get_transduction_variable(p->input_variables,name);
              if (v==NULL) {
-           	  /* Not a normal one ? Maybe an output one */
-           	  const Ustring* output=get_output_variable(p->output_variables,name);
-           	  if (output==NULL) {
-           		  switch (p->variable_error_policy) {
-       				  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
-       				  case IGNORE_VARIABLE_ERRORS: continue;
-       				  case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-           		  }
-           	  }
-           	  unichar* tmp = u_strdup(output->str);
-           	  u_tolower(tmp);
-           	  push_output_string(stack,tmp);
-           	  free(tmp);
+              /* Not a normal one ? Maybe an output one */
+              const Ustring* output=get_output_variable(p->output_variables,name);
+              if (output==NULL) {
+                  switch (p->variable_error_policy) {
+                      case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
+                      case IGNORE_VARIABLE_ERRORS: continue;
+                      case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+                  }
+              }
+              unichar* tmp = u_strdup(output->str);
+              u_tolower(tmp);
+              push_output_string(stack,tmp);
+              free(tmp);
               } else if (v->start_in_tokens==UNDEF_VAR_BOUND) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: starting position of variable $%S$ undefined\n",name); break;
@@ -331,7 +331,7 @@ for (;;) {
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
               } else if (v->start_in_tokens>v->end_in_tokens
-        				  || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
+                          || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end position before starting position for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
@@ -339,89 +339,89 @@ for (;;) {
                  }
 
 
-        		 /* begin of GV fix */
-        		 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
-        		    and v->start_in_tokens==v->end_in_tokens
-        			here we known that v->start_in_tokens <= v->end_in_tokens
-        			*/
+                 /* begin of GV fix */
+                 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
+                    and v->start_in_tokens==v->end_in_tokens
+                    here we known that v->start_in_tokens <= v->end_in_tokens
+                    */
 
               } else if (v->end_in_tokens+p->current_origin > p->buffer_size) {
                  if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {
                    error("Output warning: end variable position after end of text for variable $%S$\n",name);
                    /*error("start=%d  end=%d   origin=%d   buffer size=%d\n",v->start_in_tokens,v->end_in_tokens,p->current_origin,p->buffer_size);
                    for (int i=p->current_origin;i<p->buffer_size;i++) {
-                	   error("%S",p->tokens->value[p->buffer[i]]);
+                       error("%S",p->tokens->value[p->buffer[i]]);
                    }
                    error("\n");*/
-        		 }
+                 }
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end variable position after end of text for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
 
-        		 /* end of GV fix */
+                 /* end of GV fix */
 
 
               } else {
-            	  /* If the normal variable definition is correct */
-            	  /* Case 1: start and end in the same token*/
-            	  if (v->start_in_tokens==v->end_in_tokens-1) {
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-            		  for (int k=v->start_in_chars;k<=last;k++) {
-            			  push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
-            		  }
-            	  } else if (v->start_in_tokens==v->end_in_tokens) {
-            		  /* If the variable is empty, do nothing */
-            	  } else {
-            		  /* Case 2: first we deal with first token */
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  unichar* tmp = u_strdup(tok+v->start_in_chars);
-            		  u_tolower(tmp);
-            		  push_input_string(stack,tmp,p->protect_dic_chars);
-            		  free(tmp);
-            		  /* Then we copy all tokens until the last one */
-                	  for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
-                		  unichar* tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
-                		  u_tolower(tmp2);
-                		  push_input_string(stack,tmp2,p->protect_dic_chars);
-                		  free(tmp2);
-                	  }
+                  /* If the normal variable definition is correct */
+                  /* Case 1: start and end in the same token*/
+                  if (v->start_in_tokens==v->end_in_tokens-1) {
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                      for (int k=v->start_in_chars;k<=last;k++) {
+                          push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
+                      }
+                  } else if (v->start_in_tokens==v->end_in_tokens) {
+                      /* If the variable is empty, do nothing */
+                  } else {
+                      /* Case 2: first we deal with first token */
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      unichar* tmp = u_strdup(tok+v->start_in_chars);
+                      u_tolower(tmp);
+                      push_input_string(stack,tmp,p->protect_dic_chars);
+                      free(tmp);
+                      /* Then we copy all tokens until the last one */
+                      for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
+                          unichar* tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
+                          u_tolower(tmp2);
+                          push_input_string(stack,tmp2,p->protect_dic_chars);
+                          free(tmp2);
+                      }
 
-                	  /* Finally, we copy the last token */
+                      /* Finally, we copy the last token */
 
-                	  if ((v->end_in_tokens-1+p->current_origin) < 0) {
-                		  error("v->end_in_tokens-1+p->current_origin is below 0\n");
-                		  error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
-                	  }
-                	  else {
-                		  tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
-                		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-                		  for (int k=0;k<=last;k++) {
-                		    push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
-                	  	}
-                	  }
-            	  }
+                      if ((v->end_in_tokens-1+p->current_origin) < 0) {
+                          error("v->end_in_tokens-1+p->current_origin is below 0\n");
+                          error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
+                      }
+                      else {
+                          tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
+                          int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                          for (int k=0;k<=last;k++) {
+                            push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
+                        }
+                      }
+                  }
               }
          }
          else if (!u_strcmp(field,"TO_UPPER")) {
              /* Case of a variable like $a$ that can be either a normal one or an output one */
              struct transduction_variable* v=get_transduction_variable(p->input_variables,name);
              if (v==NULL) {
-           	  /* Not a normal one ? Maybe an output one */
-           	  const Ustring* output=get_output_variable(p->output_variables,name);
-           	  if (output==NULL) {
-           		  switch (p->variable_error_policy) {
-       				  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
-       				  case IGNORE_VARIABLE_ERRORS: continue;
-       				  case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-           		  }
-           	  }
-           	  unichar* tmp = u_strdup(output->str);
-           	  u_toupper(tmp);
-           	  push_output_string(stack,tmp);
-           	  free(tmp);
+              /* Not a normal one ? Maybe an output one */
+              const Ustring* output=get_output_variable(p->output_variables,name);
+              if (output==NULL) {
+                  switch (p->variable_error_policy) {
+                      case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
+                      case IGNORE_VARIABLE_ERRORS: continue;
+                      case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+                  }
+              }
+              unichar* tmp = u_strdup(output->str);
+              u_toupper(tmp);
+              push_output_string(stack,tmp);
+              free(tmp);
               } else if (v->start_in_tokens==UNDEF_VAR_BOUND) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: starting position of variable $%S$ undefined\n",name); break;
@@ -435,7 +435,7 @@ for (;;) {
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
               } else if (v->start_in_tokens>v->end_in_tokens
-        				  || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
+                          || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end position before starting position for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
@@ -443,90 +443,90 @@ for (;;) {
                  }
 
 
-        		 /* begin of GV fix */
-        		 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
-        		    and v->start_in_tokens==v->end_in_tokens
-        			here we known that v->start_in_tokens <= v->end_in_tokens
-        			*/
+                 /* begin of GV fix */
+                 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
+                    and v->start_in_tokens==v->end_in_tokens
+                    here we known that v->start_in_tokens <= v->end_in_tokens
+                    */
 
               } else if (v->end_in_tokens+p->current_origin > p->buffer_size) {
                  if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {
                    error("Output warning: end variable position after end of text for variable $%S$\n",name);
                    /*error("start=%d  end=%d   origin=%d   buffer size=%d\n",v->start_in_tokens,v->end_in_tokens,p->current_origin,p->buffer_size);
                    for (int i=p->current_origin;i<p->buffer_size;i++) {
-                	   error("%S",p->tokens->value[p->buffer[i]]);
+                       error("%S",p->tokens->value[p->buffer[i]]);
                    }
                    error("\n");*/
-        		 }
+                 }
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end variable position after end of text for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
 
-        		 /* end of GV fix */
+                 /* end of GV fix */
 
 
               } else {
-            	  /* If the normal variable definition is correct */
-            	  /* Case 1: start and end in the same token*/
-            	  if (v->start_in_tokens==v->end_in_tokens-1) {
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-            		  for (int k=v->start_in_chars;k<=last;k++) {
-            			  push_input_char(stack,u_toupper(tok[k]),p->protect_dic_chars);
-            		  }
-            	  } else if (v->start_in_tokens==v->end_in_tokens) {
-            		  /* If the variable is empty, do nothing */
-            	  } else {
-            		  /* Case 2: first we deal with first token */
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  unichar* tmp = u_strdup(tok+v->start_in_chars);
-            		  u_toupper(tmp);
-            		  push_input_string(stack,tmp,p->protect_dic_chars);
-            		  free(tmp);
-            		  /* Then we copy all tokens until the last one */
-                	  for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
-                		  unichar *tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
-                		  u_toupper(tmp2);
-                		  push_input_string(stack,tmp2,p->protect_dic_chars);
-                		  free(tmp2);
-                	  }
+                  /* If the normal variable definition is correct */
+                  /* Case 1: start and end in the same token*/
+                  if (v->start_in_tokens==v->end_in_tokens-1) {
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                      for (int k=v->start_in_chars;k<=last;k++) {
+                          push_input_char(stack,u_toupper(tok[k]),p->protect_dic_chars);
+                      }
+                  } else if (v->start_in_tokens==v->end_in_tokens) {
+                      /* If the variable is empty, do nothing */
+                  } else {
+                      /* Case 2: first we deal with first token */
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      unichar* tmp = u_strdup(tok+v->start_in_chars);
+                      u_toupper(tmp);
+                      push_input_string(stack,tmp,p->protect_dic_chars);
+                      free(tmp);
+                      /* Then we copy all tokens until the last one */
+                      for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
+                          unichar *tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
+                          u_toupper(tmp2);
+                          push_input_string(stack,tmp2,p->protect_dic_chars);
+                          free(tmp2);
+                      }
 
-                	  /* Finally, we copy the last token */
+                      /* Finally, we copy the last token */
 
-                	  if ((v->end_in_tokens-1+p->current_origin) < 0) {
-                		  error("v->end_in_tokens-1+p->current_origin is below 0\n");
-                		  error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
-                	  }
-                	  else {
-                		  tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
-                		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-                		  for (int k=0;k<=last;k++) {
-                		    push_input_char(stack,u_toupper(tok[k]),p->protect_dic_chars);
-                	  	}
-                	  }
-            	  }
+                      if ((v->end_in_tokens-1+p->current_origin) < 0) {
+                          error("v->end_in_tokens-1+p->current_origin is below 0\n");
+                          error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
+                      }
+                      else {
+                          tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
+                          int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                          for (int k=0;k<=last;k++) {
+                            push_input_char(stack,u_toupper(tok[k]),p->protect_dic_chars);
+                        }
+                      }
+                  }
               }
          }
          else if (!u_strcmp(field,"TO_FIRSTUPPER")) {
              /* Case of a variable like $a$ that can be either a normal one or an output one */
              struct transduction_variable* v=get_transduction_variable(p->input_variables,name);
              if (v==NULL) {
-           	  /* Not a normal one ? Maybe an output one */
-           	  const Ustring* output=get_output_variable(p->output_variables,name);
-           	  if (output==NULL) {
-           		  switch (p->variable_error_policy) {
-       				  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
-       				  case IGNORE_VARIABLE_ERRORS: continue;
-       				  case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-           		  }
-           	  }
-           	  unichar* tmp = u_strdup(output->str);
-           	  push_output_char(stack,u_toupper(tmp[0]));
-           	  u_tolower(tmp);
-           	  push_output_string(stack,tmp+1);
-           	  free(tmp);
+              /* Not a normal one ? Maybe an output one */
+              const Ustring* output=get_output_variable(p->output_variables,name);
+              if (output==NULL) {
+                  switch (p->variable_error_policy) {
+                      case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
+                      case IGNORE_VARIABLE_ERRORS: continue;
+                      case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+                  }
+              }
+              unichar* tmp = u_strdup(output->str);
+              push_output_char(stack,u_toupper(tmp[0]));
+              u_tolower(tmp);
+              push_output_string(stack,tmp+1);
+              free(tmp);
               } else if (v->start_in_tokens==UNDEF_VAR_BOUND) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: starting position of variable $%S$ undefined\n",name); break;
@@ -540,7 +540,7 @@ for (;;) {
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
               } else if (v->start_in_tokens>v->end_in_tokens
-        				  || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
+                          || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end position before starting position for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
@@ -548,72 +548,72 @@ for (;;) {
                  }
 
 
-        		 /* begin of GV fix */
-        		 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
-        		    and v->start_in_tokens==v->end_in_tokens
-        			here we known that v->start_in_tokens <= v->end_in_tokens
-        			*/
+                 /* begin of GV fix */
+                 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
+                    and v->start_in_tokens==v->end_in_tokens
+                    here we known that v->start_in_tokens <= v->end_in_tokens
+                    */
 
               } else if (v->end_in_tokens+p->current_origin > p->buffer_size) {
                  if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {
                    error("Output warning: end variable position after end of text for variable $%S$\n",name);
                    /*error("start=%d  end=%d   origin=%d   buffer size=%d\n",v->start_in_tokens,v->end_in_tokens,p->current_origin,p->buffer_size);
                    for (int i=p->current_origin;i<p->buffer_size;i++) {
-                	   error("%S",p->tokens->value[p->buffer[i]]);
+                       error("%S",p->tokens->value[p->buffer[i]]);
                    }
                    error("\n");*/
-        		 }
+                 }
                  switch (p->variable_error_policy) {
                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end variable position after end of text for variable $%S$\n",name); break;
                     case IGNORE_VARIABLE_ERRORS: continue;
                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
                  }
 
-        		 /* end of GV fix */
+                 /* end of GV fix */
 
 
               } else {
-            	  /* If the normal variable definition is correct */
-            	  /* Case 1: start and end in the same token*/
-            	  if (v->start_in_tokens==v->end_in_tokens-1) {
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-            		  push_input_char(stack,u_toupper(tok[v->start_in_chars]),p->protect_dic_chars);
-            		  for (int k=v->start_in_chars+1;k<=last;k++) {
-            			  push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
-            		  }
-            	  } else if (v->start_in_tokens==v->end_in_tokens) {
-            		  /* If the variable is empty, do nothing */
-            	  } else {
-            		  /* Case 2: first we deal with first token */
-            		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-            		  unichar* tmp = u_strdup(tok+v->start_in_chars);
-            		  push_input_char(stack,u_toupper(tmp[0]),p->protect_dic_chars);
-            		  u_tolower(tmp);
-            		  push_input_string(stack,tmp+1,p->protect_dic_chars);
-            		  free(tmp);
-            		  /* Then we copy all tokens until the last one */
-                	  for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
-                		  unichar* tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
-                		  u_tolower(tmp2);
-                		  push_input_string(stack,tmp2,p->protect_dic_chars);
-                		  free(tmp2);
-                	  }
+                  /* If the normal variable definition is correct */
+                  /* Case 1: start and end in the same token*/
+                  if (v->start_in_tokens==v->end_in_tokens-1) {
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                      push_input_char(stack,u_toupper(tok[v->start_in_chars]),p->protect_dic_chars);
+                      for (int k=v->start_in_chars+1;k<=last;k++) {
+                          push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
+                      }
+                  } else if (v->start_in_tokens==v->end_in_tokens) {
+                      /* If the variable is empty, do nothing */
+                  } else {
+                      /* Case 2: first we deal with first token */
+                      unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+                      unichar* tmp = u_strdup(tok+v->start_in_chars);
+                      push_input_char(stack,u_toupper(tmp[0]),p->protect_dic_chars);
+                      u_tolower(tmp);
+                      push_input_string(stack,tmp+1,p->protect_dic_chars);
+                      free(tmp);
+                      /* Then we copy all tokens until the last one */
+                      for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
+                          unichar* tmp2 = u_strdup(p->tokens->value[p->buffer[k+p->current_origin]]);
+                          u_tolower(tmp2);
+                          push_input_string(stack,tmp2,p->protect_dic_chars);
+                          free(tmp2);
+                      }
 
-                	  /* Finally, we copy the last token */
+                      /* Finally, we copy the last token */
 
-                	  if ((v->end_in_tokens-1+p->current_origin) < 0) {
-                		  error("v->end_in_tokens-1+p->current_origin is below 0\n");
-                		  error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
-                	  }
-                	  else {
-                		  tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
-                		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-                		  for (int k=0;k<=last;k++) {
-                		    push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
-                	  	}
-                	  }
-            	  }
+                      if ((v->end_in_tokens-1+p->current_origin) < 0) {
+                          error("v->end_in_tokens-1+p->current_origin is below 0\n");
+                          error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
+                      }
+                      else {
+                          tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
+                          int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                          for (int k=0;k<=last;k++) {
+                            push_input_char(stack,u_tolower(tok[k]),p->protect_dic_chars);
+                        }
+                      }
+                  }
               }
          }
 
@@ -653,9 +653,9 @@ for (;;) {
              * try to match an output one */
             const Ustring* output=get_output_variable(p->output_variables,name);
             if (output==NULL) {
-            	/* We do nothing, since this output variable may not exist */
+                /* We do nothing, since this output variable may not exist */
             } else {
-            	if (output->len==0) {
+                if (output->len==0) {
                   /* If the variable is empty */
                   if (field[0]=='S') {
                      /* $a.SET$ is false, we backtrack */
@@ -735,17 +735,17 @@ for (;;) {
                push_input_string(stack,entry->inflected,p->protect_dic_chars);
             }
          } else if (!u_strcmp(field,"LEMMA")) {
-        	 push_input_string(stack,entry->lemma,p->protect_dic_chars);
+             push_input_string(stack,entry->lemma,p->protect_dic_chars);
          } else if (!u_strcmp(field,"CODE")) {
-        	push_output_string(stack,entry->semantic_codes[0]);
-        	for (int i=1;i<entry->n_semantic_codes;i++) {
-        		push_output_char(stack,'+');
-        	   push_output_string(stack,entry->semantic_codes[i]);
-        	}
-        	for (int i=0;i<entry->n_inflectional_codes;i++) {
-        	   push_output_char(stack,':');
-        	   push_output_string(stack,entry->inflectional_codes[i]);
-        	}
+            push_output_string(stack,entry->semantic_codes[0]);
+            for (int i=1;i<entry->n_semantic_codes;i++) {
+                push_output_char(stack,'+');
+               push_output_string(stack,entry->semantic_codes[i]);
+            }
+            for (int i=0;i<entry->n_inflectional_codes;i++) {
+               push_output_char(stack,':');
+               push_output_string(stack,entry->inflectional_codes[i]);
+            }
          } else if (!u_strcmp(field,"CODE.GRAM")) {
             push_output_string(stack,entry->semantic_codes[0]);
          } else if (!u_strcmp(field,"CODE.SEM")) {
@@ -765,27 +765,27 @@ for (;;) {
                 }
              }
           } else if (u_starts_with(field,"CODE.ATTR=")) {
-        	  unichar* attr_name=field+10;
-        	  int attr_len=u_strlen(attr_name);
-        	  int i;
-        	  for (i=0;i<entry->n_semantic_codes;i++) {
-        		  if (u_starts_with(entry->semantic_codes[i],attr_name)) {
-        			  if (entry->semantic_codes[i][attr_len]!='='
-        					  || entry->semantic_codes[i][attr_len+1]=='\0') {
-        				  continue;
-        			  }
-        			  push_output_string(stack,entry->semantic_codes[i]+attr_len+1);
-        			  break;
-        		  }
-        	  }
-        	  if (i==entry->n_semantic_codes) {
-        		  /* If the attribute was not found, it's an error case */
-        		  switch (p->variable_error_policy) {
-        		     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Attribute %S not found in a captured entry\n",attr_name); break;
-        		     case IGNORE_VARIABLE_ERRORS: continue;
-        		     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-        		  }
-        	  }
+              unichar* attr_name=field+10;
+              int attr_len=u_strlen(attr_name);
+              int i;
+              for (i=0;i<entry->n_semantic_codes;i++) {
+                  if (u_starts_with(entry->semantic_codes[i],attr_name)) {
+                      if (entry->semantic_codes[i][attr_len]!='='
+                              || entry->semantic_codes[i][attr_len+1]=='\0') {
+                          continue;
+                      }
+                      push_output_string(stack,entry->semantic_codes[i]+attr_len+1);
+                      break;
+                  }
+              }
+              if (i==entry->n_semantic_codes) {
+                  /* If the attribute was not found, it's an error case */
+                  switch (p->variable_error_policy) {
+                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Attribute %S not found in a captured entry\n",attr_name); break;
+                     case IGNORE_VARIABLE_ERRORS: continue;
+                     case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+                  }
+              }
            } else {
             switch (p->variable_error_policy) {
                case EXIT_ON_VARIABLE_ERRORS: fatal_error("Invalid morphological variable field $%S.%S$\n",name,field); break;
@@ -798,22 +798,22 @@ for (;;) {
       i1++;
       if (l==0) {
          /* Case of $$ in order to print a $ */
-    	  push_output_char(stack,'$');
+          push_output_char(stack,'$');
          continue;
       }
       /* Case of a variable like $a$ that can be either a normal one or an output one */
       struct transduction_variable* v=get_transduction_variable(p->input_variables,name);
       if (v==NULL) {
-    	  /* Not a normal one ? Maybe an output one */
-    	  const Ustring* output=get_output_variable(p->output_variables,name);
-    	  if (output==NULL) {
-    		  switch (p->variable_error_policy) {
-				  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
-				  case IGNORE_VARIABLE_ERRORS: continue;
-				  case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
-    		  }
-    	  }
-    	  push_output_string(stack,output->str);
+          /* Not a normal one ? Maybe an output one */
+          const Ustring* output=get_output_variable(p->output_variables,name);
+          if (output==NULL) {
+              switch (p->variable_error_policy) {
+                  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name); break;
+                  case IGNORE_VARIABLE_ERRORS: continue;
+                  case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
+              }
+          }
+          push_output_string(stack,output->str);
       } else if (v->start_in_tokens==UNDEF_VAR_BOUND) {
          switch (p->variable_error_policy) {
             case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: starting position of variable $%S$ undefined\n",name); break;
@@ -827,7 +827,7 @@ for (;;) {
             case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
          }
       } else if (v->start_in_tokens>v->end_in_tokens
-				  || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
+                  || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars==-1 && v->end_in_chars<v->start_in_chars)) {
          switch (p->variable_error_policy) {
             case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end position before starting position for variable $%S$\n",name); break;
             case IGNORE_VARIABLE_ERRORS: continue;
@@ -835,64 +835,64 @@ for (;;) {
          }
 
 
-		 /* begin of GV fix */
-		 /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
-		    and v->start_in_tokens==v->end_in_tokens
-			here we known that v->start_in_tokens <= v->end_in_tokens
-			*/
+         /* begin of GV fix */
+         /* this fix is against a crash I found when (v->start_in_tokens+p->current_origin == p->buffer_size)
+            and v->start_in_tokens==v->end_in_tokens
+            here we known that v->start_in_tokens <= v->end_in_tokens
+            */
 
       } else if (v->end_in_tokens+p->current_origin > p->buffer_size) {
          if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {
            error("Output warning: end variable position after end of text for variable $%S$\n",name);
            /*error("start=%d  end=%d   origin=%d   buffer size=%d\n",v->start_in_tokens,v->end_in_tokens,p->current_origin,p->buffer_size);
            for (int i=p->current_origin;i<p->buffer_size;i++) {
-        	   error("%S",p->tokens->value[p->buffer[i]]);
+               error("%S",p->tokens->value[p->buffer[i]]);
            }
            error("\n");*/
-		 }
+         }
          switch (p->variable_error_policy) {
             case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end variable position after end of text for variable $%S$\n",name); break;
             case IGNORE_VARIABLE_ERRORS: continue;
             case BACKTRACK_ON_VARIABLE_ERRORS: stack->stack_pointer=old_stack_pointer; return 0;
          }
 
-		 /* end of GV fix */
+         /* end of GV fix */
 
 
       } else {
-    	  /* If the normal variable definition is correct */
-    	  /* Case 1: start and end in the same token*/
-    	  if (v->start_in_tokens==v->end_in_tokens-1) {
-    		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-    		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-    		  for (int k=v->start_in_chars;k<=last;k++) {
-    			  push_input_char(stack,tok[k],p->protect_dic_chars);
-    		  }
-    	  } else if (v->start_in_tokens==v->end_in_tokens) {
-    		  /* If the variable is empty, do nothing */
-    	  } else {
-    		  /* Case 2: first we deal with first token */
-    		  unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-    		  push_input_string(stack,tok+v->start_in_chars,p->protect_dic_chars);
-    		  /* Then we copy all tokens until the last one */
-        	  for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
-        		  push_input_string(stack,p->tokens->value[p->buffer[k+p->current_origin]],p->protect_dic_chars);
-        	  }
+          /* If the normal variable definition is correct */
+          /* Case 1: start and end in the same token*/
+          if (v->start_in_tokens==v->end_in_tokens-1) {
+              unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+              int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+              for (int k=v->start_in_chars;k<=last;k++) {
+                  push_input_char(stack,tok[k],p->protect_dic_chars);
+              }
+          } else if (v->start_in_tokens==v->end_in_tokens) {
+              /* If the variable is empty, do nothing */
+          } else {
+              /* Case 2: first we deal with first token */
+              unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+              push_input_string(stack,tok+v->start_in_chars,p->protect_dic_chars);
+              /* Then we copy all tokens until the last one */
+              for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
+                  push_input_string(stack,p->tokens->value[p->buffer[k+p->current_origin]],p->protect_dic_chars);
+              }
 
-        	  /* Finally, we copy the last token */
+              /* Finally, we copy the last token */
 
-        	  if ((v->end_in_tokens-1+p->current_origin) < 0) {
-        		  error("v->end_in_tokens-1+p->current_origin is below 0\n");
-        		  error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
-        	  }
-        	  else {
-        		  tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
-        		  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-        		  for (int k=0;k<=last;k++) {
-        		    push_input_char(stack,tok[k],p->protect_dic_chars);
-        	  	}
-        	  }
-    	  }
+              if ((v->end_in_tokens-1+p->current_origin) < 0) {
+                  error("v->end_in_tokens-1+p->current_origin is below 0\n");
+                  error("start=%d  end=%d\n",v->start_in_tokens,v->end_in_tokens);
+              }
+              else {
+                  tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
+                  int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+                  for (int k=0;k<=last;k++) {
+                    push_input_char(stack,tok[k],p->protect_dic_chars);
+                }
+              }
+          }
       }
    }
 }
@@ -907,29 +907,29 @@ int deal_with_output(unichar* output,struct locate_parameters* p,int *captured_c
 struct stack_unichar* stack=p->stack;
 int capture=capture_mode(p->output_variables);
 if (capture) {
-	stack=new_stack_unichar(4096);
-	if (p->debug) {
-		/* In debug mode, an output to be captured must still be
-		 * added to the normal stack, to trace the explored grammar
-		 * path. But, in this case, we remove the actual output part,
-		 * since no output is really produced there */
-		push_output_char(p->stack,DEBUG_INFO_OUTPUT_MARK);
-		int i;
-		for (i=0;output[i]!=DEBUG_INFO_COORD_MARK;i++) {
-		}
-		push_output_string(p->stack,output+i);
-	}
+    stack=new_stack_unichar(4096);
+    if (p->debug) {
+        /* In debug mode, an output to be captured must still be
+         * added to the normal stack, to trace the explored grammar
+         * path. But, in this case, we remove the actual output part,
+         * since no output is really produced there */
+        push_output_char(p->stack,DEBUG_INFO_OUTPUT_MARK);
+        int i;
+        for (i=0;output[i]!=DEBUG_INFO_COORD_MARK;i++) {
+        }
+        push_output_string(p->stack,output+i);
+    }
 }
 if (!process_output(output,p,stack,capture && p->debug)) {
-	if (capture) {
-		free_stack_unichar(stack);
-	}
-	return 0;
+    if (capture) {
+        free_stack_unichar(stack);
+    }
+    return 0;
 }
 if (capture) {
-	stack->stack[stack->stack_pointer+1]='\0';
-	*captured_chars=add_raw_string_to_output_variables(p->output_variables,stack->stack);
-	free_stack_unichar(stack);
+    stack->stack[stack->stack_pointer+1]='\0';
+    *captured_chars=add_raw_string_to_output_variables(p->output_variables,stack->stack);
+    free_stack_unichar(stack);
 }
 return 1;
 }

--- a/TransductionStack.cpp
+++ b/TransductionStack.cpp
@@ -842,14 +842,14 @@ for (;;) {
 			*/
 
       } else if (v->end_in_tokens+p->current_origin > p->buffer_size) {
-         if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {			 
+         if (p->variable_error_policy != EXIT_ON_VARIABLE_ERRORS) {
            error("Output warning: end variable position after end of text for variable $%S$\n",name);
            /*error("start=%d  end=%d   origin=%d   buffer size=%d\n",v->start_in_tokens,v->end_in_tokens,p->current_origin,p->buffer_size);
            for (int i=p->current_origin;i<p->buffer_size;i++) {
         	   error("%S",p->tokens->value[p->buffer[i]]);
            }
            error("\n");*/
-		 } 
+		 }
          switch (p->variable_error_policy) {
             case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: end variable position after end of text for variable $%S$\n",name); break;
             case IGNORE_VARIABLE_ERRORS: continue;

--- a/TransductionStackTfst.cpp
+++ b/TransductionStackTfst.cpp
@@ -99,7 +99,7 @@ u_strcat(stack,s);
 
 
 /**
- * Inserts the text interval defined by the parameters into the given string. 
+ * Inserts the text interval defined by the parameters into the given string.
  */
 void insert_text_interval_tfst(struct locate_tfst_infos* infos,Ustring* s,int start_token,int start_char,
                                int end_token,int end_char) {
@@ -107,7 +107,7 @@ void insert_text_interval_tfst(struct locate_tfst_infos* infos,Ustring* s,int st
 if (start_token>end_token || (start_token==end_token && start_char>end_char)) {
    /* In Korean, when we have a match made of several TfstTags containing less than
     * a character (for instance, a logical letter), then we can arrive here with a
-    * start position that has already been increased of 1 since the last TfstTag 
+    * start position that has already been increased of 1 since the last TfstTag
     * was dealt with. So, we can have things like 0.2 -> 0.1 and such things must
     * be ignored */
    return;

--- a/TransductionStackTfst.cpp
+++ b/TransductionStackTfst.cpp
@@ -46,9 +46,9 @@ return ((c>='A' && c<='Z') || (c>='a' && c<='z') || (c>='0' && c<='9') || c=='_'
  */
 void push_input_char_tfst(Ustring* s,unichar c,int protect_dic_chars) {
 if (protect_dic_chars && (c==',' || c=='.')) {
-	/* We want to protect dots and commas because the Locate program can be used
-	 * by Dico to generate dictionary entries */
-	u_strcat(s,"\\");
+    /* We want to protect dots and commas because the Locate program can be used
+     * by Dico to generate dictionary entries */
+    u_strcat(s,"\\");
 }
 u_strcat(s,c);
 }
@@ -139,7 +139,7 @@ for (;;) {
  * not correctly defined).
  */
 int process_output_tfst(Ustring* stack,const unichar* s,struct locate_tfst_infos* p,
-		int capture_in_debug_mode) {
+        int capture_in_debug_mode) {
 int old_length=stack->len;
 int i=0;
 if (s==NULL) {
@@ -147,17 +147,17 @@ if (s==NULL) {
    return 1;
 }
 if (capture_in_debug_mode) {
-	/* If we have a capture in debug mode, we must skip the initial char #1 */
-	i++;
+    /* If we have a capture in debug mode, we must skip the initial char #1 */
+    i++;
 }
 while (s[i]!='\0') {
     if (s[i]==DEBUG_INFO_COORD_MARK) {
-    	/* If we have found the debug mark indicating the end of the real output,
-    	 * we rawly copy the end of the output without interpreting it,
-    	 * or return if we were in capture mode */
-    	if (capture_in_debug_mode) return 1;
-    	push_output_string_tfst(stack,s+i);
-    	return 1;
+        /* If we have found the debug mark indicating the end of the real output,
+         * we rawly copy the end of the output without interpreting it,
+         * or return if we were in capture mode */
+        if (capture_in_debug_mode) return 1;
+        push_output_string_tfst(stack,s+i);
+        return 1;
     }
 
    if (s[i]=='$') {
@@ -173,7 +173,7 @@ while (s[i]!='\0') {
       }
       name[l]='\0';
       if (s[i]!='$' && s[i]!='.') {
-    	 switch (p->variable_error_policy) {
+         switch (p->variable_error_policy) {
             case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: missing closing $ after $%S\n",name);
             case IGNORE_VARIABLE_ERRORS: continue;
             case BACKTRACK_ON_VARIABLE_ERRORS: {
@@ -201,48 +201,48 @@ while (s[i]!='\0') {
             TfstTag* first_tag=NULL;
             TfstTag* last_tag=NULL;
             if (v==NULL) {
-            	/* We do nothing, since this normal variable may not exist */
+                /* We do nothing, since this normal variable may not exist */
             } else {
                first_tag=(TfstTag*)(p->tfst->tags->tab[v->start_in_tokens]);
                last_tag=(TfstTag*)(p->tfst->tags->tab[v->end_in_tokens]);
                if (v->start_in_tokens==UNDEF_VAR_BOUND || v->end_in_tokens==UNDEF_VAR_BOUND
                   || !valid_text_interval_tfst(&(first_tag->m),&(last_tag->m))) {
-            	   /* If the variable is not defined properly */
-            	   if (field[0]=='S') {
-            		   /* $a.SET$ is false, we backtrack */
-            		   stack->len=old_length;
-            		   stack->str[old_length]='\0';
-            		   return 0;
-            	   } else {
-            		   /* $a.UNSET$ is true, we go on */
-            		   continue;
-            	   }
+                   /* If the variable is not defined properly */
+                   if (field[0]=='S') {
+                       /* $a.SET$ is false, we backtrack */
+                       stack->len=old_length;
+                       stack->str[old_length]='\0';
+                       return 0;
+                   } else {
+                       /* $a.UNSET$ is true, we go on */
+                       continue;
+                   }
                } else {
-            	   /* If the variable is correctly defined */
-            	   if (field[0]=='S') {
-            		   /* $a.SET$ is true, we go on */
-            		   continue;
-            	   } else {
-            		   /* $a.UNSET$ is false, we backtrack */
-            		   stack->len=old_length;
-            		   stack->str[old_length]='\0';
-            		   return 0;
-            	   }
+                   /* If the variable is correctly defined */
+                   if (field[0]=='S') {
+                       /* $a.SET$ is true, we go on */
+                       continue;
+                   } else {
+                       /* $a.UNSET$ is false, we backtrack */
+                       stack->len=old_length;
+                       stack->str[old_length]='\0';
+                       return 0;
+                   }
                }
             }
             /* If we arrive here, the variable was not a normal one, so we
              * try to match an output one */
             const Ustring* output=get_output_variable(p->output_variables,name);
             if (output==NULL) {
-            	/* We do nothing, since this output variable may not exist */
+                /* We do nothing, since this output variable may not exist */
             } else {
                if (output->len==0) {
                   /* If the variable is empty */
                   if (field[0]=='S') {
-                	  /* $a.SET$ is false, we backtrack */
-                	  stack->len=old_length;
-                	  stack->str[old_length]='\0';
-                	  return 0;
+                      /* $a.SET$ is false, we backtrack */
+                      stack->len=old_length;
+                      stack->str[old_length]='\0';
+                      return 0;
                   } else {
                      /* $a.UNSET$ is true, we go on */
                      continue;
@@ -250,126 +250,126 @@ while (s[i]!='\0') {
                } else {
                   /* If the variable is non empty */
                   if (field[0]=='S') {
-                	  /* $a.SET$ is true, we go on */
-                	  continue;
+                      /* $a.SET$ is true, we go on */
+                      continue;
                   } else {
-                	  /* $a.UNSET$ is false, we backtrack */
-                	  stack->len=old_length;
-                	  stack->str[old_length]='\0';
-                	  return 0;
+                      /* $a.UNSET$ is false, we backtrack */
+                      stack->len=old_length;
+                      stack->str[old_length]='\0';
+                      return 0;
                   }
                }
             }
          } else {
-        	 /* Here we deal with dictionary variable things like $a.CODE$ */
-        	 struct dela_entry* entry=get_dic_variable(name,p->dic_variables);
-        	 if (entry==NULL) {
-        		 switch (p->variable_error_policy) {
-					 case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined morphological variable %S\n",name);
-					 case IGNORE_VARIABLE_ERRORS: continue;
-					 case BACKTRACK_ON_VARIABLE_ERRORS: {
-						 stack->len=old_length;
-						 stack->str[old_length]='\0';
-						 return 0;
-					 }
-        		 }
-        	 }
-        	 if (!u_strcmp(field,"INFLECTED")) {
-        		 /* We use push_input_string because it can protect special chars */
-        		 push_input_string_tfst(stack,entry->inflected,1);
-        	 } else if (!u_strcmp(field,"LEMMA")) {
-        		 push_input_string_tfst(stack,entry->lemma,1);
-        	 } else if (!u_strcmp(field,"CODE")) {
-        		 push_output_string_tfst(stack,entry->semantic_codes[0]);
-        		 for (int il=1;il<entry->n_semantic_codes;il++) {
-        			 push_output_char_tfst(stack,'+');
-        			 push_output_string_tfst(stack,entry->semantic_codes[il]);
-        		 }
-        		 for (int il=0;il<entry->n_inflectional_codes;il++) {
-        			 push_output_char_tfst(stack,':');
-        			 push_output_string_tfst(stack,entry->inflectional_codes[il]);
-        		 }
-        	 } else if (!u_strcmp(field,"CAT")) {
-        		 push_output_string_tfst(stack,entry->semantic_codes[0]);
-        		 for (int il=1;il<entry->n_semantic_codes;il++) {
-        			 push_output_char_tfst(stack,'+');
-        			 push_output_string_tfst(stack,entry->semantic_codes[il]);
-        		 }
-        	 } else if (!u_strcmp(field,"CODE.GRAM")) {
-        		 push_output_string_tfst(stack,entry->semantic_codes[0]);
-        	 } else if (!u_strcmp(field,"CODE.SEM")) {
-        		 push_output_string_tfst(stack,entry->semantic_codes[1]);
-        		 for (int il=2;il<entry->n_semantic_codes;il++) {
-        			 push_output_char_tfst(stack,'+');
-        			 push_output_string_tfst(stack,entry->semantic_codes[il]);
-        		 }
-        	 } else if (!u_strcmp(field,"CODE.FLEX")) {
-        		 for (int il=0;il<entry->n_inflectional_codes;il++) {
-        			 push_output_char_tfst(stack,':');
-        			 push_output_string_tfst(stack,entry->inflectional_codes[il]);
-        		 }
-        	 } else if (u_starts_with(field,"CODE.ATTR=")) {
-        		 unichar* attr_name=field+10;
-        		 int attr_len=u_strlen(attr_name);
-        		 int j;
-        		 for (j=0;j<entry->n_semantic_codes;j++) {
-        		    if (u_starts_with(entry->semantic_codes[j],attr_name)) {
-        		       if (entry->semantic_codes[j][attr_len]!='='
-        		          || entry->semantic_codes[j][attr_len+1]=='\0') {
-        		          continue;
-        		       }
-        		       push_output_string_tfst(stack,entry->semantic_codes[j]+attr_len+1);
-        		    }
-        		 }
-        		 if (j==entry->n_semantic_codes) {
-        		    /* If the attribute was not found, it's an error case */
-        		    switch (p->variable_error_policy) {
-        		       case EXIT_ON_VARIABLE_ERRORS: fatal_error("Attribute %S not found in a captured entry\n",attr_name);
-        		       case IGNORE_VARIABLE_ERRORS: continue;
-        		       case BACKTRACK_ON_VARIABLE_ERRORS: {
-  						  stack->len=old_length;
-  						  stack->str[old_length]='\0';
-  						  return 0;
-  					   }
-        		    }
-        		 }
-        	 } else {
-        		 switch (p->variable_error_policy) {
-					 case EXIT_ON_VARIABLE_ERRORS: fatal_error("Invalid morphological variable field $%S.%S$\n",name,field);
-					 case IGNORE_VARIABLE_ERRORS: continue;
-					 case BACKTRACK_ON_VARIABLE_ERRORS: {
-						 stack->len=old_length;
-						 stack->str[old_length]='\0';
-						 return 0;
-					 }
-        		 }
-        	 }
-        	 i++;
-        	 continue;
+             /* Here we deal with dictionary variable things like $a.CODE$ */
+             struct dela_entry* entry=get_dic_variable(name,p->dic_variables);
+             if (entry==NULL) {
+                 switch (p->variable_error_policy) {
+                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined morphological variable %S\n",name);
+                     case IGNORE_VARIABLE_ERRORS: continue;
+                     case BACKTRACK_ON_VARIABLE_ERRORS: {
+                         stack->len=old_length;
+                         stack->str[old_length]='\0';
+                         return 0;
+                     }
+                 }
+             }
+             if (!u_strcmp(field,"INFLECTED")) {
+                 /* We use push_input_string because it can protect special chars */
+                 push_input_string_tfst(stack,entry->inflected,1);
+             } else if (!u_strcmp(field,"LEMMA")) {
+                 push_input_string_tfst(stack,entry->lemma,1);
+             } else if (!u_strcmp(field,"CODE")) {
+                 push_output_string_tfst(stack,entry->semantic_codes[0]);
+                 for (int il=1;il<entry->n_semantic_codes;il++) {
+                     push_output_char_tfst(stack,'+');
+                     push_output_string_tfst(stack,entry->semantic_codes[il]);
+                 }
+                 for (int il=0;il<entry->n_inflectional_codes;il++) {
+                     push_output_char_tfst(stack,':');
+                     push_output_string_tfst(stack,entry->inflectional_codes[il]);
+                 }
+             } else if (!u_strcmp(field,"CAT")) {
+                 push_output_string_tfst(stack,entry->semantic_codes[0]);
+                 for (int il=1;il<entry->n_semantic_codes;il++) {
+                     push_output_char_tfst(stack,'+');
+                     push_output_string_tfst(stack,entry->semantic_codes[il]);
+                 }
+             } else if (!u_strcmp(field,"CODE.GRAM")) {
+                 push_output_string_tfst(stack,entry->semantic_codes[0]);
+             } else if (!u_strcmp(field,"CODE.SEM")) {
+                 push_output_string_tfst(stack,entry->semantic_codes[1]);
+                 for (int il=2;il<entry->n_semantic_codes;il++) {
+                     push_output_char_tfst(stack,'+');
+                     push_output_string_tfst(stack,entry->semantic_codes[il]);
+                 }
+             } else if (!u_strcmp(field,"CODE.FLEX")) {
+                 for (int il=0;il<entry->n_inflectional_codes;il++) {
+                     push_output_char_tfst(stack,':');
+                     push_output_string_tfst(stack,entry->inflectional_codes[il]);
+                 }
+             } else if (u_starts_with(field,"CODE.ATTR=")) {
+                 unichar* attr_name=field+10;
+                 int attr_len=u_strlen(attr_name);
+                 int j;
+                 for (j=0;j<entry->n_semantic_codes;j++) {
+                    if (u_starts_with(entry->semantic_codes[j],attr_name)) {
+                       if (entry->semantic_codes[j][attr_len]!='='
+                          || entry->semantic_codes[j][attr_len+1]=='\0') {
+                          continue;
+                       }
+                       push_output_string_tfst(stack,entry->semantic_codes[j]+attr_len+1);
+                    }
+                 }
+                 if (j==entry->n_semantic_codes) {
+                    /* If the attribute was not found, it's an error case */
+                    switch (p->variable_error_policy) {
+                       case EXIT_ON_VARIABLE_ERRORS: fatal_error("Attribute %S not found in a captured entry\n",attr_name);
+                       case IGNORE_VARIABLE_ERRORS: continue;
+                       case BACKTRACK_ON_VARIABLE_ERRORS: {
+                          stack->len=old_length;
+                          stack->str[old_length]='\0';
+                          return 0;
+                       }
+                    }
+                 }
+             } else {
+                 switch (p->variable_error_policy) {
+                     case EXIT_ON_VARIABLE_ERRORS: fatal_error("Invalid morphological variable field $%S.%S$\n",name,field);
+                     case IGNORE_VARIABLE_ERRORS: continue;
+                     case BACKTRACK_ON_VARIABLE_ERRORS: {
+                         stack->len=old_length;
+                         stack->str[old_length]='\0';
+                         return 0;
+                     }
+                 }
+             }
+             i++;
+             continue;
          }
       }
       i++;
       if (l==0) {
          /* Case of $$ in order to print a $ */
-     	   push_output_char_tfst(stack,'$');
+           push_output_char_tfst(stack,'$');
          continue;
       }
       struct transduction_variable* v=get_transduction_variable(p->input_variables,name);
       if (v==NULL) {
-       	  /* Not a normal one ? Maybe an output one */
-       	  const Ustring* output=get_output_variable(p->output_variables,name);
-       	  if (output==NULL) {
-       		  switch (p->variable_error_policy) {
-   				  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name);
-   				  case IGNORE_VARIABLE_ERRORS: continue;
-   				  case BACKTRACK_ON_VARIABLE_ERRORS:
-					  stack->len=old_length;
-					  stack->str[old_length]='\0';
-					  return 0;
-       		  }
-       	  }
-       	  push_output_string_tfst(stack,output->str);
-       	  continue;
+          /* Not a normal one ? Maybe an output one */
+          const Ustring* output=get_output_variable(p->output_variables,name);
+          if (output==NULL) {
+              switch (p->variable_error_policy) {
+                  case EXIT_ON_VARIABLE_ERRORS: fatal_error("Output error: undefined variable $%S$\n",name);
+                  case IGNORE_VARIABLE_ERRORS: continue;
+                  case BACKTRACK_ON_VARIABLE_ERRORS:
+                      stack->len=old_length;
+                      stack->str[old_length]='\0';
+                      return 0;
+              }
+          }
+          push_output_string_tfst(stack,output->str);
+          continue;
       }
       if (v->start_in_tokens==UNDEF_VAR_BOUND) {
          switch (p->variable_error_policy) {
@@ -429,25 +429,25 @@ if (output==NULL) return 1;
 Ustring* stack_foo=stack;
 int capture=capture_mode(p->output_variables);
 if (capture) {
-	stack_foo=new_Ustring(64);
-	if (p->debug) {
-		/* In debug mode, an output to be captured must still be
-		 * added to the normal stack, to trace the explored grammar
-		 * path. But, in this case, we remove the actual output part,
-		 * since no output is really produced there */
-		push_output_char_tfst(stack,DEBUG_INFO_OUTPUT_MARK);
-		int i;
-		for (i=0;output[i]!=DEBUG_INFO_COORD_MARK;i++) {
-		}
-		push_output_string_tfst(stack,output+i);
-	}
+    stack_foo=new_Ustring(64);
+    if (p->debug) {
+        /* In debug mode, an output to be captured must still be
+         * added to the normal stack, to trace the explored grammar
+         * path. But, in this case, we remove the actual output part,
+         * since no output is really produced there */
+        push_output_char_tfst(stack,DEBUG_INFO_OUTPUT_MARK);
+        int i;
+        for (i=0;output[i]!=DEBUG_INFO_COORD_MARK;i++) {
+        }
+        push_output_string_tfst(stack,output+i);
+    }
 }
 if (!process_output_tfst(stack_foo,output,p,capture && p->debug)) {
-	return 0;
+    return 0;
 }
 if (capture) {
-	*captured_chars=add_raw_string_to_output_variables(p->output_variables,stack_foo->str);
-	free_Ustring(stack_foo);
+    *captured_chars=add_raw_string_to_output_variables(p->output_variables,stack_foo->str);
+    free_Ustring(stack_foo);
 }
 return 1;
 }

--- a/TransductionStackTfst.h
+++ b/TransductionStackTfst.h
@@ -36,7 +36,7 @@ namespace unitex {
 /* Every character or string that comes from the input text must be
  * pushed with the following functions, because some characters like dots
  * and commas may have to be protected when they come from the input. This
- * is useful when LocateTfst is invoked (one day maybe) from the Dico program 
+ * is useful when LocateTfst is invoked (one day maybe) from the Dico program
  * in order to avoid producing bad lines like:
  *
  *    3,14,PI.NUM   ==>  should be:  3\,14,PI.NUM

--- a/TransductionVariables.cpp
+++ b/TransductionVariables.cpp
@@ -68,10 +68,10 @@ void reset_Variables(Variables* v) {
 if (v==NULL) return;
 int n=v->variable_index->size;
 for (int i=0;i<n;i++) {
-	   v->variables[i].start_in_tokens=UNDEF_VAR_BOUND;
-	   v->variables[i].end_in_tokens=UNDEF_VAR_BOUND;
-	   v->variables[i].start_in_chars=UNDEF_VAR_BOUND;
-	   v->variables[i].end_in_chars=UNDEF_VAR_BOUND;
+       v->variables[i].start_in_tokens=UNDEF_VAR_BOUND;
+       v->variables[i].end_in_tokens=UNDEF_VAR_BOUND;
+       v->variables[i].start_in_chars=UNDEF_VAR_BOUND;
+       v->variables[i].end_in_chars=UNDEF_VAR_BOUND;
 }
 }
 
@@ -242,7 +242,7 @@ if (backup!=NULL) free_cb(backup,prv_alloc_recycle);
  */
 void install_variable_backup(Variables* v,const int* backup) {
 if (backup==NULL) {
-	fatal_error("NULL error in install_variable_backup\n");
+    fatal_error("NULL error in install_variable_backup\n");
 }
 int l=v->variable_index->size;
 
@@ -257,7 +257,7 @@ memcpy((void*)(&(v->variables[0])),(const void*)&backup[0],sizeof(int)*NB_INT_BY
  */
 void update_variable_backup(int* backup,const Variables* v) {
 if (backup==NULL) {
-	fatal_error("NULL error in install_variable_backup\n");
+    fatal_error("NULL error in install_variable_backup\n");
 }
 int l=0;
 if (v!=NULL)
@@ -390,7 +390,7 @@ void restore_variable_array(Variables* v,variable_backup_memory_reserve* r,int* 
 int same_input_variables(int* input_variable_backup,Variables* v) {
 int* tmp=(int*)v->variables;
 for (int i=0;i<v->variable_index->size;i++) {
-	if (tmp[i]!=input_variable_backup[i]) return 0;
+    if (tmp[i]!=input_variable_backup[i]) return 0;
 }
 return 1;
 }

--- a/TransductionVariables.cpp
+++ b/TransductionVariables.cpp
@@ -299,7 +299,7 @@ int suggest_size_backup_reserve(int size_one_backup,int is_first)
 
 /* we suggest several SUGGESTED_NB_VARIABLE_BACKUP_IN_RESERVE because we want prevent malloc/free at each step */
 
-int suggested_size = size_one_backup * 
+int suggested_size = size_one_backup *
         (is_first ? SUGGESTED_NB_VARIABLE_BACKUP_IN_RESERVE_FIRST : SUGGESTED_NB_VARIABLE_BACKUP_IN_RESERVE);
 if (suggested_size > LIMIT_MAX_SUGGESTED_SIZE)
     suggested_size = LIMIT_MAX_SUGGESTED_SIZE;
@@ -374,7 +374,7 @@ r->array_int[OFFSET_SWAPPER+(r->pos_used * r->size_aligned)] = 1;
 return save;
 }
 
-    
+
 void restore_variable_array(Variables* v,variable_backup_memory_reserve* r,int* rest)
 {
     r->pos_used --;

--- a/TransductionVariables.h
+++ b/TransductionVariables.h
@@ -182,8 +182,8 @@ static inline int* create_variable_backup_using_reserve(const Variables* v,varia
 /* DIRTY==0 mean :
    - there is a least one backup
    - there is no modification made on the variable array since last backup
-   - the last used array is not a "swapper" 
-    so we can reuse the backup previously made !  
+   - the last used array is not a "swapper"
+    so we can reuse the backup previously made !
  */
 if (r->array_int[OFFSET_DIRTY+(r->pos_used * r->size_aligned)] == 0)
 {
@@ -227,7 +227,7 @@ return (r->pos_used == 0) ? 1 : 0;
  * the function below are replaced by macro for performance
  */
 /*
-  
+
 int get_dirty(variable_backup_memory_reserve* r) ;
 void set_dirty(variable_backup_memory_reserve* r,int d) ;
 

--- a/Transitions.cpp
+++ b/Transitions.cpp
@@ -276,21 +276,21 @@ while (src!=NULL) {
 
 static void reverse_list(Transition* t,Transition* *first,Transition* *last) {
 if (t==NULL) {
-	*first=*last=NULL;
-	return;
+    *first=*last=NULL;
+    return;
 }
 if (t->next==NULL) {
-	*first=*last=t;
-	(*first)->next=(*last)->next=NULL;
-	return;
+    *first=*last=t;
+    (*first)->next=(*last)->next=NULL;
+    return;
 }
 if (t->next->next==NULL) {
-	/* If there are only two elements, we swap them */
-	(*last)=t;
-	(*first)=t->next;
-	(*first)->next=(*last);
-	(*last)->next=NULL;
-	return;
+    /* If there are only two elements, we swap them */
+    (*last)=t;
+    (*first)=t->next;
+    (*first)->next=(*last);
+    (*last)->next=NULL;
+    return;
 }
 reverse_list(t->next,first,last);
 (*last)->next=t;

--- a/Transitions.cpp
+++ b/Transitions.cpp
@@ -189,7 +189,7 @@ return transition;
 
 /**
  * Clones the given transition list. If 'renumber' is not NULL, it
- * is used to renumber destination states on the fly. If 
+ * is used to renumber destination states on the fly. If
  * 'clone_tag_label' is not NULL, it is used to clone the pointer
  * labels. If NULL, transitions are rawly copied with a memcpy.
  */ // WARNING : Callback "clone"

--- a/Transitions.h
+++ b/Transitions.h
@@ -33,7 +33,7 @@
 namespace unitex {
 
 /**
- * This library provides functions and types for manipulating 
+ * This library provides functions and types for manipulating
  * automaton transitions that can be tagged either by integers
  * or by pointers.
  */
@@ -55,20 +55,20 @@ struct transition_ {
    union {
       /* Number of the transition tag */
       int tag_number;
-      
+
       /* Pointer label */
       symbol_t* label;
    };
-   
+
    /*
     * Number of the state pointed by the transition. Note that, in a fst2, this
     * number is ABSOLUTE. For instance, if the subgraph number 3 starts
     * at the state number 45, the 6th state of this subgraph will have the
     * number 45+6=51.
-    * 
+    *
     */
    int state_number;
-   
+
    /* Next transition of the list */
    struct transition_* next;
 };

--- a/Txt2Tfst.h
+++ b/Txt2Tfst.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef Txt2TfstH
 #define Txt2TfstH
 

--- a/Uncompress.cpp
+++ b/Uncompress.cpp
@@ -102,12 +102,12 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Uncompress,lopts_Uncompr
              decode_writing_encoding_parameter(&(vec.encoding_output),&(vec.bom_output),options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Uncompress[index].name);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;

--- a/Unicode.cpp
+++ b/Unicode.cpp
@@ -196,7 +196,7 @@ return u_fputc_raw(f->enc,c,f->f);
 
 int u_fputc_conv_lf_to_crlf_option(Encoding, unichar, ABSTRACTFILE*, int);
 int u_fputc_conv_lf_to_crlf_option(unichar c, U_FILE* f, int conv_lf_to_crlf_option) {
-	return u_fputc_conv_lf_to_crlf_option(f->enc, c, f->f, conv_lf_to_crlf_option);
+    return u_fputc_conv_lf_to_crlf_option(f->enc, c, f->f, conv_lf_to_crlf_option);
 }
 
 int u_fputc(Encoding,unichar,ABSTRACTFILE*);
@@ -235,21 +235,21 @@ static void fwriteString(U_FILE* f, const unichar* us, int convLFtoCRLF);
 
 void u_fputs_raw(Encoding, const unichar*, ABSTRACTFILE*);
 void u_fputs_raw(const unichar* t, U_FILE* f) {
-	fwriteString(f, t, 0);
-	//u_fputs_raw(f->enc, t, f->f);
+    fwriteString(f, t, 0);
+    //u_fputs_raw(f->enc, t, f->f);
 }
 
 void u_fputs(Encoding, const unichar*, ABSTRACTFILE*);
 void u_fputs(const unichar* t, U_FILE* f) {
-	fwriteString(f, t, 1);
-	//u_fputs(f->enc, t, f->f);
+    fwriteString(f, t, 1);
+    //u_fputs(f->enc, t, f->f);
 }
 
 
 void u_fputs_conv_lf_to_crlf_option(Encoding, const unichar*, ABSTRACTFILE*, int);
 void u_fputs_conv_lf_to_crlf_option(const unichar*t, U_FILE* f, int conv_lf_to_crlf_option) {
-	fwriteString(f, t, conv_lf_to_crlf_option);
-	//return u_fputs_conv_lf_to_crlf_option(f->enc, t, f->f, conv_lf_to_crlf_option);
+    fwriteString(f, t, conv_lf_to_crlf_option);
+    //return u_fputs_conv_lf_to_crlf_option(f->enc, t, f->f, conv_lf_to_crlf_option);
 }
 
 int u_fgets(Encoding,unichar*,ABSTRACTFILE*);
@@ -572,8 +572,8 @@ int decode_writing_encoding_parameter(Encoding* p_encoding,int* p_bom,const char
             {
                 *p_bom = write_encoding_item_list[i].bom;
                 *p_encoding = write_encoding_item_list[i].encoding;
-				if ((*p_encoding) == PLATFORM_DEPENDENT_UTF16)
-					*p_encoding = is_platform_little_endian() ? UTF16_LE : BIG_ENDIAN_UTF16;
+                if ((*p_encoding) == PLATFORM_DEPENDENT_UTF16)
+                    *p_encoding = is_platform_little_endian() ? UTF16_LE : BIG_ENDIAN_UTF16;
                 free(lower_encoding_text);
                 return 1;
             }
@@ -594,14 +594,14 @@ int get_writing_encoding_text(char* text_encoding,size_t size_text_buffer,Encodi
     {
         case UTF16_LE : result = (bom != 0) ? "utf16-le-bom" : "utf16-le-no-bom"; break;
         case BIG_ENDIAN_UTF16 : result = (bom != 0) ? "utf16-be-bom" : "utf16-be-no-bom"; break;
-		case PLATFORM_DEPENDENT_UTF16 :
-			{
-				if (is_platform_little_endian())
-					result = (bom != 0) ? "utf16-le-bom" : "utf16-le-no-bom";
-				else
-					result = (bom != 0) ? "utf16-be-bom" : "utf16-be-no-bom";
-				break;
-			}
+        case PLATFORM_DEPENDENT_UTF16 :
+            {
+                if (is_platform_little_endian())
+                    result = (bom != 0) ? "utf16-le-bom" : "utf16-le-no-bom";
+                else
+                    result = (bom != 0) ? "utf16-be-bom" : "utf16-be-no-bom";
+                break;
+            }
         case UTF8 : result = (bom == 1) ? "utf8-bom" : "utf8-no-bom"; break;
         case ASCII : result = "ascii"; break;
     }
@@ -713,7 +713,7 @@ int GetFileEncoding(ABSTRACTFILE* f,Encoding* encoding,int *is_BOM,int MASK_ENCO
  */
 U_FILE* u_fopen_internal(Encoding encoding,int is_BOM,const char* name,OpenMode MODE,int MASK_ENCODING_COMPATIBILITY) {
 if (name==NULL) {
-	fatal_error("NULL file name in u_fopen\n");
+    fatal_error("NULL file name in u_fopen\n");
 }
 ABSTRACTFILE* f;
 if (MODE==U_APPEND || MODE==U_MODIFY) {
@@ -816,7 +816,7 @@ U_FILE* u_fopen(Encoding encoding,const char* name,OpenMode MODE) {
 }
 
 U_FILE* u_fopen(const VersatileEncodingConfig* cfg,const char* name,OpenMode MODE) {
-	return u_fopen_internal(cfg->encoding_output,cfg->bom_output,name,MODE,cfg->mask_encoding_compatibility_input);
+    return u_fopen_internal(cfg->encoding_output,cfg->bom_output,name,MODE,cfg->mask_encoding_compatibility_input);
 }
 
 /*
@@ -1053,12 +1053,12 @@ switch(encoding) {
    case PLATFORM_DEPENDENT_UTF16: return is_platform_little_endian() ?
                              u_fgetc_UTF16LE_raw(f) : u_fgetc_UTF16BE_raw(f);
    case ASCII: {
-	   unsigned char c;
-	   if (af_fread(&c,1,1,f)==1)
-		   return (int)c;
-	   else
-		   return EOF;
-			   }
+       unsigned char c;
+       if (af_fread(&c,1,1,f)==1)
+           return (int)c;
+       else
+           return EOF;
+               }
 }
 return EOF;
 }
@@ -1099,7 +1099,7 @@ if (c==0x0D) {
        * is a trick in order to avoid reading a character made of several bytes
        * that we should put back to the file. */
       if (af_fread(&c,1,1,f)!=1)
-		  c=EOF;
+          c=EOF;
    } else {
       c=u_fgetc_raw(encoding,f);
    }
@@ -1289,10 +1289,10 @@ return u_fputc_raw(encoding,c,f);
 
 
 int u_fputc_conv_lf_to_crlf_option(Encoding encoding, unichar c, ABSTRACTFILE* f, int conv_lf_to_crlf_option) {
-	if ((c == '\n') && (conv_lf_to_crlf_option!=0)) {
-		if (!u_fputc_raw(encoding, 0x0D, f)) return 0;
-	}
-	return u_fputc_raw(encoding, c, f);
+    if ((c == '\n') && (conv_lf_to_crlf_option!=0)) {
+        if (!u_fputc_raw(encoding, 0x0D, f)) return 0;
+    }
+    return u_fputc_raw(encoding, c, f);
 }
 
 /**
@@ -1423,15 +1423,15 @@ return N;
 
 /*
 void u_fputs_raw(Encoding encoding, const unichar* s, ABSTRACTFILE* f) {
-	int i = 0;
-	while (s[i] != '\0')
-		u_fputc_raw(encoding, (unichar)((unsigned char)s[i++]), f);
+    int i = 0;
+    while (s[i] != '\0')
+        u_fputc_raw(encoding, (unichar)((unsigned char)s[i++]), f);
 }
 
 void u_fputs(Encoding encoding, const unichar* s, ABSTRACTFILE* f) {
-	int i = 0;
-	while (s[i] != '\0')
-		u_fputc(encoding, (unichar)((unsigned char)s[i++]), f);
+    int i = 0;
+    while (s[i] != '\0')
+        u_fputc(encoding, (unichar)((unsigned char)s[i++]), f);
 }
 */
 /**
@@ -1477,7 +1477,7 @@ return i;
 /**
   * this function act as u_fgets(encoding,line,f) if i_size==0 and
   *          like u_fgets(encoding,line,size,f) if i_size==1 and
-  *	optimized by reading several char at same time in a buffer
+  * optimized by reading several char at same time in a buffer
   */
 
 
@@ -1544,7 +1544,7 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
                     unichar c;
                     c = (unichar)((((unichar)tab_in[(i*2)+hibytepos]) << 8) | (tab_in[(i*2)+(1-hibytepos)])) ;
                     if (c==0) {
-                    	fatal_error("Corrupted UTF16 text file containing null characters\n");
+                        fatal_error("Corrupted UTF16 text file containing null characters\n");
                     }
                     if (!(((c==0x0d) && (treat_CR_as_LF == 0))))
                     {
@@ -1610,7 +1610,7 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
                     c = (((unichar)tab_in[(i)])) ;
 
                     if (c==0) {
-                    	fatal_error("Corrupted ASCII text file containing null characters\n");
+                        fatal_error("Corrupted ASCII text file containing null characters\n");
                     }
 
                     if (!(((c==0x0d) && (treat_CR_as_LF == 0))))
@@ -1705,7 +1705,7 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
                           }
 
                           if (c==0) {
-                          	fatal_error("Corrupted UTF8 text file containing null characters\n");
+                            fatal_error("Corrupted UTF8 text file containing null characters\n");
                           }
 
                     if (!((c==0x0d) && (treat_CR_as_LF == 0)))
@@ -1762,34 +1762,34 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
 #define START_SIZE_DYNAMIC_BUFFER 512
 int u_fgets_dynamic_buffer(Encoding encoding, unichar** line, size_t* buffer_size, ABSTRACTFILE* f, int treat_CR_as_LF)
 {
-	if (((*line) == NULL) || ((*buffer_size) == 0))
-	{
-		*buffer_size += START_SIZE_DYNAMIC_BUFFER;
-		*line = (unichar*)malloc(sizeof(unichar) * ((*buffer_size) + 1));
+    if (((*line) == NULL) || ((*buffer_size) == 0))
+    {
+        *buffer_size += START_SIZE_DYNAMIC_BUFFER;
+        *line = (unichar*)malloc(sizeof(unichar) * ((*buffer_size) + 1));
 
-		if ((*line) == NULL){
-			fatal_alloc_error("u_fgets_dynamic_buffer");
-		}
-	}
+        if ((*line) == NULL){
+            fatal_alloc_error("u_fgets_dynamic_buffer");
+        }
+    }
 
-	**line = 0;
-	int pos = 0;
-	for (;;)
-	{
-		int read_possible = (int)(*buffer_size) - pos;
-		int nb_read = u_fgets_buffered(encoding, (*line)+pos, 2, (int)read_possible, f, treat_CR_as_LF);
-		if (nb_read == EOF)
-			return (pos == 0) ? EOF : pos;
-		pos += nb_read;
-		*((*line) + pos) = 0;
-		if (nb_read != (read_possible - 1))
-			return pos;
-		(*buffer_size) *= 2;
-		*line = (unichar*)realloc(*line, sizeof(unichar) * ((*buffer_size) + 1));
-		if ((*line) == NULL){
-			fatal_alloc_error("u_fgets_dynamic_buffer");
-		}
-	}
+    **line = 0;
+    int pos = 0;
+    for (;;)
+    {
+        int read_possible = (int)(*buffer_size) - pos;
+        int nb_read = u_fgets_buffered(encoding, (*line)+pos, 2, (int)read_possible, f, treat_CR_as_LF);
+        if (nb_read == EOF)
+            return (pos == 0) ? EOF : pos;
+        pos += nb_read;
+        *((*line) + pos) = 0;
+        if (nb_read != (read_possible - 1))
+            return pos;
+        (*buffer_size) *= 2;
+        *line = (unichar*)realloc(*line, sizeof(unichar) * ((*buffer_size) + 1));
+        if ((*line) == NULL){
+            fatal_alloc_error("u_fgets_dynamic_buffer");
+        }
+    }
 }
 
 
@@ -1803,7 +1803,7 @@ int u_fgets_dynamic_buffer(Encoding encoding, unichar** line, size_t* buffer_siz
  * NOTE: there is no overflow control!
  */
 int u_fgets(Encoding encoding,unichar* line,ABSTRACTFILE* f) {
-	return u_fgets_buffered(encoding,line,0,0,f,0);
+    return u_fgets_buffered(encoding,line,0,0,f,0);
 }
 
 
@@ -1849,7 +1849,7 @@ return u_fgets_buffered(encoding,line,1,size,f,1);
  * option limit2 by Gilles Vollant
  */
 int u_fgets_limit2(Encoding encoding,unichar* line,int size,ABSTRACTFILE* f) {
-	return u_fgets_buffered(encoding,line,2,size,f,0);
+    return u_fgets_buffered(encoding,line,2,size,f,0);
 }
 
 
@@ -1915,156 +1915,156 @@ int u_fget_unichars_raw(Encoding encoding, unichar* buffer, int size, ABSTRACTFI
  unsigned char tab_in[BUFFER_IN_CACHE_SIZE_FGET_CHAR];
 
  switch (encoding) {
-	case UTF16_LE:
-	case BIG_ENDIAN_UTF16:
-	{
-		int hibytepos = (encoding == UTF16_LE) ? 1 : 0;
+    case UTF16_LE:
+    case BIG_ENDIAN_UTF16:
+    {
+        int hibytepos = (encoding == UTF16_LE) ? 1 : 0;
 
-		int size_to_do = size;
-		int size_done = 0;
-		for (;;)
-		{
-			if (size_to_do == 0)
-				return size_done;
-			int try_size = size_to_do;
-			if (try_size > (BUFFER_IN_CACHE_SIZE_FGET_CHAR / 2))
-				try_size = (BUFFER_IN_CACHE_SIZE_FGET_CHAR / 2);
-			size_t read_bytes_in_file = af_fread(&tab_in[0], 1, (size_t)try_size * 2, f);
-			if ((read_bytes_in_file <= 0) || (read_bytes_in_file == ((size_t)EOF)))
-			{
-				if (size_done > 0)
-					return size_done;
-				else
-					return (int)read_bytes_in_file;
-			}
-			if (read_bytes_in_file > 0)
-			{
-				int nb_unichar_read = (int)read_bytes_in_file / 2;
-				for (int i = 0; i < nb_unichar_read; i++) {
+        int size_to_do = size;
+        int size_done = 0;
+        for (;;)
+        {
+            if (size_to_do == 0)
+                return size_done;
+            int try_size = size_to_do;
+            if (try_size > (BUFFER_IN_CACHE_SIZE_FGET_CHAR / 2))
+                try_size = (BUFFER_IN_CACHE_SIZE_FGET_CHAR / 2);
+            size_t read_bytes_in_file = af_fread(&tab_in[0], 1, (size_t)try_size * 2, f);
+            if ((read_bytes_in_file <= 0) || (read_bytes_in_file == ((size_t)EOF)))
+            {
+                if (size_done > 0)
+                    return size_done;
+                else
+                    return (int)read_bytes_in_file;
+            }
+            if (read_bytes_in_file > 0)
+            {
+                int nb_unichar_read = (int)read_bytes_in_file / 2;
+                for (int i = 0; i < nb_unichar_read; i++) {
 
-					unichar c = (unichar)((((unichar)tab_in[(i * 2) + hibytepos]) << 8) | (tab_in[(i * 2) + (1 - hibytepos)]));
+                    unichar c = (unichar)((((unichar)tab_in[(i * 2) + hibytepos]) << 8) | (tab_in[(i * 2) + (1 - hibytepos)]));
 
-					*(buffer + size_done + i) = c;
+                    *(buffer + size_done + i) = c;
 
-				}
-				size_done += nb_unichar_read;
-				size_to_do -= nb_unichar_read;
+                }
+                size_done += nb_unichar_read;
+                size_to_do -= nb_unichar_read;
 
-			}
-		}
-	}
-
-
-	case UTF8:
-	{
+            }
+        }
+    }
 
 
-		size_t pos_already_read_in_disk = 0;
-		int pos_in_unichar_line = 0;
-
-		for (;;)
-		{
-			size_t size_to_read_binary = BUFFER_IN_CACHE_SIZE_FGET_CHAR - pos_already_read_in_disk;
-
-			size_t read_binary_in_file = 0;
-			if (size_to_read_binary>0)
-				read_binary_in_file = af_fread(&tab_in[pos_already_read_in_disk], 1, (size_t)size_to_read_binary, f);
-			if ((read_binary_in_file <= 0) || (read_binary_in_file == ((size_t)EOF)))
-			{
-				if (pos_in_unichar_line == 0)
-					return EOF;
-				else
-				{
-					return pos_in_unichar_line;
-				}
-			}
-			read_binary_in_file += pos_already_read_in_disk;
-
-			if (read_binary_in_file > 0)
-			{
-				int i;
-				pos_already_read_in_disk = 0;
-				for (i = 0; i<(int)read_binary_in_file;)
-				{
-					unichar c;
-					unsigned char ch = tab_in[i];
-					int nbbyte = GetUtf8Size(ch);
-
-					if (i + nbbyte >(int)read_binary_in_file)
-					{
-						pos_already_read_in_disk = read_binary_in_file - i;
-						int j;
-						for (j = 0; j<(int)pos_already_read_in_disk; j++)
-							tab_in[j] = tab_in[i + j];
-						break;
-					}
-
-					c = ((unichar)ch) & GetUtf8Mask(ch);
-					int nbbyte_loop = nbbyte;
-
-					if (nbbyte_loop>0) {
-						int i_in_char = 0;
-						for (;;)
-						{
-							nbbyte_loop--;
-							if (nbbyte_loop == 0)
-								break;
-							i_in_char++;
-							c = (unichar)((c << 6) | ((tab_in[i + i_in_char]) & 0x3F));
-						}
-					}
-
-					if (pos_in_unichar_line == size)
-					{
-						af_fseek(f, -1 * (long)(read_binary_in_file - i), SEEK_CUR);
-
-						return pos_in_unichar_line;
-					}
-
-					buffer[pos_in_unichar_line++] = c;
-
-					i += nbbyte;
-				}
-			}
-		}
-	}
+    case UTF8:
+    {
 
 
-	default:
-	case ASCII:
-	{
-		int size_to_do = size;
-		int size_done = 0;
-		for (;;)
-		{
-			if (size_to_do == 0)
-				return size_done;
-			int try_size = size_to_do;
-			if (try_size > (BUFFER_IN_CACHE_SIZE_FGET_CHAR))
-				try_size = (BUFFER_IN_CACHE_SIZE_FGET_CHAR);
-			size_t read_bytes_in_file = af_fread(&tab_in[0], 1, (size_t)try_size, f);
-			if ((read_bytes_in_file <= 0) || (read_bytes_in_file == ((size_t)EOF)))
-			{
-				if (size_done > 0)
-					return size_done;
-				else
-					return (int)read_bytes_in_file;
-			}
+        size_t pos_already_read_in_disk = 0;
+        int pos_in_unichar_line = 0;
 
-			if (read_bytes_in_file > 0)
-			{
-				int nb_unichar_read = (int)read_bytes_in_file;
-				for (int i = 0; i < nb_unichar_read; i++) {
+        for (;;)
+        {
+            size_t size_to_read_binary = BUFFER_IN_CACHE_SIZE_FGET_CHAR - pos_already_read_in_disk;
 
-					unichar c = (unichar)tab_in[i];
+            size_t read_binary_in_file = 0;
+            if (size_to_read_binary>0)
+                read_binary_in_file = af_fread(&tab_in[pos_already_read_in_disk], 1, (size_t)size_to_read_binary, f);
+            if ((read_binary_in_file <= 0) || (read_binary_in_file == ((size_t)EOF)))
+            {
+                if (pos_in_unichar_line == 0)
+                    return EOF;
+                else
+                {
+                    return pos_in_unichar_line;
+                }
+            }
+            read_binary_in_file += pos_already_read_in_disk;
 
-					*(buffer + size_done + i) = c;
-				}
-				size_done += nb_unichar_read;
-				size_to_do -= nb_unichar_read;
-			}
-		}
-	}
+            if (read_binary_in_file > 0)
+            {
+                int i;
+                pos_already_read_in_disk = 0;
+                for (i = 0; i<(int)read_binary_in_file;)
+                {
+                    unichar c;
+                    unsigned char ch = tab_in[i];
+                    int nbbyte = GetUtf8Size(ch);
+
+                    if (i + nbbyte >(int)read_binary_in_file)
+                    {
+                        pos_already_read_in_disk = read_binary_in_file - i;
+                        int j;
+                        for (j = 0; j<(int)pos_already_read_in_disk; j++)
+                            tab_in[j] = tab_in[i + j];
+                        break;
+                    }
+
+                    c = ((unichar)ch) & GetUtf8Mask(ch);
+                    int nbbyte_loop = nbbyte;
+
+                    if (nbbyte_loop>0) {
+                        int i_in_char = 0;
+                        for (;;)
+                        {
+                            nbbyte_loop--;
+                            if (nbbyte_loop == 0)
+                                break;
+                            i_in_char++;
+                            c = (unichar)((c << 6) | ((tab_in[i + i_in_char]) & 0x3F));
+                        }
+                    }
+
+                    if (pos_in_unichar_line == size)
+                    {
+                        af_fseek(f, -1 * (long)(read_binary_in_file - i), SEEK_CUR);
+
+                        return pos_in_unichar_line;
+                    }
+
+                    buffer[pos_in_unichar_line++] = c;
+
+                    i += nbbyte;
+                }
+            }
+        }
+    }
+
+
+    default:
+    case ASCII:
+    {
+        int size_to_do = size;
+        int size_done = 0;
+        for (;;)
+        {
+            if (size_to_do == 0)
+                return size_done;
+            int try_size = size_to_do;
+            if (try_size > (BUFFER_IN_CACHE_SIZE_FGET_CHAR))
+                try_size = (BUFFER_IN_CACHE_SIZE_FGET_CHAR);
+            size_t read_bytes_in_file = af_fread(&tab_in[0], 1, (size_t)try_size, f);
+            if ((read_bytes_in_file <= 0) || (read_bytes_in_file == ((size_t)EOF)))
+            {
+                if (size_done > 0)
+                    return size_done;
+                else
+                    return (int)read_bytes_in_file;
+            }
+
+            if (read_bytes_in_file > 0)
+            {
+                int nb_unichar_read = (int)read_bytes_in_file;
+                for (int i = 0; i < nb_unichar_read; i++) {
+
+                    unichar c = (unichar)tab_in[i];
+
+                    *(buffer + size_done + i) = c;
+                }
+                size_done += nb_unichar_read;
+                size_to_do -= nb_unichar_read;
+            }
+        }
+    }
  }
 }
 
@@ -2073,56 +2073,56 @@ int u_fget_unichars_raw(Encoding encoding, unichar* buffer, int size, ABSTRACTFI
  *
  */
 size_t convert_utf8_to_unichar(unichar*dest, size_t nb_unichar_alloc_walk, size_t * p_size_this_string_written,
-	const unsigned char*src, size_t buf_size)
+    const unsigned char*src, size_t buf_size)
 {
-	unichar*write_content_walk_buf = dest;
-	const unsigned char*src_walk = src;
-	size_t size_this_string_written = 0;
-	size_t nb_utf8_bytes = 0;
-	for (;;)
-	{
-		if ((src_walk == NULL) || (buf_size == 0))
-			return 0;
-		unsigned char ch = *(src_walk++);
-		buf_size--;
-		nb_utf8_bytes++;
+    unichar*write_content_walk_buf = dest;
+    const unsigned char*src_walk = src;
+    size_t size_this_string_written = 0;
+    size_t nb_utf8_bytes = 0;
+    for (;;)
+    {
+        if ((src_walk == NULL) || (buf_size == 0))
+            return 0;
+        unsigned char ch = *(src_walk++);
+        buf_size--;
+        nb_utf8_bytes++;
 
-		unichar c;
+        unichar c;
 
-		if ((ch & 0x80) == 0)
-		{
-			c = ch;
-		}
-		else
-		{
-			c = ch & GetUtf8Mask(ch);
-			int nbbyte = GetUtf8Size(ch);
-			if (((int)buf_size) + 1 < nbbyte)
-				return 0;
+        if ((ch & 0x80) == 0)
+        {
+            c = ch;
+        }
+        else
+        {
+            c = ch & GetUtf8Mask(ch);
+            int nbbyte = GetUtf8Size(ch);
+            if (((int)buf_size) + 1 < nbbyte)
+                return 0;
 
-			for (;;)
-			{
-				nbbyte--;
-				if (nbbyte == 0)
-					break;
+            for (;;)
+            {
+                nbbyte--;
+                if (nbbyte == 0)
+                    break;
 
-				c = (c << 6) | ((*(src_walk++)) & 0x3F);
-				buf_size--;
-				nb_utf8_bytes++;
-			}
-		}
+                c = (c << 6) | ((*(src_walk++)) & 0x3F);
+                buf_size--;
+                nb_utf8_bytes++;
+            }
+        }
 
-		if ((write_content_walk_buf != NULL) && (size_this_string_written<nb_unichar_alloc_walk))
-			*(write_content_walk_buf + size_this_string_written) = c;
-		size_this_string_written++;
+        if ((write_content_walk_buf != NULL) && (size_this_string_written<nb_unichar_alloc_walk))
+            *(write_content_walk_buf + size_this_string_written) = c;
+        size_this_string_written++;
 
-		if (c == 0)
-		{
-			if (p_size_this_string_written != NULL)
-				*p_size_this_string_written = size_this_string_written;
-			return nb_utf8_bytes;
-		}
-	}
+        if (c == 0)
+        {
+            if (p_size_this_string_written != NULL)
+                *p_size_this_string_written = size_this_string_written;
+            return nb_utf8_bytes;
+        }
+    }
 }
 
 
@@ -2131,7 +2131,7 @@ size_t convert_utf8_to_unichar(unichar*dest, size_t nb_unichar_alloc_walk, size_
  */
 int u_fget_unichars_raw(unichar* buffer, int size, U_FILE* f)
 {
-	return u_fget_unichars_raw(f->enc, buffer, size, f->f);
+    return u_fget_unichars_raw(f->enc, buffer, size, f->f);
 }
 
 
@@ -2199,23 +2199,23 @@ int BuildEncodedOutForUnicharString(Encoding encoding,const unichar *pc,Buffer_O
 
            case PLATFORM_DEPENDENT_UTF16:
                {
-				   if (is_platform_little_endian())
-				   {
+                   if (is_platform_little_endian())
+                   {
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c & 0xffff);
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
-				   }
-				   else
-				   {
+                   }
+                   else
+                   {
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c & 0xffff);
-				   }
+                   }
                    break;
                }
 
            case BINARY:
            {
-        	   pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c);
-        	   break;
+               pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c);
+               break;
            }
 
            case UTF8:
@@ -2293,22 +2293,22 @@ static int BuildEncodedOutForCharString(Encoding encoding,const char *pc,Buffer_
 
            case PLATFORM_DEPENDENT_UTF16:
                {
-				   if (is_platform_little_endian())
-				   {
+                   if (is_platform_little_endian())
+                   {
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c & 0xffff);
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
-				   }
-				   else
-				   {
+                   }
+                   else
+                   {
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
                      pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c & 0xffff);
-				   }
+                   }
                    break;
                }
 
            case BINARY: {
-        	   pBufOut->tabOut[(pBufOut->iPosInTabOut)++] = (unsigned char)c;
-        	   break;
+               pBufOut->tabOut[(pBufOut->iPosInTabOut)++] = (unsigned char)c;
+               break;
            }
 
            case UTF8:
@@ -2350,18 +2350,18 @@ static int BuildEncodedOutForCharString(Encoding encoding,const char *pc,Buffer_
 
 static void fwriteString(U_FILE* f, const unichar* us, int convLFtoCRLF)
 {
-	Encoding encoding = f->enc;
-	Buffer_Out BufOut;
-	ClearBufferOut(&BufOut);
+    Encoding encoding = f->enc;
+    Buffer_Out BufOut;
+    ClearBufferOut(&BufOut);
 
-	if (us != NULL) {
-		BuildEncodedOutForUnicharString(encoding, us, &BufOut, convLFtoCRLF, f->f);
-		FlushBufferOut(&BufOut, f->f);
-	}
-	else {
-		BuildEncodedOutForCharString(encoding, "(null)", &BufOut, convLFtoCRLF, f->f);
-		FlushBufferOut(&BufOut, f->f);
-	}
+    if (us != NULL) {
+        BuildEncodedOutForUnicharString(encoding, us, &BufOut, convLFtoCRLF, f->f);
+        FlushBufferOut(&BufOut, f->f);
+    }
+    else {
+        BuildEncodedOutForCharString(encoding, "(null)", &BufOut, convLFtoCRLF, f->f);
+        FlushBufferOut(&BufOut, f->f);
+    }
 }
 
 
@@ -2421,11 +2421,11 @@ while (*format) {
          case 'U': {
             int (*XXXize)(const unichar*,unichar*);
             if (*format=='H') {
-            	XXXize=htmlize;
+                XXXize=htmlize;
             } else {
-            	XXXize=URLize;
+                XXXize=URLize;
             }
-        	/* If we have a '%H' (or '%U'), it means that we have to print HTML things (or URLs) */
+            /* If we have a '%H' (or '%U'), it means that we have to print HTML things (or URLs) */
             format++;
             if (*format=='C' || *format=='c') {
                /* If we have to print a HTML character */
@@ -2649,11 +2649,11 @@ while (*format) {
          case 'U': {
             int (*XXXize)(const unichar*,unichar*);
             if (*format=='H') {
-            	XXXize=htmlize;
+                XXXize=htmlize;
             } else {
-            	XXXize=URLize;
+                XXXize=URLize;
             }
-        	/* If we have a '%H', it means that we have to print HTML things */
+            /* If we have a '%H', it means that we have to print HTML things */
             format++;
             if (*format=='S') {
                /* If we have to print a HTML string */
@@ -3296,16 +3296,16 @@ return (i-1);
 * Unicode version of strlen, count the number of char after LF to CRLF conversion
 */
 unsigned int u_strlenWithConvLFtoCRLF(const unichar* s, int convLFtoCRLF) {
-	int i = 0;
-	int nbLF = 0;
-	for (;;)
-	{
-		unichar c = s[i];
-		nbLF += (c == '\n') ? 1 : 0;
-		if (c == 0)
-			return i + ((convLFtoCRLF != 0) ? nbLF : 0);
-		i++;
-	}
+    int i = 0;
+    int nbLF = 0;
+    for (;;)
+    {
+        unichar c = s[i];
+        nbLF += (c == '\n') ? 1 : 0;
+        if (c == 0)
+            return i + ((convLFtoCRLF != 0) ? nbLF : 0);
+        i++;
+    }
 }
 
 
@@ -3473,13 +3473,13 @@ const unichar *s2=src;
 register unichar c;
 /* First we go at the end of the destination string */
 do {
-	c=*s1++;
+    c=*s1++;
 } while (c!=(unichar)'\0');
 s1-=2;
 /* And we concatenate the 'src' string */
 do {
-	c=*s2++;
-	*++s1=c;
+    c=*s2++;
+    *++s1=c;
 } while (c!=(unichar)'\0');
 return dest;
 }
@@ -3509,33 +3509,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=(unichar)*(a_p);
        b_c=(unichar)*(b_p);
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+1);
        b_c=(unichar)*(b_p+1);
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+2);
        b_c=(unichar)*(b_p+2);
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+3);
        b_c=(unichar)*(b_p+3);
        a_p+=4;
-	   b_p+=4;
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       b_p+=4;
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
     } ;
 } else {
   if (a==NULL) {
@@ -3560,33 +3560,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=fast_u_toupper((unichar)*(a_p));
        b_c=fast_u_toupper((unichar)*(b_p));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+1));
        b_c=fast_u_toupper((unichar)*(b_p+1));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+2));
        b_c=fast_u_toupper((unichar)*(b_p+2));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+3));
        b_c=fast_u_toupper((unichar)*(b_p+3));
        a_p+=4;
-	   b_p+=4;
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       b_p+=4;
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
     } ;
 } else {
   if (a==NULL) {
@@ -3603,10 +3603,10 @@ if ((a!=NULL) && (b!=NULL)) {
  */
 int u_strncmp(const unichar* s1, const unichar* s2, size_t n)
 {
-	while (n--)
-		if ((*(s1++)) != (*(s2++)))
-		return (int)(*(const unichar*)(s1 - 1) - *(const unichar*)(s2 - 1));
-	return 0;
+    while (n--)
+        if ((*(s1++)) != (*(s2++)))
+        return (int)(*(const unichar*)(s1 - 1) - *(const unichar*)(s2 - 1));
+    return 0;
 }
 
 
@@ -3618,43 +3618,43 @@ int u_strncmp(const unichar* s1, const unichar* s2, size_t n)
  *
  */
 unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
+    unichar**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
 {
-	size_t add_string_len = u_strlen(add_string);
-	size_t buffer_size_needed = add_string_len + 1;
-	if (len != NULL)
-		*len = add_string_len;
+    size_t add_string_len = u_strlen(add_string);
+    size_t buffer_size_needed = add_string_len + 1;
+    if (len != NULL)
+        *len = add_string_len;
 
-	if ((*allocated_buffer) == NULL)
-	{
-		if ((add_string_len + 1) < original_buffer_size)
-		{
-			memcpy(original_buffer, add_string, (add_string_len + 1) * sizeof(unichar));
-			return original_buffer;
-		}
-		else
-		{
-			*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-			if ((*allocated_buffer) == NULL) {
-				fatal_alloc_error("u_strcpy_optional_buffer");
-			}
+    if ((*allocated_buffer) == NULL)
+    {
+        if ((add_string_len + 1) < original_buffer_size)
+        {
+            memcpy(original_buffer, add_string, (add_string_len + 1) * sizeof(unichar));
+            return original_buffer;
+        }
+        else
+        {
+            *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+            if ((*allocated_buffer) == NULL) {
+                fatal_alloc_error("u_strcpy_optional_buffer");
+            }
 
-			memcpy((*allocated_buffer), add_string, (add_string_len + 1) * sizeof(unichar));
-			return *allocated_buffer;
-		}
-	}
-	else
-	{
-		free_cb(*allocated_buffer, prv_alloc);
+            memcpy((*allocated_buffer), add_string, (add_string_len + 1) * sizeof(unichar));
+            return *allocated_buffer;
+        }
+    }
+    else
+    {
+        free_cb(*allocated_buffer, prv_alloc);
 
-		*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-		if ((*allocated_buffer) == NULL) {
-			fatal_alloc_error("u_strcpy_optional_buffer");
-		}
+        *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+        if ((*allocated_buffer) == NULL) {
+            fatal_alloc_error("u_strcpy_optional_buffer");
+        }
 
-		memcpy((*allocated_buffer), add_string, (add_string_len + 1) * sizeof(unichar));
-		return *allocated_buffer;
-	}
+        memcpy((*allocated_buffer), add_string, (add_string_len + 1) * sizeof(unichar));
+        return *allocated_buffer;
+    }
 }
 
 
@@ -3663,43 +3663,43 @@ unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buf
  */
 
 unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const char* add_string, size_t* len, Abstract_allocator prv_alloc)
+    unichar**allocated_buffer, const char* add_string, size_t* len, Abstract_allocator prv_alloc)
 {
-	size_t add_string_len = strlen(add_string);
-	size_t buffer_size_needed = add_string_len + 1;
-	if (len != NULL)
-		*len = add_string_len;
+    size_t add_string_len = strlen(add_string);
+    size_t buffer_size_needed = add_string_len + 1;
+    if (len != NULL)
+        *len = add_string_len;
 
-	if ((*allocated_buffer) == NULL)
-	{
-		if ((add_string_len + 1) < original_buffer_size)
-		{
-			u_strcpy(original_buffer, add_string);
-			return original_buffer;
-		}
-		else
-		{
-			*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-			if ((*allocated_buffer) == NULL) {
-				fatal_alloc_error("u_strcpy_optional_buffer");
-			}
+    if ((*allocated_buffer) == NULL)
+    {
+        if ((add_string_len + 1) < original_buffer_size)
+        {
+            u_strcpy(original_buffer, add_string);
+            return original_buffer;
+        }
+        else
+        {
+            *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+            if ((*allocated_buffer) == NULL) {
+                fatal_alloc_error("u_strcpy_optional_buffer");
+            }
 
-			u_strcpy((*allocated_buffer), add_string);
-			return *allocated_buffer;
-		}
-	}
-	else
-	{
-		free_cb(*allocated_buffer, prv_alloc);
+            u_strcpy((*allocated_buffer), add_string);
+            return *allocated_buffer;
+        }
+    }
+    else
+    {
+        free_cb(*allocated_buffer, prv_alloc);
 
-		*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-		if ((*allocated_buffer) == NULL) {
-			fatal_alloc_error("u_strcpy_optional_buffer");
-		}
+        *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+        if ((*allocated_buffer) == NULL) {
+            fatal_alloc_error("u_strcpy_optional_buffer");
+        }
 
-		u_strcpy((*allocated_buffer), add_string);
-		return *allocated_buffer;
-	}
+        u_strcpy((*allocated_buffer), add_string);
+        return *allocated_buffer;
+    }
 }
 
 
@@ -3707,46 +3707,46 @@ unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buf
  * append a string in the same way
  */
 unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
+    unichar**allocated_buffer, const unichar* add_string, size_t* len, Abstract_allocator prv_alloc)
 {
-	const unichar* current_buffer = ((*allocated_buffer) != NULL) ? (*allocated_buffer) : original_buffer;
-	size_t current_string_len = u_strlen(current_buffer);
-	size_t add_string_len = u_strlen(add_string);
-	size_t buffer_size_needed = current_string_len + add_string_len + 1;
-	if (len != NULL)
-		*len = current_string_len + add_string_len;
+    const unichar* current_buffer = ((*allocated_buffer) != NULL) ? (*allocated_buffer) : original_buffer;
+    size_t current_string_len = u_strlen(current_buffer);
+    size_t add_string_len = u_strlen(add_string);
+    size_t buffer_size_needed = current_string_len + add_string_len + 1;
+    if (len != NULL)
+        *len = current_string_len + add_string_len;
 
-	if ((*allocated_buffer) == NULL)
-	{
-		if ((current_string_len + add_string_len + 1) < original_buffer_size)
-		{
-			memcpy(original_buffer + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
-			return original_buffer;
-		}
-		else
-		{
-			*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-			if ((*allocated_buffer) == NULL) {
-				fatal_alloc_error("u_strcat_optional_buffer");
-			}
+    if ((*allocated_buffer) == NULL)
+    {
+        if ((current_string_len + add_string_len + 1) < original_buffer_size)
+        {
+            memcpy(original_buffer + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
+            return original_buffer;
+        }
+        else
+        {
+            *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+            if ((*allocated_buffer) == NULL) {
+                fatal_alloc_error("u_strcat_optional_buffer");
+            }
 
-			memcpy((*allocated_buffer), original_buffer, current_string_len * sizeof(unichar));
-			memcpy((*allocated_buffer) + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
-			return *allocated_buffer;
-		}
-	}
-	else
-	{
-		*allocated_buffer = (unichar*)realloc_cb((*allocated_buffer),
-			(current_string_len + 1) * sizeof(unichar),
-			buffer_size_needed * sizeof(unichar), prv_alloc);
-		if ((*allocated_buffer) == NULL) {
-			fatal_alloc_error("u_strcat_optional_buffer");
-		}
+            memcpy((*allocated_buffer), original_buffer, current_string_len * sizeof(unichar));
+            memcpy((*allocated_buffer) + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
+            return *allocated_buffer;
+        }
+    }
+    else
+    {
+        *allocated_buffer = (unichar*)realloc_cb((*allocated_buffer),
+            (current_string_len + 1) * sizeof(unichar),
+            buffer_size_needed * sizeof(unichar), prv_alloc);
+        if ((*allocated_buffer) == NULL) {
+            fatal_alloc_error("u_strcat_optional_buffer");
+        }
 
-		memcpy((*allocated_buffer) + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
-		return *allocated_buffer;
-	}
+        memcpy((*allocated_buffer) + current_string_len, add_string, (add_string_len + 1) * sizeof(unichar));
+        return *allocated_buffer;
+    }
 }
 
 
@@ -3754,46 +3754,46 @@ unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buf
 * append a string in the same way
 */
 unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const char* add_string, size_t* len, Abstract_allocator prv_alloc)
+    unichar**allocated_buffer, const char* add_string, size_t* len, Abstract_allocator prv_alloc)
 {
-	const unichar* current_buffer = ((*allocated_buffer) != NULL) ? (*allocated_buffer) : original_buffer;
-	size_t current_string_len = u_strlen(current_buffer);
-	size_t add_string_len = strlen(add_string);
-	size_t buffer_size_needed = current_string_len + add_string_len + 1;
-	if (len != NULL)
-		*len = current_string_len + add_string_len;
+    const unichar* current_buffer = ((*allocated_buffer) != NULL) ? (*allocated_buffer) : original_buffer;
+    size_t current_string_len = u_strlen(current_buffer);
+    size_t add_string_len = strlen(add_string);
+    size_t buffer_size_needed = current_string_len + add_string_len + 1;
+    if (len != NULL)
+        *len = current_string_len + add_string_len;
 
-	if ((*allocated_buffer) == NULL)
-	{
-		if ((current_string_len + add_string_len + 1) < original_buffer_size)
-		{
-			u_strcpy(original_buffer + current_string_len, add_string);
-			return original_buffer;
-		}
-		else
-		{
-			*allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
-			if ((*allocated_buffer) == NULL) {
-				fatal_alloc_error("u_strcat_optional_buffer");
-			}
+    if ((*allocated_buffer) == NULL)
+    {
+        if ((current_string_len + add_string_len + 1) < original_buffer_size)
+        {
+            u_strcpy(original_buffer + current_string_len, add_string);
+            return original_buffer;
+        }
+        else
+        {
+            *allocated_buffer = (unichar*)malloc_cb(buffer_size_needed * sizeof(unichar), prv_alloc);
+            if ((*allocated_buffer) == NULL) {
+                fatal_alloc_error("u_strcat_optional_buffer");
+            }
 
-			memcpy((*allocated_buffer), original_buffer, current_string_len * sizeof(unichar));
-			u_strcpy((*allocated_buffer) + current_string_len, add_string);
-			return *allocated_buffer;
-		}
-	}
-	else
-	{
-		*allocated_buffer = (unichar*)realloc_cb((*allocated_buffer),
-			(current_string_len + 1) * sizeof(unichar),
-			buffer_size_needed * sizeof(unichar), prv_alloc);
-		if ((*allocated_buffer) == NULL) {
-			fatal_alloc_error("u_strcat_optional_buffer");
-		}
+            memcpy((*allocated_buffer), original_buffer, current_string_len * sizeof(unichar));
+            u_strcpy((*allocated_buffer) + current_string_len, add_string);
+            return *allocated_buffer;
+        }
+    }
+    else
+    {
+        *allocated_buffer = (unichar*)realloc_cb((*allocated_buffer),
+            (current_string_len + 1) * sizeof(unichar),
+            buffer_size_needed * sizeof(unichar), prv_alloc);
+        if ((*allocated_buffer) == NULL) {
+            fatal_alloc_error("u_strcat_optional_buffer");
+        }
 
-		u_strcpy((*allocated_buffer) + current_string_len, add_string);
-		return *allocated_buffer;
-	}
+        u_strcpy((*allocated_buffer) + current_string_len, add_string);
+        return *allocated_buffer;
+    }
 }
 
 
@@ -3802,10 +3802,10 @@ unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buf
  */
 void free_string_optional_buffer(unichar** allocated_buffer, Abstract_allocator prv_alloc)
 {
-	if ((*allocated_buffer) != NULL) {
-		free_cb(*allocated_buffer, prv_alloc);
-		*allocated_buffer = NULL;
-	}
+    if ((*allocated_buffer) != NULL) {
+        free_cb(*allocated_buffer, prv_alloc);
+        *allocated_buffer = NULL;
+    }
 }
 
 
@@ -3822,33 +3822,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=(unichar)*(a_p);
        b_c=(unichar)((unsigned char)*(b_p));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+1);
        b_c=(unichar)((unsigned char)*(b_p+1));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+2);
        b_c=(unichar)((unsigned char)*(b_p+2));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=(unichar)*(a_p+3);
        b_c=(unichar)((unsigned char)*(b_p+3));
        a_p+=4;
-	   b_p+=4;
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       b_p+=4;
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
     } ;
 } else {
   if (a==NULL) {
@@ -3873,33 +3873,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=fast_u_toupper((unichar)*(a_p));
        b_c=fast_u_toupper((unichar)((unsigned char)*(b_p)));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+1));
        b_c=fast_u_toupper((unichar)((unsigned char)*(b_p+1)));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+2));
        b_c=fast_u_toupper((unichar)((unsigned char)*(b_p+2)));
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
 
        a_c=fast_u_toupper((unichar)*(a_p+3));
        b_c=fast_u_toupper((unichar)((unsigned char)*(b_p+3)));
        a_p+=4;
-	   b_p+=4;
-	   if (a_c=='\0')
-		   return -b_c;
-	   if (a_c-b_c!=0)
-		   return (a_c-b_c);
+       b_p+=4;
+       if (a_c=='\0')
+           return -b_c;
+       if (a_c-b_c!=0)
+           return (a_c-b_c);
     } ;
 } else {
   if (a==NULL) {
@@ -3915,56 +3915,56 @@ if ((a!=NULL) && (b!=NULL)) {
  * Unicode version of strtok_r.
  */
 unichar *u_strtok_r(unichar *str, const unichar *delim, unichar **saveptr) {
-	int i = 0;
-	int len = (int)u_strlen(delim);
+    int i = 0;
+    int len = (int)u_strlen(delim);
 
 
-	/* if the original string has nothing left */
-	if (!str && !(*saveptr))
-		return NULL;
+    /* if the original string has nothing left */
+    if (!str && !(*saveptr))
+        return NULL;
 
-	/* initialize the sp during the first call */
-	if (str && !(*saveptr))
-		(*saveptr) = str;
+    /* initialize the sp during the first call */
+    if (str && !(*saveptr))
+        (*saveptr) = str;
 
-	/* find the start of the substring, skip delim */
-	unichar* p_start = (*saveptr);
-	for (;;) {
-		for (i = 0; i < len; i++) {
-			if (*p_start == delim[i]) {
-				p_start++;
-				break;
-			}
-		}
+    /* find the start of the substring, skip delim */
+    unichar* p_start = (*saveptr);
+    for (;;) {
+        for (i = 0; i < len; i++) {
+            if (*p_start == delim[i]) {
+                p_start++;
+                break;
+            }
+        }
 
-		if (i == len) {
-			(*saveptr) = p_start;
-			break;
-		}
-	}
+        if (i == len) {
+            (*saveptr) = p_start;
+            break;
+        }
+    }
 
-	/* return NULL if nothing left */
-	if (*(*saveptr) == '\0') {
-		(*saveptr) = NULL;
-		return (*saveptr);
-	}
+    /* return NULL if nothing left */
+    if (*(*saveptr) == '\0') {
+        (*saveptr) = NULL;
+        return (*saveptr);
+    }
 
-	/* find the end of the substring, and
-	replace the delimiter with null */
-	while (*(*saveptr) != '\0') {
-		for (i = 0; i < len; i++) {
-			if (*(*saveptr) == delim[i]) {
-				*(*saveptr) = '\0';
-				break;
-			}
-		}
+    /* find the end of the substring, and
+    replace the delimiter with null */
+    while (*(*saveptr) != '\0') {
+        for (i = 0; i < len; i++) {
+            if (*(*saveptr) == delim[i]) {
+                *(*saveptr) = '\0';
+                break;
+            }
+        }
 
-		(*saveptr)++;
-		if (i < len)
-			break;
-	}
+        (*saveptr)++;
+        if (i < len)
+            break;
+    }
 
-	return p_start;
+    return p_start;
 }
 
 
@@ -3972,51 +3972,51 @@ unichar *u_strtok_r(unichar *str, const unichar *delim, unichar **saveptr) {
  * Returns 1 if a is the same as b; 0 otherwise.
  */
 int u_equal(const unichar* a, const unichar* b) {
-	if ((a != NULL) && (b != NULL)) {
-		const unichar *a_p = a;
-		const unichar *b_p = b;
-		unichar a_c;
-		unichar b_c;
+    if ((a != NULL) && (b != NULL)) {
+        const unichar *a_p = a;
+        const unichar *b_p = b;
+        unichar a_c;
+        unichar b_c;
 
-		for (;;) {
-			a_c = (unichar)*(a_p);
-			b_c = (unichar)*(b_p);
-			if (a_c == '\0')
-				return (b_c == '\0') ? 1 : 0;
-			if (a_c - b_c != 0)
-				return 0;
+        for (;;) {
+            a_c = (unichar)*(a_p);
+            b_c = (unichar)*(b_p);
+            if (a_c == '\0')
+                return (b_c == '\0') ? 1 : 0;
+            if (a_c - b_c != 0)
+                return 0;
 
-			a_c = (unichar)*(a_p + 1);
-			b_c = (unichar)*(b_p + 1);
-			if (a_c == '\0')
-				return (b_c == '\0') ? 1 : 0;
-			if (a_c - b_c != 0)
-				return 0;
+            a_c = (unichar)*(a_p + 1);
+            b_c = (unichar)*(b_p + 1);
+            if (a_c == '\0')
+                return (b_c == '\0') ? 1 : 0;
+            if (a_c - b_c != 0)
+                return 0;
 
-			a_c = (unichar)*(a_p + 2);
-			b_c = (unichar)*(b_p + 2);
-			if (a_c == '\0')
-				return (b_c == '\0') ? 1 : 0;
-			if (a_c - b_c != 0)
-				return 0;
+            a_c = (unichar)*(a_p + 2);
+            b_c = (unichar)*(b_p + 2);
+            if (a_c == '\0')
+                return (b_c == '\0') ? 1 : 0;
+            if (a_c - b_c != 0)
+                return 0;
 
-			a_c = (unichar)*(a_p + 3);
-			b_c = (unichar)*(b_p + 3);
-			a_p += 4;
-			b_p += 4;
-			if (a_c == '\0')
-				return (b_c == '\0') ? 1 : 0;
-			if (a_c - b_c != 0)
-				return 0;
-		};
-	}
-	else {
-		if (a == NULL) {
-			if (b == NULL) return 1;
-			return 0;
-		}
-		return 0;
-	}
+            a_c = (unichar)*(a_p + 3);
+            b_c = (unichar)*(b_p + 3);
+            a_p += 4;
+            b_p += 4;
+            if (a_c == '\0')
+                return (b_c == '\0') ? 1 : 0;
+            if (a_c - b_c != 0)
+                return 0;
+        };
+    }
+    else {
+        if (a == NULL) {
+            if (b == NULL) return 1;
+            return 0;
+        }
+        return 0;
+    }
 }
 
 
@@ -4236,9 +4236,9 @@ return NULL;
  */
 int u_strrchr(const unichar* s,unichar t){
 for(int i=u_strlen(s)-1;i>0;i--){
-	if(s[i]==t){
-		return i;
-	}
+    if(s[i]==t){
+        return i;
+    }
 }
 return -1;
 }
@@ -4300,33 +4300,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=(unichar)*(a_p);
        b_c=(unichar)((unichar)*(b_p));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+1);
        b_c=(unichar)((unichar)*(b_p+1));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+2);
        b_c=(unichar)((unichar)*(b_p+2));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+3);
        b_c=(unichar)((unichar)*(b_p+3));
        a_p+=4;
-	   b_p+=4;
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       b_p+=4;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
     } ;
 } else {
   if (b!=NULL) {
@@ -4350,33 +4350,33 @@ if ((a!=NULL) && (b!=NULL)) {
     for(;;) {
        a_c=(unichar)*(a_p);
        b_c=(unichar)((unsigned char)*(b_p));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+1);
        b_c=(unichar)((unsigned char)*(b_p+1));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+2);
        b_c=(unichar)((unsigned char)*(b_p+2));
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
 
        a_c=(unichar)*(a_p+3);
        b_c=(unichar)((unsigned char)*(b_p+3));
        a_p+=4;
-	   b_p+=4;
-	   if (b_c=='\0')
-		   return 1;
-	   if (a_c != b_c)
-		   return 0;
+       b_p+=4;
+       if (b_c=='\0')
+           return 1;
+       if (a_c != b_c)
+           return 0;
     } ;
 } else {
   if (b!=NULL) {
@@ -4489,7 +4489,7 @@ void u_to_char_n(char* dest, const unichar* src, unsigned int n) {
 void u_chomp_new_line(unichar* s) {
 int l=u_strlen(s);
 if (l>0 && s[l-1]=='\n') {
-	s[l-1]='\0';
+    s[l-1]='\0';
 }
 }
 
@@ -4646,12 +4646,12 @@ if (src==NULL) {
 }
 int pos=0;
 for (int i=0;src[i]!='\0';i++) {
-	if (u_is_ASCII_alphanumeric(src[i])) {
-		dst[pos++]=src[i];
-	} else {
-		int n=u_sprintf(&(dst[pos]),"%%%X",src[i]);
-		pos=pos+n;
-	}
+    if (u_is_ASCII_alphanumeric(src[i])) {
+        dst[pos++]=src[i];
+    } else {
+        int n=u_sprintf(&(dst[pos]),"%%%X",src[i]);
+        pos=pos+n;
+    }
 }
 dst[pos]='\0';
 return pos;
@@ -4844,40 +4844,40 @@ return (c>=0x0386 && c<=0x03F5 && c!=0x0387 && c!=0x038B
 //------Beginning of Hyungue's inserts--------------
 
 //
-//	return true if c is a korean syllalbe
+//  return true if c is a korean syllalbe
 //
 int u_is_Hangul(unichar c)
 {
-	return( (c >= 0xac00) && (c<= 0xd7a3));
+    return( (c >= 0xac00) && (c<= 0xd7a3));
 }
 //
-//	return true if c is a korean ideograme
+//  return true if c is a korean ideograme
 //
 
 int u_is_CJK_Unified_Ideograph(unichar c)
 {
-	return( (c>= 0x4e00) && (c <= 0x9fff));
+    return( (c>= 0x4e00) && (c <= 0x9fff));
 }
 int u_is_CJK_compatibility_ideograph(unichar c)
 {
-	return( (c>= 0xf900) && (c <= 0xfaff));
+    return( (c>= 0xf900) && (c <= 0xfaff));
 }
 //
-//	return true if c is a character of the alphabet coreen
-//	when characters of this zone exit in the korean text
-//	these is symbols
+//  return true if c is a character of the alphabet coreen
+//  when characters of this zone exit in the korean text
+//  these is symbols
 //
 int u_is_Hangul_Compatility_Jamo(unichar c)
 {
-	return( (c>= 0x3130) && (c <= 0x3163));
+    return( (c>= 0x3130) && (c <= 0x3163));
 }
 //
-//	return true
-//	these charcters of this zone can not existe in the korean text
+//  return true
+//  these charcters of this zone can not existe in the korean text
 //
 int u_is_Hangul_Jamo(unichar c)
 {
-	return( (c>= 0x1100) && (c <= 0x11FF));
+    return( (c>= 0x1100) && (c <= 0x11FF));
 }
 
 int u_is_Hangul_Jamo_initial_consonant(unichar c)
@@ -5085,17 +5085,17 @@ return (c>=0x0E01 && c<=0x0E39 && c!=0x0E3F) ||
 
 // returns true if c is a greek extended letter
 //
-int u_is_greek_extended_letter(unichar c) {							//$CD:20021115
-return (c>=0x1F00 && c<=0x1F15) || (c>=0x1F18 && c<=0x1F1D) ||		//$CD:20021115
-       (c>=0x1F20 && c<=0x1F45) || (c>=0x1F48 && c<=0x1F4D) ||		//$CD:20021115
-       (c>=0x1F50 && c<=0x1F57) || 									//$CD:20021115
-        c==0x1F59 || c==0x1F5B || c==0x1F5D || 						//$CD:20021115
-       (c>=0x1F5F && c<=0x1F7D) || (c>=0x1F80 && c<=0x1FB4) ||		//$CD:20021115
-       (c>=0x1FB6 && c<=0x1FBC) || (c>=0x1FC2 && c<=0x1FC4) ||		//$CD:20021115
-       (c>=0x1FC6 && c<=0x1FCC) || (c>=0x1FD0 && c<=0x1FD3) ||		//$CD:20021115
-       (c>=0x1FD6 && c<=0x1FDB) || (c>=0x1FE0 && c<=0x1FEC) ||		//$CD:20021115
-       (c>=0x1FF2 && c<=0x1FF4) || (c>=0x1FF6 && c<=0x1FFC);		//$CD:20021115
-}																	//$CD:20021115
+int u_is_greek_extended_letter(unichar c) {                         //$CD:20021115
+return (c>=0x1F00 && c<=0x1F15) || (c>=0x1F18 && c<=0x1F1D) ||      //$CD:20021115
+       (c>=0x1F20 && c<=0x1F45) || (c>=0x1F48 && c<=0x1F4D) ||      //$CD:20021115
+       (c>=0x1F50 && c<=0x1F57) ||                                  //$CD:20021115
+        c==0x1F59 || c==0x1F5B || c==0x1F5D ||                      //$CD:20021115
+       (c>=0x1F5F && c<=0x1F7D) || (c>=0x1F80 && c<=0x1FB4) ||      //$CD:20021115
+       (c>=0x1FB6 && c<=0x1FBC) || (c>=0x1FC2 && c<=0x1FC4) ||      //$CD:20021115
+       (c>=0x1FC6 && c<=0x1FCC) || (c>=0x1FD0 && c<=0x1FD3) ||      //$CD:20021115
+       (c>=0x1FD6 && c<=0x1FDB) || (c>=0x1FE0 && c<=0x1FEC) ||      //$CD:20021115
+       (c>=0x1FF2 && c<=0x1FF4) || (c>=0x1FF6 && c<=0x1FFC);        //$CD:20021115
+}                                                                   //$CD:20021115
 
 
 //
@@ -5124,11 +5124,11 @@ return u_is_basic_latin_letter(c)
        || u_is_malayalam_letter(c)
        || u_is_sinhala_letter(c)
        || u_is_thai_letter(c)
-       || u_is_greek_extended_letter(c)	//$CD:20021115
+       || u_is_greek_extended_letter(c) //$CD:20021115
 //---------Beginning of Hyungue's inserts--------
        || u_is_Hangul(c)
-	   || u_is_CJK_Unified_Ideograph(c)
-	   || u_is_CJK_compatibility_ideograph(c)
+       || u_is_CJK_Unified_Ideograph(c)
+       || u_is_CJK_compatibility_ideograph(c)
 //---------End of Hyungue's inserts--------
        ;
 }
@@ -7963,14 +7963,14 @@ unichar u_deaccentuate (unichar c) {
 
 #ifdef CASE_CONVERSION_BY_TAB_UPPER
 unichar u_toupper (unichar c) {
-	return upperChar[c];
+    return upperChar[c];
 }
 
 void u_toupper (unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=upperChar[*s];
-	s++;
+    *s=upperChar[*s];
+    s++;
 }
 }
 
@@ -7979,12 +7979,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = upperChar[c];
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = upperChar[c];
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }
@@ -7994,8 +7994,8 @@ return is_modified;
 void u_toupper (unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=u_toupper(*s);
-	s++;
+    *s=u_toupper(*s);
+    s++;
 }
 }
 
@@ -8004,12 +8004,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = u_toupper(c);
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = u_toupper(c);
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }
@@ -8017,15 +8017,15 @@ return is_modified;
 
 #ifdef CASE_CONVERSION_BY_TAB_LOWER
 unichar u_tolower (unichar c) {
-	return lowerChar[c];
+    return lowerChar[c];
 }
 
 
 void u_tolower (unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=lowerChar[*s];
-	s++;
+    *s=lowerChar[*s];
+    s++;
 }
 }
 
@@ -8034,12 +8034,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = lowerChar[c];
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = lowerChar[c];
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }
@@ -8049,8 +8049,8 @@ return is_modified;
 void u_tolower (unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=u_tolower(*s);
-	s++;
+    *s=u_tolower(*s);
+    s++;
 }
 }
 
@@ -8059,12 +8059,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = u_tolower(c);
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = u_tolower(c);
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }
@@ -8072,14 +8072,14 @@ return is_modified;
 
 #ifdef CASE_DEACCENTUATE_BY_TAB
 unichar u_deaccentuate (unichar c) {
-	return deaccentuateChar[c];
+    return deaccentuateChar[c];
 }
 
 void u_deaccentuate(unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=deaccentuateChar[*s];
-	s++;
+    *s=deaccentuateChar[*s];
+    s++;
 }
 }
 
@@ -8088,12 +8088,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = deaccentuateChar[c];
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = deaccentuateChar[c];
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }
@@ -8103,8 +8103,8 @@ return is_modified;
 void u_deaccentuate(unichar* s) {
 if (s==NULL) return;
 while (*s!='\0') {
-	*s=u_deaccentuate(*s);
-	s++;
+    *s=u_deaccentuate(*s);
+    s++;
 }
 }
 
@@ -8113,12 +8113,12 @@ if (s==NULL) return 0;
 int is_modified = 0;
 unichar c = '\0';
 do {
-	c = *(s++);
-	unichar cu = u_deaccentuate(c);
-	if (c != cu) {
-		*(s-1) = cu;
-		is_modified = 1;
-	}
+    c = *(s++);
+    unichar cu = u_deaccentuate(c);
+    if (c != cu) {
+        *(s-1) = cu;
+        is_modified = 1;
+    }
 } while(c!='\0');
 return is_modified;
 }

--- a/Unicode.cpp
+++ b/Unicode.cpp
@@ -408,7 +408,7 @@ const struct write_encoding_item write_encoding_item_list[] =
     { "utf16le", 7, UTF16_LE, 2 },
     { "utf16le-no-bom", 14, UTF16_LE, 0 },
     { "utf16le-bom", 11, UTF16_LE, 1 },
-	
+
     { "utf-16-platform", 15, PLATFORM_DEPENDENT_UTF16, 2 },
     { "utf-16-platform-no-bom", 22, PLATFORM_DEPENDENT_UTF16, 0 },
     { "utf-16-platform-bom", 19, PLATFORM_DEPENDENT_UTF16, 1 },
@@ -469,7 +469,7 @@ char *strdup_lower_case(const char* text)
 int decode_reading_encoding_parameter(int* p_mask_encoding_compatibility,const char* encoding_text)
 {
     char* lower_encoding_text=strdup_lower_case(encoding_text);
-    int ret=0;   
+    int ret=0;
     char * cur_encoding_text = lower_encoding_text;
     char * next_encoding_text;
     int mask_encoding_compatibility = 0;
@@ -502,7 +502,7 @@ int decode_reading_encoding_parameter(int* p_mask_encoding_compatibility,const c
                     ret = 1;
                     mask_encoding_compatibility = mask_encoding_compatibility | reading_encoding_item_list[i].encoding_flag;
                     break;
-                }           
+                }
 
             i++;
         }
@@ -633,7 +633,7 @@ int GetFileEncoding(ABSTRACTFILE* f,Encoding* encoding,int *is_BOM,int MASK_ENCO
         if ((MASK_ENCODING_COMPATIBILITY & UTF16_LE_BOM_POSSIBLE) != 0)
             if ((tab[0] == 0xff) && (tab[1]==0xfe))
             {
-                af_fseek(f,0,0);            
+                af_fseek(f,0,0);
                 *encoding=UTF16_LE;
                 *is_BOM=1;
                 return 1;
@@ -844,7 +844,7 @@ U_FILE* u_fopen_creating_versatile_encoding(Encoding encoding,int write_bom,cons
 
 
 /**
- * Before writing a file, predict the planned size in bytes of file for optimization. 
+ * Before writing a file, predict the planned size in bytes of file for optimization.
  */
 void u_fsetsizereservation_by_bytes(U_FILE*f, long size_planned)
 {
@@ -1050,7 +1050,7 @@ switch(encoding) {
    case UTF16_LE: return u_fgetc_UTF16LE_raw(f);
    case BIG_ENDIAN_UTF16: return u_fgetc_UTF16BE_raw(f);
    case UTF8: return u_fgetc_UTF8_raw(f);
-   case PLATFORM_DEPENDENT_UTF16: return is_platform_little_endian() ? 
+   case PLATFORM_DEPENDENT_UTF16: return is_platform_little_endian() ?
                              u_fgetc_UTF16LE_raw(f) : u_fgetc_UTF16BE_raw(f);
    case ASCII: {
 	   unsigned char c;
@@ -1608,7 +1608,7 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
                  {
                     unichar c;
                     c = (((unichar)tab_in[(i)])) ;
-                    
+
                     if (c==0) {
                     	fatal_error("Corrupted ASCII text file containing null characters\n");
                     }
@@ -1754,7 +1754,7 @@ int u_fgets_buffered(Encoding encoding,unichar* line,int i_is_size,int size,ABST
  *   unichar* line = NULL;
  *   size_t size_buffer_line = 0;
  *   int len_read; while ((len_read=u_fgets_dynamic_buffer(&line, &size_buffer_line,f)) != EOF) { work on line }
- *    or 
+ *    or
  *   while (u_fgets_dynamic_buffer(&line, &size_buffer_line,f) != EOF) { work on line }
  *   and at end, at same time than u_close(f)
  *   if (line != NULL) free(line);
@@ -1945,7 +1945,7 @@ int u_fget_unichars_raw(Encoding encoding, unichar* buffer, int size, ABSTRACTFI
 					unichar c = (unichar)((((unichar)tab_in[(i * 2) + hibytepos]) << 8) | (tab_in[(i * 2) + (1 - hibytepos)]));
 
 					*(buffer + size_done + i) = c;
-				
+
 				}
 				size_done += nb_unichar_read;
 				size_to_do -= nb_unichar_read;
@@ -1954,7 +1954,7 @@ int u_fget_unichars_raw(Encoding encoding, unichar* buffer, int size, ABSTRACTFI
 		}
 	}
 
-	
+
 	case UTF8:
 	{
 
@@ -2017,12 +2017,12 @@ int u_fget_unichars_raw(Encoding encoding, unichar* buffer, int size, ABSTRACTFI
 					if (pos_in_unichar_line == size)
 					{
 						af_fseek(f, -1 * (long)(read_binary_in_file - i), SEEK_CUR);
-							
+
 						return pos_in_unichar_line;
 					}
 
 					buffer[pos_in_unichar_line++] = c;
-					 
+
 					i += nbbyte;
 				}
 			}
@@ -2189,7 +2189,7 @@ int BuildEncodedOutForUnicharString(Encoding encoding,const unichar *pc,Buffer_O
                    pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
                    break;
                }
-			   
+
            case BIG_ENDIAN_UTF16:
                {
                    pBufOut->tabOut[(pBufOut->iPosInTabOut)++]=(unsigned char)(c >> 8);
@@ -3322,7 +3322,7 @@ do {
 } while (c!='\0');
 return s;
 }*/
-    
+
 unichar* u_strcpy(unichar* dst,const unichar* src)
 {
     unichar *s = dst; // backup pointer to start of destination string
@@ -3333,42 +3333,42 @@ unichar* u_strcpy(unichar* dst,const unichar* src)
         *dst = c0;
         if (c0 == '\0')
             break;
-        
+
         unichar c1 = *(src+1);
         *(dst+1) = c1;
         if (c1 == '\0')
             break;
-        
+
         unichar c2 = *(src+2);
         *(dst+2) = c2;
         if (c2 == '\0')
             break;
-        
+
         unichar c3 = *(src+3);
         *(dst+3) = c3;
         if (c3 == '\0')
             break;
-        
+
         unichar c4 = *(src+4);
         *(dst+4) = c4;
         if (c4 == '\0')
             break;
-        
+
         unichar c5 = *(src+5);
         *(dst+5) = c5;
         if (c5 == '\0')
             break;
-        
+
         unichar c6 = *(src+6);
         *(dst+6) = c6;
         if (c6 == '\0')
             break;
-        
+
         unichar c7 = *(src+7);
         *(dst+7) = c7;
         if (c7 == '\0')
             break;
-        
+
         src += 8;
         dst += 8;
     }
@@ -4190,7 +4190,7 @@ return NULL;
  */
 const unichar* u_strchr(const unichar* s,unichar c) {
 if (s==NULL) return NULL;
-while ((*s)) {	
+while ((*s)) {
    if (*s==c) {
      return s;
    }
@@ -4202,7 +4202,7 @@ return NULL;
 
 unichar* u_strchr(unichar* s,unichar c) {
 if (s==NULL) return NULL;
-while ((*s)) {	
+while ((*s)) {
    if (*s==c) {
      return s;
    }
@@ -4447,7 +4447,7 @@ int u_substr(const unichar *str, const unichar *target) {
  *
  * Author: Sébastien Paumier
  * Modified by Sébastian Nagel
- * Modified by Cristian Martinez 
+ * Modified by Cristian Martinez
  */
 void u_to_char(char *dest,unichar *src) {
   // C-style reinterpret cast, @see http://stackoverflow.com/a/5042335/2042871
@@ -4497,20 +4497,20 @@ if (l>0 && s[l-1]=='\n') {
 #ifndef NO_CPP_TEMPLATE_SUPPORT
 /**
  * @brief  Converts all non-ASCII Unicode characters to Unicode escape-sequences
- * 
+ *
  * Gets the numeric Unicode code point of each character between U+0080 (128)
- * and U+FFFF (65535) and escape it using its 4-digit hexadecimal value 
+ * and U+FFFF (65535) and escape it using its 4-digit hexadecimal value
  * prefixed with \u. Resulting escape sequences are in the form \u[a-f0-9]{4}
- * e.g. "Fran\u00e7ais" for "Français" 
- * 
- * @remark 
- *      Notice that unichar is for now a 16-bits type and pairs of surrogate  
- *      code points are not handled by Unitex. If this changes in the future, 
- *      this function should be updated.  
- * 
+ * e.g. "Fran\u00e7ais" for "Français"
+ *
+ * @remark
+ *      Notice that unichar is for now a 16-bits type and pairs of surrogate
+ *      code points are not handled by Unitex. If this changes in the future,
+ *      this function should be updated.
+ *
  * @see http://tools.ietf.org/html/rfc5137
- * @see http://billposer.org/Software/ListOfRepresentations.html 
- * 
+ * @see http://billposer.org/Software/ListOfRepresentations.html
+ *
  * @param[in] source unichar string to be escaped
  * @param[out] destination array where the escaped string is to be copied
  * @return the length of the destination string
@@ -4519,20 +4519,20 @@ template <typename T>
 int u_escape(const unichar* source, T* destination) {
   if (!source) {
      fatal_error("NULL error in ASCIIize\n");
-  }   
-  
+  }
+
   const unichar* it = source;
   int pos = 0;
-  
+
   // loop till the end of string
-  while (*it != '\0') { 
+  while (*it != '\0') {
     // ASCII characters are lower than 0x7f and will not be escaped
-    if(*it <= 0x7F) {                            
+    if(*it <= 0x7F) {
       destination[pos++] = (T)*it;
-    } 
-    // 2-bytes unicode codepoints 
+    }
+    // 2-bytes unicode codepoints
     else {
-      // Parse code point hex nibbles 
+      // Parse code point hex nibbles
       // e.g. for U+2764
       //   -----------------------------------------------------------------
       //   |       2       |       7       |       6       |       4       |
@@ -4544,8 +4544,8 @@ int u_escape(const unichar* source, T* destination) {
       T nibble_1h = (*it >> 4)  & 0x0F;
       T nibble_2l = (*it >> 8)  & 0x0F;
       T nibble_2h = (*it >> 12) & 0x0F;
-      
-      // Build the escape sequence as \u[a-f0-9]{4} 
+
+      // Build the escape sequence as \u[a-f0-9]{4}
       // e.g. \u2764
       destination[pos++] = '\\';
       destination[pos++] = 'u';
@@ -4554,20 +4554,20 @@ int u_escape(const unichar* source, T* destination) {
       destination[pos++] = nibble_1h + (nibble_1h < 0x0A ? '0' : 'W');
       destination[pos++] = nibble_1l + (nibble_1l < 0x0A ? '0' : 'W');
     }
-    
+
     // advance the character pointer
     ++it;
-  }  
-  
+  }
+
   // indicate the end of the string
   destination[pos] = '\0';
-  
+
   // return the length of the destination string
   return pos;
 }
 
 // Converts all non-ASCII Unicode characters to Unicode escape-sequences
-// destination is a unichar buffer 
+// destination is a unichar buffer
 template int u_escape(const unichar* source, unichar* destination);
 
 // Converts all non-ASCII Unicode characters to Unicode escape-sequences
@@ -4579,11 +4579,11 @@ template int u_escape(const unichar* source, char* destination);
 
 /**
  * @brief JSON-escapes a unichar string
- * 
- * JSON-escapes a source string before copy it into destination 
- * this function conforms with "The application/json Media Type 
- * for JavaScript Object Notation (JSON)" RFC 4627. 
- * 
+ *
+ * JSON-escapes a source string before copy it into destination
+ * this function conforms with "The application/json Media Type
+ * for JavaScript Object Notation (JSON)" RFC 4627.
+ *
  * @param[in]  source unichar string to be escaped
  * @param[out] destination unichar array where the escaped string is to be copied
  * @return the length of the destination string
@@ -4591,18 +4591,18 @@ template int u_escape(const unichar* source, char* destination);
 int JSONize(const unichar* source,unichar* destination) {
   if (!source) {
      fatal_error("NULL error in JSONize\n");
-  }  
- 
+  }
+
   const unichar* it = source;
   int pos = 0;
 
 // U_STRCPY_LITERAL macro copies a literal string, starting at pos position,
-// into a destination unichar buffer, then it increments the pos variable by 
-// the length of the literal. In this case the length is computed at compile 
-// time       
+// into a destination unichar buffer, then it increments the pos variable by
+// the length of the literal. In this case the length is computed at compile
+// time
 #define U_STRCPY_LITERAL(destination, pos, literal) \
         u_strcpy(&*(destination+pos),literal);      \
-        pos+=sizeof(literal)-1  
+        pos+=sizeof(literal)-1
   // loop till the end of string
   while (*it != '\0') {
     switch(*it) {
@@ -4616,17 +4616,17 @@ int JSONize(const unichar* source,unichar* destination) {
       case '\t': U_STRCPY_LITERAL(destination,pos,"\\t");     break;
       case '&':  U_STRCPY_LITERAL(destination,pos,"\\u0026"); break;
       case '<':  U_STRCPY_LITERAL(destination,pos,"\\u003C"); break;
-      case '>':  U_STRCPY_LITERAL(destination,pos,"\\u003E"); break; 
+      case '>':  U_STRCPY_LITERAL(destination,pos,"\\u003E"); break;
       default :  destination[pos++] = *it;
     }
     // advance the character pointer
     ++it;
   }
-// undefines U_STRCPY_LITERAL macro right before we use them   
-#undef U_STRCPY_LITERAL     
+// undefines U_STRCPY_LITERAL macro right before we use them
+#undef U_STRCPY_LITERAL
   // indicate the end of the string
   destination[pos] = '\0';
-  
+
   // return the length of the destination string
   return pos;
 }

--- a/Unicode.h
+++ b/Unicode.h
@@ -90,8 +90,8 @@ typedef uint16_t unichar;
  * This structure is used to represent a file with its encoding.
  */
 typedef struct {
-	ABSTRACTFILE* f;
-	Encoding enc;
+    ABSTRACTFILE* f;
+    Encoding enc;
 } U_FILE;
 
 
@@ -270,13 +270,13 @@ unichar* u_strcat(unichar*,const unichar*);
 unichar* u_strcat(unichar*,const char*);
 
 unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const unichar* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
+    unichar**allocated_buffer, const unichar* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
 unichar* u_strcpy_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const char* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
+    unichar**allocated_buffer, const char* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
 unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const unichar* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
+    unichar**allocated_buffer, const unichar* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
 unichar* u_strcat_optional_buffer(unichar * original_buffer, size_t original_buffer_size,
-	unichar**allocated_buffer, const char* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
+    unichar**allocated_buffer, const char* add_string, size_t* len = NULL, Abstract_allocator prv_alloc = NULL);
 void free_string_optional_buffer(unichar** allocated_buffer, Abstract_allocator prv_alloc = NULL);
 
 int is_str_mono_unichar_string(const unichar*, unichar);
@@ -314,11 +314,11 @@ unichar* u_strdup(const char* str,Abstract_allocator prv_alloc);
 unichar* u_strdup(const unichar* str,int n,Abstract_allocator prv_alloc);
 
 size_t convert_utf8_to_unichar(unichar*dest, size_t nb_unichar_alloc_walk, size_t * p_size_this_string_written,
-	const unsigned char*src, size_t buf_size);
+    const unsigned char*src, size_t buf_size);
 
 // define NO_CPP_TEMPLATE_SUPPORT if you archeological C++ compiler don't support template
 #ifndef NO_CPP_TEMPLATE_SUPPORT
-template <typename T> 
+template <typename T>
 int u_escape(const unichar* source, T* destination);
 #endif
 
@@ -360,7 +360,7 @@ int u_is_kannada_letter(unichar);
 int u_is_malayalam_letter(unichar);
 int u_is_sinhala_letter(unichar);
 int u_is_thai_letter(unichar);
-int u_is_greek_extended_letter(unichar);	//$CD:20021115
+int u_is_greek_extended_letter(unichar);    //$CD:20021115
 //--------Beginning of Hyungue's inserts------------------
 int u_is_Hangul(unichar c);
 int u_is_CJK_Unified_Ideograph(unichar c);

--- a/UnitexGetOpt.cpp
+++ b/UnitexGetOpt.cpp
@@ -1,5 +1,5 @@
-/*	$OpenBSD: getopt_long.c,v 1.16 2004/02/04 18:17:25 millert Exp $	*/
-/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+/*  $OpenBSD: getopt_long.c,v 1.16 2004/02/04 18:17:25 millert Exp $    */
+/*  $NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $  */
 
 /*
  * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
@@ -74,23 +74,23 @@ static char *rcsid = "$OpenBSD: getopt_long.c,v 1.16 2004/02/04 18:17:25 millert
 namespace unitex {
 
 
-#define PRINT_ERROR	((vars->opterr) && (*options != ':'))
+#define PRINT_ERROR ((vars->opterr) && (*options != ':'))
 
-#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
-#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
-#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+#define FLAG_PERMUTE    0x01    /* permute non-options to the end of argv */
+#define FLAG_ALLARGS    0x02    /* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY   0x04    /* operate as getopt_long_only */
 
 /* return values */
-#define	BADCH		(int)'?'
-#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
-#define	INORDER 	(int)1
+#define BADCH       (int)'?'
+#define BADARG      ((*options == ':') ? (int)':' : (int)'?')
+#define INORDER     (int)1
 
 static const char EMSG[] = "";
 
 static int getopt_internal_TS(int, char * const *, const char *,
-			   const struct option_TS *, int *, int,struct OptVars*);
+               const struct option_TS *, int *, int,struct OptVars*);
 static int parse_long_options_TS(char * const *, const char *,
-			      const struct option_TS *, int *, int,struct OptVars*);
+                  const struct option_TS *, int *, int,struct OptVars*);
 static int gcd(int, int);
 static void permute_args(int, int, int, char * const *);
 
@@ -103,16 +103,16 @@ static void permute_args(int, int, int, char * const *);
 static int
 gcd(int a, int b)
 {
-	int c;
+    int c;
 
-	c = a % b;
-	while (c != 0) {
-		a = b;
-		b = c;
-		c = a % b;
-	}
+    c = a % b;
+    while (c != 0) {
+        a = b;
+        b = c;
+        c = a % b;
+    }
 
-	return (b);
+    return (b);
 }
 
 /*
@@ -122,176 +122,176 @@ gcd(int a, int b)
  */
 static void
 permute_args(int panonopt_start, int panonopt_end, int opt_end,
-	char * const *nargv)
+    char * const *nargv)
 {
-	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
-	char *swap;
+    int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+    char *swap;
 
-	/*
-	 * compute lengths of blocks and number and size of cycles
-	 */
-	nnonopts = panonopt_end - panonopt_start;
-	nopts = opt_end - panonopt_end;
-	ncycle = gcd(nnonopts, nopts);
-	cyclelen = (opt_end - panonopt_start) / ncycle;
+    /*
+     * compute lengths of blocks and number and size of cycles
+     */
+    nnonopts = panonopt_end - panonopt_start;
+    nopts = opt_end - panonopt_end;
+    ncycle = gcd(nnonopts, nopts);
+    cyclelen = (opt_end - panonopt_start) / ncycle;
 
-	for (i = 0; i < ncycle; i++) {
-		cstart = panonopt_end+i;
-		pos = cstart;
-		for (j = 0; j < cyclelen; j++) {
-			if (pos >= panonopt_end)
-				pos -= nnonopts;
-			else
-				pos += nopts;
-			swap = nargv[pos];
-			/* LINTED const cast */
-			((char **) nargv)[pos] = nargv[cstart];
-			/* LINTED const cast */
-			((char **)nargv)[cstart] = swap;
-		}
-	}
+    for (i = 0; i < ncycle; i++) {
+        cstart = panonopt_end+i;
+        pos = cstart;
+        for (j = 0; j < cyclelen; j++) {
+            if (pos >= panonopt_end)
+                pos -= nnonopts;
+            else
+                pos += nopts;
+            swap = nargv[pos];
+            /* LINTED const cast */
+            ((char **) nargv)[pos] = nargv[cstart];
+            /* LINTED const cast */
+            ((char **)nargv)[cstart] = swap;
+        }
+    }
 }
 
 // a tolerant version of strncmp which accept interoperate - and _
 static int strncmp_tolerant(const char*str1, const char*str2, size_t Count)
 {
-	char c1, c2;
-	int v;
+    char c1, c2;
+    int v;
 
-	if (Count == 0)
-		return 0;
+    if (Count == 0)
+        return 0;
 
-	do {
-		c1 = *str1++;
-		c2 = *str2++;
-		if (c1 == '_') c1 = '-';
-		if (c2 == '_') c2 = '-';
-		v = (unsigned int)c1 - (unsigned int)c2;
-	} while ((v == 0) && (c1 != '\0') && (--Count > 0));
+    do {
+        c1 = *str1++;
+        c2 = *str2++;
+        if (c1 == '_') c1 = '-';
+        if (c2 == '_') c2 = '-';
+        v = (unsigned int)c1 - (unsigned int)c2;
+    } while ((v == 0) && (c1 != '\0') && (--Count > 0));
 
-	return v;
+    return v;
 }
 
 /*
  * parse_long_options --
- *	Parse long options in argc/argv argument vector.
+ *  Parse long options in argc/argv argument vector.
  * Returns -1 if short_too is set and the option does not match long_options.
  */
 static int
 parse_long_options_TS(char * const *nargv, const char *options,
-	const struct option_TS *long_options, int *idx, int short_too,struct OptVars* vars)
+    const struct option_TS *long_options, int *idx, int short_too,struct OptVars* vars)
 {
-	const char *current_argv, *has_equal;
-	size_t current_argv_len;
-	int i, match;
+    const char *current_argv, *has_equal;
+    size_t current_argv_len;
+    int i, match;
 
-	current_argv = vars->place;
-	match = -1;
+    current_argv = vars->place;
+    match = -1;
 
-	(vars->optind)++;
+    (vars->optind)++;
 
-	if ((has_equal = strchr(current_argv, '=')) != NULL) {
-		/* argument found (--option=arg) */
-		current_argv_len = has_equal - current_argv;
-		has_equal++;
-	} else
-		current_argv_len = strlen(current_argv);
+    if ((has_equal = strchr(current_argv, '=')) != NULL) {
+        /* argument found (--option=arg) */
+        current_argv_len = has_equal - current_argv;
+        has_equal++;
+    } else
+        current_argv_len = strlen(current_argv);
 
-	for (i = 0; long_options[i].name; i++) {
-		/* find matching long option */
-		if (strncmp_tolerant(current_argv, long_options[i].name,
-		    current_argv_len))
-			continue;
+    for (i = 0; long_options[i].name; i++) {
+        /* find matching long option */
+        if (strncmp_tolerant(current_argv, long_options[i].name,
+            current_argv_len))
+            continue;
 
-		if (strlen(long_options[i].name) == current_argv_len) {
-			/* exact match */
-			match = i;
-			break;
-		}
-		/*
-		 * If this is a known short option, don't allow
-		 * a partial match of a single character.
-		 */
-		if (short_too && current_argv_len == 1)
-			continue;
+        if (strlen(long_options[i].name) == current_argv_len) {
+            /* exact match */
+            match = i;
+            break;
+        }
+        /*
+         * If this is a known short option, don't allow
+         * a partial match of a single character.
+         */
+        if (short_too && current_argv_len == 1)
+            continue;
 
-		if (match == -1)	/* partial match */
-			match = i;
-		else {
-			/* ambiguous abbreviation */
-			if (PRINT_ERROR) {
-			//	warnx(ambig, (int)current_argv_len, current_argv);
+        if (match == -1)    /* partial match */
+            match = i;
+        else {
+            /* ambiguous abbreviation */
+            if (PRINT_ERROR) {
+            //  warnx(ambig, (int)current_argv_len, current_argv);
          }
-			vars->optopt = 0;
-			return (BADCH);
-		}
-	}
-	if (match != -1) {		/* option found */
-	   *idx = match;
-		if (long_options[match].has_arg == no_argument_TS
-		    && has_equal) {
-			if (PRINT_ERROR) {
-				//warnx(noarg, (int)current_argv_len, current_argv);
-                 }			/*
-			 * XXX: GNU sets optopt to val regardless of flag
-			 */
-			if (long_options[match].flag == NULL)
-				vars->optopt = long_options[match].val;
-			else
-				vars->optopt = 0;
-			return (BADARG);
-		}
-		if (long_options[match].has_arg == required_argument_TS ||
-		    long_options[match].has_arg == optional_argument_TS) {
-			if (has_equal)
-				vars->optarg = has_equal;
-			else if (long_options[match].has_arg ==
-			    required_argument_TS) {
-				/*
-				 * optional argument doesn't use next nargv
-				 */
-			   vars->optarg = nargv[(vars->optind)++];
-			}
-		}
-		if ((long_options[match].has_arg == required_argument_TS)
-		    && (vars->optarg == NULL)) {
-			/*
-			 * Missing argument; leading ':' indicates no error
-			 * should be generated.
-			 */
-			if (PRINT_ERROR) {
-			//	warnx(recargstring,  current_argv);
+            vars->optopt = 0;
+            return (BADCH);
+        }
+    }
+    if (match != -1) {      /* option found */
+       *idx = match;
+        if (long_options[match].has_arg == no_argument_TS
+            && has_equal) {
+            if (PRINT_ERROR) {
+                //warnx(noarg, (int)current_argv_len, current_argv);
+                 }          /*
+             * XXX: GNU sets optopt to val regardless of flag
+             */
+            if (long_options[match].flag == NULL)
+                vars->optopt = long_options[match].val;
+            else
+                vars->optopt = 0;
+            return (BADARG);
+        }
+        if (long_options[match].has_arg == required_argument_TS ||
+            long_options[match].has_arg == optional_argument_TS) {
+            if (has_equal)
+                vars->optarg = has_equal;
+            else if (long_options[match].has_arg ==
+                required_argument_TS) {
+                /*
+                 * optional argument doesn't use next nargv
+                 */
+               vars->optarg = nargv[(vars->optind)++];
+            }
+        }
+        if ((long_options[match].has_arg == required_argument_TS)
+            && (vars->optarg == NULL)) {
+            /*
+             * Missing argument; leading ':' indicates no error
+             * should be generated.
+             */
+            if (PRINT_ERROR) {
+            //  warnx(recargstring,  current_argv);
          }
-			/*
-			 * XXX: GNU sets optopt to val regardless of flag
-			 */
-			if (long_options[match].flag == NULL)
-			   vars->optopt = long_options[match].val;
-			else
-			   vars->optopt = 0;
-			--(vars->optind);
-			return (BADARG);
-		}
-	} else {			/* unknown option */
-		if (short_too) {
-			--(vars->optind);
-			return (-1);
-		}
-		if (PRINT_ERROR) {
-		//	warnx(illoptstring, current_argv);
+            /*
+             * XXX: GNU sets optopt to val regardless of flag
+             */
+            if (long_options[match].flag == NULL)
+               vars->optopt = long_options[match].val;
+            else
+               vars->optopt = 0;
+            --(vars->optind);
+            return (BADARG);
+        }
+    } else {            /* unknown option */
+        if (short_too) {
+            --(vars->optind);
+            return (-1);
+        }
+        if (PRINT_ERROR) {
+        //  warnx(illoptstring, current_argv);
       }
-		vars->optopt = 0;
-		/* S.P. */
-		vars->optarg = current_argv;
-		*idx=0;
-		/* S.P. end */
-		return (BADCH);
-	}
-	if (long_options[match].flag) {
-		*long_options[match].flag = long_options[match].val;
-		return (0);
-	} else
-		return (long_options[match].val);
+        vars->optopt = 0;
+        /* S.P. */
+        vars->optarg = current_argv;
+        *idx=0;
+        /* S.P. end */
+        return (BADCH);
+    }
+    if (long_options[match].flag) {
+        *long_options[match].flag = long_options[match].val;
+        return (0);
+    } else
+        return (long_options[match].val);
 }
 
 #if defined(WINAPI_FAMILY) && defined(WINAPI_FAMILY_APP)
@@ -310,248 +310,248 @@ static const int posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
 
 /*
  * getopt_internal --
- *	Parse argc/argv argument vector.  Called by user level routines.
+ *  Parse argc/argv argument vector.  Called by user level routines.
  */
 static int
 getopt_internal_TS(int nargc, char * const *nargv, const char *options,
-	const struct option_TS *long_options, int *idx, int flags,struct OptVars* vars)
+    const struct option_TS *long_options, int *idx, int flags,struct OptVars* vars)
 {
-	char *oli;				/* option letter list index */
-	int optchar, short_too;
+    char *oli;              /* option letter list index */
+    int optchar, short_too;
 
-	if (options == NULL)
-		return (-1);
+    if (options == NULL)
+        return (-1);
 
-	/*
-	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
-	 * string begins with a '+'.
-	 */
-	if (posixly_correct || *options == '+')
-		flags &= ~FLAG_PERMUTE;
-	else if (*options == '-')
-		flags |= FLAG_ALLARGS;
-	if (*options == '+' || *options == '-')
-		options++;
+    /*
+     * Disable GNU extensions if POSIXLY_CORRECT is set or options
+     * string begins with a '+'.
+     */
+    if (posixly_correct || *options == '+')
+        flags &= ~FLAG_PERMUTE;
+    else if (*options == '-')
+        flags |= FLAG_ALLARGS;
+    if (*options == '+' || *options == '-')
+        options++;
 
-	/*
-	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
-	 * XXX using optreset.  Work around this braindamage.
-	 */
-	if (vars->optind == 0)
-	   vars->optind = vars->optreset = 1;
+    /*
+     * XXX Some GNU programs (like cvs) set optind to 0 instead of
+     * XXX using optreset.  Work around this braindamage.
+     */
+    if (vars->optind == 0)
+       vars->optind = vars->optreset = 1;
 
-	vars->optarg = NULL;
-	if (vars->optreset)
-	   vars->nonopt_start = vars->nonopt_end = -1;
+    vars->optarg = NULL;
+    if (vars->optreset)
+       vars->nonopt_start = vars->nonopt_end = -1;
 start:
-	if (vars->optreset || !*(vars->place)) {		/* update scanning pointer */
-	   vars->optreset = 0;
-		if (vars->optind >= nargc) {          /* end of argument vector */
-			(vars->place) = EMSG;
-			if (vars->nonopt_end != -1) {
-				/* do permutation, if we have to */
-				permute_args(vars->nonopt_start, vars->nonopt_end,
-				      vars->optind, nargv);
-				vars->optind -= vars->nonopt_end - vars->nonopt_start;
-			}
-			else if (vars->nonopt_start != -1) {
-				/*
-				 * If we skipped non-options, set optind
-				 * to the first of them.
-				 */
-			   vars->optind = vars->nonopt_start;
-			}
-			vars->nonopt_start = vars->nonopt_end = -1;
-			return (-1);
-		}
-		if (*((vars->place) = nargv[vars->optind]) != '-' ||
-		    ((vars->place)[1] == '\0' && strchr(options, '-') == NULL)) {
-			(vars->place) = EMSG;		/* found non-option */
-			if (flags & FLAG_ALLARGS) {
-				/*
-				 * GNU extension:
-				 * return non-option as argument to option 1
-				 */
-			   vars->optarg = nargv[(vars->optind)++];
-				return (INORDER);
-			}
-			if (!(flags & FLAG_PERMUTE)) {
-				/*
-				 * If no permutation wanted, stop parsing
-				 * at first non-option.
-				 */
-				return (-1);
-			}
-			/* do permutation */
-			if (vars->nonopt_start == -1)
-			   vars->nonopt_start = vars->optind;
-			else if (vars->nonopt_end != -1) {
-				permute_args(vars->nonopt_start, vars->nonopt_end,
-				      vars->optind, nargv);
-				vars->nonopt_start = vars->optind -
-				    (vars->nonopt_end - vars->nonopt_start);
-				vars->nonopt_end = -1;
-			}
-			(vars->optind)++;
-			/* process next argument */
-			goto start;
-		}
-		if (vars->nonopt_start != -1 && vars->nonopt_end == -1)
-		   vars->nonopt_end = vars->optind;
-
-		/*
-		 * If we have "-" do nothing, if "--" we are done.
-		 */
-		if ((vars->place)[1] != '\0' && *++(vars->place) == '-' && (vars->place)[1] == '\0') {
-			(vars->optind)++;
-			(vars->place) = EMSG;
-			/*
-			 * We found an option (--), so if we skipped
-			 * non-options, we have to permute.
-			 */
-			if (vars->nonopt_end != -1) {
-				permute_args(vars->nonopt_start, vars->nonopt_end,
-				      vars->optind, nargv);
-				vars->optind -= vars->nonopt_end - vars->nonopt_start;
-			}
-			vars->nonopt_start = vars->nonopt_end = -1;
-			return (-1);
-		}
-	}
-
-	/*
-	 * Check long options if:
-	 *  1) we were passed some
-	 *  2) the arg is not just "-"
-	 *  3) either the arg starts with -- we are getopt_long_only()
-	 */
-	if (long_options != NULL && (vars->place) != nargv[vars->optind] &&
-	    (*(vars->place) == '-' || (flags & FLAG_LONGONLY))) {
-		short_too = 0;
-		if (*(vars->place) == '-')
-			(vars->place)++;		/* --foo long option */
-		else if (*(vars->place) != ':' && strchr(options, *(vars->place)) != NULL)
-			short_too = 1;		/* could be short option too */
-
-		optchar = parse_long_options_TS(nargv, options, long_options,
-		    idx, short_too,vars);
-		if (optchar != -1) {
-			(vars->place) = EMSG;
-			return (optchar);
-		}
-	}
-
-	if ((optchar = (int)*(vars->place)++) == (int)':' ||
-	    (optchar == (int)'-' && *(vars->place) != '\0') ||
-	    (oli = (char*)strchr(options, optchar)) == NULL) {
-		/*
-		 * If the user specified "-" and  '-' isn't listed in
-		 * options, return -1 (non-option) as per POSIX.
-		 * Otherwise, it is an unknown option character (or ':').
-		 */
-		if (optchar == (int)'-' && *(vars->place) == '\0')
-			return (-1);
-		if (!*(vars->place))
-			++(vars->optind);
-		if (PRINT_ERROR) {
-		//	warnx(illoptchar, optchar);
-      }
-		vars->optopt = optchar;
-		return (BADCH);
-	}
-	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
-		/* -W long-option */
-		if (*(vars->place))	{		/* no space */
-			/* NOTHING */
-		}
-		else if (++(vars->optind) >= nargc) {	/* no arg */
-			(vars->place) = EMSG;
-			if (PRINT_ERROR) {
-			//	warnx(recargchar, optchar);
-         }
-			vars->optopt = optchar;
-			return (BADARG);
-		} else				/* white space */
-			(vars->place) = nargv[vars->optind];
-		optchar = parse_long_options_TS(nargv, options, long_options, idx, 0,vars);
-		(vars->place) = EMSG;
-		return (optchar);
-	}
-	if (*++oli != ':') {			/* doesn't take argument */
-		if (!*(vars->place))
-			++(vars->optind);
-	} else {				/* takes (optional) argument */
-	   vars->optarg = NULL;
-		if (*(vars->place))			/* no white space */
-		   vars->optarg = (vars->place);
-		/* XXX: disable test for :: if PC? (GNU doesn't) */
-		else if (oli[1] != ':') {	/* arg not optional */
-			if (++(vars->optind) >= nargc) {	/* no arg */
-				(vars->place) = EMSG;
-				if (PRINT_ERROR) {
-				//	warnx(recargcha, optchar);
+    if (vars->optreset || !*(vars->place)) {        /* update scanning pointer */
+       vars->optreset = 0;
+        if (vars->optind >= nargc) {          /* end of argument vector */
+            (vars->place) = EMSG;
+            if (vars->nonopt_end != -1) {
+                /* do permutation, if we have to */
+                permute_args(vars->nonopt_start, vars->nonopt_end,
+                      vars->optind, nargv);
+                vars->optind -= vars->nonopt_end - vars->nonopt_start;
             }
-				vars->optopt = optchar;
-				return (BADARG);
-			} else
-			   vars->optarg = nargv[vars->optind];
-		} else if (!(flags & FLAG_PERMUTE)) {
-			/*
-			 * If permutation is disabled, we can accept an
-			 * optional arg separated by whitespace.
-			 */
-			if (vars->optind + 1 < nargc)
-			   vars->optarg = nargv[++(vars->optind)];
-		}
-		(vars->place) = EMSG;
-		++(vars->optind);
-	}
-	/* dump back option letter */
-	return (optchar);
+            else if (vars->nonopt_start != -1) {
+                /*
+                 * If we skipped non-options, set optind
+                 * to the first of them.
+                 */
+               vars->optind = vars->nonopt_start;
+            }
+            vars->nonopt_start = vars->nonopt_end = -1;
+            return (-1);
+        }
+        if (*((vars->place) = nargv[vars->optind]) != '-' ||
+            ((vars->place)[1] == '\0' && strchr(options, '-') == NULL)) {
+            (vars->place) = EMSG;       /* found non-option */
+            if (flags & FLAG_ALLARGS) {
+                /*
+                 * GNU extension:
+                 * return non-option as argument to option 1
+                 */
+               vars->optarg = nargv[(vars->optind)++];
+                return (INORDER);
+            }
+            if (!(flags & FLAG_PERMUTE)) {
+                /*
+                 * If no permutation wanted, stop parsing
+                 * at first non-option.
+                 */
+                return (-1);
+            }
+            /* do permutation */
+            if (vars->nonopt_start == -1)
+               vars->nonopt_start = vars->optind;
+            else if (vars->nonopt_end != -1) {
+                permute_args(vars->nonopt_start, vars->nonopt_end,
+                      vars->optind, nargv);
+                vars->nonopt_start = vars->optind -
+                    (vars->nonopt_end - vars->nonopt_start);
+                vars->nonopt_end = -1;
+            }
+            (vars->optind)++;
+            /* process next argument */
+            goto start;
+        }
+        if (vars->nonopt_start != -1 && vars->nonopt_end == -1)
+           vars->nonopt_end = vars->optind;
+
+        /*
+         * If we have "-" do nothing, if "--" we are done.
+         */
+        if ((vars->place)[1] != '\0' && *++(vars->place) == '-' && (vars->place)[1] == '\0') {
+            (vars->optind)++;
+            (vars->place) = EMSG;
+            /*
+             * We found an option (--), so if we skipped
+             * non-options, we have to permute.
+             */
+            if (vars->nonopt_end != -1) {
+                permute_args(vars->nonopt_start, vars->nonopt_end,
+                      vars->optind, nargv);
+                vars->optind -= vars->nonopt_end - vars->nonopt_start;
+            }
+            vars->nonopt_start = vars->nonopt_end = -1;
+            return (-1);
+        }
+    }
+
+    /*
+     * Check long options if:
+     *  1) we were passed some
+     *  2) the arg is not just "-"
+     *  3) either the arg starts with -- we are getopt_long_only()
+     */
+    if (long_options != NULL && (vars->place) != nargv[vars->optind] &&
+        (*(vars->place) == '-' || (flags & FLAG_LONGONLY))) {
+        short_too = 0;
+        if (*(vars->place) == '-')
+            (vars->place)++;        /* --foo long option */
+        else if (*(vars->place) != ':' && strchr(options, *(vars->place)) != NULL)
+            short_too = 1;      /* could be short option too */
+
+        optchar = parse_long_options_TS(nargv, options, long_options,
+            idx, short_too,vars);
+        if (optchar != -1) {
+            (vars->place) = EMSG;
+            return (optchar);
+        }
+    }
+
+    if ((optchar = (int)*(vars->place)++) == (int)':' ||
+        (optchar == (int)'-' && *(vars->place) != '\0') ||
+        (oli = (char*)strchr(options, optchar)) == NULL) {
+        /*
+         * If the user specified "-" and  '-' isn't listed in
+         * options, return -1 (non-option) as per POSIX.
+         * Otherwise, it is an unknown option character (or ':').
+         */
+        if (optchar == (int)'-' && *(vars->place) == '\0')
+            return (-1);
+        if (!*(vars->place))
+            ++(vars->optind);
+        if (PRINT_ERROR) {
+        //  warnx(illoptchar, optchar);
+      }
+        vars->optopt = optchar;
+        return (BADCH);
+    }
+    if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+        /* -W long-option */
+        if (*(vars->place)) {       /* no space */
+            /* NOTHING */
+        }
+        else if (++(vars->optind) >= nargc) {   /* no arg */
+            (vars->place) = EMSG;
+            if (PRINT_ERROR) {
+            //  warnx(recargchar, optchar);
+         }
+            vars->optopt = optchar;
+            return (BADARG);
+        } else              /* white space */
+            (vars->place) = nargv[vars->optind];
+        optchar = parse_long_options_TS(nargv, options, long_options, idx, 0,vars);
+        (vars->place) = EMSG;
+        return (optchar);
+    }
+    if (*++oli != ':') {            /* doesn't take argument */
+        if (!*(vars->place))
+            ++(vars->optind);
+    } else {                /* takes (optional) argument */
+       vars->optarg = NULL;
+        if (*(vars->place))         /* no white space */
+           vars->optarg = (vars->place);
+        /* XXX: disable test for :: if PC? (GNU doesn't) */
+        else if (oli[1] != ':') {   /* arg not optional */
+            if (++(vars->optind) >= nargc) {    /* no arg */
+                (vars->place) = EMSG;
+                if (PRINT_ERROR) {
+                //  warnx(recargcha, optchar);
+            }
+                vars->optopt = optchar;
+                return (BADARG);
+            } else
+               vars->optarg = nargv[vars->optind];
+        } else if (!(flags & FLAG_PERMUTE)) {
+            /*
+             * If permutation is disabled, we can accept an
+             * optional arg separated by whitespace.
+             */
+            if (vars->optind + 1 < nargc)
+               vars->optarg = nargv[++(vars->optind)];
+        }
+        (vars->place) = EMSG;
+        ++(vars->optind);
+    }
+    /* dump back option letter */
+    return (optchar);
 }
 
 /*
  * getopt in thread safe version
- *	Parse argc/argv argument vector.
+ *  Parse argc/argv argument vector.
  */
 int
 getopt_TS(int nargc, char * const *nargv, const char *options,struct OptVars* vars)
 {
 
-	/*
-	 * We dont' pass FLAG_PERMUTE to getopt_internal() since
-	 * the BSD getopt(3) (unlike GNU) has never done this.
-	 *
-	 * Furthermore, since many privileged programs call getopt()
-	 * before dropping privileges it makes sense to keep things
-	 * as simple (and bug-free) as possible.
-	 */
-	return (getopt_internal_TS(nargc, nargv, options, NULL, NULL, /*0*/FLAG_PERMUTE,vars));
+    /*
+     * We dont' pass FLAG_PERMUTE to getopt_internal() since
+     * the BSD getopt(3) (unlike GNU) has never done this.
+     *
+     * Furthermore, since many privileged programs call getopt()
+     * before dropping privileges it makes sense to keep things
+     * as simple (and bug-free) as possible.
+     */
+    return (getopt_internal_TS(nargc, nargv, options, NULL, NULL, /*0*/FLAG_PERMUTE,vars));
 }
 
 /*
  * getopt_long in thread safe version
- *	Parse argc/argv argument vector.
+ *  Parse argc/argv argument vector.
  */
 int
 getopt_long_TS(int nargc, char * const *nargv, const char *options,
             const struct option_TS *long_options,int* idx,struct OptVars* vars)
 {
 
-	return getopt_internal_TS(nargc, nargv, options, long_options, idx,FLAG_PERMUTE,vars);
+    return getopt_internal_TS(nargc, nargv, options, long_options, idx,FLAG_PERMUTE,vars);
 }
 
 /*
  * getopt_long_only in thread safe version
- *	Parse argc/argv argument vector.
+ *  Parse argc/argv argument vector.
  */
 int
 getopt_long_only_TS(int nargc, char * const *nargv, const char *options,
                  const struct option_TS * long_options,int* idx,struct OptVars* vars)
 {
 
-	return getopt_internal_TS(nargc, nargv, options, long_options, idx,
-	                          FLAG_PERMUTE|FLAG_LONGONLY,vars);
+    return getopt_internal_TS(nargc, nargv, options, long_options, idx,
+                              FLAG_PERMUTE|FLAG_LONGONLY,vars);
 }
 
 

--- a/UnitexGetOpt.h
+++ b/UnitexGetOpt.h
@@ -49,7 +49,7 @@
 
 namespace unitex {
 #endif
-    
+
 /**
  * struct option, no_argument, required_argument and optional_argument may already
  * have been defined if someone use both libunitex.so and the original getopt.
@@ -68,7 +68,7 @@ namespace unitex {
  */
 struct option_TS {
    const char *name;  // the name of the option
-   int  has_arg;      // no_argument_TS, required_argument_TS or optional_argument_TS 
+   int  has_arg;      // no_argument_TS, required_argument_TS or optional_argument_TS
    int *flag;         // If flag is a null pointer, val is a value which identifies
                       // this option. If not, it is the address of an int variable
                       // which is the flag for this option
@@ -102,29 +102,29 @@ int getopt_long_only_TS(int, char *const *, const char *, const struct option_TS
 /* ************************************************************************** */
 /**
  * @class    UnitexGetOpt
- * 
+ *
  * @brief    A class wrapper (RAII) around Unitex's thread-safe getopt functions
- * 
+ *
  * @author   cristian.martinez@univ-paris-est.fr (martinec)
  * @date     July 2015
  */
 class UnitexGetOpt {
  public :
- 
+
   // Constructor
   /**
    * @brief  Default constructor
-   * 
+   *
    * Allocates and initializes an empty OptVars struct
    */
   UnitexGetOpt() :
     data_(new_OptVars()) {
   }
-  
+
   // Destructor
   /**
    * @brief  Destroys the object
-   * 
+   *
    * Free the memory allocated to the internal OptVars struct
    */
   ~UnitexGetOpt() {
@@ -137,18 +137,18 @@ class UnitexGetOpt {
 
   /**
    * @brief  Thread safe version of getopt
-   * 
+   *
    * Parse argc/argv argument vector
-   */   
+   */
   int parse(int nargc, char* const* nargv, const char* options) const {
-    return getopt_TS(nargc, nargv, options, data_); 
+    return getopt_TS(nargc, nargv, options, data_);
   }
 
   /**
    * @brief  Thread safe version of getopt_long
-   * 
+   *
    * Parse argc/argv argument vector
-   */   
+   */
   int parse_long(int nargc,
                   char* const* nargv,
                   const char*  options,
@@ -156,27 +156,27 @@ class UnitexGetOpt {
                   int* idx) const {
     return getopt_long_TS(nargc, nargv, options, long_options, idx, data_);
   }
-                 
+
   /**
    * @brief  Thread safe version of getopt_long_only
-   * 
+   *
    * Parse argc/argv argument vector
-   */   
+   */
   int parse_long_only(int nargc,
                   char* const* nargv,
                   const char*  options,
                   const struct option_TS* long_options,
                   int* idx) const {
     return getopt_long_only_TS(nargc, nargv, options, long_options, idx, data_);
-  }  
+  }
 
   // Element access
 
   /**
    * @brief  Get the underline OptVars structure
-   * 
+   *
    * @return A pointer to the underlying OptVars structure
-   * 
+   *
    * @attention The caller should not delete the return value
    */
   OptVars* vars() const {
@@ -186,16 +186,16 @@ class UnitexGetOpt {
   /**
    * @brief  Implicit conversion from UnitexGetOpt to the underlying OptVars
    * object
-   * 
-   * @see  c_optvars() const  
+   *
+   * @see  c_optvars() const
    */
   // UNITEX_EXPLICIT_CONVERSIONS
   operator OptVars*() const {
     return data_;
-  }  
-  
+  }
+
  private :
- 
+
   // Methods
   /**
    * @brief  Free the memory allocated to the internal OptVars
@@ -205,12 +205,12 @@ class UnitexGetOpt {
     free_OptVars(data_);
   }
 
-  // Data Members (except static const data members) 
+  // Data Members (except static const data members)
   /**
    * @brief  underline OptVars container
    */
   OptVars* data_;
-};  // class UnitexGetOpt  
+};  // class UnitexGetOpt
 /* ************************************************************************** */
 #endif
 

--- a/UnitexLibAndJni/fr_umlv_unitex_jni_UnitexJni.cpp
+++ b/UnitexLibAndJni/fr_umlv_unitex_jni_UnitexJni.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -140,7 +140,7 @@ jstringToCUtf::~jstringToCUtf()
 static int countArgs(char** args)
 {
 	int count=0;
-	
+
 	char**tmp=args;
 	while ((*tmp) != NULL)
 	{
@@ -204,7 +204,7 @@ size_t dwDestPos = 0;
 static char**argsFromStrArray(JNIEnv* jenv, jobjectArray strArray)
 {
 int nSize = jenv->GetArrayLength(strArray);
-char **args=NULL;	
+char **args=NULL;
     if (nSize>0)
         args = (char**)malloc((nSize+1) * sizeof(char*));
 
@@ -234,7 +234,7 @@ char **args=NULL;
 static char**argsFromJString(JNIEnv* jenv, jstring jstr)
 {
 	jstringToCUtf jtcu;
-	
+
 	const char*cmdLine=jtcu.initJString(jenv,jstr);
     size_t len_cmd_line=strlen(cmdLine);
 
@@ -379,7 +379,7 @@ JNIEXPORT jboolean JNICALL Java_fr_umlv_unitex_jni_UnitexJni_writeUnitexFile__Lj
 	jstc_filename.initJString(env,filename);
 	jsize len = env->GetArrayLength(filedata);
 	jchar * buffer=env->GetCharArrayElements(filedata,NULL);
-	
+
 	jboolean retValue= (WriteUnitexFile(jstc_filename.getJString(),buffer,len,NULL,0) == 0);
 	env->ReleaseCharArrayElements(filedata,buffer,0);
 	return retValue;
@@ -397,7 +397,7 @@ JNIEXPORT jboolean JNICALL Java_fr_umlv_unitex_jni_UnitexJni_writeUnitexFile__Lj
 	jstc_filename.initJString(env,filename);
 	jsize len = env->GetArrayLength(filedata);
 	jbyte * buffer=env->GetByteArrayElements(filedata,NULL);
-	
+
 	jboolean retValue= (WriteUnitexFile(jstc_filename.getJString(),buffer,len,NULL,0) == 0);
 	env->ReleaseByteArrayElements(filedata,buffer,0);
 	return retValue;
@@ -492,7 +492,7 @@ static jboolean doWriteUnitexFileUtf(JNIEnv* env,jstring filename,jstring fileco
 	jstringToCUtf jstc_filename;
 	jstc_filename.initJString(env,filename);
 
-	
+
 	jstringToCUtf jstc_content;
 	jstc_content.initJString(env,filecontent);
 
@@ -598,7 +598,7 @@ JNIEXPORT jstring JNICALL Java_fr_umlv_unitex_jni_UnitexJni_getUnitexFileString
             is_utf16_swap_endianess = ! is_utf16_native_endianess;
             size_bom = 2;
         }
-    
+
     if (size_file>1)
         if (((*(bufchar))==0xfe) && ((*(bufchar+1))==0xff))
         {
@@ -607,7 +607,7 @@ JNIEXPORT jstring JNICALL Java_fr_umlv_unitex_jni_UnitexJni_getUnitexFileString
             is_utf16_swap_endianess = ! is_utf16_native_endianess;
             size_bom = 2;
         }
-    
+
     if (size_file>2)
         if (((*(bufchar))==0xef) && ((*(bufchar+1))==0xbb) && ((*(bufchar+2))==0xbf))
         {

--- a/UnitexLibDir.h
+++ b/UnitexLibDir.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -45,7 +45,7 @@ extern "C" {
 
 //int af_remove_folder(const char*name);
 int RemoveFileSystemFolder(const char*foldername);
-    
+
 #ifdef __cplusplus
 }
 #endif

--- a/UnitexLibDirPosix.cpp
+++ b/UnitexLibDirPosix.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -43,25 +43,25 @@
 #define perror(a) return (-1)
 
 int recursiveDelete(const char* dirname) {
-    
+
     DIR *dp;
     struct dirent *ep;
-    
+
     char abs_filename[FILENAME_MAX];
-    
+
     dp = opendir (dirname);
     if (dp != NULL)
     {
         while (NULL != (ep = readdir (dp))) {
             struct stat stFileInfo;
-            
+
             snprintf(abs_filename, FILENAME_MAX, "%s/%s", dirname, ep->d_name);
-            
+
             if (lstat(abs_filename, &stFileInfo) < 0)
                 perror ( abs_filename );
-            
+
             if(S_ISDIR(stFileInfo.st_mode)) {
-                if(strcmp(ep->d_name, ".") && 
+                if(strcmp(ep->d_name, ".") &&
                    strcmp(ep->d_name, "..")) {
                     printf("%s directory\n",abs_filename);
                     recursiveDelete(abs_filename);
@@ -75,11 +75,11 @@ int recursiveDelete(const char* dirname) {
     }
     else
         perror ("Couldn't open the directory");
-    
-    
+
+
     remove(dirname);
     return 0;
-    
+
 }
 
 int RemoveFileSystemFolder(const char*foldername)

--- a/UnitexLibDirWin.cpp
+++ b/UnitexLibDirWin.cpp
@@ -53,13 +53,13 @@
 #ifdef UNITEX_USING_WINRT_API
 #include <strsafe.h>
 static BOOL IsDotsW(const WCHAR* str) {
-	if ((*str)!='.')
-		return FALSE;
-	if ((*str)=='\0')
-		return TRUE;
-	if ((*(str+1))=='.')
-		if ((*(str+2))=='\0')
-			return TRUE;
+    if ((*str)!='.')
+        return FALSE;
+    if ((*str)=='\0')
+        return TRUE;
+    if ((*(str+1))=='.')
+        if ((*(str+2))=='\0')
+            return TRUE;
     return FALSE;
 }
 
@@ -88,7 +88,7 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
     while(bSearch) { // until we finds an entry
         if(FindNextFileW(hFind,&FindFileData)) {
             if(IsDotsW(FindFileData.cFileName)) continue;
-			StringCchCatW(FileName,MAX_PATH+0x200,FindFileData.cFileName);
+            StringCchCatW(FileName,MAX_PATH+0x200,FindFileData.cFileName);
             //strcat(FileName,FindFileData.cFileName);
             if((FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
 
@@ -99,7 +99,7 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
                 }
                 RemoveDirectoryW(FileName); // remove the empty directory
                 //strcpy(FileName,DirPath);
-				StringCchCopyW(FileName,MAX_PATH+0x200,DirPath);
+                StringCchCopyW(FileName,MAX_PATH+0x200,DirPath);
             }
             else {
 
@@ -108,7 +108,7 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
                     return FALSE;
                 }
                 //strcpy(FileName,DirPath);
-				StringCchCopyW(FileName,MAX_PATH+0x200,DirPath);
+                StringCchCopyW(FileName,MAX_PATH+0x200,DirPath);
             }
         }
         else {
@@ -131,9 +131,9 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
 
 
 BOOL DeleteDirectory(const char* sPath) {
-	WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
-	MultiByteToWideChar(CP_ACP,0,sPath,-1,filenameW,FILENAME_MAX + 0x200);
-	return DeleteDirectoryW(filenameW);
+    WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+    MultiByteToWideChar(CP_ACP,0,sPath,-1,filenameW,FILENAME_MAX + 0x200);
+    return DeleteDirectoryW(filenameW);
 }
 #else
 

--- a/UnitexLibDirWin.cpp
+++ b/UnitexLibDirWin.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -70,20 +70,20 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
     HANDLE hFind;  // file handle
 
     WIN32_FIND_DATAW FindFileData;
-    
+
     WCHAR DirPath[MAX_PATH+0x200];
     WCHAR FileName[MAX_PATH+0x200];
-    
+
     StringCchCopyW(DirPath,MAX_PATH+0x200,sPath);
     StringCchCatW(DirPath,MAX_PATH+0x200,L"\\*");    // searching all files
-    
+
     StringCchCopyW(FileName,MAX_PATH+0x200,sPath);
     StringCchCatW(FileName,MAX_PATH+0x200,L"\\");
-    
+
     hFind = FindFirstFileExW(DirPath,FindExInfoBasic,&FindFileData,FindExSearchNameMatch,NULL,0); // find the first file
     if(hFind == INVALID_HANDLE_VALUE) return FALSE;
     StringCchCopyW(DirPath,MAX_PATH+0x200,FileName);
-    
+
     bool bSearch = true;
     while(bSearch) { // until we finds an entry
         if(FindNextFileW(hFind,&FindFileData)) {
@@ -91,10 +91,10 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
 			StringCchCatW(FileName,MAX_PATH+0x200,FindFileData.cFileName);
             //strcat(FileName,FindFileData.cFileName);
             if((FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-                
+
                 // we have found a directory, recurse
-                if(!DeleteDirectoryW(FileName)) { 
-                    FindClose(hFind); 
+                if(!DeleteDirectoryW(FileName)) {
+                    FindClose(hFind);
                     return FALSE; // directory couldn't be deleted
                 }
                 RemoveDirectoryW(FileName); // remove the empty directory
@@ -104,9 +104,9 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
             else {
 
                 if(!DeleteFileW(FileName)) {  // delete the file
-                    FindClose(hFind); 
-                    return FALSE; 
-                }                 
+                    FindClose(hFind);
+                    return FALSE;
+                }
                 //strcpy(FileName,DirPath);
 				StringCchCopyW(FileName,MAX_PATH+0x200,DirPath);
             }
@@ -116,17 +116,17 @@ BOOL DeleteDirectoryW(const WCHAR* sPath) {
                 bSearch = false;
             else {
                 // some error occured, close the handle and return FALSE
-                FindClose(hFind); 
+                FindClose(hFind);
                 return FALSE;
             }
-            
+
         }
-        
+
     }
     FindClose(hFind);  // closing file handle
-    
+
     return RemoveDirectoryW(sPath); // remove the empty directory
-    
+
 }
 
 
@@ -146,30 +146,30 @@ BOOL DeleteDirectory(const char* sPath) {
     HANDLE hFind;  // file handle
 
     WIN32_FIND_DATAA FindFileData;
-    
+
     char DirPath[MAX_PATH];
     char FileName[MAX_PATH];
-    
+
     strcpy(DirPath,sPath);
     strcat(DirPath,"\\*");    // searching all files
-    
+
     strcpy(FileName,sPath);
     strcat(FileName,"\\");
-    
+
     hFind = FindFirstFileA(DirPath,&FindFileData); // find the first file
     if(hFind == INVALID_HANDLE_VALUE) return FALSE;
     strcpy(DirPath,FileName);
-    
+
     bool bSearch = true;
     while(bSearch) { // until we finds an entry
         if(FindNextFileA(hFind,&FindFileData)) {
             if(IsDots(FindFileData.cFileName)) continue;
             strcat(FileName,FindFileData.cFileName);
             if((FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-                
+
                 // we have found a directory, recurse
-                if(!DeleteDirectory(FileName)) { 
-                    FindClose(hFind); 
+                if(!DeleteDirectory(FileName)) {
+                    FindClose(hFind);
                     return FALSE; // directory couldn't be deleted
                 }
                 RemoveDirectoryA(FileName); // remove the empty directory
@@ -178,9 +178,9 @@ BOOL DeleteDirectory(const char* sPath) {
             else {
 
                 if(!DeleteFileA(FileName)) {  // delete the file
-                    FindClose(hFind); 
-                    return FALSE; 
-                }                 
+                    FindClose(hFind);
+                    return FALSE;
+                }
                 strcpy(FileName,DirPath);
             }
         }
@@ -189,23 +189,23 @@ BOOL DeleteDirectory(const char* sPath) {
                 bSearch = false;
             else {
                 // some error occured, close the handle and return FALSE
-                FindClose(hFind); 
+                FindClose(hFind);
                 return FALSE;
             }
-            
+
         }
-        
+
     }
     FindClose(hFind);  // closing file handle
-    
+
     return RemoveDirectoryA(sPath); // remove the empty directory
-    
+
 }
 
 #endif
 
 int recursiveDelete(const char* dirname)
-{    
+{
     return DeleteDirectory(dirname) ? 0 : -1;
 }
 

--- a/UnitexLibIO.h
+++ b/UnitexLibIO.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -60,22 +60,22 @@ UNITEX_FUNC int UNITEX_CALL RemoveUnitexFile(const char*name);
 UNITEX_FUNC int UNITEX_CALL RenameUnitexFile(const char*oldName,const char*newName);
 
 UNITEX_FUNC int UNITEX_CALL CopyUnitexFile(const char*srcName,const char*dstName);
-    
+
 UNITEX_FUNC int UNITEX_CALL CreateUnitexFolder(const char*name);
-    
+
 UNITEX_FUNC int UNITEX_CALL RemoveUnitexFolder(const char*name);
 
 UNITEX_FUNC int UNITEX_CALL UnitexAbstractPathExists(const char* path);
 
 
 #ifdef HAS_LIST_FILE
-#define UNITEX_IO_HAS_LIST_FILE 1	
+#define UNITEX_IO_HAS_LIST_FILE 1
 
 UNITEX_FUNC char** UNITEX_CALL GetUnitexFileList(const char* path);
 
 UNITEX_FUNC void UNITEX_CALL ReleaseUnitexFileList(const char* path,char**list);
 #endif
-    
+
 #ifdef __cplusplus
 }
 #endif

--- a/UnitexLibIO_ICU.cpp
+++ b/UnitexLibIO_ICU.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -35,13 +35,13 @@
 #include <stdlib.h>
 
 
-// uima c++ users can replace UnicodeString by UnicodeStringRef 
+// uima c++ users can replace UnicodeString by UnicodeStringRef
 /**
  * Write an Unitex file content (to system filesystem or filespace)
  * it write from two buffer (prefix and suffix). This is useful for writing both header and footer (or BOM and text...)
  */
 	UNITEX_FUNC int UNITEX_CALL WriteUnicodeUnitexFile(const char*filename, icu::UnicodeString const& uString)
-	{		
+	{
 		UChar uBom = 0xfeff;
 
 		const UChar * uBuffer = uString.getBuffer();
@@ -51,7 +51,7 @@
 
 		return result;
 	}
- 
+
 
 #define GetUtf8_Size(ch)  \
 	(((((unsigned char)(ch)) & ((unsigned char)0x80))==((unsigned char)0x00)) ? 1 : \
@@ -78,7 +78,7 @@
 		for (;;)
 		{
 			if ((src_walk==NULL) || (buf_size==0))
-			{				
+			{
 				if (p_size_this_string_written!=NULL)
 					*p_size_this_string_written = size_this_string_written;
 				return 0;
@@ -207,11 +207,11 @@
 				{
 					size_t len_buf_UChar = bufferSize+1+1;
 					UChar* stringUChar = new UChar[len_buf_UChar + 1];
-				
+
 
 					size_t nb_written = 0;
 					unpack_utf8_string(stringUChar,len_buf_UChar,&nb_written,bufchar + size_bom, bufferSize - size_bom);
-		
+
 
 					uString.setTo((const UChar*)stringUChar, nb_written);
 					delete [] stringUChar;
@@ -220,7 +220,7 @@
 			CloseUnitexFileReadBuffer(pFileHandle, buffer, bufferSize);
 			return 1;
 		}
-		
+
 		return 0;
 	}
 

--- a/UnitexLibIO_ICU.cpp
+++ b/UnitexLibIO_ICU.cpp
@@ -40,189 +40,189 @@
  * Write an Unitex file content (to system filesystem or filespace)
  * it write from two buffer (prefix and suffix). This is useful for writing both header and footer (or BOM and text...)
  */
-	UNITEX_FUNC int UNITEX_CALL WriteUnicodeUnitexFile(const char*filename, icu::UnicodeString const& uString)
-	{
-		UChar uBom = 0xfeff;
+    UNITEX_FUNC int UNITEX_CALL WriteUnicodeUnitexFile(const char*filename, icu::UnicodeString const& uString)
+    {
+        UChar uBom = 0xfeff;
 
-		const UChar * uBuffer = uString.getBuffer();
-		int32_t uLength = uString.length();
+        const UChar * uBuffer = uString.getBuffer();
+        int32_t uLength = uString.length();
 
-		bool result = WriteUnitexFile(filename, &uBom, sizeof(UChar), uBuffer, uLength * sizeof(UChar)) == 0;
+        bool result = WriteUnitexFile(filename, &uBom, sizeof(UChar), uBuffer, uLength * sizeof(UChar)) == 0;
 
-		return result;
-	}
+        return result;
+    }
 
 
 #define GetUtf8_Size(ch)  \
-	(((((unsigned char)(ch)) & ((unsigned char)0x80))==((unsigned char)0x00)) ? 1 : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xe0))==((unsigned char)0xc0)) ? 2 : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xf0))==((unsigned char)0xe0)) ? 3 : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xf8))==((unsigned char)0xf0)) ? 4 : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xfc))==((unsigned char)0xf8)) ? 5 : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xfe))==((unsigned char)0xfc)) ? 6 : 001))))))
+    (((((unsigned char)(ch)) & ((unsigned char)0x80))==((unsigned char)0x00)) ? 1 : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xe0))==((unsigned char)0xc0)) ? 2 : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xf0))==((unsigned char)0xe0)) ? 3 : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xf8))==((unsigned char)0xf0)) ? 4 : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xfc))==((unsigned char)0xf8)) ? 5 : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xfe))==((unsigned char)0xfc)) ? 6 : 001))))))
 
 
 #define GetUtf8_Mask(ch)  \
-	(((((unsigned char)(ch)) & ((unsigned char)0x80))==((unsigned char)0x00)) ? ((unsigned char)0x7f) : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xe0))==((unsigned char)0xc0)) ? ((unsigned char)0x1f) : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xf0))==((unsigned char)0xe0)) ? ((unsigned char)0x0f) : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xf8))==((unsigned char)0xf0)) ? ((unsigned char)0x07) : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xfc))==((unsigned char)0xf8)) ? ((unsigned char)0x03) : \
-	(((((unsigned char)(ch)) & ((unsigned char)0xfe))==((unsigned char)0xfc)) ? ((unsigned char)0x01) : 0))))))
+    (((((unsigned char)(ch)) & ((unsigned char)0x80))==((unsigned char)0x00)) ? ((unsigned char)0x7f) : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xe0))==((unsigned char)0xc0)) ? ((unsigned char)0x1f) : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xf0))==((unsigned char)0xe0)) ? ((unsigned char)0x0f) : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xf8))==((unsigned char)0xf0)) ? ((unsigned char)0x07) : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xfc))==((unsigned char)0xf8)) ? ((unsigned char)0x03) : \
+    (((((unsigned char)(ch)) & ((unsigned char)0xfe))==((unsigned char)0xfc)) ? ((unsigned char)0x01) : 0))))))
 
-	static size_t unpack_utf8_string(UChar*write_content_walk_buf,size_t nb_unichar_alloc_walk,size_t * p_size_this_string_written,
-		const unsigned char*src_walk,size_t buf_size)
-	{
-		size_t size_this_string_written=0;
-		size_t nb_pack_read=0;
-		for (;;)
-		{
-			if ((src_walk==NULL) || (buf_size==0))
-			{
-				if (p_size_this_string_written!=NULL)
-					*p_size_this_string_written = size_this_string_written;
-				return 0;
-			}
-			unsigned char ch = *(src_walk++);
-			buf_size--;
-			nb_pack_read++;
+    static size_t unpack_utf8_string(UChar*write_content_walk_buf,size_t nb_unichar_alloc_walk,size_t * p_size_this_string_written,
+        const unsigned char*src_walk,size_t buf_size)
+    {
+        size_t size_this_string_written=0;
+        size_t nb_pack_read=0;
+        for (;;)
+        {
+            if ((src_walk==NULL) || (buf_size==0))
+            {
+                if (p_size_this_string_written!=NULL)
+                    *p_size_this_string_written = size_this_string_written;
+                return 0;
+            }
+            unsigned char ch = *(src_walk++);
+            buf_size--;
+            nb_pack_read++;
 
-			UChar c;
-
-
-
-			if ((ch&0x80) == 0)
-			{
-				c=ch;
-			}
-			else
-			{
-				c=ch & GetUtf8_Mask(ch);
-				int nbbyte=GetUtf8_Size(ch);
-				if (((int)buf_size)+1 < nbbyte)
-				{
-					if (p_size_this_string_written!=NULL)
-						*p_size_this_string_written = size_this_string_written;
-					return 0;
-				}
-
-				for(;;)
-				{
-					nbbyte--;
-					if (nbbyte==0)
-						break;
-
-					c = (c<<6) | ( (*(src_walk++)) & 0x3F);
-					buf_size--;
-					nb_pack_read++;
-				}
-			}
-
-			if ((write_content_walk_buf!=NULL) && (size_this_string_written<nb_unichar_alloc_walk))
-				*(write_content_walk_buf + size_this_string_written)=c;
-			size_this_string_written++;
-
-			if (c==0)
-			{
-				if (p_size_this_string_written!=NULL)
-					*p_size_this_string_written = size_this_string_written;
-				return nb_pack_read;
-			}
-		}
-	}
-
-	/// <summary>
-	/// Gets the whole contents of a (virtual) file into a Unicode string.
-	/// </summary>
-	/// <param name='fileName'>The file name.</param>
-	/// <param name='uString'>The Unicode string where to store the file contents.</param>
-	/// <returns>1 if ok, 0 if failed.</returns>
-	UNITEX_FUNC int UNITEX_CALL GetUnicodeStringFromUnitexFile(const char* filename, UnicodeString& uString)
-	{
-		uString.remove();
-
-		UNITEXFILEMAPPED* pFileHandle;
-		const void* buffer = NULL;
-		size_t bufferSize = 0;
-		GetUnitexFileReadBuffer(filename, &pFileHandle, &buffer, &bufferSize);
-
-		if (pFileHandle != NULL) {
-			if (bufferSize > 0) {
-				const unsigned char* bufchar= (const unsigned char*) buffer;
-				size_t size_bom = 0;
-				bool is_utf16_native_endianess = false;
-				bool is_utf16_swap_endianess = false;
-
-				if (bufferSize > 1) {
-					UChar UTF16Bom = *((const UChar*)buffer);
-
-					if (UTF16Bom == 0xfeff)
-					{
-						// native endian
-						is_utf16_native_endianess = true;
-						size_bom = 2;
-					}
-
-					if (UTF16Bom == 0xfffe)
-					{
-						// reverse endian
-						is_utf16_swap_endianess = true;
-						size_bom = 2;
-					}
-				}
+            UChar c;
 
 
-				if (bufferSize > 2) {
-					if (((*(bufchar)) == 0xef) && ((*(bufchar + 1)) == 0xbb) && ((*(bufchar + 2)) == 0xbf))
-					{
-						size_bom = 3;
-					}
-				}
 
-				if (is_utf16_native_endianess)
-				{
-					const UChar* uBuffer = (const UChar*)(bufchar + size_bom);
-					size_t uSize = (bufferSize - size_bom) / U_SIZEOF_UCHAR;
-					uString.setTo(uBuffer, uSize);
-				}
-				else if (is_utf16_swap_endianess)
-				{
-					unsigned char* returnedUTF16buffer = new unsigned char [bufferSize];
-					if (returnedUTF16buffer != NULL)
-					{
-						for (size_t i = 0; i<bufferSize; i += 2)
-						{
-							unsigned char c1 = *(bufchar + i);
-							unsigned char c2 = *(bufchar + i + 1);
-							*(returnedUTF16buffer + i) = c2;
-							*(returnedUTF16buffer + i + 1) = c1;
-						}
-						const UChar* uBuffer = (const UChar*)(returnedUTF16buffer + size_bom);
-						size_t uSize = (bufferSize - size_bom) / U_SIZEOF_UCHAR;
-						uString.setTo(uBuffer, uSize);
-						delete [] returnedUTF16buffer;
-					}
-				}
-				else
-				{
-					size_t len_buf_UChar = bufferSize+1+1;
-					UChar* stringUChar = new UChar[len_buf_UChar + 1];
+            if ((ch&0x80) == 0)
+            {
+                c=ch;
+            }
+            else
+            {
+                c=ch & GetUtf8_Mask(ch);
+                int nbbyte=GetUtf8_Size(ch);
+                if (((int)buf_size)+1 < nbbyte)
+                {
+                    if (p_size_this_string_written!=NULL)
+                        *p_size_this_string_written = size_this_string_written;
+                    return 0;
+                }
+
+                for(;;)
+                {
+                    nbbyte--;
+                    if (nbbyte==0)
+                        break;
+
+                    c = (c<<6) | ( (*(src_walk++)) & 0x3F);
+                    buf_size--;
+                    nb_pack_read++;
+                }
+            }
+
+            if ((write_content_walk_buf!=NULL) && (size_this_string_written<nb_unichar_alloc_walk))
+                *(write_content_walk_buf + size_this_string_written)=c;
+            size_this_string_written++;
+
+            if (c==0)
+            {
+                if (p_size_this_string_written!=NULL)
+                    *p_size_this_string_written = size_this_string_written;
+                return nb_pack_read;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the whole contents of a (virtual) file into a Unicode string.
+    /// </summary>
+    /// <param name='fileName'>The file name.</param>
+    /// <param name='uString'>The Unicode string where to store the file contents.</param>
+    /// <returns>1 if ok, 0 if failed.</returns>
+    UNITEX_FUNC int UNITEX_CALL GetUnicodeStringFromUnitexFile(const char* filename, UnicodeString& uString)
+    {
+        uString.remove();
+
+        UNITEXFILEMAPPED* pFileHandle;
+        const void* buffer = NULL;
+        size_t bufferSize = 0;
+        GetUnitexFileReadBuffer(filename, &pFileHandle, &buffer, &bufferSize);
+
+        if (pFileHandle != NULL) {
+            if (bufferSize > 0) {
+                const unsigned char* bufchar= (const unsigned char*) buffer;
+                size_t size_bom = 0;
+                bool is_utf16_native_endianess = false;
+                bool is_utf16_swap_endianess = false;
+
+                if (bufferSize > 1) {
+                    UChar UTF16Bom = *((const UChar*)buffer);
+
+                    if (UTF16Bom == 0xfeff)
+                    {
+                        // native endian
+                        is_utf16_native_endianess = true;
+                        size_bom = 2;
+                    }
+
+                    if (UTF16Bom == 0xfffe)
+                    {
+                        // reverse endian
+                        is_utf16_swap_endianess = true;
+                        size_bom = 2;
+                    }
+                }
 
 
-					size_t nb_written = 0;
-					unpack_utf8_string(stringUChar,len_buf_UChar,&nb_written,bufchar + size_bom, bufferSize - size_bom);
+                if (bufferSize > 2) {
+                    if (((*(bufchar)) == 0xef) && ((*(bufchar + 1)) == 0xbb) && ((*(bufchar + 2)) == 0xbf))
+                    {
+                        size_bom = 3;
+                    }
+                }
+
+                if (is_utf16_native_endianess)
+                {
+                    const UChar* uBuffer = (const UChar*)(bufchar + size_bom);
+                    size_t uSize = (bufferSize - size_bom) / U_SIZEOF_UCHAR;
+                    uString.setTo(uBuffer, uSize);
+                }
+                else if (is_utf16_swap_endianess)
+                {
+                    unsigned char* returnedUTF16buffer = new unsigned char [bufferSize];
+                    if (returnedUTF16buffer != NULL)
+                    {
+                        for (size_t i = 0; i<bufferSize; i += 2)
+                        {
+                            unsigned char c1 = *(bufchar + i);
+                            unsigned char c2 = *(bufchar + i + 1);
+                            *(returnedUTF16buffer + i) = c2;
+                            *(returnedUTF16buffer + i + 1) = c1;
+                        }
+                        const UChar* uBuffer = (const UChar*)(returnedUTF16buffer + size_bom);
+                        size_t uSize = (bufferSize - size_bom) / U_SIZEOF_UCHAR;
+                        uString.setTo(uBuffer, uSize);
+                        delete [] returnedUTF16buffer;
+                    }
+                }
+                else
+                {
+                    size_t len_buf_UChar = bufferSize+1+1;
+                    UChar* stringUChar = new UChar[len_buf_UChar + 1];
 
 
-					uString.setTo((const UChar*)stringUChar, nb_written);
-					delete [] stringUChar;
-				}
-			}
-			CloseUnitexFileReadBuffer(pFileHandle, buffer, bufferSize);
-			return 1;
-		}
+                    size_t nb_written = 0;
+                    unpack_utf8_string(stringUChar,len_buf_UChar,&nb_written,bufchar + size_bom, bufferSize - size_bom);
 
-		return 0;
-	}
+
+                    uString.setTo((const UChar*)stringUChar, nb_written);
+                    delete [] stringUChar;
+                }
+            }
+            CloseUnitexFileReadBuffer(pFileHandle, buffer, bufferSize);
+            return 1;
+        }
+
+        return 0;
+    }
 
 
 

--- a/UnitexLibIO_ICU.h
+++ b/UnitexLibIO_ICU.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -29,7 +29,7 @@
  *
  */
 
-/* these sample function uses UnitexLibIO to read and write UnitexFile 
+/* these sample function uses UnitexLibIO to read and write UnitexFile
   (in virtual file system or hard disk) from/to icu UnicodeString */
 
 
@@ -45,10 +45,10 @@
 extern "C" {
 #endif
 
-	// note : uima c++ user can uses UnicodeStringRef
-	UNITEX_FUNC int UNITEX_CALL WriteUnicodeUnitexFile(const char*, icu::UnicodeString const& uString);
+    // note : uima c++ user can uses UnicodeStringRef
+    UNITEX_FUNC int UNITEX_CALL WriteUnicodeUnitexFile(const char*, icu::UnicodeString const& uString);
 
-	UNITEX_FUNC int UNITEX_CALL GetUnicodeStringFromUnitexFile(const char* filename, icu::UnicodeString& uString);
+    UNITEX_FUNC int UNITEX_CALL GetUnicodeStringFromUnitexFile(const char* filename, icu::UnicodeString& uString);
 
 #ifdef __cplusplus
 }

--- a/UnitexNet/UnitexNet.cpp
+++ b/UnitexNet/UnitexNet.cpp
@@ -264,7 +264,7 @@ namespace UnitexNet
 		return ret;
 	}
 
-	bool Unitex::WriteUnitexFile(String^ filename, array<Byte>^ byteArray) 
+	bool Unitex::WriteUnitexFile(String^ filename, array<Byte>^ byteArray)
 	{
 		std::string stdFilename = clix::marshalString<clix::E_UTF8>(filename);
 
@@ -395,7 +395,7 @@ namespace UnitexNet
 		const void* buffer;
 		size_t size_file;
 		GetUnitexFileReadBuffer(stdFilename.c_str(), &amf, &buffer, &size_file);
-		
+
 		array<Byte>^ byteArray = gcnew array<Byte>(size_file);
 		if (byteArray != nullptr) {
 			IntPtr intPtr = IntPtr((unsigned char*) buffer);

--- a/UnitexRevisionInfo.cpp
+++ b/UnitexRevisionInfo.cpp
@@ -72,55 +72,55 @@ const char* UnitexRevisionConstant = "Unitex version unknown";
 
 
 const char* get_unitex_verbose_version_string() {
-	return UnitexRevisionConstant;
+    return UnitexRevisionConstant;
 }
 
 
 const char* get_unitex_semver_string() {
-	// with this code, you can enter under Windows type UnitexToolLogger.exe | find "semver="
-	const char* include_semver_in_binary = "\n\0semver=" UNITEX_SEMVER_STRING "\0\n";
-	return include_semver_in_binary + 9;
+    // with this code, you can enter under Windows type UnitexToolLogger.exe | find "semver="
+    const char* include_semver_in_binary = "\n\0semver=" UNITEX_SEMVER_STRING "\0\n";
+    return include_semver_in_binary + 9;
 }
 
 UNITEX_FUNC const char* UNITEX_CALL GetUnitexSemVerString() {
-	return get_unitex_semver_string();
+    return get_unitex_semver_string();
 }
 
 int get_unitex_revision()
 {
-	return (int)SVN_REVISION;
+    return (int)SVN_REVISION;
 }
 
 int get_unitex_new_revision()
 {
-	return (int)SVN_NEW_REVISION;
+    return (int)SVN_NEW_REVISION;
 }
 
 #ifdef GIT_HEAD_REVISION
-	#define GIT_REVISION_STRING GIT_HEAD_REVISION
+    #define GIT_REVISION_STRING GIT_HEAD_REVISION
 #else
-	#define GIT_REVISION_STRING ""
+    #define GIT_REVISION_STRING ""
 #endif
 
 const char* get_unitex_core_git_revision()
 {
-	return GIT_REVISION_STRING;
+    return GIT_REVISION_STRING;
 }
 
 
 UNITEX_FUNC int UNITEX_CALL GetUnitexRevision()
 {
-	return get_unitex_revision();
+    return get_unitex_revision();
 }
 
 UNITEX_FUNC int UNITEX_CALL GetUnitexNewRevision()
 {
-	return get_unitex_new_revision();
+    return get_unitex_new_revision();
 }
 
 UNITEX_FUNC const char* UNITEX_CALL GetUnitexCoreGitRevision()
 {
-	return get_unitex_core_git_revision();
+    return get_unitex_core_git_revision();
 }
 
 void get_unitex_version(unsigned int* major_version_number, unsigned int* minor_version_number)
@@ -139,59 +139,59 @@ unsigned int unitexMinorVersion = UNITEX_MINOR_VERSION_NUMBER;
 unsigned int unitexMinorVersion = 1;
 #endif
 
-	if (major_version_number != NULL) {
-		*major_version_number = unitexMajorVersion;
-	}
+    if (major_version_number != NULL) {
+        *major_version_number = unitexMajorVersion;
+    }
 
-	if (minor_version_number != NULL) {
-		*minor_version_number = unitexMinorVersion;
-	}
+    if (minor_version_number != NULL) {
+        *minor_version_number = unitexMinorVersion;
+    }
 }
 
 
 size_t get_unitex_version_revision_xml_string(char* string, size_t buflen)
 {
-	const char* xmlStringRevision = "\0<UnitexRevision>" STRINGIZE(SVN_REVISION) "</UnitexRevision>\0";
-	const char* xmlStringNewRevision = "\0<UnitexNewRevision>" STRINGIZE(SVN_NEW_REVISION) "</UnitexNewRevision>\0";
+    const char* xmlStringRevision = "\0<UnitexRevision>" STRINGIZE(SVN_REVISION) "</UnitexRevision>\0";
+    const char* xmlStringNewRevision = "\0<UnitexNewRevision>" STRINGIZE(SVN_NEW_REVISION) "</UnitexNewRevision>\0";
 
 #ifdef GIT_HEAD_REVISION
-	const char* xmlStringGitHeadRevision = "\0<UnitexGitHead>" GIT_HEAD_REVISION "</UnitexGitHead>\0";
+    const char* xmlStringGitHeadRevision = "\0<UnitexGitHead>" GIT_HEAD_REVISION "</UnitexGitHead>\0";
 #else
-	const char* xmlStringGitHeadRevision = "\0<UnitexGitHead></UnitexGitHead>\0";
+    const char* xmlStringGitHeadRevision = "\0<UnitexGitHead></UnitexGitHead>\0";
 #endif
 
 #if defined(UNITEX_MAJOR_VERSION_NUMBER) && defined(UNITEX_MINOR_VERSION_NUMBER)
-	const char* xmlStringVersion = "\0<UnitexMajorVersion>"  STRINGIZE(UNITEX_MAJOR_VERSION_NUMBER) "</UnitexMajorVersion>" \
-		"<UnitexMinorVersion>"  STRINGIZE(UNITEX_MINOR_VERSION_NUMBER) "</UnitexMinorVersion>" \
-		"\0";
+    const char* xmlStringVersion = "\0<UnitexMajorVersion>"  STRINGIZE(UNITEX_MAJOR_VERSION_NUMBER) "</UnitexMajorVersion>" \
+        "<UnitexMinorVersion>"  STRINGIZE(UNITEX_MINOR_VERSION_NUMBER) "</UnitexMinorVersion>" \
+        "\0";
 #else
-	const char* xmlStringVersion = "\0<UnitexMajorVersion>x</UnitexMajorVersion>"
-		"<UnitexMinorVersion>x</UnitexMinorVersion>\0";
+    const char* xmlStringVersion = "\0<UnitexMajorVersion>x</UnitexMajorVersion>"
+        "<UnitexMinorVersion>x</UnitexMinorVersion>\0";
 #endif
 
-	const char* xmlStringSemVer = "\0<UnitexSemVer>" UNITEX_SEMVER_STRING "</UnitexSemVer>";
+    const char* xmlStringSemVer = "\0<UnitexSemVer>" UNITEX_SEMVER_STRING "</UnitexSemVer>";
 
-	const char* usableXmlStringRevision = xmlStringRevision + 1;
-	const char* usableXmlStringNewRevision = xmlStringNewRevision + 1;
-	const char* usableXmlStringGitHead = xmlStringGitHeadRevision + 1;
-	const char* usableXmlStringVersion = xmlStringVersion + 1;
-	const char* usableXmlStringSemVer = xmlStringSemVer + 1;
-	size_t len = strlen(usableXmlStringRevision)+strlen(usableXmlStringNewRevision)+strlen(usableXmlStringGitHead)+
-		strlen(usableXmlStringVersion)+strlen(usableXmlStringSemVer)+(5*strlen("\n"));
-	if (buflen > len) {
-		strcpy(string, usableXmlStringVersion);
-		strcat(string, "\n");
-		strcat(string, usableXmlStringRevision);
-		strcat(string, "\n");
-		strcat(string, usableXmlStringNewRevision);
-		strcat(string, "\n");
-		strcat(string, usableXmlStringGitHead);
-		strcat(string, "\n");
-		strcat(string, usableXmlStringSemVer);
-		strcat(string, "\n");
-	}
+    const char* usableXmlStringRevision = xmlStringRevision + 1;
+    const char* usableXmlStringNewRevision = xmlStringNewRevision + 1;
+    const char* usableXmlStringGitHead = xmlStringGitHeadRevision + 1;
+    const char* usableXmlStringVersion = xmlStringVersion + 1;
+    const char* usableXmlStringSemVer = xmlStringSemVer + 1;
+    size_t len = strlen(usableXmlStringRevision)+strlen(usableXmlStringNewRevision)+strlen(usableXmlStringGitHead)+
+        strlen(usableXmlStringVersion)+strlen(usableXmlStringSemVer)+(5*strlen("\n"));
+    if (buflen > len) {
+        strcpy(string, usableXmlStringVersion);
+        strcat(string, "\n");
+        strcat(string, usableXmlStringRevision);
+        strcat(string, "\n");
+        strcat(string, usableXmlStringNewRevision);
+        strcat(string, "\n");
+        strcat(string, usableXmlStringGitHead);
+        strcat(string, "\n");
+        strcat(string, usableXmlStringSemVer);
+        strcat(string, "\n");
+    }
 
-	return len + 1;
+    return len + 1;
 }
 
 
@@ -199,39 +199,39 @@ size_t get_unitex_version_revision_json_string(char* string, size_t buflen)
 {
 
 #ifdef GIT_HEAD_REVISION
-	#define JSON_GIT ", \"UnitexGitHead\":\"" GIT_HEAD_REVISION "\""
+    #define JSON_GIT ", \"UnitexGitHead\":\"" GIT_HEAD_REVISION "\""
 #else
-	#define JSON_GIT ", \"UnitexGitHead\":\"" "\""
+    #define JSON_GIT ", \"UnitexGitHead\":\"" "\""
 #endif
 
 #if defined(UNITEX_MAJOR_VERSION_NUMBER) && defined(UNITEX_MINOR_VERSION_NUMBER) && defined (SVN_REVISION)
-	const char* jsonString = "\0{\"UnitexMajorVersion\":" STRINGIZE(UNITEX_MAJOR_VERSION_NUMBER)
-		", \"UnitexMinorVersion\":" STRINGIZE(UNITEX_MINOR_VERSION_NUMBER) \
-		", \"UnitexRevision\":" STRINGIZE(SVN_REVISION) \
-		", \"UnitexNewRevision\":" STRINGIZE(SVN_NEW_REVISION) \
-		JSON_GIT \
-		", \"UnitexSemVer\":\"" UNITEX_SEMVER_STRING "\"}";
+    const char* jsonString = "\0{\"UnitexMajorVersion\":" STRINGIZE(UNITEX_MAJOR_VERSION_NUMBER)
+        ", \"UnitexMinorVersion\":" STRINGIZE(UNITEX_MINOR_VERSION_NUMBER) \
+        ", \"UnitexRevision\":" STRINGIZE(SVN_REVISION) \
+        ", \"UnitexNewRevision\":" STRINGIZE(SVN_NEW_REVISION) \
+        JSON_GIT \
+        ", \"UnitexSemVer\":\"" UNITEX_SEMVER_STRING "\"}";
 #else
-	const char* jsonString = "\0{\"UnitexMajorVersion\":-1, \"UnitexMinorVersion\":-1, \"UnitexRevision\":-1, \"UnitexSemVer\":\"" UNITEX_SEMVER_STRING "\"}";
+    const char* jsonString = "\0{\"UnitexMajorVersion\":-1, \"UnitexMinorVersion\":-1, \"UnitexRevision\":-1, \"UnitexSemVer\":\"" UNITEX_SEMVER_STRING "\"}";
 #endif
 
-	const char* usableStringRevision = jsonString + 1;
+    const char* usableStringRevision = jsonString + 1;
 
-	size_t len = strlen(usableStringRevision);
-	if (buflen > len) {
-		strcpy(string, usableStringRevision);
-	}
+    size_t len = strlen(usableStringRevision);
+    if (buflen > len) {
+        strcpy(string, usableStringRevision);
+    }
 
-	return len + 1;
+    return len + 1;
 }
 
 
 UNITEX_FUNC void UNITEX_CALL GetUnitexVersion(unsigned int* major_version_number, unsigned int* minor_version_number)
 {
-	char bufXml[0x200];
-	get_unitex_version_revision_xml_string(bufXml, sizeof(bufXml));
+    char bufXml[0x200];
+    get_unitex_version_revision_xml_string(bufXml, sizeof(bufXml));
 
-	get_unitex_version(major_version_number, minor_version_number);
+    get_unitex_version(major_version_number, minor_version_number);
 }
 
 } // namespace unitex

--- a/UnitexRevisionInfo.cpp
+++ b/UnitexRevisionInfo.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -33,7 +33,7 @@
  * SVN_NEW_REVISION : this is the SVN revision number at new hitHub svn https://github.com/UnitexGramLab/unitex-core
  * UNITEX_NEW_SVN_DIFFERENCE = 1632
  * SVN_REVISION was the svn revision from historic https://gforgeigm.univ-mlv.fr/svn/unitex/Unitex-C++
- * SVN_REVISION = SVN_NEW_REVISION + UNITEX_NEW_SVN_DIFFERENCE on version from new github server 
+ * SVN_REVISION = SVN_NEW_REVISION + UNITEX_NEW_SVN_DIFFERENCE on version from new github server
  * so "historic" SVN_REVISION value allow compare svn revision number between build made on old and new repository
  *
  */

--- a/UnitexRevisionInfo.h
+++ b/UnitexRevisionInfo.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/UnitexRuby/UnitexRuby.cpp
+++ b/UnitexRuby/UnitexRuby.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -125,32 +125,32 @@ public:
         utf8_encoding_index = rb_enc_find_index("UTF-8");
         utf16le_encoding_index = rb_enc_find_index("UTF-16LE");
         utf16be_encoding_index = rb_enc_find_index("UTF-16BE");
-        
+
         utf8_encoding = rb_enc_find("UTF-8");
         utf16le_encoding = rb_enc_find("UTF-16LE");
         utf16be_encoding = rb_enc_find("UTF-16BE");
-        
+
         //
         /* name -> rb_encoding */
         //rb_encoding * rb_enc_find(const char *name);
-        
+
         mutex = SyncBuildMutex();
     };
-    
+
     ~rubyTool()
     {
         SyncDeleteMutex(mutex);
         mutex = NULL;
     };
-    
+
     int get_utf8_encoding_index() { return utf8_encoding_index; } ;
     int get_utf16le_encoding_index() { return utf16le_encoding_index; } ;
     int get_utf16be_encoding_index() { return utf16be_encoding_index; } ;
-    
+
     rb_encoding * get_utf8_encoding() { return utf8_encoding; } ;
     rb_encoding * get_utf16le_encoding() { return utf16le_encoding; } ;
     rb_encoding * get_utf16be_encoding() { return utf16be_encoding; } ;
-    
+
     void get_incremented_counter(unsigned long *high, unsigned long* low)
     {
         SyncGetMutex(mutex);
@@ -169,11 +169,11 @@ private:
     int utf8_encoding_index;
     int utf16le_encoding_index;
     int utf16be_encoding_index;
-    
+
     rb_encoding * utf8_encoding;
     rb_encoding * utf16le_encoding;
     rb_encoding * utf16be_encoding;
-    
+
     SYNC_Mutex_OBJECT mutex;
     unsigned long counterLow, counterHigh;
 };
@@ -188,7 +188,7 @@ VALUE method_getUniqueString(VALUE self)
     unsigned long high = 0;
     _rubyTool.get_incremented_counter(&high, &low);
     sprintf(szText, "%ld_%ld",low,high);
-    
+
     return rb_str_new2(szText);
 }
 
@@ -203,15 +203,15 @@ static const char* CopyStrArg(const char*lpSrc,char* lpDest,size_t dwMaxSize)
 {
     int isInQuote=0;
     size_t dwDestPos = 0;
-    
+
     *lpDest = '\0';
-    
+
     if (lpSrc==NULL)
         return NULL;
-    
+
     while ((*lpSrc) == ' ')
         lpSrc++;
-    
+
     while (((*lpSrc) != '\0') && ((dwMaxSize==0) || (dwDestPos<dwMaxSize)))
     {
         if ((*lpSrc) == '"')
@@ -220,14 +220,14 @@ static const char* CopyStrArg(const char*lpSrc,char* lpDest,size_t dwMaxSize)
             lpSrc++;
             continue;
         }
-        
+
         if (((*lpSrc) == ' ') && (!isInQuote))
         {
             while ((*lpSrc) == ' ')
                 lpSrc++;
             return lpSrc;
         }
-        
+
         *lpDest = *lpSrc;
         lpDest++;
         dwDestPos++;
@@ -241,14 +241,14 @@ static const char* CopyStrArg(const char*lpSrc,char* lpDest,size_t dwMaxSize)
 static char**argsFromCmdLine( const char* cmdLine)
 {
     size_t len_cmd_line=strlen(cmdLine);
-    
+
     char* work_buf = (char*)malloc(len_cmd_line+0x10);
     if (work_buf==NULL)
         return 0;
-    
+
     const char*lpParcLine;
     int nb_args_found=0;
-    
+
     lpParcLine = cmdLine;
     while ((*lpParcLine) != '\0')
     {
@@ -256,19 +256,19 @@ static char**argsFromCmdLine( const char* cmdLine)
         lpParcLine = CopyStrArg(lpParcLine, work_buf, len_cmd_line+8);
         nb_args_found ++;
     }
-    
+
 	char **args=NULL;
     if (nb_args_found>0)
         args = (char**)malloc((nb_args_found+1) * sizeof(char*));
     else
         args = NULL;
-    
+
 	if (args == NULL)
     {
         free(work_buf);
         return NULL;
     }
-    
+
     lpParcLine = cmdLine;
     int i=0;
     while ((*lpParcLine) != '\0')
@@ -279,7 +279,7 @@ static char**argsFromCmdLine( const char* cmdLine)
 		i++;
     }
 	args[i] = NULL;
-    
+
     free(work_buf);
     return args;
 }
@@ -287,7 +287,7 @@ static char**argsFromCmdLine( const char* cmdLine)
 static int countArgs(char** args)
 {
 	int count=0;
-	
+
 	char**tmp=args;
 	while ((*tmp) != NULL)
 	{
@@ -312,11 +312,11 @@ static void freeArgs(char**args)
 VALUE method_UnitexTool(VALUE self, VALUE r_args)
 {
     char* args_cstr = StringValueCStr(r_args);
-    
+
 	char**args=argsFromCmdLine(args_cstr);
 	int retValue = (int)main_UnitexTool_C(countArgs(args),args);
 	freeArgs(args);
-    
+
     return INT2NUM(retValue);
 }
 
@@ -334,7 +334,7 @@ VALUE method_UnitexToolArray(VALUE self, VALUE r_args_array)
     args[i] = NULL;
 	int retValue = (int)main_UnitexTool_C(countArgs(args),args);
 	freeArgs(args);
-    
+
     return INT2NUM(retValue);
 }
 
@@ -372,8 +372,8 @@ VALUE method_getUnitexInfoString(VALUE self)
 {
     char szText[0x200];
     sprintf(szText, "Unitex %d.%d revision %d",
-            
-            
+
+
 #ifdef UNITEX_MAJOR_VERSION_NUMBER
             UNITEX_MAJOR_VERSION_NUMBER,
 #else
@@ -384,15 +384,15 @@ VALUE method_getUnitexInfoString(VALUE self)
 #else
             1,
 #endif
-            
+
 #ifdef SVN_REVISION
             SVN_REVISION
 #else
             -1
 #endif
             );
-    
-    return rb_str_new2(szText);    
+
+    return rb_str_new2(szText);
 }
 
 
@@ -410,7 +410,7 @@ VALUE method_usingOffsetFile(VALUE self)
 VALUE method_numberAbstractFileSpaceInstalled(VALUE self)
 {
     int numberAbstractFileSpace = GetNbAbstractFileSpaceInstalled();
-    
+
     return INT2NUM(numberAbstractFileSpace);
 }
 
@@ -438,7 +438,7 @@ VALUE method_loadPersistentDictionary(VALUE self, VALUE r_args)
 {
     char* filename = StringValueCStr(r_args);
     VALUE rret = Qnil;
-    
+
     size_t len_buffer = strlen(filename) + 0x200;
     char* persistent_filename=(char*)malloc(len_buffer+1);
     if (persistent_filename == NULL) {
@@ -455,7 +455,7 @@ VALUE method_loadPersistentFst2(VALUE self, VALUE r_args)
 {
     char* filename = StringValueCStr(r_args);
     VALUE rret = Qnil;
-    
+
     size_t len_buffer = strlen(filename) + 0x200;
     char* persistent_filename=(char*)malloc(len_buffer+1);
     if (persistent_filename == NULL) {
@@ -472,7 +472,7 @@ VALUE method_loadPersistentAlphabet(VALUE self, VALUE r_args)
 {
     char* filename = StringValueCStr(r_args);
     VALUE rret = Qnil;
-    
+
     size_t len_buffer = strlen(filename) + 0x200;
     char* persistent_filename=(char*)malloc(len_buffer+1);
     if (persistent_filename == NULL) {
@@ -510,9 +510,9 @@ VALUE method_copyUnitexFile(VALUE self, VALUE fileSrc, VALUE fileDst)
 {
     char* filenameSrc = StringValueCStr(fileSrc);
     char* filenameDst = StringValueCStr(fileDst);
-    
+
     int result = (CopyUnitexFile(filenameSrc,filenameDst) == 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
@@ -520,45 +520,45 @@ VALUE method_renameUnitexFile(VALUE self, VALUE fileSrc, VALUE fileDst)
 {
     char* filenameSrc = StringValueCStr(fileSrc);
     char* filenameDst = StringValueCStr(fileDst);
-    
+
     int result = (RenameUnitexFile(filenameSrc,filenameDst) == 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
 VALUE method_unitexAbstractPathExists(VALUE self, VALUE filename)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     int result = (UnitexAbstractPathExists(c_filename) != 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
 VALUE method_removeUnitexFolder(VALUE self, VALUE filename)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     int result = (RemoveUnitexFolder(c_filename) == 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
 VALUE method_createUnitexFolder(VALUE self, VALUE filename)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     int result = (CreateUnitexFolder(c_filename) == 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
 VALUE method_removeUnitexFile(VALUE self, VALUE filename)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     int result = (RemoveUnitexFile(c_filename) == 0);
-    
+
     return result ? Qtrue : Qfalse;
 }
 
@@ -566,16 +566,16 @@ VALUE method_removeUnitexFile(VALUE self, VALUE filename)
 VALUE method_getUnitexFileRaw(VALUE self, VALUE filename)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     UNITEXFILEMAPPED *amf = NULL;
     const void*buffer = 0;
     size_t size_file = 0;
 	GetUnitexFileReadBuffer(c_filename,&amf, &buffer,&size_file);
     if (amf == NULL)
         return Qnil;
-    
+
     VALUE vret = rb_str_new((const char*)buffer, size_file);
-    
+
     CloseUnitexFileReadBuffer(amf, buffer, size_file);
     return vret;
 }
@@ -584,10 +584,10 @@ VALUE method_writeUnitexFileRaw(VALUE self, VALUE filename, VALUE string)
 {
     char* c_filename = StringValueCStr(filename);
     char* c_string = StringValueCStr(string);
-    
+
 	int ret = (WriteUnitexFile(c_filename,NULL,0,
                                c_string,strlen(c_string)) == 0);
-    
+
 	return ret ? Qtrue : Qfalse;
 }
 
@@ -595,10 +595,10 @@ VALUE method_appendUnitexFileRaw(VALUE self, VALUE filename, VALUE string)
 {
     char* c_filename = StringValueCStr(filename);
     char* c_string = StringValueCStr(string);
-    
+
 	int ret = (AppendUnitexFile(c_filename,
                                    c_string,strlen(c_string)) == 0);
-    
+
 	return ret ? Qtrue : Qfalse;
 }
 
@@ -608,18 +608,18 @@ VALUE method_appendUnitexFileRaw(VALUE self, VALUE filename, VALUE string)
 VALUE method_writeUnitexFileString(VALUE self, VALUE filename, VALUE string)
 {
     char* c_filename = StringValueCStr(filename);
-    
+
     rb_encoding *utf8_enc = rb_enc_find("UTF-8");
     VALUE utf8_string = rb_str_export_to_enc(string, utf8_enc);
     const char *c_string = StringValueCStr(utf8_string);
-    
-    
+
+
 	const unsigned char UTF8BOM[3] = { 0xef,0xbb,0xbf };
     int hasBom = 1; // put 1 to write UTF8 bom
-    
+
 	int ret = (WriteUnitexFile(c_filename, UTF8BOM, hasBom ? 3:0,
                                c_string, strlen(c_string)) == 0);
-    
+
 	return ret ? Qtrue : Qfalse;
 }
 
@@ -632,39 +632,39 @@ VALUE method_getUnitexFileStringEncoded(VALUE self, VALUE filename)
     VALUE vret = Qnil;
 	size_t size_bom = 0;
     char* c_filename = StringValueCStr(filename);
-    
+
 	GetUnitexFileReadBuffer(c_filename,&amf, &buffer,&size_file);
 	const unsigned char* bufchar=(const unsigned char*)buffer;
-    
+
     if (amf == NULL)
         return Qnil;
-    
+
     if (size_file>1)
         if (((*(bufchar))==0xff) && ((*(bufchar+1))==0xfe))
         {
 			// utf-16 little endian
             size_bom = 2;
-            
+
             vret = rb_external_str_new_with_enc((const char*)bufchar + size_bom, size_file - size_bom, rb_enc_find("UTF-16LE"));
             vret = rb_str_export_to_enc(vret, rb_enc_find("UTF-8"));
         }
-    
+
     if (size_file>1)
         if (((*(bufchar))==0xfe) && ((*(bufchar+1))==0xff))
         {
 			// utf-16 big endian
             size_bom = 2;
-            
+
             vret = rb_external_str_new_with_enc((const char*)bufchar + size_bom, size_file - size_bom, rb_enc_find("UTF-16BE"));
             vret = rb_str_export_to_enc(vret, rb_enc_find("UTF-8"));
         }
-    
+
     if (size_file>2)
         if (((*(bufchar))==0xef) && ((*(bufchar+1))==0xbb) && ((*(bufchar+2))==0xbf))
         {
             size_bom = 3;
         }
-    
+
 
     if (vret == Qnil)
     {
@@ -684,43 +684,43 @@ VALUE method_getUnitexFileString(VALUE self, VALUE filename)
     VALUE vret = Qnil;
 	size_t size_bom = 0;
     char* c_filename = StringValueCStr(filename);
-    
+
 	GetUnitexFileReadBuffer(c_filename,&amf, &buffer,&size_file);
 	const unsigned char* bufchar=(const unsigned char*)buffer;
-    
+
     if (amf == NULL)
         return Qnil;
-    
+
     if (size_file>1)
         if (((*(bufchar))==0xff) && ((*(bufchar+1))==0xfe))
         {
 			// utf-16 little endian
             size_bom = 2;
-            
+
             vret = rb_external_str_new_with_enc((const char*)bufchar + size_bom, size_file - size_bom, rb_enc_find("UTF-16LE"));
         }
-    
+
     if (size_file>1)
         if (((*(bufchar))==0xfe) && ((*(bufchar+1))==0xff))
         {
 			// utf-16 big endian
             size_bom = 2;
-            
+
             vret = rb_external_str_new_with_enc((const char*)bufchar + size_bom, size_file - size_bom, rb_enc_find("UTF-16BE"));
         }
-    
+
     if (size_file>2)
         if (((*(bufchar))==0xef) && ((*(bufchar+1))==0xbb) && ((*(bufchar+2))==0xbf))
         {
             size_bom = 3;
         }
-    
-    
+
+
     if (vret == Qnil)
     {
         vret = rb_external_str_new_with_enc((const char*)bufchar + size_bom, size_file - size_bom, rb_enc_find("UTF-8"));
     }
-    
+
     CloseUnitexFileReadBuffer(amf, buffer, size_file);
     return vret;
 }
@@ -736,12 +736,12 @@ VALUE method_installLogger(VALUE self, VALUE foldername, VALUE v_store_file_out_
     char* c_foldername = StringValueCStr(foldername);
 	if (p_ruby_ule)
 		return Qfalse;
-    
+
 	p_ruby_ule= (struct UniLoggerSpace *)malloc(sizeof(struct UniLoggerSpace));
     if (!p_ruby_ule)
 		return Qfalse;
 	memset(p_ruby_ule,0,sizeof(struct UniLoggerSpace));
-    
+
 	p_ruby_ule->size_of_struct = sizeof(struct UniLoggerSpace);
 	p_ruby_ule->privateUnloggerData = NULL;
 	p_ruby_ule->szPathLog = strdup(c_foldername);
@@ -753,10 +753,10 @@ VALUE method_installLogger(VALUE self, VALUE foldername, VALUE v_store_file_out_
 	p_ruby_ule->store_std_out_content = 0;
 	p_ruby_ule->store_std_err_content = 0;
 	p_ruby_ule->auto_increment_logfilename = 1;
-    
+
 	if (0 != AddActivityLogger(p_ruby_ule))
 		return Qtrue;
-    
+
 	free(p_ruby_ule);
 	return Qfalse;
 }
@@ -785,7 +785,7 @@ VALUE method_getFileList(VALUE self, VALUE foldername)
 	char**list=GetUnitexFileList(c_foldername);
 	if (list==NULL)
 		return Qnil;
-    
+
     VALUE array = rb_ary_new();
 	unsigned int iter_file = 0;
 	while ((*(list + iter_file)) != NULL)
@@ -794,9 +794,9 @@ VALUE method_getFileList(VALUE self, VALUE foldername)
         rb_ary_push(array, item);
 		iter_file ++;
 	}
-    
+
     ReleaseUnitexFileList(c_foldername, list);
-    
+
     return array;
 }
 
@@ -828,9 +828,9 @@ UNITEX_FUNC int UNITEX_CALL AddUnitexRubyInitializer(const t_unitex_ruby_initial
     new_item->uri.func_array.size_func_array = func_array_param->size_func_array;
     new_item->uri.func_array.fnc_unitex_ruby_initializer = func_array_param->fnc_unitex_ruby_initializer;
     new_item->uri.privateSpacePtr = privateSpacePtr;
-    
+
 	new_item->next = NULL;
-    
+
 	if (p_unitex_ruby_initializer_space_list == NULL)
       p_unitex_ruby_initializer_space_list = new_item;
 	else {
@@ -839,7 +839,7 @@ UNITEX_FUNC int UNITEX_CALL AddUnitexRubyInitializer(const t_unitex_ruby_initial
           tmp = tmp->next;
 		tmp->next = new_item;
 	}
-    
+
 	return 1;
 }
 
@@ -847,7 +847,7 @@ UNITEX_FUNC int UNITEX_CALL RemoveUnitexRubyInitializer(const t_unitex_ruby_init
 {
 	struct List_UnitexRubyInitializer* tmp = p_unitex_ruby_initializer_space_list;
 	struct List_UnitexRubyInitializer* tmp_previous = NULL;
-    
+
 	while (tmp != NULL)
 	{
         if ((tmp->uri.func_array.fnc_unitex_ruby_initializer == func_array_param->fnc_unitex_ruby_initializer) &&
@@ -857,7 +857,7 @@ UNITEX_FUNC int UNITEX_CALL RemoveUnitexRubyInitializer(const t_unitex_ruby_init
               p_unitex_ruby_initializer_space_list = tmp->next;
 			else
               tmp_previous->next = tmp->next;
-            
+
 			free(tmp);
 			return 1;
 		}
@@ -876,10 +876,10 @@ typedef VALUE (*t_r_method)(ANYARGS);
 extern "C" UNITEX_FUNC void Init_unitexruby()
 {
     UnitexRuby = rb_define_module("UnitexRuby");
-    
+
 	rb_define_method(UnitexRuby, "UnitexTool", (t_r_method) &method_UnitexTool, 1);
 	rb_define_method(UnitexRuby, "UnitexToolArray", (t_r_method) &method_UnitexToolArray, 1);
-    
+
 	rb_define_method(UnitexRuby, "getUnitexInfoString", (t_r_method) &method_getUnitexInfoString, 0);
 	rb_define_method(UnitexRuby, "getMajorVersionNumber", (t_r_method) &method_getMajorVersionNumber, 0);
 	rb_define_method(UnitexRuby, "getMinorVersionNumber", (t_r_method) &method_getMinorVersionNumber, 0);
@@ -907,7 +907,7 @@ extern "C" UNITEX_FUNC void Init_unitexruby()
 	rb_define_method(UnitexRuby, "installLogger", (t_r_method) &method_installLogger, 2);
 	rb_define_method(UnitexRuby, "removeLogger", (t_r_method) &method_removeLogger, 0);
 
-    
+
 #ifndef RUBY_VINTAGE
 	rb_define_method(UnitexRuby, "writeUnitexFileString", (t_r_method) &method_writeUnitexFileString, 2);
 	rb_define_method(UnitexRuby, "getUnitexFileStringEncoded", (t_r_method) &method_getUnitexFileStringEncoded, 1);
@@ -915,9 +915,9 @@ extern "C" UNITEX_FUNC void Init_unitexruby()
 	rb_define_method(UnitexRuby, "getUniqueString", (t_r_method) &method_getUniqueString, 0);
 
 #endif
-    
+
 	struct List_UnitexRubyInitializer* tmp = p_unitex_ruby_initializer_space_list;
-    
+
 	while (tmp != NULL)
 	{
         (tmp->uri.func_array.fnc_unitex_ruby_initializer)(UnitexRuby, tmp->uri.privateSpacePtr);

--- a/UnitexString.h
+++ b/UnitexString.h
@@ -19,18 +19,18 @@
  *
  */
 /**
- * @file     UnitexString.h  
- * @brief    Implements the Unitex::UnitexString class, a wrapper around Unitex 
+ * @file     UnitexString.h
+ * @brief    Implements the Unitex::UnitexString class, a wrapper around Unitex
  *           unicode strings data types and functions
- * 
+ *
  * @author   cristian.martinez@univ-paris-est.fr (martinec)
- *          
+ *
  * @note     Use cpplint.py tool to detect style errors:
  *           `curl -L http://goo.gl/O1I32H -o cpplint.py ; chmod +x cpplint.py ;
  *           ./cpplint.py UnitexString.h`
- *          
+ *
  * @date     November 2014
- * 
+ *
  * This file was contributed as part of the [DataMaTex](http://unitex.amabis.fr)
  * project developed by [Amabis SARL](http://www.amabis.fr) with the collaboration
  * of the [LIGM](http://infolingu.univ-mlv.fr/). For further information on this,
@@ -64,12 +64,12 @@ namespace unitex {
 /* ************************************************************************** */
 /**
  * @class    UnitexString
- * 
- * @brief    A class wrapper (RAII) around Unitex unicode strings data types and 
+ *
+ * @brief    A class wrapper (RAII) around Unitex unicode strings data types and
  *           functions
- * 
+ *
  * @details  This class is build upon the next data types :
- * 
+ *
  * @code{.cpp}
  *           const char            // character
  *           const char*           // string
@@ -78,11 +78,11 @@ namespace unitex {
  *           const Ustring*        // string
  *           const UnitexString&   // string
  * @endcode
- * 
+ *
  * @defgroup UnitexString UnitexString
- * @ingroup  Unicode 
- * 
- * @see      Ustring.h 
+ * @ingroup  Unicode
+ *
+ * @see      Ustring.h
  * @see      Unicode.h
  */
 class UnitexString {
@@ -95,7 +95,7 @@ class UnitexString {
 
   /**
    * @brief  Unitex unicode elemental type
-   * 
+   *
    * unichar is the type of a unicode character. Note that it is a 16-bits type,
    * so that it cannot handle characters >= 0xFFFF. Such characters, theoretically
    * represented with low and high surrogate characters are not handled by Unitex
@@ -104,7 +104,7 @@ class UnitexString {
 
   /**
    * @brief  Read/Write reference to a unichar character
-   * 
+   *
    * @see    value_type
    */
   typedef unichar& reference;
@@ -131,7 +131,7 @@ class UnitexString {
 
   /**
    * @brief  Read/Write unichar pointer used as iterator
-   * 
+   *
    */
   typedef unichar* iterator;
 
@@ -146,19 +146,19 @@ class UnitexString {
   /// @{
 
   /**
-   * @brief  Returned by functions when they fail, literally indicates past 
+   * @brief  Returned by functions when they fail, literally indicates past
    *         the end
    */
   static const size_type  npos = static_cast<size_type>(-1);
 
   /**
    * @brief  Max buffer size
-   * 
-   * Max buffer size, expressed in number of characters, used in 
+   *
+   * Max buffer size, expressed in number of characters, used in
    * UnitexString::format and UnitexString::append_format functions
-   * 
+   *
    * @see    format
-   * @see    append_format 
+   * @see    append_format
    */
   static const size_type  kMaxBufferSize = 1024;
 
@@ -167,8 +167,8 @@ class UnitexString {
   // Constructors
   /**
    * @brief  Default constructor
-   * 
-   * Allocates and initializes an empty string, with a length of zero 
+   *
+   * Allocates and initializes an empty string, with a length of zero
    * characters
    */
   UnitexString() :
@@ -177,9 +177,9 @@ class UnitexString {
 
   /**
    * @brief  Copy constructor
-   * 
+   *
    * Constructs string as copy of a string
-   * 
+   *
    * @param  string Source string
    */
   UnitexString(const UnitexString& string) :
@@ -188,11 +188,11 @@ class UnitexString {
 
   /**
    * @brief  Substring constructor
-   * 
-   * Copies the portion of str that begins at the character position pos and 
-   * spans n characters, or until the end of str, if either str is too short 
+   *
+   * Copies the portion of str that begins at the character position pos and
+   * spans n characters, or until the end of str, if either str is too short
    * or if n is UnitexString::npos
-   * 
+   *
    * @param  string Source string
    * @param  pos    Index of first character to copy from
    * @param  n      Number of characters to copy (default remainder)
@@ -211,10 +211,10 @@ class UnitexString {
 
   /**
    * @brief  Constructor from c-string
-   * 
-   * Allocates and initializes a string from a null-terminated character 
+   *
+   * Allocates and initializes a string from a null-terminated character
    * sequence (C-string)
-   * 
+   *
    * @param  string A null-terminated character sequence (C-string)
    */
   /*explicit*/ UnitexString(const char* string) :                   // NOLINT
@@ -223,10 +223,10 @@ class UnitexString {
   }
 
   /**
-   * @brief  Constructor from c-buffer 
-   * 
+   * @brief  Constructor from c-buffer
+   *
    * Copies  the first n chars from the array of characters pointed by string
-   * 
+   *
    * @param  string A null-terminated character sequence (C-string)
    * @param  n      Number of characters to copy
    */
@@ -237,13 +237,13 @@ class UnitexString {
 
   /**
    * @brief  Fill constructor from char
-   * 
+   *
    * Fills the string with n consecutive copies of character c
-   * 
+   *
    * @param  n         Number of characters to fill
-   * @param  character Character to fill the string with. Each of the n 
-   *                   characters in the string will be initialized to a 
-   *                   copy of this value. 
+   * @param  character Character to fill the string with. Each of the n
+   *                   characters in the string will be initialized to a
+   *                   copy of this value.
    */
   UnitexString(size_type n, char character) :
       data_(new_Ustring(n)) {
@@ -259,11 +259,11 @@ class UnitexString {
 
   /**
    * @brief  Range constructor from C-string iterators
-   * 
-   * Copies the sequence of characters in the range [first,last), in the 
-   * same order, including the character pointed by first but not the 
+   *
+   * Copies the sequence of characters in the range [first,last), in the
+   * same order, including the character pointed by first but not the
    * character pointed by last.
-   * 
+   *
    * @param  first  Input iterator (C-string) to the initial position in a range
    * @param  last   Input iterator (C-string) to the final position in a range
    */
@@ -278,11 +278,11 @@ class UnitexString {
   }
 
   /**
-   * @brief  Constructor from unitex unichar 
-   * 
-   * Allocates and initializes a string from a null-terminated character 
+   * @brief  Constructor from unitex unichar
+   *
+   * Allocates and initializes a string from a null-terminated character
    * sequence (unichar-string)
-   * 
+   *
    * @param  string A null-terminated character sequence (unichar-string)
    */
   explicit UnitexString(const unichar* string) :
@@ -291,9 +291,9 @@ class UnitexString {
 
   /**
    * @brief  Constructor from unichar buffer
-   * 
+   *
    * Copies the first n chars from the array of characters pointed by string
-   * 
+   *
    * @param  string A null-terminated character sequence (unichar-string)
    * @param  n      Number of characters to copy
    */
@@ -304,13 +304,13 @@ class UnitexString {
 
   /**
    * @brief  Fill constructor from unichar
-   * 
+   *
    * Fills the string with n consecutive copies of character c (unichar)
-   * 
+   *
    * @param  n         Number of characters to fill
-   * @param  character Character to fill the string with. Each of the n 
-   *                   characters in the string will be initialized to a 
-   *                   copy of this value. 
+   * @param  character Character to fill the string with. Each of the n
+   *                   characters in the string will be initialized to a
+   *                   copy of this value.
    */
   UnitexString(size_type n, unichar character) :
       data_(new_Ustring(n)) {
@@ -326,11 +326,11 @@ class UnitexString {
 
   /**
    * @brief  Range constructor from unichar-string iterators
-   * 
-   * Copies the sequence of characters in the range [first,last), in the 
-   * same order, including the character pointed by first but not the 
+   *
+   * Copies the sequence of characters in the range [first,last), in the
+   * same order, including the character pointed by first but not the
    * character pointed by last.
-   * 
+   *
    * @param  first  Input iterator (unichar) to the initial position in a range
    * @param  last   Input iterator (unichar) to the final position in a range
    */
@@ -345,11 +345,11 @@ class UnitexString {
   }
 
   /**
-   * @brief  Constructor from unitex Ustring 
-   * 
-   * Allocates and initializes a string from a null-terminated character 
+   * @brief  Constructor from unitex Ustring
+   *
+   * Allocates and initializes a string from a null-terminated character
    * sequence (Ustring-string)
-   * 
+   *
    * @param  string A null-terminated character sequence (Ustring-string)
    */
   explicit UnitexString(const Ustring* string) :
@@ -358,9 +358,9 @@ class UnitexString {
 
   /**
    * @brief  Constructor from Ustring buffer
-   * 
+   *
    * Copies the first n chars from the array of characters pointed by string
-   * 
+   *
    * @param  string A null-terminated character sequence (Ustring-string)
    * @param  n      Number of characters to copy
    */
@@ -373,7 +373,7 @@ class UnitexString {
 
   /**
    * @brief  Destroys the string object
-   * 
+   *
    * Free the memory allocated to the internal string
    */
   ~UnitexString() {
@@ -385,9 +385,9 @@ class UnitexString {
 
   /**
    * @brief  Return iterator to beginning
-   * 
+   *
    * Returns an iterator pointing to the first character of the string
-   * 
+   *
    * @return An iterator to the beginning of the string
    */
   iterator begin() {
@@ -396,9 +396,9 @@ class UnitexString {
 
   /**
    * @brief  Return constant iterator to beginning
-   * 
+   *
    * Returns a constant iterator pointing to the first character of the string
-   * 
+   *
    * @return A constant iterator to the beginning of the string
    */
   const_iterator begin() const {
@@ -407,10 +407,10 @@ class UnitexString {
 
   /**
    * @brief  Return constant iterator to beginning
-   * 
+   *
    * Returns a constant iterator pointing to the first character of the string.
    * This is an alias of UnitexString::begin
-   * 
+   *
    * @return A constant iterator to the beginning of the string
    */
   const_iterator cbegin() const {
@@ -418,12 +418,12 @@ class UnitexString {
   }
 
   /**
-   * @brief  Returns an iterator pointing to the past-the-end character of 
+   * @brief  Returns an iterator pointing to the past-the-end character of
    * the string
-   * 
-   * The past-the-end character is a theoretical character that would follow 
+   *
+   * The past-the-end character is a theoretical character that would follow
    * the last character in the string. It shall not be dereferenced
-   * 
+   *
    * @return An iterator to the past-the-end of the string
    */
   iterator end() {
@@ -433,10 +433,10 @@ class UnitexString {
   /**
    * @brief  Returns a constant iterator pointing to the past-the-end character
    *  of  the string
-   * 
-   * The past-the-end character is a theoretical character that would follow 
+   *
+   * The past-the-end character is a theoretical character that would follow
    * the last character in the string. It shall not be dereferenced
-   * 
+   *
    * @return A constant iterator to the past-the-end of the string
    */
   const_iterator end() const {
@@ -446,11 +446,11 @@ class UnitexString {
   /**
    * @brief  Returns a constant iterator pointing to the past-the-end character
    *  of  the string
-   * 
-   * The past-the-end character is a theoretical character that would follow 
-   * the last character in the string. It shall not be dereferenced. This is an 
+   *
+   * The past-the-end character is a theoretical character that would follow
+   * the last character in the string. It shall not be dereferenced. This is an
    * alias of UnitexString::end
-   * 
+   *
    * @return A constant iterator to the past-the-end of the string
    */
   const_iterator cend() const {
@@ -461,9 +461,9 @@ class UnitexString {
 
   /**
    * @brief  String assignment from char
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
+   *
    * @param  rhs    A character. The string value is set to a single copy of this
    *                character (the string length becomes 1).
    * @return *this
@@ -476,10 +476,10 @@ class UnitexString {
 
   /**
    * @brief  String assignment from a C-string
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
-   * @param  rhs    A null-terminated character sequence (C-string). The sequence 
+   *
+   * @param  rhs    A null-terminated character sequence (C-string). The sequence
    *                is copied as the new value for the string.
    * @return *this
    */
@@ -490,9 +490,9 @@ class UnitexString {
 
   /**
    * @brief  String assignment from unichar
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
+   *
    * @param  rhs    A character. The string value is set to a single copy of this
    *                character (the string length becomes 1).
    * @return *this
@@ -505,10 +505,10 @@ class UnitexString {
 
   /**
    * @brief  String assignment from a unichar-string
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
-   * @param  rhs    A Unitex unichar-string. The sequence  is copied as the new 
+   *
+   * @param  rhs    A Unitex unichar-string. The sequence  is copied as the new
    *                value for the string.
    * @return *this
    */
@@ -521,10 +521,10 @@ class UnitexString {
 
   /**
    * @brief  String assignment from a Ustring-string
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
-   * @param  rhs    A Unitex Ustring-string. The sequence  is copied as the new 
+   *
+   * @param  rhs    A Unitex Ustring-string. The sequence  is copied as the new
    *                value for the string.
    * @return *this
    */
@@ -537,10 +537,10 @@ class UnitexString {
 
   /**
    * @brief  String assignment from a UnitexString object
-   * 
+   *
    * Assigns a new value to the string, replacing its current contents
-   * 
-   * @param  rhs  A null-terminated character sequence (C-string). The sequence 
+   *
+   * @param  rhs  A null-terminated character sequence (C-string). The sequence
    *              is copied as the new value for the string.
    * @return *this
    */
@@ -552,11 +552,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from char
-   * 
-   * Extends the string by appending an additional character at the end of its 
+   *
+   * Extends the string by appending an additional character at the end of its
    * current value
-   * 
-   * @param  rhs    A character, which is appended to the current value of 
+   *
+   * @param  rhs    A character, which is appended to the current value of
    *                the string
    * @return *this
    */
@@ -566,11 +566,11 @@ class UnitexString {
 
   /**
    * @brief Append to string from a C-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  rhs    A null-terminated character sequence (C-string). The 
+   *
+   * @param  rhs    A null-terminated character sequence (C-string). The
    *                sequence is appended to the current value of the string
    * @return *this
    */
@@ -580,11 +580,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from unichar
-   * 
-   * Extends the string by appending an additional character at the end of its 
+   *
+   * Extends the string by appending an additional character at the end of its
    * current value
-   * 
-   * @param  rhs    A character, which is appended to the current value of 
+   *
+   * @param  rhs    A character, which is appended to the current value of
    *                the string
    * @return *this
    */
@@ -594,11 +594,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a unichar-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  rhs    A Unitex unichar-string. The sequence is appended to the 
+   *
+   * @param  rhs    A Unitex unichar-string. The sequence is appended to the
    *                current value of the string
    * @return *this
    */
@@ -608,11 +608,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a Ustring-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  rhs    A Unitex Ustring-string. The sequence is appended to the 
+   *
+   * @param  rhs    A Unitex Ustring-string. The sequence is appended to the
    *                current value of the string
    * @return *this
    */
@@ -622,10 +622,10 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a UnitexString object
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
+   *
    * @param  rhs    A UnitexString object, whose value is copied at the end
    * @return *this
    */
@@ -637,13 +637,13 @@ class UnitexString {
 
   /**
    * @brief  Get character of string
-   * 
+   *
    * Returns a reference to the character at position index in the string
-   * 
+   *
    * @param  index  Value with the position of a character within the string
    * @return a UnitexString::reference
-   * 
-   * @attention This function doesn't check bounds, unlike UnitexString::at() 
+   *
+   * @attention This function doesn't check bounds, unlike UnitexString::at()
    * method.
    */
   reference operator[] (size_type index) {
@@ -652,16 +652,16 @@ class UnitexString {
 
   /**
    * @brief  Get character of string
-   * 
-   * Returns a constant reference to the character at position index in 
+   *
+   * Returns a constant reference to the character at position index in
    * the string
-   * 
+   *
    * @param  index  Value with the position of a character within the string
    * @return a UnitexString::const_reference
-   * 
-   * @attention This function doesn't check bounds, unlike UnitexString::at() 
+   *
+   * @attention This function doesn't check bounds, unlike UnitexString::at()
    * method.
-   */  
+   */
   const_reference operator[] (size_type index) const {
     return *(begin() + index);
   }
@@ -670,7 +670,7 @@ class UnitexString {
 
   /**
    * @brief  Test equivalence of C-string and UnitexString
-   *  
+   *
    * @param  rhs    A null-terminated character sequence (C-string)
    * @return True if this->compare(rhs) == 0.  False otherwise
    */
@@ -680,7 +680,7 @@ class UnitexString {
 
   /**
    * @brief  Test equivalence of unichar-string and UnitexString
-   *  
+   *
    * @param  rhs    A Unitex unichar-string
    * @return True if this->compare(rhs) == 0.  False otherwise
    */
@@ -690,7 +690,7 @@ class UnitexString {
 
   /**
    * @brief  Test equivalence of Ustring-string and UnitexString
-   *  
+   *
    * @param  rhs    A Unitex Ustring-string
    * @return True if this->compare(rhs) == 0.  False otherwise
    */
@@ -700,7 +700,7 @@ class UnitexString {
 
   /**
    * @brief  Test equivalence between two UnitexString objects
-   *  
+   *
    * @param  rhs    A UnitexString object
    * @return True if this->compare(rhs) == 0.  False otherwise
    */
@@ -712,7 +712,7 @@ class UnitexString {
 
   /**
    * @brief  Test difference of C-string and UnitexString
-   *  
+   *
    * @param  rhs    A null-terminated character sequence (C-string)
    * @return True if this->compare(rhs) != 0.  False otherwise
    */
@@ -722,7 +722,7 @@ class UnitexString {
 
   /**
    * @brief  Test difference of unichar-string and UnitexString
-   *  
+   *
    * @param  rhs    A Unitex unichar-string
    * @return True if this->compare(rhs) != 0.  False otherwise
    */
@@ -732,7 +732,7 @@ class UnitexString {
 
   /**
    * @brief  Test difference of Ustring-string and UnitexString
-   *  
+   *
    * @param  rhs    A Unitex Ustring-string
    * @return True if this->compare(rhs) != 0.  False otherwise
    */
@@ -742,7 +742,7 @@ class UnitexString {
 
   /**
    * @brief  Test difference between two UnitexString objects
-   *  
+   *
    * @param  rhs    A UnitexString object
    * @return True if this->compare(rhs) != 0.  False otherwise
    */
@@ -754,21 +754,21 @@ class UnitexString {
 
   /**
    * @brief  This function formats a list of arguments to a UnitexString
-   * 
+   *
    * @param  format C-string that contains the text to be written to stdout.
-   *                It supports all the printf format options plus some 
-   *                extensions described in unitex::u_vsprintf 
-   * @param  ...    (additional arguments) Depending on the format string, the 
-   *                function may expect a sequence of additional arguments, 
-   *                each containing a value to be used to replace a format 
-   *                specifier in the format string. There should be at least 
-   *                as many of these arguments as the number of values 
-   *                specified in the format specifiers.                
-   * @return an UnitexString object              
-   *                
+   *                It supports all the printf format options plus some
+   *                extensions described in unitex::u_vsprintf
+   * @param  ...    (additional arguments) Depending on the format string, the
+   *                function may expect a sequence of additional arguments,
+   *                each containing a value to be used to replace a format
+   *                specifier in the format string. There should be at least
+   *                as many of these arguments as the number of values
+   *                specified in the format specifiers.
+   * @return an UnitexString object
+   *
    * @see    unitex::u_vsprintf  in Unicode.h for supported @e format options
-   * 
-   * @note   Buffer is limit to kMaxBufferSize (1024) unicode characters    
+   *
+   * @note   Buffer is limit to kMaxBufferSize (1024) unicode characters
    */
   // UNITEX_PARAMS_NON_NULL
   // UNITEX_PRINTF_LIKE_FORMAT_CHECK(1,2)
@@ -793,9 +793,9 @@ class UnitexString {
 
   /**
    * @brief  Get character in string
-   * 
-   * Returns a reference to the character at position @e pos in the string 
-   * 
+   *
+   * Returns a reference to the character at position @e pos in the string
+   *
    * @param  pos    The position of the character to access
    * @return Read/write reference to the character
    */
@@ -808,10 +808,10 @@ class UnitexString {
 
   /**
    * @brief  Get character in string
-   * 
-   * Returns a constant reference to the character at position @e pos in 
-   * the string 
-   * 
+   *
+   * Returns a constant reference to the character at position @e pos in
+   * the string
+   *
    * @param  pos    The position of the character to access
    * @return Read-only (const) reference to the character.
    */
@@ -822,8 +822,8 @@ class UnitexString {
 
   /**
    * @brief  Get the first character in string
-   * 
-   * @return The character at position @e 0 in the string 
+   *
+   * @return The character at position @e 0 in the string
    */
   unichar front() const {
     assert(!this->is_empty());
@@ -832,8 +832,8 @@ class UnitexString {
 
   /**
    * @brief  Get the last character in string
-   * 
-   * @return The character at position @e length-1 in the string 
+   *
+   * @return The character at position @e length-1 in the string
    */
   unichar back() const {
     assert(!this->is_empty());
@@ -842,12 +842,12 @@ class UnitexString {
 
   /**
    * @brief  Resize string
-   * 
+   *
    * Resizes the the string to a length of @a size characters.
    * The buffer size is never decreased
-   * 
+   *
    * @param  size   New string length, expressed in number of characters
-   * 
+   *
    * @attention     You cannot set a size<1
    */
   void resize(size_type size) {
@@ -856,7 +856,7 @@ class UnitexString {
 
   /**
    * @brief  Return length of string
-   * 
+   *
    * Returns the length of the string, in terms of number of characters
    */
   size_type length() const {
@@ -865,7 +865,7 @@ class UnitexString {
 
   /**
    * @brief  Return length of string
-   * 
+   *
    * Returns the length of the string, in terms of number of characters
    */
   size_type size() const {
@@ -874,7 +874,7 @@ class UnitexString {
 
   /**
    * @brief  Return length of string
-   * 
+   *
    * Returns the length of the string, in terms of bytes.
    */
   size_type bytes() const {
@@ -883,9 +883,9 @@ class UnitexString {
 
   /**
    * @brief  Truncates string to the given length
-   * 
+   *
    * Restricts the maximum length of the string
-   * 
+   *
    * @param  length The length of the string, in terms of number of characters
    */
   void truncate(size_type length) {
@@ -894,14 +894,14 @@ class UnitexString {
 
   /**
    * @brief  Generate substring
-   *  
+   *
    * Returns a newly constructed string object with its value initialized
    * to a copy of a substring of this object
-   * 
+   *
    * @param  pos    Position of the first character to be copied as a substring
-   * @param  len    Number of characters to include in the substring (if the 
+   * @param  len    Number of characters to include in the substring (if the
    *                string is shorter, as many characters as possible are used).
-   *                A value of string::npos indicates all characters until the 
+   *                A value of string::npos indicates all characters until the
    *                end of the string
    * @return        A UnitexString object with a substring of this object
    */
@@ -918,8 +918,8 @@ class UnitexString {
 
   /**
    * @brief  Return size of allocated storage
-   * 
-   * Returns the size of the storage space currently allocated for the string, 
+   *
+   * Returns the size of the storage space currently allocated for the string,
    * expressed in terms of bytes.
    */
   size_type capacity() const {
@@ -928,17 +928,17 @@ class UnitexString {
 
   /**
    * @brief  Request a change in capacity
-   * 
+   *
    * Requests that the string capacity be adapted to a planned change in size
    * to a length of *up to* n characters.
-   * 
-   * @param  n      Planned length for the string, expressed in number of 
+   *
+   * @param  n      Planned length for the string, expressed in number of
    *                characters
-   * 
-   * @note          The resulting string capacity may be equal or greater 
-   *                than @e n. Notice also that in all other cases, the buffer 
+   *
+   * @note          The resulting string capacity may be equal or greater
+   *                than @e n. Notice also that in all other cases, the buffer
    *                size is never decreased
-   */  
+   */
   void reserve(size_type n = 0) {
     unitex::resize(data_, data_->len + n);
   }
@@ -948,14 +948,14 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a C-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  string A null-terminated character sequence (C-string). The 
+   *
+   * @param  string A null-terminated character sequence (C-string). The
    *                sequence is appended to the current value of the string
    * @return *this
-   */  
+   */
   UnitexString& append(const char* string) {
     unitex::u_strcat(data_, string);
     return *this;
@@ -963,15 +963,15 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a C-substring
-   * 
+   *
    * Appends a copy of the first @e n characters in the array of characters
    * pointed by a string const char*
-   * 
+   *
    * @param  string Pointer to an array of characters (C-string)
    * @param  n      Number of characters to copy
-   * 
+   *
    * @return *this
-   */    
+   */
   UnitexString& append(const char* string, size_type n) {
     unitex::u_strcat(data_, string, n);
     return *this;
@@ -979,11 +979,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from unichar
-   * 
-   * Extends the string by appending an additional character at the end of its 
+   *
+   * Extends the string by appending an additional character at the end of its
    * current value
-   * 
-   * @param  character Unitex unichar character, which is appended to the 
+   *
+   * @param  character Unitex unichar character, which is appended to the
    *                   current value of the string
    * @return *this
    */
@@ -994,11 +994,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a unichar-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  string A Unitex unichar-string. The sequence is appended to the 
+   *
+   * @param  string A Unitex unichar-string. The sequence is appended to the
    *                current value of the string
    * @return *this
    */
@@ -1009,15 +1009,15 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a unichar-substring
-   * 
+   *
    * Appends a copy of the first n characters in the array of characters
    * pointed by a string const unichar*
-   * 
+   *
    * @param  string Pointer to an array of characters (unichar-string)
    * @param  n      Number of characters to copy
-   * 
+   *
    * @return *this
-   */      
+   */
   UnitexString& append(const unichar* string, size_type n) {
     unitex::u_strcat(data_, string, n);
     return *this;
@@ -1025,11 +1025,11 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a Ustring-string
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
-   * @param  string A Unitex Ustring-string. The sequence is appended to the 
+   *
+   * @param  string A Unitex Ustring-string. The sequence is appended to the
    *                current value of the string
    * @return *this
    */
@@ -1040,25 +1040,25 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a Ustring-substring
-   * 
+   *
    * Appends a copy of the first n characters in the array of characters
    * pointed by a string const Ustring*
-   * 
+   *
    * @param  string Pointer to an array of characters (Ustring-string)
    * @param  n      Number of characters to copy
-   * 
+   *
    * @return *this
-   */      
+   */
   UnitexString& append(const Ustring* string, size_type n) {
     return this->append(string, n);
   }
 
   /**
    * @brief  Append to string from a UnitexString object
-   * 
-   * Extends the string by appending additional characters at the end of its 
+   *
+   * Extends the string by appending additional characters at the end of its
    * current value
-   * 
+   *
    * @param  string A UnitexString object, whose value is copied at the end
    * @return *this
    */
@@ -1068,15 +1068,15 @@ class UnitexString {
 
   /**
    * @brief  Append to string from a UnitexString object
-   * 
+   *
    * Appends a copy of the first n characters in the array of characters
    * pointed by a UnitexString object
-   * 
+   *
    * @param  string UnitexString object, whose value is copied at the end
    * @param  n      Number of characters to copy
-   * 
+   *
    * @return *this
-   */     
+   */
   UnitexString& append(const UnitexString& string, size_type n) {
     return this->append(string.data_, n);
   }
@@ -1084,25 +1084,25 @@ class UnitexString {
 
   /**
    * @brief  This function append a formated list of arguments to a UnitexString
-   * 
-   * Formats a list of arguments and append the final result to the underline 
+   *
+   * Formats a list of arguments and append the final result to the underline
    * string returning the UnitexString object
-   * 
+   *
    * @param  format C-string that contains the text to be written to stdout.
-   *                It supports all the printf format options plus some 
-   *                extensions described in unitex::u_vsprintf 
-   * @param  ...    (additional arguments) Depending on the format string, the 
-   *                function may expect a sequence of additional arguments, 
-   *                each containing a value to be used to replace a format 
-   *                specifier in the format string. There should be at least 
-   *                as many of these arguments as the number of values 
-   *                specified in the format specifiers.                
-   * @return *this              
-   *                
+   *                It supports all the printf format options plus some
+   *                extensions described in unitex::u_vsprintf
+   * @param  ...    (additional arguments) Depending on the format string, the
+   *                function may expect a sequence of additional arguments,
+   *                each containing a value to be used to replace a format
+   *                specifier in the format string. There should be at least
+   *                as many of these arguments as the number of values
+   *                specified in the format specifiers.
+   * @return *this
+   *
    * @see    UnitexString::format(const char* format, ...)
-   * 
-   * @note   Buffer is limit to kMaxBufferSize (1024) unicode characters    
-   */  
+   *
+   * @note   Buffer is limit to kMaxBufferSize (1024) unicode characters
+   */
   // UNITEX_PARAMS_NON_NULL
   UnitexString& append_format(const char* format, ...) {
     va_list args;
@@ -1124,8 +1124,8 @@ class UnitexString {
   }
 
   /**
-   * @brief  Lowercase the characters in the string 
-   * @return *this 
+   * @brief  Lowercase the characters in the string
+   * @return *this
    */
   UnitexString& tolower() {
     unitex::u_tolower(data_->str);
@@ -1153,9 +1153,9 @@ class UnitexString {
 
   /**
    * @brief  Append character to string
-   * 
+   *
    * Appends character c to the end of the string, increasing its length by one
-   * 
+   *
    * @param  character Character added to the string
    */
   void push_back(const unichar character) {
@@ -1171,18 +1171,18 @@ class UnitexString {
 
   /**
    * @brief  Compare to a C-string
-   *  
+   *
    * @param  string A null-terminated character sequence (C-string)
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings:
    *         -  0 : They compare equal
-   *         - <0 : Either the value of the first character that does not match 
-   *                is lower in the compared string, or all compared characters 
+   *         - <0 : Either the value of the first character that does not match
+   *                is lower in the compared string, or all compared characters
    *                match but the compared string is shorter
-   *         - >0 : Either the value of the first character that does not match 
-   *                is greater in the compared string, or all compared characters 
-   *                match but the compared string is longer.       
-   * 
+   *         - >0 : Either the value of the first character that does not match
+   *                is greater in the compared string, or all compared characters
+   *                match but the compared string is longer.
+   *
    * @note   Null strings are allowed
    */
   int compare(const char* string) const {
@@ -1191,11 +1191,11 @@ class UnitexString {
 
   /**
    * @brief  Compare to a unichar-string
-   *  
+   *
    * @param  string A Unitex unichar-string
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::compare(const char* string) const
    */
   int compare(const unichar* string) const {
@@ -1204,11 +1204,11 @@ class UnitexString {
 
   /**
    * @brief  Compare to a Ustring-string
-   *  
+   *
    * @param  string A Unitex Ustring-string
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::compare(const char* string) const
    */
   int compare(const Ustring* string) const {
@@ -1217,11 +1217,11 @@ class UnitexString {
 
   /**
    * @brief  Compare to a UnitexString object
-   *  
+   *
    * @param  string A UnitexString object
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::compare(const char* string) const
    */
   int compare(const UnitexString& string) const {
@@ -1230,18 +1230,18 @@ class UnitexString {
 
   /**
    * @brief  Case insensitive compare to a C-string
-   *  
+   *
    * @param  string A null-terminated character sequence (C-string)
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings:
    *         -  0 : They compare equal
-   *         - <0 : Either the value of the first character that does not match 
-   *                is lower in the compared string, or all compared characters 
+   *         - <0 : Either the value of the first character that does not match
+   *                is lower in the compared string, or all compared characters
    *                match but the compared string is shorter
-   *         - >0 : Either the value of the first character that does not match 
-   *                is greater in the compared string, or all compared characters 
-   *                match but the compared string is longer.       
-   * 
+   *         - >0 : Either the value of the first character that does not match
+   *                is greater in the compared string, or all compared characters
+   *                match but the compared string is longer.
+   *
    * @note   Null strings are allowed
    */
   int icompare(const char* string) const {
@@ -1250,11 +1250,11 @@ class UnitexString {
 
   /**
    * @brief  Case insensitive compare to a unichar-string
-   *  
+   *
    * @param  string A Unitex unichar-string
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::icompare(const char* string) const
    */
   int icompare(const unichar* string) const {
@@ -1263,11 +1263,11 @@ class UnitexString {
 
   /**
    * @brief  Case insensitive compare to a Ustring-string
-   *  
+   *
    * @param  string A Unitex Ustring-string
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::icompare(const char* string) const
    */
   int icompare(const Ustring* string) const {
@@ -1276,11 +1276,11 @@ class UnitexString {
 
   /**
    * @brief  Case insensitive compare to a UnitexString object
-   *  
+   *
    * @param  string A UnitexString object
-   * @return Returns a signed integral indicating the relation between 
+   * @return Returns a signed integral indicating the relation between
    *         the strings.
-   * 
+   *
    * @see    UnitexString::icompare(const char* string) const
    */
   int icompare(const UnitexString& string) const {
@@ -1289,9 +1289,9 @@ class UnitexString {
 
   /**
    * @brief  Get unichar-string equivalent
-   * 
+   *
    * @return A pointer to the underlying built-in unichar
-   * 
+   *
    * @attention The caller should not delete the return value
    */
   const unichar* c_unichar() const {
@@ -1303,8 +1303,8 @@ class UnitexString {
   /**
    * @brief  Implicit conversion from UnitexString to the underlying unichar
    *         buffer
-   * 
-   * @see  c_unichar() const  
+   *
+   * @see  c_unichar() const
    */
   // UNITEX_EXPLICIT_CONVERSIONS
   operator const unichar*() const {
@@ -1313,9 +1313,9 @@ class UnitexString {
 
   /**
    * @brief  Get string data
-   * 
+   *
    * @return A pointer to the underlying built-in unichar
-   * 
+   *
    * @attention The caller should not delete the return value
    */
   const unichar* data() const {
@@ -1324,9 +1324,9 @@ class UnitexString {
 
   /**
    * @brief  Get Ustring-string equivalent
-   * 
+   *
    * @return A pointer to the underlying built-in Ustring
-   * 
+   *
    * @attention The caller should not delete the return value
    */
   const Ustring* c_ustring() const {
@@ -1336,8 +1336,8 @@ class UnitexString {
   /**
    * @brief  Implicit conversion from UnitexString to the underlying Ustring
    * object
-   * 
-   * @see  c_ustring() const  
+   *
+   * @see  c_ustring() const
    */
   // UNITEX_EXPLICIT_CONVERSIONS
   operator const Ustring*() const {
@@ -1346,9 +1346,9 @@ class UnitexString {
 
   /**
    * @brief  Test whether the string is NULL
-   * 
+   *
    * @return True if the string is NULL. False otherwise
-   * 
+   *
    * @note   NULL and the empty string are different
    */
   bool is_null() const {
@@ -1357,15 +1357,15 @@ class UnitexString {
 
   /**
    * @brief  Test whether the string is empty
-   * 
+   *
    * @return True if the string is empty. False otherwise
-   * 
+   *
    * Returns whether the string is empty (i.e. whether its length is 0).
-   * 
-   * @note   This differs from unitex::empty() function in Ustring.h. Note also 
+   *
+   * @note   This differs from unitex::empty() function in Ustring.h. Note also
    *         that NULL and the empty string are different.
-   *         
-   * @see    is_null() const         
+   *
+   * @see    is_null() const
    */
   bool is_empty() const {
     return (!is_null() && length() == 0);
@@ -1373,10 +1373,10 @@ class UnitexString {
 
   /**
    * @brief  Clear string
-   * 
+   *
    * Erases the contents of the string, which becomes an empty string
    * (with a length of 0 characters).
-   * 
+   *
    * @note   The capacity of the internal buffer remains unchanged
    */
   void clear() {
@@ -1385,11 +1385,11 @@ class UnitexString {
 
   /**
    * @brief  Swap string values
-   * 
+   *
    * Exchanges the content of the container by the content of string,
    * which is another UnitexString object.
-   * 
-   * @param  string Another UnitexString object, whose value is swapped with 
+   *
+   * @param  string Another UnitexString object, whose value is swapped with
    *                that of this string
    */
   void swap(UnitexString& string) {
@@ -1404,7 +1404,7 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a char and a UnitexString object
-   * 
+   *
    * @param  lhs    A UnitexString object
    * @param  rhs    A char whose value will be concatenated to lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
@@ -1416,7 +1416,7 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a UnitexString object and a char
-   * 
+   *
    * @param  lhs    A char
    * @param  rhs    A UnitexString object whose value will be concatenated to lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
@@ -1428,9 +1428,9 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a C-string and a UnitexString object
-   * 
+   *
    * @param  lhs    A UnitexString object
-   * @param  rhs    A null-terminated character sequence (C-string) whose value 
+   * @param  rhs    A null-terminated character sequence (C-string) whose value
    *                will be concatenated to lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
@@ -1441,7 +1441,7 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a unichar-string and a UnitexString object
-   * 
+   *
    * @param  lhs    A UnitexString object
    * @param  rhs    A Unitex unichar-string whose value will be concatenated to
    *                lhs
@@ -1453,8 +1453,8 @@ class UnitexString {
   }
 
   /**
-   * @brief  Concatenate a UnitexString object and a unichar-string 
-   * 
+   * @brief  Concatenate a UnitexString object and a unichar-string
+   *
    * @param  lhs    A Unitex unichar-string
    * @param  rhs    A UnitexString object whose value will be concatenated to
    *                lhs
@@ -1466,10 +1466,10 @@ class UnitexString {
   }
 
   /**
-   * @brief  Concatenate a C-string and a UnitexString object 
-   * 
+   * @brief  Concatenate a C-string and a UnitexString object
+   *
    * @param  lhs    A null-terminated character sequence (C-string)
-   * @param  rhs    A UnitexString object whose value will be concatenated to 
+   * @param  rhs    A UnitexString object whose value will be concatenated to
    *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
@@ -1480,10 +1480,10 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a unichar-string and a UnitexString object
-   * 
+   *
    * @param  lhs    A UnitexString object
-   * @param  rhs    A Unitex unichar-string whose value will be concatenated to 
-   *                lhs 
+   * @param  rhs    A Unitex unichar-string whose value will be concatenated to
+   *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
   friend UnitexString operator+(const UnitexString& lhs,
@@ -1493,10 +1493,10 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a UnitexString object and a unichar-string
-   * 
-   * @param  lhs    A Unitex unichar-string 
-   * @param  rhs    A UnitexString object whose value will be concatenated to 
-   *                lhs 
+   *
+   * @param  lhs    A Unitex unichar-string
+   * @param  rhs    A UnitexString object whose value will be concatenated to
+   *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
   friend UnitexString operator+(const unichar* lhs,
@@ -1506,10 +1506,10 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a Ustring-string and a UnitexString object
-   * 
+   *
    * @param  lhs    A UnitexString object
-   * @param  rhs    A Unitex Ustring-string whose value will be concatenated to 
-   *                lhs 
+   * @param  rhs    A Unitex Ustring-string whose value will be concatenated to
+   *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
   friend UnitexString operator+(const UnitexString& lhs,
@@ -1519,10 +1519,10 @@ class UnitexString {
 
   /**
    * @brief  Concatenate a UnitexString object and a Ustring-string
-   * 
-   * @param  lhs    A Unitex Ustring-string 
-   * @param  rhs    A UnitexString object whose value will be concatenated to 
-   *                lhs 
+   *
+   * @param  lhs    A Unitex Ustring-string
+   * @param  rhs    A UnitexString object whose value will be concatenated to
+   *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
   friend UnitexString operator+(const Ustring* lhs,
@@ -1533,10 +1533,10 @@ class UnitexString {
   // concatenation const UnitexString&
   /**
    * @brief  Concatenate two UnitexString objects
-   * 
+   *
    * @param  lhs    A UnitexString object
-   * @param  rhs    A UnitexString object whose value will be concatenated to 
-   *                lhs 
+   * @param  rhs    A UnitexString object whose value will be concatenated to
+   *                lhs
    * @return A UnitexString whose value is the concatenation of lhs and rhs
    */
   friend UnitexString operator+(const UnitexString& lhs,
@@ -1575,10 +1575,10 @@ class UnitexString {
 
   /**
    * @brief  Swap two values T
-   * 
+   *
    * Exchanges the values of a and b
-   * 
-   * @param  a,b Two objects, whose contents are swapped 
+   *
+   * @param  a,b Two objects, whose contents are swapped
    */
   template<class T>
   void swap(T& a, T& b) {
@@ -1601,11 +1601,11 @@ class UnitexString {
 
 /**
  * @brief    Is less than string comparison
- * 
- * Return True either the value of the first character that does not match is 
- * lower in the compared string, or all compared characters match but the 
+ *
+ * Return True either the value of the first character that does not match is
+ * lower in the compared string, or all compared characters match but the
  * compared string is shorter.
- *  
+ *
  * @param    lhs    A UnitexString object
  * @param    rhs    A UnitexString object
  * @return   True if lhs.compare(rhs) < 0. False otherwise
@@ -1616,11 +1616,11 @@ inline bool operator<(const UnitexString& lhs, const UnitexString& rhs) {
 
 /**
  * @brief    Is less than or equal string comparison
- * 
- * Return True either the value of the first character that does not match is 
- * lower in the compared string, all compared characters match but the 
+ *
+ * Return True either the value of the first character that does not match is
+ * lower in the compared string, all compared characters match but the
  * compared string is shorter, or the string compare is equal
- *  
+ *
  * @param    lhs    A UnitexString object
  * @param    rhs    A UnitexString object
  * @return   True if lhs.compare(rhs) <= 0. False otherwise
@@ -1631,11 +1631,11 @@ inline bool operator<=(const UnitexString& lhs, const UnitexString& rhs) {
 
 /**
  * @brief    Is greater than string comparison
- * 
- * Return True Either the value of the first character that does not match is 
- * greater in the compared string, or all compared characters match but the 
+ *
+ * Return True Either the value of the first character that does not match is
+ * greater in the compared string, or all compared characters match but the
  * compared string is longer.
- *  
+ *
  * @param    lhs    A UnitexString object
  * @param    rhs    A UnitexString object
  * @return   True if lhs.compare(rhs) > 0. False otherwise
@@ -1646,11 +1646,11 @@ inline bool operator>(const UnitexString& lhs, const UnitexString& rhs) {
 
 /**
  * @brief    Is greater than or equal string comparison
- * 
- * Return True Either the value of the first character that does not match is 
- * greater in the compared string, all compared characters match but the 
- * compared string is longer, or the string compare is equal 
- *  
+ *
+ * Return True Either the value of the first character that does not match is
+ * greater in the compared string, all compared characters match but the
+ * compared string is longer, or the string compare is equal
+ *
  * @param    lhs    A UnitexString object
  * @param    rhs    A UnitexString object
  * @return   True if lhs.compare(rhs) >= 0. False otherwise
@@ -1661,7 +1661,7 @@ inline bool operator>=(const UnitexString& lhs, const UnitexString& rhs) {
 
 /**
  * @brief    Exchanges the values of two UnitexString objects
- *  
+ *
  * @param    a,b Two UnitexString objects, whose contents are swapped
  */
 inline void swap(UnitexString& a, UnitexString& b) {                // NOLINT

--- a/UnitexTool.cpp
+++ b/UnitexTool.cpp
@@ -309,13 +309,13 @@ using namespace logger;
 #endif
 
 struct utility_item {
-	const char* name;
-	int len_name;
-	mainFunc* fnc;
+    const char* name;
+    int len_name;
+    mainFunc* fnc;
 
-	const char* usage;
-	const char* optstring;
-	const struct option_TS *lopts;
+    const char* usage;
+    const char* optstring;
+    const struct option_TS *lopts;
 } ;
 
 const struct utility_item utility_array[]=
@@ -327,266 +327,266 @@ const struct utility_item utility_array[]=
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_BUILDKRMWUDIC))) || defined(TOOL_BUILDKRMWUDIC))
-	{ "BuildKrMwuDic",13,&main_BuildKrMwuDic,usage_BuildKrMwuDic, optstring_BuildKrMwuDic, lopts_BuildKrMwuDic},
+    { "BuildKrMwuDic",13,&main_BuildKrMwuDic,usage_BuildKrMwuDic, optstring_BuildKrMwuDic, lopts_BuildKrMwuDic},
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_CASSYS))) || defined(TOOL_CASSYS))
-	{ "Cassys",6,&main_Cassys,usage_Cassys, optstring_Cassys, lopts_Cassys},
+    { "Cassys",6,&main_Cassys,usage_Cassys, optstring_Cassys, lopts_Cassys},
 #endif
 
 #if (((!defined(NO_TOOL_CHECKDIC))) || defined(TOOL_CHECKDIC))
-	{ "CheckDic", 8, &main_CheckDic, usage_CheckDic, optstring_CheckDic, lopts_CheckDic } ,
+    { "CheckDic", 8, &main_CheckDic, usage_CheckDic, optstring_CheckDic, lopts_CheckDic } ,
 #endif
 
 #if (((!defined(NO_TOOL_COMPRESS))) || defined(TOOL_COMPRESS))
-	{ "Compress", 8, &main_Compress, usage_Compress, optstring_Compress, lopts_Compress } ,
+    { "Compress", 8, &main_Compress, usage_Compress, optstring_Compress, lopts_Compress } ,
 #endif
 
 #if (((!defined(NO_TOOL_CONCORD))) || defined(TOOL_CONCORD))
-	{ "Concord", 7, &main_Concord, usage_Concord, optstring_Concord, lopts_Concord } ,
+    { "Concord", 7, &main_Concord, usage_Concord, optstring_Concord, lopts_Concord } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_CONCORDIFF))) || defined(TOOL_CONCORDIFF))
-	{ "ConcorDiff", 10, &main_ConcorDiff, usage_ConcorDiff, optstring_ConcorDiff, lopts_ConcorDiff } ,
+    { "ConcorDiff", 10, &main_ConcorDiff, usage_ConcorDiff, optstring_ConcorDiff, lopts_ConcorDiff } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!defined(NO_TOOL_CONVERT))) || defined(TOOL_CONVERT))
-	{ "Convert", 7, &main_Convert, usage_Convert, optstring_Convert, lopts_Convert } ,
+    { "Convert", 7, &main_Convert, usage_Convert, optstring_Convert, lopts_Convert } ,
 #endif
 
 #if (((!defined(NO_TOOL_DICO))) || defined(TOOL_DICO))
-	{ "Dico", 4, &main_Dico, usage_Dico, optstring_Dico, lopts_Dico } ,
+    { "Dico", 4, &main_Dico, usage_Dico, optstring_Dico, lopts_Dico } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_DUMPOFFSETS))) || defined(TOOL_DUMPOFFSETS))
-	{ "DumpOffsets", 11, &main_DumpOffsets, usage_DumpOffsets, optstring_DumpOffsets, lopts_DumpOffsets },
+    { "DumpOffsets", 11, &main_DumpOffsets, usage_DumpOffsets, optstring_DumpOffsets, lopts_DumpOffsets },
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_DUPLICATEFILE))) || defined(TOOL_DUPLICATEFILE) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "DuplicateFile", 13, &main_DuplicateFile, usage_DuplicateFile, optstring_DuplicateFile, lopts_DuplicateFile } ,
+    { "DuplicateFile", 13, &main_DuplicateFile, usage_DuplicateFile, optstring_DuplicateFile, lopts_DuplicateFile } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_ELAG))) || defined(TOOL_ELAG))
-	{ "Elag", 4, &main_Elag, usage_Elag, optstring_Elag, lopts_Elag } ,
+    { "Elag", 4, &main_Elag, usage_Elag, optstring_Elag, lopts_Elag } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_ELAGCOMP))) || defined(TOOL_ELAGCOMP))
-	{ "ElagComp", 8, &main_ElagComp, usage_ElagComp, optstring_ElagComp, lopts_ElagComp } ,
+    { "ElagComp", 8, &main_ElagComp, usage_ElagComp, optstring_ElagComp, lopts_ElagComp } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_EVAMB))) || defined(TOOL_EVAMB))
-	{ "Evamb", 5, &main_Evamb, usage_Evamb, optstring_Evamb, lopts_Evamb } ,
+    { "Evamb", 5, &main_Evamb, usage_Evamb, optstring_Evamb, lopts_Evamb } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!defined(NO_TOOL_EXTRACT))) || defined(TOOL_EXTRACT))
-	{ "Extract", 7, &main_Extract, usage_Extract, optstring_Extract, lopts_Extract } ,
+    { "Extract", 7, &main_Extract, usage_Extract, optstring_Extract, lopts_Extract } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_FLATTEN))) || defined(TOOL_FLATTEN))
-	{ "Flatten", 7, &main_Flatten, usage_Flatten, optstring_Flatten, lopts_Flatten } ,
+    { "Flatten", 7, &main_Flatten, usage_Flatten, optstring_Flatten, lopts_Flatten } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_FST2CHECK))) || defined(TOOL_FST2CHECK))
-	{ "Fst2Check", 9, &main_Fst2Check, usage_Fst2Check, optstring_Fst2Check, lopts_Fst2Check } ,
+    { "Fst2Check", 9, &main_Fst2Check, usage_Fst2Check, optstring_Fst2Check, lopts_Fst2Check } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_FST2LIST))) || defined(TOOL_FST2LIST))
-	{ "Fst2List", 8, &main_Fst2List, usage_Fst2List, NULL, NULL } ,
+    { "Fst2List", 8, &main_Fst2List, usage_Fst2List, NULL, NULL } ,
 #endif
 
 #if (((!defined(NO_TOOL_FST2TXT))) || defined(TOOL_FST2TXT))
-	{ "Fst2Txt", 7, &main_Fst2Txt, usage_Fst2Txt, optstring_Fst2Txt, lopts_Fst2Txt } ,
+    { "Fst2Txt", 7, &main_Fst2Txt, usage_Fst2Txt, optstring_Fst2Txt, lopts_Fst2Txt } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_GRF2FST2))) || defined(TOOL_GRF2FST2))
-	{ "Grf2Fst2", 8, &main_Grf2Fst2, usage_Grf2Fst2, optstring_Grf2Fst2, lopts_Grf2Fst2 } ,
+    { "Grf2Fst2", 8, &main_Grf2Fst2, usage_Grf2Fst2, optstring_Grf2Fst2, lopts_Grf2Fst2 } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_GRFDIFF))) || defined(TOOL_GRFDIFF))
-	{ "GrfDiff", 7, &main_GrfDiff, usage_GrfDiff, optstring_GrfDiff, lopts_GrfDiff } ,
+    { "GrfDiff", 7, &main_GrfDiff, usage_GrfDiff, optstring_GrfDiff, lopts_GrfDiff } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_GRFDIFF3))) || defined(TOOL_GRFDIFF3))
-	{ "GrfDiff3", 8, &main_GrfDiff3, usage_GrfDiff3, optstring_GrfDiff3, lopts_GrfDiff3 } ,
+    { "GrfDiff3", 8, &main_GrfDiff3, usage_GrfDiff3, optstring_GrfDiff3, lopts_GrfDiff3 } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_GRFTEST))) || defined(TOOL_GRFTEST))
-	{ "GrfTest", 7, &main_GrfTest, usage_GrfTest, optstring_GrfTest, lopts_GrfTest } ,
+    { "GrfTest", 7, &main_GrfTest, usage_GrfTest, optstring_GrfTest, lopts_GrfTest } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_IMPLODETFST))) || defined(TOOL_IMPLODETFST))
-	{ "ImplodeTfst", 11, &main_ImplodeTfst, usage_ImplodeTfst, optstring_ImplodeTfst, lopts_ImplodeTfst } ,
+    { "ImplodeTfst", 11, &main_ImplodeTfst, usage_ImplodeTfst, optstring_ImplodeTfst, lopts_ImplodeTfst } ,
 #endif
 
 #if defined(UNITEXTOOL_TOOL_FROM_LOGGER) || defined(UNITEX_TOOL_LINKPKG_SCRIPT)
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_INSTALLING_LING_RESOURCE_PACKAGE))) || defined(TOOL_INSTALLING_LING_RESOURCE_PACKAGE) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "InstallLingResourcePackage", 26, &main_InstallLingResourcePackage, usage_InstallLingResourcePackage, optstring_InstallLingResourcePackage, lopts_InstallLingResourcePackage },
+    { "InstallLingResourcePackage", 26, &main_InstallLingResourcePackage, usage_InstallLingResourcePackage, optstring_InstallLingResourcePackage, lopts_InstallLingResourcePackage },
 #endif
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!defined(NO_TOOL_KEYWORDS))) || defined(TOOL_KEYWORDS))
-	{ "KeyWords", 8, &main_KeyWords, usage_KeyWords, optstring_KeyWords, lopts_KeyWords } ,
+    { "KeyWords", 8, &main_KeyWords, usage_KeyWords, optstring_KeyWords, lopts_KeyWords } ,
 #endif
 
 #if (((!defined(NO_TOOL_LOCATE))) || defined(TOOL_LOCATE))
-	{ "Locate", 6, &main_Locate, usage_Locate, optstring_Locate, lopts_Locate } ,
+    { "Locate", 6, &main_Locate, usage_Locate, optstring_Locate, lopts_Locate } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!defined(NO_TOOL_LOCATETFST))) || defined(TOOL_LOCATETFST))
-	{ "LocateTfst", 10, &main_LocateTfst, usage_LocateTfst, optstring_LocateTfst, lopts_LocateTfst } ,
+    { "LocateTfst", 10, &main_LocateTfst, usage_LocateTfst, optstring_LocateTfst, lopts_LocateTfst } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_MULTIFLEX))) || defined(TOOL_MULTIFLEX))
-	{ "MultiFlex", 9, &main_MultiFlex, usage_MultiFlex, optstring_MultiFlex, lopts_MultiFlex } ,
+    { "MultiFlex", 9, &main_MultiFlex, usage_MultiFlex, optstring_MultiFlex, lopts_MultiFlex } ,
 #endif
 
 #ifdef UNITEXTOOL_TOOL_FROM_LOGGER
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(TOOL_MZREPAIR_ULP))) || defined(NO_TOOL_MZREPAIR_ULP))
-	{ "MzRepairUlp", 11, &main_MzRepairUlp, usage_MzRepairUlp, optstring_MzRepairUlp, lopts_MzRepairUlp },
+    { "MzRepairUlp", 11, &main_MzRepairUlp, usage_MzRepairUlp, optstring_MzRepairUlp, lopts_MzRepairUlp },
 #endif
 #endif
 
 #if (((!defined(NO_TOOL_NORMALIZE))) || defined(TOOL_NORMALIZE))
-	{ "Normalize", 9, &main_Normalize, usage_Normalize, optstring_Normalize, lopts_Normalize } ,
+    { "Normalize", 9, &main_Normalize, usage_Normalize, optstring_Normalize, lopts_Normalize } ,
 #endif
 
 #if defined(UNITEXTOOL_TOOL_FROM_LOGGER) || defined(UNITEX_TOOL_LINKPKG_SCRIPT)
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_PACKFILE))) || defined(TOOL_PACKFILE) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "PackFile", 8, &main_PackFile, usage_PackFile, optstring_PackFile, lopts_PackFile } ,
+    { "PackFile", 8, &main_PackFile, usage_PackFile, optstring_PackFile, lopts_PackFile } ,
 #endif
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_PERSISTRESOURCE))) || defined(TOOL_PERSISTRESOURCE) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "PersistResource", 15, &main_PersistResource, usage_PersistResource, optstring_PersistResource, lopts_PersistResource } ,
+    { "PersistResource", 15, &main_PersistResource, usage_PersistResource, optstring_PersistResource, lopts_PersistResource } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_POLYLEX))) || defined(TOOL_POLYLEX))
-	{ "PolyLex", 7, &main_PolyLex, usage_PolyLex, optstring_PolyLex, lopts_PolyLex } ,
+    { "PolyLex", 7, &main_PolyLex, usage_PolyLex, optstring_PolyLex, lopts_PolyLex } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_REBUILDTFST))) || defined(TOOL_REBUILDTFST))
-	{ "RebuildTfst", 11, &main_RebuildTfst, usage_RebuildTfst, optstring_RebuildTfst, lopts_RebuildTfst } ,
+    { "RebuildTfst", 11, &main_RebuildTfst, usage_RebuildTfst, optstring_RebuildTfst, lopts_RebuildTfst } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_RECONSTRUCTAO))) || defined(TOOL_RECONSTRUCTAO))
-	{ "Reconstrucao", 12, &main_Reconstrucao, usage_Reconstrucao, optstring_Reconstrucao, lopts_Reconstrucao } ,
+    { "Reconstrucao", 12, &main_Reconstrucao, usage_Reconstrucao, optstring_Reconstrucao, lopts_Reconstrucao } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_REG2GRF))) || defined(TOOL_REG2GRF))
-	{ "Reg2Grf", 7, &main_Reg2Grf, usage_Reg2Grf, optstring_Reg2Grf, lopts_Reg2Grf } ,
+    { "Reg2Grf", 7, &main_Reg2Grf, usage_Reg2Grf, optstring_Reg2Grf, lopts_Reg2Grf } ,
 #endif
 
 #if defined(UNITEXTOOL_TOOL_FROM_LOGGER) || defined(UNITEX_TOOL_LINKPKG_SCRIPT)
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(TOOL_UNIRUNLOGGER_ULP))) || defined(NO_TOOL_UNIRUNLOGGER_ULP))
-	{ "RunLog", 6, &main_RunLog, usage_RunLog, optstring_RunLog, lopts_RunLog },
+    { "RunLog", 6, &main_RunLog, usage_RunLog, optstring_RunLog, lopts_RunLog },
 #endif
 #endif
 
 
 #if defined(UNITEXTOOL_TOOL_FROM_LOGGER) || defined(UNITEX_TOOL_LINKPKG_SCRIPT)
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(TOOL_UNIRUNSCRIPT))) || defined(NO_TOOL_UNIRUNSCRIPT) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "RunScript", 9, &main_UniRunScript, usage_UniRunScript, optstring_UniRunScript, lopts_UniRunScript },
+    { "RunScript", 9, &main_UniRunScript, usage_UniRunScript, optstring_UniRunScript, lopts_UniRunScript },
 #endif
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_SELECTOUTPUT))) || defined(TOOL_SELECTOUTPUT) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "SelectOutput", 12, &main_SelectOutput, usage_SelectOutput, optstring_SelectOutput, lopts_SelectOutput } ,
+    { "SelectOutput", 12, &main_SelectOutput, usage_SelectOutput, optstring_SelectOutput, lopts_SelectOutput } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_SEQ2GRF))) || defined(TOOL_SEQ2GRF))
-	{ "Seq2Grf", 7, &main_Seq2Grf, usage_Seq2Grf, optstring_Seq2Grf, lopts_Seq2Grf } ,
+    { "Seq2Grf", 7, &main_Seq2Grf, usage_Seq2Grf, optstring_Seq2Grf, lopts_Seq2Grf } ,
 #endif
 
 #if (((!defined(NO_TOOL_SORTTXT))) || defined(TOOL_SORTTXT))
-	{ "SortTxt", 7, &main_SortTxt, usage_SortTxt, optstring_SortTxt, lopts_SortTxt } ,
+    { "SortTxt", 7, &main_SortTxt, usage_SortTxt, optstring_SortTxt, lopts_SortTxt } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_SPELLCHECK))) || defined(TOOL_SPELLCHECK))
-	{ "SpellCheck", 10, &main_SpellCheck, usage_SpellCheck, optstring_SpellCheck, lopts_SpellCheck },
+    { "SpellCheck", 10, &main_SpellCheck, usage_SpellCheck, optstring_SpellCheck, lopts_SpellCheck },
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_STATS))) || defined(TOOL_STATS))
-	{ "Stats", 5, &main_Stats, usage_Stats, optstring_Stats, lopts_Stats } ,
+    { "Stats", 5, &main_Stats, usage_Stats, optstring_Stats, lopts_Stats } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TABLE2GRF))) || defined(TOOL_TABLE2GRF))
-	{ "Table2Grf", 9, &main_Table2Grf, usage_Table2Grf, optstring_Table2Grf, lopts_Table2Grf } ,
+    { "Table2Grf", 9, &main_Table2Grf, usage_Table2Grf, optstring_Table2Grf, lopts_Table2Grf } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TAGGER))) || defined(TOOL_TAGGER))
-	{ "Tagger", 6, &main_Tagger, usage_Tagger, optstring_Tagger, lopts_Tagger } ,
+    { "Tagger", 6, &main_Tagger, usage_Tagger, optstring_Tagger, lopts_Tagger } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TAGSETNORMTFST))) || defined(TOOL_TAGSETNORMTFST))
-	{ "TagsetNormTfst", 14, &main_TagsetNormTfst, usage_TagsetNormTfst, optstring_TagsetNormTfst, lopts_TagsetNormTfst } ,
+    { "TagsetNormTfst", 14, &main_TagsetNormTfst, usage_TagsetNormTfst, optstring_TagsetNormTfst, lopts_TagsetNormTfst } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TEI2TXT))) || defined(TOOL_TEI2TXT))
-	{ "TEI2Txt", 7, &main_TEI2Txt, usage_TEI2Txt, optstring_TEI2Txt, lopts_TEI2Txt } ,
+    { "TEI2Txt", 7, &main_TEI2Txt, usage_TEI2Txt, optstring_TEI2Txt, lopts_TEI2Txt } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TFST2GRF))) || defined(TOOL_TFST2GRF))
-	{ "Tfst2Grf", 8, &main_Tfst2Grf, usage_Tfst2Grf, optstring_Tfst2Grf, lopts_Tfst2Grf } ,
+    { "Tfst2Grf", 8, &main_Tfst2Grf, usage_Tfst2Grf, optstring_Tfst2Grf, lopts_Tfst2Grf } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TFSTTAG))) || defined(TOOL_TFSTTAG))
-	{ "TfstTag", 7, &main_TfstTag, usage_TfstTag, optstring_TfstTag, lopts_TfstTag } ,
+    { "TfstTag", 7, &main_TfstTag, usage_TfstTag, optstring_TfstTag, lopts_TfstTag } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TFST2UNAMBIG))) || defined(TOOL_TFST2UNAMBIG))
-	{ "Tfst2Unambig", 12, &main_Tfst2Unambig, usage_Tfst2Unambig, optstring_Tfst2Unambig, lopts_Tfst2Unambig } ,
+    { "Tfst2Unambig", 12, &main_Tfst2Unambig, usage_Tfst2Unambig, optstring_Tfst2Unambig, lopts_Tfst2Unambig } ,
 #endif
 
 #if (((!defined(NO_TOOL_TOKENIZE))) || defined(TOOL_TOKENIZE))
-	{ "Tokenize", 8, &main_Tokenize, usage_Tokenize, optstring_Tokenize, lopts_Tokenize } ,
+    { "Tokenize", 8, &main_Tokenize, usage_Tokenize, optstring_Tokenize, lopts_Tokenize } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TRAININGTAGGER))) || defined(TOOL_TRAININGTAGGER))
-	{ "TrainingTagger", 14, &main_TrainingTagger, usage_TrainingTagger, optstring_TrainingTagger, lopts_TrainingTagger } ,
+    { "TrainingTagger", 14, &main_TrainingTagger, usage_TrainingTagger, optstring_TrainingTagger, lopts_TrainingTagger } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_TXT2TFST))) || defined(TOOL_TXT2TFST))
-	{ "Txt2Tfst", 8, &main_Txt2Tfst, usage_Txt2Tfst, optstring_Txt2Tfst, lopts_Txt2Tfst } ,
+    { "Txt2Tfst", 8, &main_Txt2Tfst, usage_Txt2Tfst, optstring_Txt2Tfst, lopts_Txt2Tfst } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_UNCOMPRESS))) || defined(TOOL_UNCOMPRESS))
-	{ "Uncompress", 10, &main_Uncompress, usage_Uncompress, optstring_Uncompress, lopts_Uncompress } ,
+    { "Uncompress", 10, &main_Uncompress, usage_Uncompress, optstring_Uncompress, lopts_Uncompress } ,
 #endif
 
 #if defined(UNITEXTOOL_TOOL_FROM_LOGGER) || defined(UNITEX_TOOL_LINKPKG_SCRIPT)
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_PACKFILE))) || defined(TOOL_PACKFILE) || defined(UNITEX_TOOL_LINKPKG_SCRIPT))
-	{ "UnpackFile", 10, &main_UnpackFile, usage_UnpackFile, optstring_UnpackFile, lopts_UnpackFile } ,
+    { "UnpackFile", 10, &main_UnpackFile, usage_UnpackFile, optstring_UnpackFile, lopts_UnpackFile } ,
 #endif
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_UNPREPROCESS))) || defined(TOOL_UNPREPROCESS))
-	{ "UnPreprocess", 12, &main_UnPreprocess, usage_UnPreprocess, optstring_UnPreprocess, lopts_UnPreprocess },
+    { "UnPreprocess", 12, &main_UnPreprocess, usage_UnPreprocess, optstring_UnPreprocess, lopts_UnPreprocess },
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_UNTOKENIZE))) || defined(TOOL_UNTOKENIZE))
-	{ "Untokenize", 10, &main_Untokenize, usage_Untokenize, optstring_Untokenize, lopts_Untokenize } ,
+    { "Untokenize", 10, &main_Untokenize, usage_Untokenize, optstring_Untokenize, lopts_Untokenize } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_UNXMLIZE))) || defined(TOOL_UNXMLIZE))
-	{ "Unxmlize", 8, &main_Unxmlize, usage_Unxmlize, optstring_Unxmlize, lopts_Unxmlize } ,
+    { "Unxmlize", 8, &main_Unxmlize, usage_Unxmlize, optstring_Unxmlize, lopts_Unxmlize } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_VERSIONINFO))) || defined(TOOL_VERSIONINFO))
-	{ "VersionInfo", 11, &main_VersionInfo, usage_VersionInfo, optstring_VersionInfo, lopts_VersionInfo } ,
+    { "VersionInfo", 11, &main_VersionInfo, usage_VersionInfo, optstring_VersionInfo, lopts_VersionInfo } ,
 #endif
 
 #if (((!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS))) && (!(defined(UNITEX_ONLY_EXEC_GRAPH_TOOLS_RICH))) && (!defined(NO_TOOL_XMLIZER))) || defined(TOOL_XMLIZER))
-	{ "XMLizer", 7, &main_XMLizer, usage_XMLizer, optstring_XMLizer, lopts_XMLizer } ,
+    { "XMLizer", 7, &main_XMLizer, usage_XMLizer, optstring_XMLizer, lopts_XMLizer } ,
 #endif
 
-	{ "", 0, NULL, NULL, NULL, NULL}
+    { "", 0, NULL, NULL, NULL, NULL}
 };
 
 
 struct utility_alias {
-	const char* name;
-	int len_name;
-	const char* real_tool_name;
+    const char* name;
+    int len_name;
+    const char* real_tool_name;
 };
 
 
@@ -594,39 +594,39 @@ struct utility_alias {
 //  (if a tool is renamed, we can keep old name for script compatibility)
 const struct utility_alias utility_alias_array[] =
 {
-	{ NULL, 0, NULL }
+    { NULL, 0, NULL }
 };
 
 
 static const struct utility_item* found_utility(const char* search)
 {
-	int len_search = (int)strlen(search);
-	int i;
+    int len_search = (int)strlen(search);
+    int i;
 
-	i = 0;
-	while (utility_alias_array[i].len_name > 0)
-	{
-		if (utility_alias_array[i].len_name == len_search)
-		{
-			if (strcmp(utility_alias_array[i].name, search) == 0)
-			{
-				search = utility_alias_array[i].real_tool_name;
-				len_search = (int)strlen(search);
-				break;
-			}
-		}
-		i++;
-	}
+    i = 0;
+    while (utility_alias_array[i].len_name > 0)
+    {
+        if (utility_alias_array[i].len_name == len_search)
+        {
+            if (strcmp(utility_alias_array[i].name, search) == 0)
+            {
+                search = utility_alias_array[i].real_tool_name;
+                len_search = (int)strlen(search);
+                break;
+            }
+        }
+        i++;
+    }
 
-	i = 0;
-	while (utility_array[i].len_name > 0)
-	{
-		if (utility_array[i].len_name == len_search)
-			if (strcmp(utility_array[i].name,search)==0)
-				return &utility_array[i];
-		i++;
-	}
-	return NULL;
+    i = 0;
+    while (utility_array[i].len_name > 0)
+    {
+        if (utility_array[i].len_name == len_search)
+            if (strcmp(utility_array[i].name,search)==0)
+                return &utility_array[i];
+        i++;
+    }
+    return NULL;
 }
 
 
@@ -636,9 +636,9 @@ const struct utility_item* utility_called = found_utility(toolname);
 if (utility_called == NULL)
   return -1;
 else {
-	if (usage != NULL) *usage=utility_called->usage;
-	if (optstring != NULL) *optstring = utility_called->optstring;
-	if (lopts != NULL) *lopts = utility_called->lopts;
+    if (usage != NULL) *usage=utility_called->usage;
+    if (optstring != NULL) *optstring = utility_called->optstring;
+    if (lopts != NULL) *lopts = utility_called->lopts;
     if (pfunc != NULL) *pfunc = utility_called->fnc;
   return 0;
 }
@@ -648,23 +648,23 @@ int GetToolInfo_bynumber(int toolnumber,const char**toolname,mainFunc** pfunc,co
 {
 const struct utility_item* utility_called = &(utility_array[toolnumber]);
 {
-	if (toolname != NULL) *toolname = utility_called->name;
-	if (usage != NULL) *usage=utility_called->usage;
-	if (optstring != NULL) *optstring = utility_called->optstring;
-	if (lopts != NULL) *lopts = utility_called->lopts;
-	if (pfunc != NULL) *pfunc = utility_called->fnc;
-	return 0;
+    if (toolname != NULL) *toolname = utility_called->name;
+    if (usage != NULL) *usage=utility_called->usage;
+    if (optstring != NULL) *optstring = utility_called->optstring;
+    if (lopts != NULL) *lopts = utility_called->lopts;
+    if (pfunc != NULL) *pfunc = utility_called->fnc;
+    return 0;
 }
 }
 
 int GetNumberOfTool()
 {
-	int i=0;
-	while (utility_array[i].len_name > 0)
-	{
-		i++;
-	}
-	return i;
+    int i=0;
+    while (utility_array[i].len_name > 0)
+    {
+        i++;
+    }
+    return i;
 }
 
 
@@ -701,8 +701,8 @@ void list_unused_option_letter()
                     lopts[val-'a']=1;
                 j++;
             }
-		i++;
-	}
+        i++;
+    }
 
     u_printf("unused letter for optstring : ");
     for (i=0;i<26;i++)
@@ -720,26 +720,26 @@ void list_unused_option_letter()
 
 const char* usage_UnitexTool_prefix =
     "Usage: UnitexTool <Utility> [OPTIONS]\n"
-		          "where OPTIONS can be -h/--help to display help\n"
-			       "and Utility is from this list :\n";
+                  "where OPTIONS can be -h/--help to display help\n"
+                   "and Utility is from this list :\n";
 
 void unitex_tool_usage(int several, int display_copyright)
 {
-	int i=0;
+    int i=0;
     if (display_copyright != 0)
-	  display_copyright_notice();
-	u_printf(usage_UnitexTool_prefix);
-	while (utility_array[i].len_name > 0)
-	{
-		u_printf("%s\n",utility_array[i].name);
-		i++;
-	}
+      display_copyright_notice();
+    u_printf(usage_UnitexTool_prefix);
+    while (utility_array[i].len_name > 0)
+    {
+        u_printf("%s\n",utility_array[i].name);
+        i++;
+    }
 
-	if (several != 0)
-		u_printf(
-		   "\n"
-		   "You can chain several utility call by using\n"
-		   "UnitexTool { <Utility> [OPTIONS] } { <Utility> [OPTIONS] } ...\n");
+    if (several != 0)
+        u_printf(
+           "\n"
+           "You can chain several utility call by using\n"
+           "UnitexTool { <Utility> [OPTIONS] } { <Utility> [OPTIONS] } ...\n");
     //list_unused_option_letter();
 }
 
@@ -757,7 +757,7 @@ extern "C" int CheckDateTimeBomb();
 #else
 static int CheckDateTimeBomb()
 {
-	return 1;
+    return 1;
 }
 #endif
 
@@ -791,8 +791,8 @@ return CallToolLogged(utility_called->fnc,argc-1,((char**)argv)+1);
 void run_command_direct(int argc, char* const argv[], int* p_command_found, int* p_return_value) {
 const struct utility_item* utility_called = NULL;
 if (argc>1)
-	utility_called = found_utility(argv[0]);
-if (utility_called == NULL)	{
+    utility_called = found_utility(argv[0]);
+if (utility_called == NULL) {
   *p_command_found = 0;
   *p_return_value = -1;
 }
@@ -805,11 +805,11 @@ else {
 
 typedef struct
 {
-	int argc;
-	char* const* argv;
-	int* p_number_done;
-	struct pos_tools_in_arg* ptia;
-	int ret;
+    int argc;
+    char* const* argv;
+    int* p_number_done;
+    struct pos_tools_in_arg* ptia;
+    int ret;
 } unitexTool_run_in_thread_infos;
 
 
@@ -818,310 +818,310 @@ static int UnitexTool_several_info_ignore_stack_option(int argc, char* const arg
 #ifdef UNITEXTOOL_HAVE_SYNC_LOGGER
 static void SYNC_CALLBACK_UNITEX DoWorkUnitexToolInThread(void* privateDataPtr, unsigned int /*iNbThread*/)
 {
-	unitexTool_run_in_thread_infos* infos = (unitexTool_run_in_thread_infos*)privateDataPtr;
-	infos->ret = UnitexTool_several_info_ignore_stack_option(infos->argc, infos->argv, infos->p_number_done, infos->ptia, 1);
+    unitexTool_run_in_thread_infos* infos = (unitexTool_run_in_thread_infos*)privateDataPtr;
+    infos->ret = UnitexTool_several_info_ignore_stack_option(infos->argc, infos->argv, infos->p_number_done, infos->ptia, 1);
 }
 #endif
 
 static int UnitexTool_several_info_ignore_stack_option(int argc,char* const argv[],int* p_number_done,struct pos_tools_in_arg* ptia, int ignore_stack_option)
 {
-	int ret=0;
-	int number_done_dummy=0;
-	int pos = 1;
-	int next_num_util = 0;
-	pos_tools_in_arg tia_dummy;
+    int ret=0;
+    int number_done_dummy=0;
+    int pos = 1;
+    int next_num_util = 0;
+    pos_tools_in_arg tia_dummy;
 
-	const char* fTime=NULL;
-	hTimeElapsed startTime=NULL;
-	const char* firstArg=NULL;
-	if (argc>1)
-		firstArg=argv[1];
+    const char* fTime=NULL;
+    hTimeElapsed startTime=NULL;
+    const char* firstArg=NULL;
+    if (argc>1)
+        firstArg=argv[1];
 
-	if ((firstArg != NULL) && ((strstr(firstArg, "--stack-size=") == firstArg) || (strstr(firstArg, "--stack_size=") == firstArg))) {
+    if ((firstArg != NULL) && ((strstr(firstArg, "--stack-size=") == firstArg) || (strstr(firstArg, "--stack_size=") == firstArg))) {
 #ifdef UNITEXTOOL_HAVE_SYNC_LOGGER
-		if (ignore_stack_option == 0)
-		{
-			unitexTool_run_in_thread_infos infos;
-			unitexTool_run_in_thread_infos* pinfos = &infos;
-			const char* stack_size_option = firstArg + 13;
+        if (ignore_stack_option == 0)
+        {
+            unitexTool_run_in_thread_infos infos;
+            unitexTool_run_in_thread_infos* pinfos = &infos;
+            const char* stack_size_option = firstArg + 13;
 
-			char cSuffix = 0;
-			char foo = 0;
-			unsigned int stack_size = 0;
-			int r = sscanf(stack_size_option, "%u%c%c", &stack_size, &cSuffix, &foo);
+            char cSuffix = 0;
+            char foo = 0;
+            unsigned int stack_size = 0;
+            int r = sscanf(stack_size_option, "%u%c%c", &stack_size, &cSuffix, &foo);
 
-			if ((r == 2) && ((cSuffix == 'k') || (cSuffix == 'K')))
-			{
-				stack_size = stack_size * 1024;
-			}
-			else
-			if ((r == 2) && ((cSuffix == 'm') || (cSuffix == 'M')))
-			{
-				stack_size = stack_size * 1024 * 1024;
-			}
-			else
-			if (r != 1)
-			{
-				error("Invalid stack-size argument: %s\n", stack_size_option);
-				if (p_number_done != NULL)
-					*p_number_done = 0;
-				if (ptia != NULL)
-				{
-					ptia->argcpos = 1;
-					ptia->nbargs = 1;
-					ptia->tool_number = 0;
-					ptia->ret = USAGE_ERROR_CODE;
-				}
-				return USAGE_ERROR_CODE;
-			}
+            if ((r == 2) && ((cSuffix == 'k') || (cSuffix == 'K')))
+            {
+                stack_size = stack_size * 1024;
+            }
+            else
+            if ((r == 2) && ((cSuffix == 'm') || (cSuffix == 'M')))
+            {
+                stack_size = stack_size * 1024 * 1024;
+            }
+            else
+            if (r != 1)
+            {
+                error("Invalid stack-size argument: %s\n", stack_size_option);
+                if (p_number_done != NULL)
+                    *p_number_done = 0;
+                if (ptia != NULL)
+                {
+                    ptia->argcpos = 1;
+                    ptia->nbargs = 1;
+                    ptia->tool_number = 0;
+                    ptia->ret = USAGE_ERROR_CODE;
+                }
+                return USAGE_ERROR_CODE;
+            }
 
 
-			infos.argc = argc;
-			infos.argv = argv;
-			infos.p_number_done = p_number_done;
-			infos.ptia = ptia;
+            infos.argc = argc;
+            infos.argv = argv;
+            infos.p_number_done = p_number_done;
+            infos.ptia = ptia;
 
-			SyncDoRunThreadsWithStackSize(1, DoWorkUnitexToolInThread, (void**)&pinfos, stack_size);
-			return infos.ret;
-		}
+            SyncDoRunThreadsWithStackSize(1, DoWorkUnitexToolInThread, (void**)&pinfos, stack_size);
+            return infos.ret;
+        }
 #endif
 
-		pos++;
-		if (argc>pos)
-			firstArg = argv[pos];
-	}
+        pos++;
+        if (argc>pos)
+            firstArg = argv[pos];
+    }
 
 
-	if ((firstArg!=NULL) && (strstr(firstArg,"--time=")==firstArg)) {
+    if ((firstArg!=NULL) && (strstr(firstArg,"--time=")==firstArg)) {
 
-		fTime = firstArg + 7;
-		startTime = SyncBuidTimeMarkerObject();
-		pos++;
-		/*
-		if (argc>pos)
-			firstArg = argv[pos];
-			*/
-	}
+        fTime = firstArg + 7;
+        startTime = SyncBuidTimeMarkerObject();
+        pos++;
+        /*
+        if (argc>pos)
+            firstArg = argv[pos];
+            */
+    }
 
-	if (p_number_done == NULL)
-		p_number_done = &number_done_dummy;
-	if (ptia == NULL)
-		ptia = &tia_dummy;
+    if (p_number_done == NULL)
+        p_number_done = &number_done_dummy;
+    if (ptia == NULL)
+        ptia = &tia_dummy;
 
-	ptia->tool_number = 0;
-	ptia->argcpos = 0;
-	ptia->nbargs = 0;
-	ptia->ret = 0;
+    ptia->tool_number = 0;
+    ptia->argcpos = 0;
+    ptia->nbargs = 0;
+    ptia->ret = 0;
 
 
 #ifdef DEBUG
-	int icount;
-	for (icount=0;icount<argc;icount++) u_printf("%s ",argv[icount]);
-	u_printf("\n");
+    int icount;
+    for (icount=0;icount<argc;icount++) u_printf("%s ",argv[icount]);
+    u_printf("\n");
 #endif
 
-	if (argc <= pos)
-	{
-		unitex_tool_usage(1,1);
-	}
-	else
-	while ((pos<argc) && (ret == 0))
-	{
-		if ((strcmp(argv[pos],"{")==0) && ((pos+1) < argc))
-		{
-			int j;
-			for (j=pos;j<argc;j++)
-			{
-				if (strcmp(argv[j],"}")==0) {
-					next_num_util++;
-					break;
-				}
-			}
+    if (argc <= pos)
+    {
+        unitex_tool_usage(1,1);
+    }
+    else
+    while ((pos<argc) && (ret == 0))
+    {
+        if ((strcmp(argv[pos],"{")==0) && ((pos+1) < argc))
+        {
+            int j;
+            for (j=pos;j<argc;j++)
+            {
+                if (strcmp(argv[j],"}")==0) {
+                    next_num_util++;
+                    break;
+                }
+            }
 
-			if (j==argc)
-			{
-				ret = -1;
-				break;
-			}
-			else
-			{
-				const struct utility_item* utility_called = found_utility(argv[pos+1]);
-				if (utility_called != NULL) {
-					ptia->argcpos = pos+1;
-					ptia->nbargs = j-(pos+1);
-					ptia->tool_number = next_num_util;
-					ptia->ret = ret = CallToolLogged(utility_called->fnc,ptia->nbargs,((char**)argv)+ptia->argcpos);
-				}
-				else
-					ret = 1 ;
+            if (j==argc)
+            {
+                ret = -1;
+                break;
+            }
+            else
+            {
+                const struct utility_item* utility_called = found_utility(argv[pos+1]);
+                if (utility_called != NULL) {
+                    ptia->argcpos = pos+1;
+                    ptia->nbargs = j-(pos+1);
+                    ptia->tool_number = next_num_util;
+                    ptia->ret = ret = CallToolLogged(utility_called->fnc,ptia->nbargs,((char**)argv)+ptia->argcpos);
+                }
+                else
+                    ret = 1 ;
 
-				if (ret == 0)
-					(*p_number_done)++;
-				else
-					break;
-				pos = j + 1;
-			}
-		}
-		else
-		{
-			const struct utility_item* utility_called = found_utility(argv[pos]);
-			if (utility_called != NULL) {
-				ptia->argcpos = pos;
-				ptia->nbargs = argc-pos;
-				ptia->ret = ret = CallToolLogged(utility_called->fnc,ptia->nbargs,((char**)argv)+ptia->argcpos);
-			}
-			else
-			{
-				unitex_tool_usage(1,1);
-				ret = 1;
-			}
+                if (ret == 0)
+                    (*p_number_done)++;
+                else
+                    break;
+                pos = j + 1;
+            }
+        }
+        else
+        {
+            const struct utility_item* utility_called = found_utility(argv[pos]);
+            if (utility_called != NULL) {
+                ptia->argcpos = pos;
+                ptia->nbargs = argc-pos;
+                ptia->ret = ret = CallToolLogged(utility_called->fnc,ptia->nbargs,((char**)argv)+ptia->argcpos);
+            }
+            else
+            {
+                unitex_tool_usage(1,1);
+                ret = 1;
+            }
 
-			if (ret == 0)
-				(*p_number_done)++;
-			break;
-		}
-	}
+            if (ret == 0)
+                (*p_number_done)++;
+            break;
+        }
+    }
 
-	if (fTime!=NULL) {
-		double msec=(double)(SyncGetMSecElapsed(startTime)/((double)1000.));
-		U_FILE* f=u_fopen(UTF8,fTime,U_WRITE);
-		if (f==NULL) {
-			fatal_error("Unable to open time file %s\n",fTime);
-		}
-		u_fprintf(f,"%.4g\n",msec);
-		u_fclose(f);
-	}
-	return ret;
+    if (fTime!=NULL) {
+        double msec=(double)(SyncGetMSecElapsed(startTime)/((double)1000.));
+        U_FILE* f=u_fopen(UTF8,fTime,U_WRITE);
+        if (f==NULL) {
+            fatal_error("Unable to open time file %s\n",fTime);
+        }
+        u_fprintf(f,"%.4g\n",msec);
+        u_fclose(f);
+    }
+    return ret;
 }
 
 
 
 int UnitexTool_several_info(int argc, char* const argv[], int* p_number_done, struct pos_tools_in_arg* ptia)
 {
-	return UnitexTool_several_info_ignore_stack_option(argc, argv, p_number_done, ptia, 0);
+    return UnitexTool_several_info_ignore_stack_option(argc, argv, p_number_done, ptia, 0);
 }
 
 
 static int countArgs(char** args)
 {
-	int count = 0;
+    int count = 0;
 
-	char**tmp = args;
-	while ((*tmp) != NULL)
-	{
-		count++;
-		tmp++;
-	}
-	return count;
+    char**tmp = args;
+    while ((*tmp) != NULL)
+    {
+        count++;
+        tmp++;
+    }
+    return count;
 }
 
 
 static void freeArgs(char**args)
 {
-	char** tmp = args;
-	while ((*tmp) != NULL)
-	{
-		free(*tmp);
-		tmp++;
-	}
-	free(args);
+    char** tmp = args;
+    while ((*tmp) != NULL)
+    {
+        free(*tmp);
+        tmp++;
+    }
+    free(args);
 }
 
 
 static const char* CopyStrArg(const char*lpSrc, char* lpDest, size_t dwMaxSize)
 {
-	int isInQuote = 0;
-	size_t dwDestPos = 0;
+    int isInQuote = 0;
+    size_t dwDestPos = 0;
 
-	*lpDest = '\0';
+    *lpDest = '\0';
 
-	if (lpSrc == NULL)
-		return NULL;
+    if (lpSrc == NULL)
+        return NULL;
 
-	while ((*lpSrc) == ' ')
-		lpSrc++;
+    while ((*lpSrc) == ' ')
+        lpSrc++;
 
-	while (((*lpSrc) != '\0') && ((dwMaxSize == 0) || (dwDestPos<dwMaxSize)))
-	{
-		if ((*lpSrc) == '"')
-		{
-			isInQuote = !isInQuote;
-			lpSrc++;
-			continue;
-		}
+    while (((*lpSrc) != '\0') && ((dwMaxSize == 0) || (dwDestPos<dwMaxSize)))
+    {
+        if ((*lpSrc) == '"')
+        {
+            isInQuote = !isInQuote;
+            lpSrc++;
+            continue;
+        }
 
-		if (((*lpSrc) == ' ') && (!isInQuote))
-		{
-			while ((*lpSrc) == ' ')
-				lpSrc++;
-			return lpSrc;
-		}
+        if (((*lpSrc) == ' ') && (!isInQuote))
+        {
+            while ((*lpSrc) == ' ')
+                lpSrc++;
+            return lpSrc;
+        }
 
-		*lpDest = *lpSrc;
-		lpDest++;
-		dwDestPos++;
-		*lpDest = '\0';
-		lpSrc++;
-	}
-	return lpSrc;
+        *lpDest = *lpSrc;
+        lpDest++;
+        dwDestPos++;
+        *lpDest = '\0';
+        lpSrc++;
+    }
+    return lpSrc;
 }
 
 
 static char**argsFromCString(const char* cmdLine)
 {
-	size_t len_cmd_line = strlen(cmdLine);
+    size_t len_cmd_line = strlen(cmdLine);
 
-	char* work_buf = (char*)malloc(len_cmd_line + 0x10);
-	if (work_buf == NULL)
-		return 0;
+    char* work_buf = (char*)malloc(len_cmd_line + 0x10);
+    if (work_buf == NULL)
+        return 0;
 
-	const char*lpParcLine;
-	int nb_args_found = 0;
+    const char*lpParcLine;
+    int nb_args_found = 0;
 
-	lpParcLine = cmdLine;
-	while ((*lpParcLine) != '\0')
-	{
-		*work_buf = 0;
-		lpParcLine = CopyStrArg(lpParcLine, work_buf, len_cmd_line + 8);
-		nb_args_found++;
-	}
+    lpParcLine = cmdLine;
+    while ((*lpParcLine) != '\0')
+    {
+        *work_buf = 0;
+        lpParcLine = CopyStrArg(lpParcLine, work_buf, len_cmd_line + 8);
+        nb_args_found++;
+    }
 
-	char **args = NULL;
-	if (nb_args_found>0)
-		args = (char**)malloc((nb_args_found + 1) * sizeof(char*));
-	else
-		args = NULL;
+    char **args = NULL;
+    if (nb_args_found>0)
+        args = (char**)malloc((nb_args_found + 1) * sizeof(char*));
+    else
+        args = NULL;
 
-	if (args == NULL)
-	{
-		free(work_buf);
-		return NULL;
-	}
+    if (args == NULL)
+    {
+        free(work_buf);
+        return NULL;
+    }
 
-	lpParcLine = cmdLine;
-	int i = 0;
-	while ((*lpParcLine) != '\0')
-	{
-		*work_buf = 0;
-		lpParcLine = CopyStrArg(lpParcLine, work_buf, len_cmd_line + 8);
-		args[i] = strdup(work_buf);
-		i++;
-	}
-	args[i] = NULL;
+    lpParcLine = cmdLine;
+    int i = 0;
+    while ((*lpParcLine) != '\0')
+    {
+        *work_buf = 0;
+        lpParcLine = CopyStrArg(lpParcLine, work_buf, len_cmd_line + 8);
+        args[i] = strdup(work_buf);
+        i++;
+    }
+    args[i] = NULL;
 
-	free(work_buf);
-	return args;
+    free(work_buf);
+    return args;
 }
 
 
 
 int UnitexTool_commandstring_several_info(const char* cmd_line, int* p_number_done, struct pos_tools_in_arg* ptia)
 {
-	char** argv = argsFromCString(cmd_line);
-	int argc = countArgs(argv);
-	int ret_value = UnitexTool_several_info(argc, argv, p_number_done, ptia);
-	freeArgs(argv);
-	return ret_value;
+    char** argv = argsFromCString(cmd_line);
+    int argc = countArgs(argv);
+    int ret_value = UnitexTool_several_info(argc, argv, p_number_done, ptia);
+    freeArgs(argv);
+    return ret_value;
 }
 
 
@@ -1131,27 +1131,27 @@ int UnitexTool_commandstring_several_info(const char* cmd_line, int* p_number_do
 
 int UnitexTool_several(int argc,char* const argv[],int* p_number_done)
 {
-	return UnitexTool_several_info(argc,argv,p_number_done,NULL);
+    return UnitexTool_several_info(argc,argv,p_number_done,NULL);
 }
 
 int main_UnitexTool_C_internal(int argc,char* const argv[])
 {
-	return UnitexTool_several_info(argc,argv,NULL,NULL);
+    return UnitexTool_several_info(argc,argv,NULL,NULL);
 }
 
 int main_UnitexTool_internal(int argc,char* const argv[])
 {
-	return UnitexTool_several_info(argc,argv,NULL,NULL);
+    return UnitexTool_several_info(argc,argv,NULL,NULL);
 }
 
 UNITEX_FUNC int UNITEX_CALL main_UnitexTool(int argc,char* const argv[])
 {
-	return UnitexTool_several_info(argc,argv,NULL,NULL);
+    return UnitexTool_several_info(argc,argv,NULL,NULL);
 }
 
 UNITEX_FUNC int UNITEX_CALL main_UnitexTool_C(int argc,char* const argv[])
 {
-	return UnitexTool_several_info(argc,argv,NULL,NULL);
+    return UnitexTool_several_info(argc,argv,NULL,NULL);
 }
 
 
@@ -1163,24 +1163,24 @@ UNITEX_FUNC int UNITEX_CALL UnitexTool_public_run(int argc,char* const argv[],in
 
 UNITEX_FUNC int UNITEX_CALL UnitexTool_public_run_string(const char* cmd_line)
 {
-	return UnitexTool_commandstring_several_info(cmd_line, NULL, NULL);
+    return UnitexTool_commandstring_several_info(cmd_line, NULL, NULL);
 }
 
 UNITEX_FUNC int UNITEX_CALL UnitexTool_public_run_string_ret_infos(const char* cmd_line, int* p_number_done, struct pos_tools_in_arg* ptia)
 {
-	return UnitexTool_commandstring_several_info(cmd_line, p_number_done, ptia);
+    return UnitexTool_commandstring_several_info(cmd_line, p_number_done, ptia);
 }
 
 
 UNITEX_FUNC int UNITEX_CALL UnitexTool_public_run_one_tool(const char*toolname,int argc,char* const argv[])
 {
-	const struct utility_item* utility_called = found_utility(toolname);
-	if (utility_called != NULL) {
-		return CallToolLogged(utility_called->fnc,argc,argv);
-	}
-	else {
-		return 0;
-	}
+    const struct utility_item* utility_called = found_utility(toolname);
+    if (utility_called != NULL) {
+        return CallToolLogged(utility_called->fnc,argc,argv);
+    }
+    else {
+        return 0;
+    }
 }
 
 

--- a/UnitexTool.cpp
+++ b/UnitexTool.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -579,7 +579,7 @@ const struct utility_item utility_array[]=
 	{ "XMLizer", 7, &main_XMLizer, usage_XMLizer, optstring_XMLizer, lopts_XMLizer } ,
 #endif
 
-	{ "", 0, NULL, NULL, NULL, NULL} 
+	{ "", 0, NULL, NULL, NULL, NULL}
 };
 
 
@@ -661,7 +661,7 @@ int GetNumberOfTool()
 {
 	int i=0;
 	while (utility_array[i].len_name > 0)
-	{		
+	{
 		i++;
 	}
 	return i;
@@ -719,7 +719,7 @@ void list_unused_option_letter()
 }
 
 const char* usage_UnitexTool_prefix =
-    "Usage: UnitexTool <Utility> [OPTIONS]\n" 
+    "Usage: UnitexTool <Utility> [OPTIONS]\n"
 		          "where OPTIONS can be -h/--help to display help\n"
 			       "and Utility is from this list :\n";
 
@@ -844,7 +844,7 @@ static int UnitexTool_several_info_ignore_stack_option(int argc,char* const argv
 			unitexTool_run_in_thread_infos infos;
 			unitexTool_run_in_thread_infos* pinfos = &infos;
 			const char* stack_size_option = firstArg + 13;
-			
+
 			char cSuffix = 0;
 			char foo = 0;
 			unsigned int stack_size = 0;
@@ -912,14 +912,14 @@ static int UnitexTool_several_info_ignore_stack_option(int argc,char* const argv
 	ptia->argcpos = 0;
 	ptia->nbargs = 0;
 	ptia->ret = 0;
-	
+
 
 #ifdef DEBUG
 	int icount;
 	for (icount=0;icount<argc;icount++) u_printf("%s ",argv[icount]);
 	u_printf("\n");
 #endif
-	
+
 	if (argc <= pos)
 	{
 		unitex_tool_usage(1,1);

--- a/UnitexTool.h
+++ b/UnitexTool.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -41,7 +41,7 @@
 #define UNITEX_HAVING_OFFSET_FILE 1
 
 #define UNITEX_HAVING_MINI_PERSISTANCE 1
-	
+
 #ifndef UNITEX_HAVING_PERSISTANCE_INTERFACE
 #define UNITEX_HAVING_PERSISTANCE_INTERFACE 1
 #endif
@@ -64,10 +64,10 @@ int main_UnitexTool_single(int argc,char* const argv[]);
 
 
 struct pos_tools_in_arg {
-	int tool_number;
-	int argcpos;
-	int nbargs;
-	int ret;
+    int tool_number;
+    int argcpos;
+    int nbargs;
+    int ret;
 } ;
 
 int UnitexTool_several_info(int argc,char* const argv[],int* p_number_done,struct pos_tools_in_arg* ptia);

--- a/Untokenize.cpp
+++ b/Untokenize.cpp
@@ -281,7 +281,7 @@ for (size_t i=0;i<nb_item;i++) {
             u_fprintf(text,"\n", tok->token[*(buf+i)]);
         }
         else {
-			u_fputs(tok->token[*(buf+i)], text);
+            u_fputs(tok->token[*(buf+i)], text);
         }
     }
 }

--- a/Untokenize.cpp
+++ b/Untokenize.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -170,11 +170,11 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Untokenize,lopts_Untoken
              break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Untokenize[index].name);
-             return USAGE_ERROR_CODE;            
+             return USAGE_ERROR_CODE;
    case '?': index==-1 ? error("Invalid option -%c\n",options.vars()->optopt) :
                          error("Invalid option --%s\n",options.vars()->optarg);
              return USAGE_ERROR_CODE;

--- a/Untokenize.h
+++ b/Untokenize.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/Unxmlize.cpp
+++ b/Unxmlize.cpp
@@ -38,34 +38,34 @@
 namespace unitex {
 
 const char* usage_Unxmlize =
-		 "Usage: Unxmlize <file>\n"
-		 "\n"
-		 "  <file>: an unicode .xml or .html file to be processed\n"
-		 "\n"
-		 "OPTIONS:\n"
-		 "  -o TXT/--output=TXT: output file. By default, foo.xml => foo.txt\n"
-		 "  --input_offsets=XXX: base offset file to be used\n"
-		 "  --output_offsets=XXX: specifies the offset file to be produced\n"
-		 "  --PRLG=XXX: extracts to file XXX special information used in the\n"
-		 "              PRLG project on ancient Greek (requires --output_offsets)\n"
-		 "\n"
-		 "  -t/--html: consider the file as html file (disregard extension)\n"
-		 "  -x/--xml: consider the file as xml file (disregard extension)\n"
-		 "  -l/--tolerate: try tolerate somes markup langage malformation\n"
-		 "\n"
-		 "  --comments=IGNORE: every comment is removed (default)\n"
-		 "  --comments=SPACE: every comment is replaced by a single space\n"
-		 "  --scripts=IGNORE: every script block is removed\n"
-		 "  --scripts=SPACE: every comment is replaced by a single space (default for .html)\n"
-		 "    Note: by default, script tags are handled as normal tags (default for .xml)\n"
-		 "\n"
-		 "  --normal_tags=IGNORE: every other tag is removed (default for .xml)\n"
-		 "  --normal_tags=SPACE: every other tag is replaced by a single space(default for .html)\n"
+         "Usage: Unxmlize <file>\n"
+         "\n"
+         "  <file>: an unicode .xml or .html file to be processed\n"
+         "\n"
+         "OPTIONS:\n"
+         "  -o TXT/--output=TXT: output file. By default, foo.xml => foo.txt\n"
+         "  --input_offsets=XXX: base offset file to be used\n"
+         "  --output_offsets=XXX: specifies the offset file to be produced\n"
+         "  --PRLG=XXX: extracts to file XXX special information used in the\n"
+         "              PRLG project on ancient Greek (requires --output_offsets)\n"
+         "\n"
+         "  -t/--html: consider the file as html file (disregard extension)\n"
+         "  -x/--xml: consider the file as xml file (disregard extension)\n"
+         "  -l/--tolerate: try tolerate somes markup langage malformation\n"
+         "\n"
+         "  --comments=IGNORE: every comment is removed (default)\n"
+         "  --comments=SPACE: every comment is replaced by a single space\n"
+         "  --scripts=IGNORE: every script block is removed\n"
+         "  --scripts=SPACE: every comment is replaced by a single space (default for .html)\n"
+         "    Note: by default, script tags are handled as normal tags (default for .xml)\n"
+         "\n"
+         "  --normal_tags=IGNORE: every other tag is removed (default for .xml)\n"
+         "  --normal_tags=SPACE: every other tag is replaced by a single space(default for .html)\n"
      "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"
-		 "  -h/--help: this help\n"
-		 "\n"
-		 "Removes all xml tags from the given file to produce a text file that\n"
-		 "can be processed by Unitex.\n";
+         "  -h/--help: this help\n"
+         "\n"
+         "Removes all xml tags from the given file to produce a text file that\n"
+         "can be processed by Unitex.\n";
 
 
 static void usage() {
@@ -142,37 +142,37 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Unxmlize,lopts_Unxmlize,
                 strcpy(output_PRLG,options.vars()->optarg);
                 break;
    case 'c': {
-	   if (!strcmp(options.vars()->optarg,"IGNORE")) {
-		   comments=UNXMLIZE_IGNORE;
-	   } else if (!strcmp(options.vars()->optarg,"SPACE")) {
-		   comments=UNXMLIZE_REPLACE_BY_SPACE;
-	   } else {
-		   error("Invalid argument for option --comments\n");
+       if (!strcmp(options.vars()->optarg,"IGNORE")) {
+           comments=UNXMLIZE_IGNORE;
+       } else if (!strcmp(options.vars()->optarg,"SPACE")) {
+           comments=UNXMLIZE_REPLACE_BY_SPACE;
+       } else {
+           error("Invalid argument for option --comments\n");
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 's': {
-	   if (!strcmp(options.vars()->optarg,"IGNORE")) {
-		   scripts=UNXMLIZE_IGNORE;
-	   } else if (!strcmp(options.vars()->optarg,"SPACE")) {
-		   scripts=UNXMLIZE_REPLACE_BY_SPACE;
-	   } else {
-		   error("Invalid argument for option --scripts\n");
+       if (!strcmp(options.vars()->optarg,"IGNORE")) {
+           scripts=UNXMLIZE_IGNORE;
+       } else if (!strcmp(options.vars()->optarg,"SPACE")) {
+           scripts=UNXMLIZE_REPLACE_BY_SPACE;
+       } else {
+           error("Invalid argument for option --scripts\n");
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 'n': {
-	   if (!strcmp(options.vars()->optarg,"IGNORE")) {
-		   normal_tags=UNXMLIZE_IGNORE;
-	   } else if (!strcmp(options.vars()->optarg,"SPACE")) {
-		   normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
-	   } else {
-		   error("Invalid argument for option --normal_tags\n");
+       if (!strcmp(options.vars()->optarg,"IGNORE")) {
+           normal_tags=UNXMLIZE_IGNORE;
+       } else if (!strcmp(options.vars()->optarg,"SPACE")) {
+           normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
+       } else {
+           error("Invalid argument for option --normal_tags\n");
        return USAGE_ERROR_CODE;
-	   }
-	   break;
+       }
+       break;
    }
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
@@ -226,8 +226,8 @@ if (output[0]=='\0') {
 
 f_input=u_fopen(&vec,argv[options.vars()->optind],U_READ);
 if (f_input==NULL) {
-	error("Cannot open file %s\n",argv[options.vars()->optind]);
-	return DEFAULT_ERROR_CODE;
+    error("Cannot open file %s\n",argv[options.vars()->optind]);
+    return DEFAULT_ERROR_CODE;
 }
 
 char extension[FILENAME_MAX];
@@ -243,13 +243,13 @@ if (force_xml!=0) {
 }
 
 if (consider_as_html!=0) {
-	opts.comments=UNXMLIZE_IGNORE;
-	opts.scripts=UNXMLIZE_REPLACE_BY_SPACE;
-	opts.normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
+    opts.comments=UNXMLIZE_IGNORE;
+    opts.scripts=UNXMLIZE_REPLACE_BY_SPACE;
+    opts.normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
 } else {
-	opts.comments=UNXMLIZE_IGNORE;
-	opts.scripts=UNXMLIZE_DO_NOTHING;
-	opts.normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
+    opts.comments=UNXMLIZE_IGNORE;
+    opts.scripts=UNXMLIZE_DO_NOTHING;
+    opts.normal_tags=UNXMLIZE_REPLACE_BY_SPACE;
 }
 if (comments!=-1) {
   opts.comments=comments;
@@ -269,45 +269,45 @@ if (f_output==NULL) {
 }
 
 if (output_offsets[0]!='\0') {
-	if (input_offsets[0] != '\0') {
-		v_input_offsets = load_offsets(&vec, input_offsets);
-	}
-	f_offsets=u_fopen(&vec,output_offsets,U_WRITE);
-	if (f_offsets==NULL) {
-	  error("Cannot create offset file %s\n",output_offsets);
+    if (input_offsets[0] != '\0') {
+        v_input_offsets = load_offsets(&vec, input_offsets);
+    }
+    f_offsets=u_fopen(&vec,output_offsets,U_WRITE);
+    if (f_offsets==NULL) {
+      error("Cannot create offset file %s\n",output_offsets);
     free_vector_offset(v_input_offsets);
     u_fclose(f_output);
     u_fclose(f_input);
     return DEFAULT_ERROR_CODE;
-	}
-	offsets=new_vector_offset();
+    }
+    offsets=new_vector_offset();
 }
 unichar* PRLG_ptrs[10]={0,0,0,0,0,0,0,0,0,0};
 unichar** PRLG=NULL;
 U_FILE* f_PRLG=NULL;
 if (output_PRLG[0]!='\0') {
-	if (f_offsets==NULL) {
-		error("Cannot use the --PRLG option if --output_offsets is not used\n");
+    if (f_offsets==NULL) {
+        error("Cannot use the --PRLG option if --output_offsets is not used\n");
     free_vector_offset(offsets);
     free_vector_offset(v_input_offsets);
     u_fclose(f_output);
     u_fclose(f_input);
     return DEFAULT_ERROR_CODE;
-	}
-	PRLG=PRLG_ptrs;
-	f_PRLG=u_fopen(&vec,output_PRLG,U_WRITE);
-	if (f_offsets==NULL) {
-		error("Cannot create PRLG file %s\n",output_PRLG);
+    }
+    PRLG=PRLG_ptrs;
+    f_PRLG=u_fopen(&vec,output_PRLG,U_WRITE);
+    if (f_offsets==NULL) {
+        error("Cannot create PRLG file %s\n",output_PRLG);
     free_vector_offset(offsets);
     u_fclose(f_offsets);
     free_vector_offset(v_input_offsets);
     u_fclose(f_output);
     u_fclose(f_input);
     return DEFAULT_ERROR_CODE;
-	}
+    }
 }
 if (!unxmlize(f_input,f_output,offsets,&opts,PRLG,f_PRLG,tolerate_markup_malformation)) {
-	error("The input file was not a valid xml one. Operation aborted.\n");
+    error("The input file was not a valid xml one. Operation aborted.\n");
 
   for (int i=0;i<10;i++) {
     if (PRLG_ptrs[i]!=NULL) {
@@ -336,7 +336,7 @@ for (int i=0;i<10;i++) {
 }
 
 if (offsets!=NULL) {
-	process_offsets(v_input_offsets,offsets,f_offsets);
+    process_offsets(v_input_offsets,offsets,f_offsets);
 }
 
 u_fclose(f_PRLG);

--- a/Unxmlize.cpp
+++ b/Unxmlize.cpp
@@ -191,7 +191,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_Unxmlize,lopts_Unxmlize,
    case 'l': tolerate_markup_malformation=1; break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_Unxmlize[index].name);

--- a/UserCancelling.cpp
+++ b/UserCancelling.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/UserCancelling.cpp
+++ b/UserCancelling.cpp
@@ -44,14 +44,14 @@
 namespace unitex {
 
 struct UserCancellingInfo {
-	t_user_cancelling_func_array func_array;
-	void* privateCancelPtr;
+    t_user_cancelling_func_array func_array;
+    void* privateCancelPtr;
 } ;
 
 
 struct List_UserCancellingInfo {
-	UserCancellingInfo lgi;
-	List_UserCancellingInfo* next;
+    UserCancellingInfo lgi;
+    List_UserCancellingInfo* next;
 } ;
 
 
@@ -61,58 +61,58 @@ struct List_UserCancellingInfo* p_user_cancelling_info_list=NULL;
 
 UNITEX_FUNC int UNITEX_CALL AddUserCancellingInfo(const t_user_cancelling_func_array* func_array,void* privateCancelPtr)
 {
-	struct List_UserCancellingInfo* new_item;
+    struct List_UserCancellingInfo* new_item;
     if (func_array->fnc_is_cancelling == NULL)
         return 0;
 
-	new_item = (struct List_UserCancellingInfo*)malloc(sizeof(struct UserCancellingInfo));
-	if (new_item == NULL)
-		return 0;
+    new_item = (struct List_UserCancellingInfo*)malloc(sizeof(struct UserCancellingInfo));
+    if (new_item == NULL)
+        return 0;
 
-	new_item->lgi.func_array = *func_array;
-	new_item->lgi.privateCancelPtr = privateCancelPtr;
-	new_item->next = NULL;
+    new_item->lgi.func_array = *func_array;
+    new_item->lgi.privateCancelPtr = privateCancelPtr;
+    new_item->next = NULL;
 
-	if (p_user_cancelling_info_list == NULL)
-		p_user_cancelling_info_list = new_item;
-	else {
-		struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
-		while ((tmp->next) != NULL)
-			tmp = tmp->next;
-		tmp->next = new_item;
-	}
+    if (p_user_cancelling_info_list == NULL)
+        p_user_cancelling_info_list = new_item;
+    else {
+        struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
+        while ((tmp->next) != NULL)
+            tmp = tmp->next;
+        tmp->next = new_item;
+    }
 
-	if ((new_item->lgi.func_array.fnc_Init_User_Cancelling) != NULL)
-		(*(new_item->lgi.func_array.fnc_Init_User_Cancelling))(new_item->lgi.privateCancelPtr);
+    if ((new_item->lgi.func_array.fnc_Init_User_Cancelling) != NULL)
+        (*(new_item->lgi.func_array.fnc_Init_User_Cancelling))(new_item->lgi.privateCancelPtr);
 
-	return 1;
+    return 1;
 }
 
 UNITEX_FUNC int UNITEX_CALL RemoveUserCancellingInfo(const t_user_cancelling_func_array* func_array,void* privateCancelPtr)
 {
-	struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
-	struct List_UserCancellingInfo* tmp_previous = NULL;
+    struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
+    struct List_UserCancellingInfo* tmp_previous = NULL;
 
-	while (tmp != NULL)
-	{
-		if ((memcmp(&tmp->lgi.func_array,func_array,sizeof(t_user_cancelling_func_array))==0) &&
-			(tmp->lgi.privateCancelPtr == privateCancelPtr))
-		{
-			if (tmp_previous == NULL)
-				p_user_cancelling_info_list = tmp->next;
-			else
-				tmp_previous->next = tmp->next;
+    while (tmp != NULL)
+    {
+        if ((memcmp(&tmp->lgi.func_array,func_array,sizeof(t_user_cancelling_func_array))==0) &&
+            (tmp->lgi.privateCancelPtr == privateCancelPtr))
+        {
+            if (tmp_previous == NULL)
+                p_user_cancelling_info_list = tmp->next;
+            else
+                tmp_previous->next = tmp->next;
 
-			if ((tmp->lgi.func_array.fnc_Uninit_User_Cancelling) != NULL)
-				(*(tmp->lgi.func_array.fnc_Uninit_User_Cancelling))(tmp->lgi.privateCancelPtr);
+            if ((tmp->lgi.func_array.fnc_Uninit_User_Cancelling) != NULL)
+                (*(tmp->lgi.func_array.fnc_Uninit_User_Cancelling))(tmp->lgi.privateCancelPtr);
 
-			free(tmp);
-			return 1;
-		}
-		tmp_previous = tmp;
-		tmp = tmp->next;
-	}
-	return 0;
+            free(tmp);
+            return 1;
+        }
+        tmp_previous = tmp;
+        tmp = tmp->next;
+    }
+    return 0;
 }
 
 
@@ -120,23 +120,23 @@ UNITEX_FUNC int UNITEX_CALL GetNbUserCancellingInfoInstalled()
 {
     int count=0;
     struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         count++;
-		tmp = tmp->next;
-	}
-	return count;
+        tmp = tmp->next;
+    }
+    return count;
 }
 
 int is_cancelling_requested()
 {
     struct List_UserCancellingInfo* tmp = p_user_cancelling_info_list;
-	while (tmp != NULL)
-	{
+    while (tmp != NULL)
+    {
         if (((*(tmp->lgi.func_array.fnc_is_cancelling))(tmp->lgi.privateCancelPtr)) != 0)
             return 1;
         tmp = tmp->next;
-	}
+    }
     return 0;
 }
 

--- a/UserCancelling.h
+++ b/UserCancelling.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -40,7 +40,7 @@
 
 namespace unitex {
 #endif
-    
+
 int is_cancelling_requested();
 
 #ifdef __cplusplus

--- a/UserCancellingPlugCallback.h
+++ b/UserCancellingPlugCallback.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -56,7 +56,7 @@ extern "C" {
  */
 
 
-/* there fopen callback are called when an Unitex tool open a file 
+/* there fopen callback are called when an Unitex tool open a file
  *  In the Unitex context, MODE is one of these value :
  *   - "rb" : open the file in read only mode
  *   - "wb" : open the file in write only mode (the previous file is erased, if exist)

--- a/Ustring.cpp
+++ b/Ustring.cpp
@@ -290,7 +290,7 @@ void u_strcpy(Ustring* ustr,const unichar* str,unsigned int length) {
     for (unsigned int i=0;i<length;i++) {
        ustr->str[i]=str[i];
   }
-    
+
   ustr->str[newlen] = 0;
   ustr->len=newlen;
 }

--- a/Ustring.cpp
+++ b/Ustring.cpp
@@ -177,7 +177,7 @@ ustr->size=buffer_size;
  */
 void truncate(Ustring* ustr,unsigned int length) {
 if (length>ustr->len) {
-	fatal_error("Cannot truncate Ustring of length %u to greater size %u\n",ustr->len,length);
+    fatal_error("Cannot truncate Ustring of length %u to greater size %u\n",ustr->len,length);
 }
 ustr->len=length;
 ustr->str[length]='\0';
@@ -217,11 +217,11 @@ ustr->len=newlen;
 void u_strcat(Ustring* ustr,unichar c) {
 unsigned int newlen=ustr->len+1;
 if (ustr->size<newlen+1) {
-	/* If necessary, we enlarge the internal buffer */
-	unsigned int n=ustr->size;
-	if (n==0) n=1;
+    /* If necessary, we enlarge the internal buffer */
+    unsigned int n=ustr->size;
+    if (n==0) n=1;
     while (n<=newlen+1) {
-    	n=n*2;
+        n=n*2;
     }
     resize(ustr,n);
 }
@@ -243,8 +243,8 @@ if (str==NULL || str[0]=='\0' || length==0) {
 unsigned int newlen=ustr->len+length;
 if (ustr->size<newlen+1) {
    /* If necessary, we enlarge the internal buffer */
-	unsigned int n=ustr->size;
-	if (n==0) n=1;
+    unsigned int n=ustr->size;
+    if (n==0) n=1;
    while (n<=newlen+1) {
        n=n*2;
    }
@@ -374,8 +374,8 @@ Ustring* s=new_Ustring();
 int ret=readline(s,f);
 unichar* result=NULL;
 if (ret!=EOF) {
-	result=s->str;
-	s->str=NULL;
+    result=s->str;
+    s->str=NULL;
 }
 free_Ustring(s);
 return result;

--- a/Ustring.h
+++ b/Ustring.h
@@ -89,7 +89,7 @@ int readline_keep_CR(Ustring*,U_FILE*);
 int readline(Ustring*,U_FILE*);
 unichar* readline_safe(U_FILE* f);
 
-    
+
 void u_strcpy(Ustring* ustr,const unichar* str,unsigned int length);
 
 /* Inline implementations */
@@ -125,9 +125,9 @@ return s->len;
 
 static inline unichar* free_Ustring_get_str(Ustring*s)
 {
-	unichar*str = s->str;
-	free(s);
-	return str;
+    unichar*str = s->str;
+    free(s);
+    return str;
 }
 
 
@@ -160,7 +160,7 @@ u_strcat(ustr,(char*)str,(int)strlen(str));
  * Copies 'src' content in to the given Ustring, whose previous content
  * is lost.
  */
-    
+
 static inline void u_strcpy(Ustring* dest,const unichar* str) {
 if (dest==NULL) {
    fatal_error("NULL Ustring error in u_strcpy\n");

--- a/VariableUtils.cpp
+++ b/VariableUtils.cpp
@@ -34,7 +34,7 @@ struct transduction_variable* v=get_transduction_variable(p->input_variables,nam
 if (v==NULL || v->start_in_tokens==UNDEF_VAR_BOUND || v->end_in_tokens==UNDEF_VAR_BOUND
     || v->start_in_tokens>v->end_in_tokens
     || (v->start_in_tokens==v->end_in_tokens && v->end_in_chars!=-1 && v->end_in_chars<v->start_in_chars)) {
- 	return NULL;
+    return NULL;
 }
 Ustring* res=new_Ustring(128);
 /* Case 1: start and end in the same token*/
@@ -42,22 +42,22 @@ if (v->start_in_tokens==v->end_in_tokens-1) {
    unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
    int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
    for (int k=v->start_in_chars;k<=last;k++) {
-	   u_strcat(res,tok[k]);
+       u_strcat(res,tok[k]);
    }
 } else {
-	/* Case 2: first we deal with first token */
-	unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
-	u_strcat(res,tok+v->start_in_chars);
-	/* Then we copy all tokens until the last one */
-	for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
-		u_strcat(res,p->tokens->value[p->buffer[k+p->current_origin]]);
-	}
-	/* Finally, we copy the last token */
-	tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
-	int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
-	for (int k=0;k<=last;k++) {
-		u_strcat(res,tok[k]);
-	}
+    /* Case 2: first we deal with first token */
+    unichar* tok=p->tokens->value[p->buffer[v->start_in_tokens+p->current_origin]];
+    u_strcat(res,tok+v->start_in_chars);
+    /* Then we copy all tokens until the last one */
+    for (int k=v->start_in_tokens+1;k<v->end_in_tokens-1;k++) {
+        u_strcat(res,p->tokens->value[p->buffer[k+p->current_origin]]);
+    }
+    /* Finally, we copy the last token */
+    tok=p->tokens->value[p->buffer[v->end_in_tokens-1+p->current_origin]];
+    int last=(v->end_in_chars!=-1) ? (v->end_in_chars) : (((int)u_strlen(tok))-1);
+    for (int k=0;k<=last;k++) {
+        u_strcat(res,tok[k]);
+    }
 }
 return res;
 }
@@ -71,9 +71,9 @@ return new_Ustring(res->str);
 
 
 unichar* get_output_variable_content_str(const unichar* name, struct locate_parameters* p) {
-	const Ustring* res = get_output_variable(p->output_variables, name);
-	if (res == NULL) return NULL;
-	return res->str;
+    const Ustring* res = get_output_variable(p->output_variables, name);
+    if (res == NULL) return NULL;
+    return res->str;
 }
 
 
@@ -85,9 +85,9 @@ return new_Ustring(entry->inflected);
 
 
 unichar* get_dic_variable_content_str(const unichar* name, struct locate_parameters* p) {
-	struct dela_entry* entry = get_dic_variable(name, p->dic_variables);
-	if (entry == NULL) return NULL;
-	return entry->inflected;
+    struct dela_entry* entry = get_dic_variable(name, p->dic_variables);
+    if (entry == NULL) return NULL;
+    return entry->inflected;
 }
 
 /**
@@ -96,8 +96,8 @@ unichar* get_dic_variable_content_str(const unichar* name, struct locate_paramet
  */
 Ustring* get_var_content(unichar* name,struct locate_parameters* p) {
 if (name[0]=='#') {
-	/* The user asked for a constant string */
-	return new_Ustring(name+1);
+    /* The user asked for a constant string */
+    return new_Ustring(name+1);
 }
 Ustring* res=get_variable_content(name,p);
 if (res!=NULL) return res;
@@ -108,19 +108,19 @@ return get_dic_variable_content_Ustring(name,p);
 
 
 unichar* get_var_content_str(const unichar* name, struct locate_parameters* p, int*free_needed) {
-	*free_needed = 0;
-	if (name[0] == '#') {
-		/* The user asked for a constant string */
-		return (unichar*)name + 1;
-	}
-	Ustring* res = get_variable_content(name, p);
-	if (res != NULL) {
-		*free_needed = 1;
-		return free_Ustring_get_str(res);
-	}
-	unichar* str = get_output_variable_content_str(name, p);
-	if (str != NULL) return str;
-	return get_dic_variable_content_str(name, p);
+    *free_needed = 0;
+    if (name[0] == '#') {
+        /* The user asked for a constant string */
+        return (unichar*)name + 1;
+    }
+    Ustring* res = get_variable_content(name, p);
+    if (res != NULL) {
+        *free_needed = 1;
+        return free_Ustring_get_str(res);
+    }
+    unichar* str = get_output_variable_content_str(name, p);
+    if (str != NULL) return str;
+    return get_dic_variable_content_str(name, p);
 }
 
 
@@ -137,19 +137,19 @@ int compare_variables(const unichar* var1,const unichar* var2,struct locate_para
 int free_v1;
 unichar* v1=get_var_content_str(var1,p,&free_v1);
 if (!v1) {
-	return VAR_CMP_ERROR;
+    return VAR_CMP_ERROR;
 }
 int free_v2;
 unichar* v2=get_var_content_str(var2,p,&free_v2);
 if (!v2) {
-	if (free_v1) free(v1);
-	return VAR_CMP_ERROR;
+    if (free_v1) free(v1);
+    return VAR_CMP_ERROR;
 }
 int ret=case_matters?u_strcmp(v1,v2):u_strcmp_ignore_case(v1,v2);
 if (free_v1) free(v1);
 if (free_v2) free(v2);
 if (ret==0) {
-	return VAR_CMP_EQUAL;
+    return VAR_CMP_EQUAL;
 }
 return VAR_CMP_DIFF;
 }
@@ -160,19 +160,19 @@ DISCARD_UNUSED_PARAMETER(case_matters)
 int free_v1;
 unichar* v1 = get_var_content_str(var1, p, &free_v1);
 if (!v1) {
-	return VAR_CMP_ERROR;
+    return VAR_CMP_ERROR;
 }
 int free_v2;
 unichar* v2 = get_var_content_str(var2, p, &free_v2);
 if (!v2) {
-	if (free_v1) free(v1);
-	return VAR_CMP_ERROR;
+    if (free_v1) free(v1);
+    return VAR_CMP_ERROR;
 }
 int ret=u_substr(v1,v2);
 if (free_v1) free(v1);
 if (free_v2) free(v2);
 if (ret != 0) {
-	return VAR_CMP_EQUAL;
+    return VAR_CMP_EQUAL;
 }
 return VAR_CMP_DIFF;
 }

--- a/Vector.h
+++ b/Vector.h
@@ -34,7 +34,7 @@ namespace unitex {
 
 /**
  * This library provides implementations of autoresizable arrays:
- * 
+ *
  * - vector_ptr:    data type=void*
  * - vector_int:    data type=int
  * - vector_float:  data type=float
@@ -187,7 +187,7 @@ if (dst==NULL) return;
 dst->nbelems=0;
 if (src==NULL) return;
 for (int i=0;i<src->nbelems;i++) {
-	vector_int_add(dst,src->tab[i],prv_alloc);
+    vector_int_add(dst,src->tab[i],prv_alloc);
 }
 }
 
@@ -196,7 +196,7 @@ inline vector_int* vector_int_dup(vector_int* src,Abstract_allocator prv_alloc=N
 if (src==NULL) return NULL;
 vector_int* dst=new_vector_int(src->nbelems,prv_alloc);
 for (int i=0;i<src->nbelems;i++) {
-	vector_int_add(dst,src->tab[i],prv_alloc);
+    vector_int_add(dst,src->tab[i],prv_alloc);
 }
 return dst;
 }
@@ -302,7 +302,7 @@ return vec->nbelems-1;
 
 inline int vector_int_contains(vector_int* v,int n) {
 for (int i=0;i<v->nbelems;i++) {
-	if (v->tab[i]==n) return i;
+    if (v->tab[i]==n) return i;
 }
 return -1;
 }
@@ -310,7 +310,7 @@ return -1;
 
 inline int vector_float_contains(vector_float* v,float n) {
 for (int i=0;i<v->nbelems;i++) {
-	if (v->tab[i]==n) return i;
+    if (v->tab[i]==n) return i;
 }
 return -1;
 }
@@ -318,7 +318,7 @@ return -1;
 
 inline int vector_double_contains(vector_double* v,double n) {
 for (int i=0;i<v->nbelems;i++) {
-	if (v->tab[i]==n) return i;
+    if (v->tab[i]==n) return i;
 }
 return -1;
 }
@@ -326,7 +326,7 @@ return -1;
 
 inline int vector_ptr_contains(vector_ptr* v,void* n) {
 for (int i=0;i<v->nbelems;i++) {
-	if (v->tab[i]==n) return i;
+    if (v->tab[i]==n) return i;
 }
 return -1;
 }
@@ -334,28 +334,28 @@ return -1;
 
 inline void vector_int_add_if_absent(vector_int* vec,int data) {
 if (-1==vector_int_contains(vec,data)) {
-	vector_int_add(vec,data);
+    vector_int_add(vec,data);
 }
 }
 
 
 inline void vector_float_add_if_absent(vector_float* vec,float data) {
 if (-1==vector_float_contains(vec,data)) {
-	vector_float_add(vec,data);
+    vector_float_add(vec,data);
 }
 }
 
 
 inline void vector_double_add_if_absent(vector_double* vec,double data) {
 if (-1==vector_double_contains(vec,data)) {
-	vector_double_add(vec,data);
+    vector_double_add(vec,data);
 }
 }
 
 
 inline void vector_ptr_add_if_absent(vector_ptr* vec,void* data) {
 if (-1==vector_ptr_contains(vec,data)) {
-	vector_ptr_add(vec,data);
+    vector_ptr_add(vec,data);
 }
 }
 
@@ -405,7 +405,7 @@ return 1;
 inline int vector_int_equals(vector_int* a,vector_int* b) {
 if (a->nbelems!=b->nbelems) return 0;
 for (int i=0;i<a->nbelems;i++) {
-	if (a->tab[i]!=b->tab[i]) return 0;
+    if (a->tab[i]!=b->tab[i]) return 0;
 }
 return 1;
 }
@@ -417,7 +417,7 @@ return 1;
 inline int vector_float_equals(vector_float* a,vector_float* b) {
 if (a->nbelems!=b->nbelems) return 0;
 for (int i=0;i<a->nbelems;i++) {
-	if (a->tab[i]!=b->tab[i]) return 0;
+    if (a->tab[i]!=b->tab[i]) return 0;
 }
 return 1;
 }
@@ -429,7 +429,7 @@ return 1;
 inline int vector_double_equals(vector_double* a,vector_double* b) {
 if (a->nbelems!=b->nbelems) return 0;
 for (int i=0;i<a->nbelems;i++) {
-	if (a->tab[i]!=b->tab[i]) return 0;
+    if (a->tab[i]!=b->tab[i]) return 0;
 }
 return 1;
 }
@@ -441,7 +441,7 @@ return 1;
 inline int vector_ptr_equals(vector_ptr* a,vector_ptr* b) {
 if (a->nbelems!=b->nbelems) return 0;
 for (int i=0;i<a->nbelems;i++) {
-	if (a->tab[i]!=b->tab[i]) return 0;
+    if (a->tab[i]!=b->tab[i]) return 0;
 }
 return 1;
 }

--- a/VersionInfo.cpp
+++ b/VersionInfo.cpp
@@ -273,14 +273,14 @@ if (do_json_info) {
     u_sprintf(DisplayText,"%s", buf);
 } else if (do_user_friendly_info) {
     char buf[0x200]="";
-	strcpy(buf, get_unitex_verbose_version_string());
+    strcpy(buf, get_unitex_verbose_version_string());
     u_sprintf(DisplayText,"%s", buf);
 } else if (do_semver_info) {
     char buf[0x200]="";
-	strcpy(buf,get_unitex_semver_string());
+    strcpy(buf,get_unitex_semver_string());
     u_sprintf(DisplayText,"%s", buf);
 } else if (do_copyright_only) {
-	get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
+    get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
 }
 else if (do_revision_only) {
     u_sprintf(DisplayText,"%d",revision);
@@ -290,12 +290,12 @@ else if (do_version_only) {
 }
 else {
     if (revision == -1) {
-		get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
+        get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
         u_sprintf(DisplayText+u_strlen(DisplayText),"\nUnitex Version: %u.%u\n",
                 unitexMajorVersion,unitexMinorVersion);
     }
     else {
-		get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
+        get_copyright_notice(DisplayText, MAX_SIZE_DISPLAY_TEXT);
         u_sprintf(DisplayText+u_strlen(DisplayText),"\nUnitex Version: %u.%u\nUnitex SVN revision: %d\n",
                 unitexMajorVersion,unitexMinorVersion,revision);
     }

--- a/VersionInfo.cpp
+++ b/VersionInfo.cpp
@@ -216,7 +216,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_VersionInfo,lopts_Versio
              break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_VersionInfo[index].name);
@@ -345,11 +345,11 @@ else {
 
 free(DisplayText);
 
-// FIXME(gvollant) To conform with the C/C++ standard, isn't a good idea to 
+// FIXME(gvollant) To conform with the C/C++ standard, isn't a good idea to
 // return a custom integer equal to get_unitex_revision() here
 // An exit value greater than 255 returns an exit code modulo 256
 // see http://www.tldp.org/LDP/abs/html/exitcodes.html#AEN23629
-return retValue; 
+return retValue;
 }
 
 } // namespace unitex

--- a/VersionInfo.h
+++ b/VersionInfo.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/VirtualFiles.cpp
+++ b/VirtualFiles.cpp
@@ -50,18 +50,18 @@ static void fill_fileio_func_array_extensible(t_fileio_func_array_extensible * m
 * Description of a VFS inode.
 */
 typedef struct VFS_INODE_ {
-	struct VFS* vfs;
-	char* name;
-	void* ptr;
-	unsigned long size;
-	unsigned long capacity;
-	int open_in_write_mode;
-	/* How many open pointers have we on this inode ?
-	* If we don't know, we can't make remove operation safely */
-	int n_open;
-	int to_remove;
+    struct VFS* vfs;
+    char* name;
+    void* ptr;
+    unsigned long size;
+    unsigned long capacity;
+    int open_in_write_mode;
+    /* How many open pointers have we on this inode ?
+    * If we don't know, we can't make remove operation safely */
+    int n_open;
+    int to_remove;
 
-	struct VFS_INODE_* next;
+    struct VFS_INODE_* next;
 } VFS_INODE;
 
 
@@ -69,9 +69,9 @@ typedef struct VFS_INODE_ {
 * Description of a file pointer returned by our open.
 */
 typedef struct {
-	VFS_INODE* inode;
-	TYPEOPEN_MF open_type;
-	unsigned long pos;
+    VFS_INODE* inode;
+    TYPEOPEN_MF open_type;
+    unsigned long pos;
 } VFS_FILE;
 
 
@@ -79,9 +79,9 @@ typedef struct {
 * Description of the VFS space
 */
 struct VFS {
-	const char* pfx;
-	int default_block_size;
-	VFS_INODE* list;
+    const char* pfx;
+    int default_block_size;
+    VFS_INODE* list;
 };
 
 
@@ -92,38 +92,38 @@ static struct VFS VFS_id = { VIRTUAL_FILE_PFX, 4096, NULL };
 class InitVirtualFiles
 {
 public:
-	InitVirtualFiles();
-	~InitVirtualFiles();
-	inline SYNC_Mutex_OBJECT getMutex() { return mutex; };
-	void performInit();
-	void performUninit();
+    InitVirtualFiles();
+    ~InitVirtualFiles();
+    inline SYNC_Mutex_OBJECT getMutex() { return mutex; };
+    void performInit();
+    void performUninit();
 private:
-	SYNC_Mutex_OBJECT mutex;
-	bool init_done;
+    SYNC_Mutex_OBJECT mutex;
+    bool init_done;
 };
 
 InitVirtualFiles::InitVirtualFiles()
-	: mutex(NULL),init_done(false)
+    : mutex(NULL),init_done(false)
 {
-	performInit();
+    performInit();
 }
 
 InitVirtualFiles::~InitVirtualFiles()
 {
-	performUninit();
+    performUninit();
 }
 
 void InitVirtualFiles::performInit()
 {
 if (init_done) {
-	return;
+    return;
 }
 mutex = SyncBuildMutex();
 t_fileio_func_array_extensible my_VFS;
 fill_fileio_func_array_extensible(&my_VFS);
 
 if (!AddAbstractFileSpaceExtensible(&my_VFS, &VFS_id)) {
-	fatal_error("Cannot create virtual file system\n");
+    fatal_error("Cannot create virtual file system\n");
 }
 init_done = true;
 }
@@ -131,19 +131,19 @@ init_done = true;
 void InitVirtualFiles::performUninit()
 {
 if (!init_done) {
-	return;
+    return;
 }
 
 t_fileio_func_array_extensible my_VFS;
 fill_fileio_func_array_extensible(&my_VFS);
 
 if (!RemoveAbstractFileSpaceExtensible(&my_VFS, &VFS_id)) {
-	fatal_error("Cannot uninstall virtual file system\n");
+    fatal_error("Cannot uninstall virtual file system\n");
 }
 
 if (mutex != NULL) {
-	SyncDeleteMutex(mutex);
-	mutex = NULL;
+    SyncDeleteMutex(mutex);
+    mutex = NULL;
 }
 init_done = false;
 }
@@ -153,11 +153,11 @@ static InitVirtualFiles InitVirtualFilesInstance;
 // init_virtual_files is not a public api. it is here only for compatibility
 
 void init_virtual_files() {
-	return InitVirtualFilesInstance.performInit();
+    return InitVirtualFilesInstance.performInit();
 }
 
 void uninit_virtual_files() {
-	return InitVirtualFilesInstance.performUninit();
+    return InitVirtualFilesInstance.performUninit();
 }
 
 #define VFS_mutex (InitVirtualFilesInstance.getMutex())
@@ -179,11 +179,11 @@ static VFS_INODE* get_inode(VFS* vfs,const char* name) {
 SyncGetMutex(VFS_mutex);
 VFS_INODE* inode=vfs->list;
 while (inode!=NULL) {
-	if (!strcmp(inode->name,name)) {
-		SyncReleaseMutex(VFS_mutex);
-		return inode;
-	}
-	inode=inode->next;
+    if (!strcmp(inode->name,name)) {
+        SyncReleaseMutex(VFS_mutex);
+        return inode;
+    }
+    inode=inode->next;
 }
 SyncReleaseMutex(VFS_mutex);
 return NULL;
@@ -194,18 +194,18 @@ static VFS_INODE* create_inode(VFS* vfs,const char* name,TYPEOPEN_MF TypeOpen) {
 DISCARD_UNUSED_PARAMETER(TypeOpen)
 VFS_INODE* inode=(VFS_INODE*)malloc(sizeof(VFS_INODE));
 if (inode==NULL) {
-	fatal_alloc_error("create_inode");
+    fatal_alloc_error("create_inode");
 }
 inode->vfs=vfs;
 inode->name=strdup(name);
 if (inode->name==NULL) {
-	fatal_alloc_error("create_inode");
+    fatal_alloc_error("create_inode");
 }
 inode->size=0;
 inode->capacity=inode->vfs->default_block_size;
 inode->ptr=malloc(inode->capacity);
 if (inode->ptr==NULL) {
-	fatal_alloc_error("create_inode");
+    fatal_alloc_error("create_inode");
 }
 inode->open_in_write_mode=0;
 inode->n_open=0;
@@ -220,15 +220,15 @@ return inode;
 
 static VFS_INODE* remove_inode(VFS_INODE* list,VFS_INODE* inode) {
 if (list==NULL) {
-	return NULL;
+    return NULL;
 }
 if (list!=inode) {
-	list->next=remove_inode(list->next,inode);
-	return list;
+    list->next=remove_inode(list->next,inode);
+    return list;
 }
 VFS_INODE* next=list->next;
 if (inode->ptr!=NULL) {
-	free(inode->ptr);
+    free(inode->ptr);
 }
 free(inode->name);
 free(inode);
@@ -252,8 +252,8 @@ static int load_file_content(VFS_INODE* inode) {
 SyncGetMutex(VFS_mutex);
 FILE* f=real_fopen(inode->name+strlen(inode->vfs->pfx),"rb");
 if (f==NULL) {
-	SyncReleaseMutex(VFS_mutex);
-	return 0;
+    SyncReleaseMutex(VFS_mutex);
+    return 0;
 }
 fseek(f,0,SEEK_END);
 inode->size=ftell(f);
@@ -261,10 +261,10 @@ inode->capacity=inode->size;
 fseek(f,0,SEEK_SET);
 inode->ptr=malloc(inode->size);
 if (inode->ptr==NULL) {
-	fatal_alloc_error("load_file_content");
+    fatal_alloc_error("load_file_content");
 }
 if (inode->size!=(unsigned long)fread(inode->ptr,1,inode->size,f)) {
-	fatal_error("Error loading content of %s\n",inode->name);
+    fatal_error("Error loading content of %s\n",inode->name);
 }
 fclose(f);
 SyncReleaseMutex(VFS_mutex);
@@ -285,34 +285,34 @@ case OPEN_CREATE_MF: error("open CREATE: %s\n",name); break;
 VFS_INODE* inode=get_inode(vfs,name);
 int inode_created=0;
 if (inode==NULL) {
-	if (TypeOpen == OPEN_READ_MF) {
-		return NULL;
-	}
-	inode=create_inode(vfs,name,TypeOpen);
-	inode_created=1;
+    if (TypeOpen == OPEN_READ_MF) {
+        return NULL;
+    }
+    inode=create_inode(vfs,name,TypeOpen);
+    inode_created=1;
 }
 /* If an inode exists, we must test if there is a concurrent
  * write access on the file */
 if (TypeOpen!=OPEN_READ_MF) {
-	if (inode->open_in_write_mode) {
-		fatal_error("Cannot have a concurrent write access on virtual file %s\n",name);
-	} else {
-		inode->open_in_write_mode=1;
-	}
+    if (inode->open_in_write_mode) {
+        fatal_error("Cannot have a concurrent write access on virtual file %s\n",name);
+    } else {
+        inode->open_in_write_mode=1;
+    }
 }
 if (inode_created && TypeOpen!=OPEN_CREATE_MF) {
-	/* If we have to load the file content from disk, we do it */
-	if (!load_file_content(inode)) {
-		return NULL;
-	}
+    /* If we have to load the file content from disk, we do it */
+    if (!load_file_content(inode)) {
+        return NULL;
+    }
 }
 if (TypeOpen==OPEN_CREATE_MF) {
-	/* A created file must be truncated */
-	inode->size=0;
+    /* A created file must be truncated */
+    inode->size=0;
 }
 VFS_FILE* f=(VFS_FILE*)malloc(sizeof(VFS_FILE));
 if (f==NULL) {
-	fatal_alloc_error("my_fnc_memOpenLowLevel");
+    fatal_alloc_error("my_fnc_memOpenLowLevel");
 }
 f->inode=inode;
 f->open_type=TypeOpen;
@@ -329,12 +329,12 @@ size_t ABSTRACT_CALLBACK_UNITEX my_fnc_memLowLevelRead(ABSTRACTFILE_PTR llFile, 
 DISCARD_UNUSED_PARAMETER(privateSpacePtr)
 VFS_FILE* f=(VFS_FILE*)llFile;
 if (f->open_type==OPEN_CREATE_MF) {
-	/* Cannot read in write-only mode */
-	return 0;
+    /* Cannot read in write-only mode */
+    return 0;
 }
 unsigned int to_read=(unsigned int)(f->inode->size-f->pos);
 if (size<to_read) {
-	to_read=(unsigned int)size;
+    to_read=(unsigned int)size;
 }
 memcpy(Buf,((char*)f->inode->ptr)+f->pos,to_read);
 f->pos+=to_read;
@@ -349,24 +349,24 @@ size_t ABSTRACT_CALLBACK_UNITEX my_fnc_memLowLevelWrite(ABSTRACTFILE_PTR llFile,
 DISCARD_UNUSED_PARAMETER(privateSpacePtr)
 VFS_FILE* f=(VFS_FILE*)llFile;
 if (f->open_type==OPEN_READ_MF) {
-	/* Cannot write in read-only mode */
-	return 0;
+    /* Cannot write in read-only mode */
+    return 0;
 }
 if (f->pos+size>f->inode->capacity) {
-	/* We need to enlarge our buffer */
-	unsigned int n=(unsigned int)(f->inode->capacity);
-	if (n==0) n=1;
-	while (f->pos+size>n) n=n*2;
-	f->inode->ptr=realloc(f->inode->ptr,n);
-	if (f->inode->ptr==NULL) {
-		fatal_error("Cannot allocate buffer to write virtual file %s\n",f->inode->name);
-	}
-	f->inode->capacity=n;
+    /* We need to enlarge our buffer */
+    unsigned int n=(unsigned int)(f->inode->capacity);
+    if (n==0) n=1;
+    while (f->pos+size>n) n=n*2;
+    f->inode->ptr=realloc(f->inode->ptr,n);
+    if (f->inode->ptr==NULL) {
+        fatal_error("Cannot allocate buffer to write virtual file %s\n",f->inode->name);
+    }
+    f->inode->capacity=n;
 }
 memcpy((char*)(f->inode->ptr)+f->pos,Buf,size);
 f->pos+=(unsigned long)size;
 if (f->pos>f->inode->size) {
-	f->inode->size=f->pos;
+    f->inode->size=f->pos;
 }
 return size;
 }
@@ -386,8 +386,8 @@ case SEEK_END: new_pos=(int)(f->inode->size+Pos); break;
 }
 if (new_pos<0) return -1;
 if ((unsigned int)new_pos>f->inode->size) {
-	fatal_error("Nasty fseek beyond the end of virtual file %s is not permitted\n",f->inode->name);
-	return -1;
+    fatal_error("Nasty fseek beyond the end of virtual file %s is not permitted\n",f->inode->name);
+    return -1;
 }
 f->pos=new_pos;
 return 0;
@@ -404,14 +404,14 @@ VFS_INODE* inode=f->inode;
 (f->inode->n_open)--;
 /* We have to update the open_in_write_mode flag */
 if (f->open_type!=OPEN_READ_MF) {
-	/* As there should only be one file in write mode at the same time,
-	 * if the current one was, we reset the flag
-	 */
-	f->inode->open_in_write_mode=0;
+    /* As there should only be one file in write mode at the same time,
+     * if the current one was, we reset the flag
+     */
+    f->inode->open_in_write_mode=0;
 }
 free(f);
 if (inode->n_open==0 && inode->to_remove) {
-	delete_inode(inode);
+    delete_inode(inode);
 }
 return 0;
 }
@@ -447,7 +447,7 @@ if (!strcmp(_OldFilename,_NewFilename)) return 0;
 free(inode->name);
 inode->name=strdup(_NewFilename);
 if (inode->name==NULL) {
-	fatal_alloc_error("my_fnc_memFileRename");
+    fatal_alloc_error("my_fnc_memFileRename");
 }
 return 0;
 }
@@ -461,14 +461,14 @@ VFS_INODE* inode=get_inode((VFS*)privateSpacePtr,lpFileName);
 if (inode==NULL) return 1;
 inode->to_remove=1;
 if (inode->n_open==0) {
-	delete_inode(inode);
+    delete_inode(inode);
 }
 return 0;
 }
 
 
 const void* my_fnc_memFile_getMapPointer(ABSTRACTFILE_PTR llFile, afs_size_type pos, afs_size_type /*len*/,int /*options*/,
-		afs_size_type /* value_for_options*/,void* /* privateSpacePtr */) {
+        afs_size_type /* value_for_options*/,void* /* privateSpacePtr */) {
 VFS_FILE* f=(VFS_FILE*)llFile;
 return ((char*)f->inode->ptr)+pos;
 }
@@ -480,45 +480,45 @@ char** VFS_ls() {
 VFS_INODE* inode=VFS_id.list;
 int n=0;
 while (inode!=NULL) {
-	n++;
-	inode=inode->next;
+    n++;
+    inode=inode->next;
 }
 n++;
 char** names=(char**)malloc(n*sizeof(char*));
 if (names==NULL) {
-	fatal_alloc_error("VFS_ls");
+    fatal_alloc_error("VFS_ls");
 }
 inode=VFS_id.list;
 n=0;
 while (inode!=NULL) {
-	names[n]=strdup(inode->name);
-	if (names[n]==NULL) {
-		fatal_alloc_error("VFS_ls");
-	}
-	n++;
-	inode=inode->next;
+    names[n]=strdup(inode->name);
+    if (names[n]==NULL) {
+        fatal_alloc_error("VFS_ls");
+    }
+    n++;
+    inode=inode->next;
 }
 names[n]=NULL;
 return names;
 }
 
 char** ABSTRACT_CALLBACK_UNITEX my_memFile_getList(void* /*privateSpacePtr*/) {
-	return VFS_ls();
+    return VFS_ls();
 }
 
 
 void ABSTRACT_CALLBACK_UNITEX my_memFile_releaseList(char**list,void* /*privateSpacePtr*/)
 {
-	if (list==NULL)
-		return;
+    if (list==NULL)
+        return;
 
-	char** list_walk=list;
-	while ((*list_walk)!=NULL)
-	{
-		free(*list_walk);
-		list_walk++;
-	}
-	free(list);
+    char** list_walk=list;
+    while ((*list_walk)!=NULL)
+    {
+        free(*list_walk);
+        list_walk++;
+    }
+    free(list);
 }
 
 /**
@@ -526,23 +526,23 @@ void ABSTRACT_CALLBACK_UNITEX my_memFile_releaseList(char**list,void* /*privateS
  */
 
 static void fill_fileio_func_array_extensible(t_fileio_func_array_extensible * my_VFS) {
-	memset(my_VFS, 0, sizeof(t_fileio_func_array_extensible));
-	my_VFS->size_func_array = sizeof(t_fileio_func_array_extensible);
-	my_VFS->fnc_is_filename_object = my_fnc_is_filename_object;
-	my_VFS->fnc_Init_FileSpace = NULL;
-	my_VFS->fnc_Uninit_FileSpace = NULL;
-	my_VFS->fnc_memOpenLowLevel = my_fnc_memOpenLowLevel;
-	my_VFS->fnc_memLowLevelWrite = my_fnc_memLowLevelWrite;
-	my_VFS->fnc_memLowLevelRead = my_fnc_memLowLevelRead;
-	my_VFS->fnc_memLowLevelSeek = my_fnc_memLowLevelSeek;
-	my_VFS->fnc_memLowLevelGetSize = my_fnc_memLowLevelGetSize;
-	my_VFS->fnc_memLowLevelTell = my_fnc_memLowLevelTell;
-	my_VFS->fnc_memLowLevelClose = my_fnc_memLowLevelClose;
-	my_VFS->fnc_memLowLevelSetSizeReservation = NULL;
-	my_VFS->fnc_memFileRemove = my_fnc_memFileRemove;
-	my_VFS->fnc_memFileRename = my_fnc_memFileRename;
-	my_VFS->fnc_memFile_getList = my_memFile_getList;
-	my_VFS->fnc_memFile_releaseList = my_memFile_releaseList;
+    memset(my_VFS, 0, sizeof(t_fileio_func_array_extensible));
+    my_VFS->size_func_array = sizeof(t_fileio_func_array_extensible);
+    my_VFS->fnc_is_filename_object = my_fnc_is_filename_object;
+    my_VFS->fnc_Init_FileSpace = NULL;
+    my_VFS->fnc_Uninit_FileSpace = NULL;
+    my_VFS->fnc_memOpenLowLevel = my_fnc_memOpenLowLevel;
+    my_VFS->fnc_memLowLevelWrite = my_fnc_memLowLevelWrite;
+    my_VFS->fnc_memLowLevelRead = my_fnc_memLowLevelRead;
+    my_VFS->fnc_memLowLevelSeek = my_fnc_memLowLevelSeek;
+    my_VFS->fnc_memLowLevelGetSize = my_fnc_memLowLevelGetSize;
+    my_VFS->fnc_memLowLevelTell = my_fnc_memLowLevelTell;
+    my_VFS->fnc_memLowLevelClose = my_fnc_memLowLevelClose;
+    my_VFS->fnc_memLowLevelSetSizeReservation = NULL;
+    my_VFS->fnc_memFileRemove = my_fnc_memFileRemove;
+    my_VFS->fnc_memFileRename = my_fnc_memFileRename;
+    my_VFS->fnc_memFile_getList = my_memFile_getList;
+    my_VFS->fnc_memFile_releaseList = my_memFile_releaseList;
 }
 
 /**
@@ -552,7 +552,7 @@ static void fill_fileio_func_array_extensible(t_fileio_func_array_extensible * m
 long VFS_size(const char* name) {
 VFS_INODE* inode=get_inode(&VFS_id,name);
 if (inode==NULL) {
-	return -1;
+    return -1;
 }
 return inode->size;
 }
@@ -567,7 +567,7 @@ return inode->size;
 void* VFS_content(const char* name) {
 VFS_INODE* inode=get_inode(&VFS_id,name);
 if (inode==NULL) {
-	return NULL;
+    return NULL;
 }
 return inode->ptr;
 }
@@ -580,7 +580,7 @@ return inode->ptr;
 int VFS_reload(const char* name) {
 VFS_INODE* inode=get_inode(&VFS_id,name);
 if (inode==NULL) {
-	return 0;
+    return 0;
 }
 return load_file_content(inode);
 }
@@ -596,11 +596,11 @@ if (inode==NULL) return 0;
 create_path_to_file(name+strlen(inode->vfs->pfx));
 FILE* f=real_fopen(name+strlen(inode->vfs->pfx),"wb");
 if (f==NULL) {
-	return 0;
+    return 0;
 }
 if (inode->size!=fwrite(inode->ptr,1,inode->size,f)) {
-	fclose(f);
-	return 0;
+    fclose(f);
+    return 0;
 }
 fclose(f);
 return 1;
@@ -616,7 +616,7 @@ my_fnc_memFileRemove(inode->name,&VFS_id);
 
 void VFS_reset() {
 while (VFS_id.list!=NULL) {
-	my_fnc_memFileRemove(VFS_id.list->name,&VFS_id);
+    my_fnc_memFileRemove(VFS_id.list->name,&VFS_id);
 }
 }
 

--- a/XMLizer.cpp
+++ b/XMLizer.cpp
@@ -141,11 +141,11 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_XMLizer,lopts_XMLizer,&i
              break;
    case 'V': only_verify_arguments = true;
              break;
-   case 'h': usage(); 
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_XMLizer[index].name);
-             return USAGE_ERROR_CODE;                         
+             return USAGE_ERROR_CODE;
    case 'k': if (options.vars()->optarg[0]=='\0') {
                 error("Empty input_encoding argument\n");
                 return USAGE_ERROR_CODE;
@@ -160,8 +160,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_XMLizer,lopts_XMLizer,&i
              break;
    case '?': index==-1  ? error("Invalid option -%c\n",options.vars()->optopt) :
                           error("Invalid option --%s\n",options.vars()->optarg);
-             return USAGE_ERROR_CODE;             
-  
+             return USAGE_ERROR_CODE;
+
    }
    index=-1;
 }
@@ -247,7 +247,7 @@ int xmlize(const VersatileEncodingConfig* vec,const char* fin,const char* fout,i
 	if (input == NULL) {
     error("Input file '%s' not found!\n", fin);
     return DEFAULT_ERROR_CODE;
-  }  
+  }
 
 	U_FILE* output = u_fopen(UTF8, fout, U_WRITE);
 	if (output == NULL) {

--- a/XMLizer.cpp
+++ b/XMLizer.cpp
@@ -229,7 +229,7 @@ free_fst2txt_parameters(p);
 
 if (output[0]=='\0') {
   remove_extension(input,output);
-	strcat(output,".xml");
+    strcat(output,".xml");
 }
 
 int return_value = xmlize(&vec,snt,output,output_style);
@@ -243,144 +243,144 @@ return return_value;
 
 
 int xmlize(const VersatileEncodingConfig* vec,const char* fin,const char* fout,int ouput_style) {
-	U_FILE* input = u_fopen(vec, fin, U_READ);
-	if (input == NULL) {
+    U_FILE* input = u_fopen(vec, fin, U_READ);
+    if (input == NULL) {
     error("Input file '%s' not found!\n", fin);
     return DEFAULT_ERROR_CODE;
   }
 
-	U_FILE* output = u_fopen(UTF8, fout, U_WRITE);
-	if (output == NULL) {
+    U_FILE* output = u_fopen(UTF8, fout, U_WRITE);
+    if (output == NULL) {
     error("Cannot open output file '%s'!\n", fout);
-		u_fclose(input);
+        u_fclose(input);
     return DEFAULT_ERROR_CODE;
-	} else // FIXME(johndoe) put breaks
+    } else // FIXME(johndoe) put breaks
 
-	if(ouput_style==XML) {
-	   u_fprintf(output, xml_open);
-	}
-	else {
-	   u_fprintf(output, tei_open);
-	}
+    if(ouput_style==XML) {
+       u_fprintf(output, xml_open);
+    }
+    else {
+       u_fprintf(output, tei_open);
+    }
 
   int sentence_count = 1;
   int sentence_count_relative = 1;
   int paragraph_count = 1;
 
-	u_fprintf(output, "<p><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
+    u_fprintf(output, "<p><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
 
-	int current_state = 0;
-	unichar c;
-	int i;
-	while ((i = u_fgetc(input)) != EOF) {
-		c = (unichar)i;
-		switch (current_state) {
-			case 0: {
-				if ( c == '{') current_state = 1;
-				else if(c == '&') u_fprintf(output, "&amp;");
-				else if(c == '<') u_fprintf(output, "&lt;");
-				else if(c == '>') u_fprintf(output, "&gt;");
-				else u_fputc(c, output);
-				break;
-			}
-			case 1: {
-				if (c == 'S') current_state = 2;
-				else {
-					u_fputc('{', output);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 2: {
-				if (c == '}') current_state = 3;
-				else {
-					u_fputc('{', output);
-					u_fputc('S', output);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 3: {
-				if (c == '{') current_state = 4;
-				else if (c == '\n' || c == ' ' || c == '\t') {
-					u_fputc(c, output);
-					current_state = 3;
-				}
-				else {
-					u_fprintf(output, "</s><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 4: {
-				if (c == 'S') current_state = 7;
-				else if (c == 'P') current_state = 5;
-				else {
-					u_fputc('{', output);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 5: {
-				if (c == '}') {
-					u_fprintf(output, "</s></p>\n");
-					paragraph_count++;
-					sentence_count_relative=1;
-					current_state = 6;
-				} else {
-					u_fputc('{', output);
-					u_fputc('P', output);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 6: {
-				if (c == '\n' || c == ' ' || c == '\t') u_fputc(c, output);
-				else {
-					u_fprintf(output, "<p><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-			case 7: {
-				if (c == '}') {
-					current_state = 3;
-				}
-				else {
-					u_fputc('{', output);
-					u_fputc('S', output);
-					u_fputc(c, output);
-					current_state = 0;
-				}
-				break;
-			}
-		}
-	}
+    int current_state = 0;
+    unichar c;
+    int i;
+    while ((i = u_fgetc(input)) != EOF) {
+        c = (unichar)i;
+        switch (current_state) {
+            case 0: {
+                if ( c == '{') current_state = 1;
+                else if(c == '&') u_fprintf(output, "&amp;");
+                else if(c == '<') u_fprintf(output, "&lt;");
+                else if(c == '>') u_fprintf(output, "&gt;");
+                else u_fputc(c, output);
+                break;
+            }
+            case 1: {
+                if (c == 'S') current_state = 2;
+                else {
+                    u_fputc('{', output);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 2: {
+                if (c == '}') current_state = 3;
+                else {
+                    u_fputc('{', output);
+                    u_fputc('S', output);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 3: {
+                if (c == '{') current_state = 4;
+                else if (c == '\n' || c == ' ' || c == '\t') {
+                    u_fputc(c, output);
+                    current_state = 3;
+                }
+                else {
+                    u_fprintf(output, "</s><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 4: {
+                if (c == 'S') current_state = 7;
+                else if (c == 'P') current_state = 5;
+                else {
+                    u_fputc('{', output);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 5: {
+                if (c == '}') {
+                    u_fprintf(output, "</s></p>\n");
+                    paragraph_count++;
+                    sentence_count_relative=1;
+                    current_state = 6;
+                } else {
+                    u_fputc('{', output);
+                    u_fputc('P', output);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 6: {
+                if (c == '\n' || c == ' ' || c == '\t') u_fputc(c, output);
+                else {
+                    u_fprintf(output, "<p><s id=\"n%d\" xml:id=\"d1p%ds%d\">",sentence_count++,paragraph_count,sentence_count_relative++);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+            case 7: {
+                if (c == '}') {
+                    current_state = 3;
+                }
+                else {
+                    u_fputc('{', output);
+                    u_fputc('S', output);
+                    u_fputc(c, output);
+                    current_state = 0;
+                }
+                break;
+            }
+        }
+    }
 
-	if (current_state == 3) {
-		//...
-	} else if (current_state == 6) {
-		//...
-	} else {
-		u_fprintf(output, "</s></p>\n");
-	}
+    if (current_state == 3) {
+        //...
+    } else if (current_state == 6) {
+        //...
+    } else {
+        u_fprintf(output, "</s></p>\n");
+    }
 
-	if(ouput_style==XML) {
-	   u_fprintf(output, xml_close);
-	}
-	else {
-	   u_fprintf(output, tei_close);
-	}
+    if(ouput_style==XML) {
+       u_fprintf(output, xml_close);
+    }
+    else {
+       u_fprintf(output, tei_close);
+    }
 
-	u_fclose(input);
-	u_fclose(output);
-	u_printf("Done.\n");
+    u_fclose(input);
+    u_fclose(output);
+    u_printf("Done.\n");
   return SUCCESS_RETURN_CODE;
 }
 

--- a/XMLizer.h
+++ b/XMLizer.h
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
  *
  */
-  
+
 #ifndef XMLizerH
 #define XMLizerH
 

--- a/Xml.cpp
+++ b/Xml.cpp
@@ -32,9 +32,9 @@
 namespace unitex {
 
 int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-		UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien);
+        UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien);
 int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-		void* html_ctx);
+        void* html_ctx);
 
 
 /**
@@ -45,38 +45,38 @@ int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset
  * (i.e. skipping script code, replacing any tag by a space).
  */
 int unxmlize(U_FILE* input,U_FILE* output,vector_offset* offsets,UnxmlizeOpts* options,
-		unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation) {
+        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation) {
 int c;
 int pos=0,new_pos=0;
 void* html_ctx=init_HTML_character_context();
 while ((c=u_fgetc_raw(input))!=EOF) {
-	int markup_malformation=0;
-	pos++;
-	if (c=='<') {
-		if (!skip_tag(input,output,&pos,&new_pos,offsets,options,bastien,f_bastien)) {
-			//free_HTML_character_context(html_ctx);
-			markup_malformation=1;
-		}
-	}
-	else if (c=='&') {
-		if (!decode_html_char(input,output,&pos,&new_pos,offsets,html_ctx)) {
-			//free_HTML_character_context(html_ctx);
-			markup_malformation=1;
-		}
-	} else {
-		u_fputc_raw((unichar)c,output);
-		new_pos++;
-	}
+    int markup_malformation=0;
+    pos++;
+    if (c=='<') {
+        if (!skip_tag(input,output,&pos,&new_pos,offsets,options,bastien,f_bastien)) {
+            //free_HTML_character_context(html_ctx);
+            markup_malformation=1;
+        }
+    }
+    else if (c=='&') {
+        if (!decode_html_char(input,output,&pos,&new_pos,offsets,html_ctx)) {
+            //free_HTML_character_context(html_ctx);
+            markup_malformation=1;
+        }
+    } else {
+        u_fputc_raw((unichar)c,output);
+        new_pos++;
+    }
 
-	if (markup_malformation!=0) {
-		if (tolerate_markup_malformation==0) {
-			free_HTML_character_context(html_ctx);
-			return 0;
-		} else {
-		  u_fputc_raw((unichar)c,output);
-		  new_pos++;
-		}
-	}
+    if (markup_malformation!=0) {
+        if (tolerate_markup_malformation==0) {
+            free_HTML_character_context(html_ctx);
+            return 0;
+        } else {
+          u_fputc_raw((unichar)c,output);
+          new_pos++;
+        }
+    }
 }
 free_HTML_character_context(html_ctx);
 return 1;
@@ -85,7 +85,7 @@ return 1;
 
 void write_offsets(vector_offset* offsets,int a,int b,int c,int d) {
 if (offsets!=NULL) {
-	vector_offset_add(offsets,a,b,c,d);
+    vector_offset_add(offsets,a,b,c,d);
 }
 }
 
@@ -97,26 +97,26 @@ if (offsets!=NULL) {
 int skip_comment(U_FILE* f,int *pos) {
 int c,state=0;
 while (state!=3) {
-	c=u_fgetc_raw(f);
-	if (c==EOF) return 0;
-	(*pos)++;
-	switch(state) {
-	case 0: {
-		if (c=='-') state=1;
-		break;
-	}
-	case 1: {
-		if (c=='-') state=2;
-		else state=0;
-		break;
-	}
-	case 2: {
-		if (c=='-') state=2;
-		else if (c=='>') state=3;
-		else state=0;
-		break;
-	}
-	}
+    c=u_fgetc_raw(f);
+    if (c==EOF) return 0;
+    (*pos)++;
+    switch(state) {
+    case 0: {
+        if (c=='-') state=1;
+        break;
+    }
+    case 1: {
+        if (c=='-') state=2;
+        else state=0;
+        break;
+    }
+    case 2: {
+        if (c=='-') state=2;
+        else if (c=='>') state=3;
+        else state=0;
+        break;
+    }
+    }
 }
 return 1;
 }
@@ -128,8 +128,8 @@ return 1;
  */
 int read(U_FILE* f,const char* seq) {
 while (*seq) {
-	if (u_fgetc_raw(f)!=*seq) return 0;
-	seq++;
+    if (u_fgetc_raw(f)!=*seq) return 0;
+    seq++;
 }
 return 1;
 }
@@ -141,9 +141,9 @@ return 1;
 int read2(U_FILE* f,const char* seq) {
 int c;
 while (*seq) {
-	c=u_fgetc_raw(f);
-	if (u_toupper((unichar)c)!=u_toupper(*seq)) return 0;
-	seq++;
+    c=u_fgetc_raw(f);
+    if (u_toupper((unichar)c)!=u_toupper(*seq)) return 0;
+    seq++;
 }
 return 1;
 }
@@ -157,143 +157,143 @@ return 1;
 int skip_cdata(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets) {
 int c,state=0;
 while (state!=3) {
-	c=u_fgetc_raw(f);
-	if (c==EOF) return 0;
-	(*pos)++;
-	switch (state) {
-	case 0: {
-		if (c==']') state=1;
-		else if (c=='&') state=4;
-		else {
-			u_fputc_raw((unichar)c,f_out);
-			(*new_pos)++;
-			state=0;
-		}
-		break;
-	}
-	case 1: {
-		if (c==']') state=2;
-		else if (c=='&') {
-			/* To come here, we had read a ] that will not be used as a
-			 * part of ]]> so we have to dump this char in the output file */
-			state=4;
-			u_fputc_raw(']',f_out);
-			(*new_pos)++;
-		}
-		else {
-			/* We have to save ]c */
-			u_fputc_raw(']',f_out);
-			u_fputc_raw((unichar)c,f_out);
-			(*new_pos)+=2;
-			state=0;
-		}
-		break;
-	}
-	case 2: {
-		if (c==']') {
-			/* This is the third ], we have to save one */
-			u_fputc_raw(']',f_out);
-			(*new_pos)++;
-			state=2;
-		}
-		else if (c=='&') {
-			/* We have ]] to save */
-			u_fputc_raw(']',f_out);
-			u_fputc_raw(']',f_out);
-			(*new_pos)+=2;
-			state=4;
-		}
-		else if (c=='>') state=3;
-		else {
-			/* We have ]]c to save */
-			u_fputc_raw(']',f_out);
-			u_fputc_raw(']',f_out);
-			u_fputc_raw((unichar)c,f_out);
-			(*new_pos)+=3;
-			state=0;
-		}
-		break;
-	}
-	case 4: {
-		if (c==']') {
-			/* We have & to save */
-			u_fputc_raw('&',f_out);
-			(*new_pos)++;
-			state=1;
-		}
-		else if (c=='&') {
-			/* We have & to save */
-			u_fputc_raw('&',f_out);
-			(*new_pos)++;
-			state=4;
-		}
-		else if (c=='g') state=5;
-		else {
-			/* We have &c to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw((unichar)c,f_out);
-			(*new_pos)+=2;
-			state=0;
-		}
-		break;
-	}
-	case 5: {
-		if (c==']') {
-			/* We have &g to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			(*new_pos)+=2;
-			state=1;
-		} else if (c=='&') {
-			/* We have &g to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			(*new_pos)+=2;
-			state=4;
-		} else if (c=='t') state=6;
-		else {
-			/* We have &g to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			(*new_pos)+=2;
-			state=0;
-		}
-		break;
-	}
-	case 6: {
-		if (c==']') {
-			/* We have &gt to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			u_fputc_raw('t',f_out);
-			(*new_pos)+=3;
-			state=1;
-		}
-		else if (c=='&') {
-			/* We have &gt to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			u_fputc_raw('t',f_out);
-			(*new_pos)+=3;
-			state=4;
-		} else if (c==';') {
-			/* We have to replace &gt; by > */
-			u_fputc_raw('>',f_out);
-			write_offsets(offsets,(*pos)-4,*pos,*new_pos,(*new_pos)+1);
-			(*new_pos)++;
-			state=0;
-		}
-		else {
-			/* We have &gt to save */
-			u_fputc_raw('&',f_out);
-			u_fputc_raw('g',f_out);
-			u_fputc_raw('t',f_out);
-			(*new_pos)+=3;
-			state=0;
-		}
-		break;
-	}
-	}
+    c=u_fgetc_raw(f);
+    if (c==EOF) return 0;
+    (*pos)++;
+    switch (state) {
+    case 0: {
+        if (c==']') state=1;
+        else if (c=='&') state=4;
+        else {
+            u_fputc_raw((unichar)c,f_out);
+            (*new_pos)++;
+            state=0;
+        }
+        break;
+    }
+    case 1: {
+        if (c==']') state=2;
+        else if (c=='&') {
+            /* To come here, we had read a ] that will not be used as a
+             * part of ]]> so we have to dump this char in the output file */
+            state=4;
+            u_fputc_raw(']',f_out);
+            (*new_pos)++;
+        }
+        else {
+            /* We have to save ]c */
+            u_fputc_raw(']',f_out);
+            u_fputc_raw((unichar)c,f_out);
+            (*new_pos)+=2;
+            state=0;
+        }
+        break;
+    }
+    case 2: {
+        if (c==']') {
+            /* This is the third ], we have to save one */
+            u_fputc_raw(']',f_out);
+            (*new_pos)++;
+            state=2;
+        }
+        else if (c=='&') {
+            /* We have ]] to save */
+            u_fputc_raw(']',f_out);
+            u_fputc_raw(']',f_out);
+            (*new_pos)+=2;
+            state=4;
+        }
+        else if (c=='>') state=3;
+        else {
+            /* We have ]]c to save */
+            u_fputc_raw(']',f_out);
+            u_fputc_raw(']',f_out);
+            u_fputc_raw((unichar)c,f_out);
+            (*new_pos)+=3;
+            state=0;
+        }
+        break;
+    }
+    case 4: {
+        if (c==']') {
+            /* We have & to save */
+            u_fputc_raw('&',f_out);
+            (*new_pos)++;
+            state=1;
+        }
+        else if (c=='&') {
+            /* We have & to save */
+            u_fputc_raw('&',f_out);
+            (*new_pos)++;
+            state=4;
+        }
+        else if (c=='g') state=5;
+        else {
+            /* We have &c to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw((unichar)c,f_out);
+            (*new_pos)+=2;
+            state=0;
+        }
+        break;
+    }
+    case 5: {
+        if (c==']') {
+            /* We have &g to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            (*new_pos)+=2;
+            state=1;
+        } else if (c=='&') {
+            /* We have &g to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            (*new_pos)+=2;
+            state=4;
+        } else if (c=='t') state=6;
+        else {
+            /* We have &g to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            (*new_pos)+=2;
+            state=0;
+        }
+        break;
+    }
+    case 6: {
+        if (c==']') {
+            /* We have &gt to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            u_fputc_raw('t',f_out);
+            (*new_pos)+=3;
+            state=1;
+        }
+        else if (c=='&') {
+            /* We have &gt to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            u_fputc_raw('t',f_out);
+            (*new_pos)+=3;
+            state=4;
+        } else if (c==';') {
+            /* We have to replace &gt; by > */
+            u_fputc_raw('>',f_out);
+            write_offsets(offsets,(*pos)-4,*pos,*new_pos,(*new_pos)+1);
+            (*new_pos)++;
+            state=0;
+        }
+        else {
+            /* We have &gt to save */
+            u_fputc_raw('&',f_out);
+            u_fputc_raw('g',f_out);
+            u_fputc_raw('t',f_out);
+            (*new_pos)+=3;
+            state=0;
+        }
+        break;
+    }
+    }
 }
 /* We have to write ]]> => nothing in the offsets */
 write_offsets(offsets,(*pos)-3,*pos,*new_pos,(*new_pos));
@@ -312,67 +312,67 @@ int tag_name_found=(bastien!=NULL)?0:-1;
 int tag_index=-1;
 int old_pos=*pos;
 while ((c=u_fgetc_raw(f))!='>') {
-	if (c==EOF) goto err;
-	(*pos)++;
-	if (c=='"') {
-		/* If we have to skip an attribute between double quotes */
-		empty(ustr);
-		while ((c=u_fgetc_raw(f))!='"') {
-			if (c==EOF) goto err;
-			u_strcat(ustr,(unichar)c);
-			(*pos)++;
-		}
-		if (tag_name_found==2) {
-			tag_name_found=3;
-			for (int i=tag_index;i<10;i++) {
-				free(bastien[i]);
-				bastien[i]=NULL;
-			}
-			bastien[tag_index]=u_strdup(ustr->str);
-			empty(ustr);
-			for (int i=0;i<10;i++) {
-				if (bastien[i]!=NULL) {
-					if (ustr->len!=0) {
-						u_strcat(ustr,'-');
-					}
-					u_strcat(ustr,bastien[i]);
-				}
-			}
-			u_fprintf(f_bastien,"%d %S\n",old_pos,ustr->str);
-		}
-		(*pos)++;
-		continue;
-	}
-	if (c=='\'') {
-		/* If we have to skip an attribute between single quotes */
-		while ((c=u_fgetc_raw(f))!='\'') {
-			if (c==EOF) goto err;
-			(*pos)++;
-		}
-		(*pos)++;
-		continue;
-	}
-	if (c!=' ' && c!='=') {
-		u_strcat(ustr,(unichar)c);
-	}
-	if (c==' ') {
-		if (tag_name_found==0) {
-			tag_name_found=1;
-			unichar z,foo;
-			if (1==u_sscanf(ustr->str,"R%C%C",&z,&foo) && z>='0' && z<='9') {
-				tag_index=z-'0';
-			}
-		}
-		empty(ustr);
-	}
-	if (c=='=') {
-		if (tag_name_found==1) {
-			if (!u_strcmp(ustr->str,"utxShort")) {
-				tag_name_found=2;
-			}
-		}
-		empty(ustr);
-	}
+    if (c==EOF) goto err;
+    (*pos)++;
+    if (c=='"') {
+        /* If we have to skip an attribute between double quotes */
+        empty(ustr);
+        while ((c=u_fgetc_raw(f))!='"') {
+            if (c==EOF) goto err;
+            u_strcat(ustr,(unichar)c);
+            (*pos)++;
+        }
+        if (tag_name_found==2) {
+            tag_name_found=3;
+            for (int i=tag_index;i<10;i++) {
+                free(bastien[i]);
+                bastien[i]=NULL;
+            }
+            bastien[tag_index]=u_strdup(ustr->str);
+            empty(ustr);
+            for (int i=0;i<10;i++) {
+                if (bastien[i]!=NULL) {
+                    if (ustr->len!=0) {
+                        u_strcat(ustr,'-');
+                    }
+                    u_strcat(ustr,bastien[i]);
+                }
+            }
+            u_fprintf(f_bastien,"%d %S\n",old_pos,ustr->str);
+        }
+        (*pos)++;
+        continue;
+    }
+    if (c=='\'') {
+        /* If we have to skip an attribute between single quotes */
+        while ((c=u_fgetc_raw(f))!='\'') {
+            if (c==EOF) goto err;
+            (*pos)++;
+        }
+        (*pos)++;
+        continue;
+    }
+    if (c!=' ' && c!='=') {
+        u_strcat(ustr,(unichar)c);
+    }
+    if (c==' ') {
+        if (tag_name_found==0) {
+            tag_name_found=1;
+            unichar z,foo;
+            if (1==u_sscanf(ustr->str,"R%C%C",&z,&foo) && z>='0' && z<='9') {
+                tag_index=z-'0';
+            }
+        }
+        empty(ustr);
+    }
+    if (c=='=') {
+        if (tag_name_found==1) {
+            if (!u_strcmp(ustr->str,"utxShort")) {
+                tag_name_found=2;
+            }
+        }
+        empty(ustr);
+    }
 }
 (*pos)++;
 free_Ustring(ustr);
@@ -395,54 +395,54 @@ return 0;
 int skip_script(U_FILE* f,int *pos) {
 int c,state=0;
 while (state!=9) {
-	c=u_fgetc_raw(f);
-	if (c==EOF) return 0;
-	(*pos)++;
-	switch(state) {
-		case 0: {
-		if (c=='<') state=1;
-		break;
-	}
-	case 1: {
-		if (c=='/') state=2;
-		else state=0;
-		break;
-	}
-	case 2: {
-		if (c=='s' || c=='S') state=3;
-		else state=0;
-		break;
-	}
-	case 3: {
-		if (c=='c' || c=='C') state=4;
-		else state=0;
-		break;
-	}
-	case 4: {
-		if (c=='r' || c=='R') state=5;
-		else state=0;
-		break;
-	}
-	case 5: {
-		if (c=='i' || c=='I') state=6;
-		else state=0;
-		break;
-	}
-	case 6: {
-		if (c=='p' || c=='P') state=7;
-		else state=0;
-		break;
-	}
-	case 7: {
-		if (c=='t' || c=='T') state=8;
-		else state=0;
-		break;
-	}
-	case 8: {
-		if (c=='>') state=9;
-		else state=0;
-		break;
-	}
+    c=u_fgetc_raw(f);
+    if (c==EOF) return 0;
+    (*pos)++;
+    switch(state) {
+        case 0: {
+        if (c=='<') state=1;
+        break;
+    }
+    case 1: {
+        if (c=='/') state=2;
+        else state=0;
+        break;
+    }
+    case 2: {
+        if (c=='s' || c=='S') state=3;
+        else state=0;
+        break;
+    }
+    case 3: {
+        if (c=='c' || c=='C') state=4;
+        else state=0;
+        break;
+    }
+    case 4: {
+        if (c=='r' || c=='R') state=5;
+        else state=0;
+        break;
+    }
+    case 5: {
+        if (c=='i' || c=='I') state=6;
+        else state=0;
+        break;
+    }
+    case 6: {
+        if (c=='p' || c=='P') state=7;
+        else state=0;
+        break;
+    }
+    case 7: {
+        if (c=='t' || c=='T') state=8;
+        else state=0;
+        break;
+    }
+    case 8: {
+        if (c=='>') state=9;
+        else state=0;
+        break;
+    }
 }
 }
 return 1;
@@ -456,79 +456,79 @@ return 1;
  * Returns 1 in case of success; 0 if the tag is malformed.
  */
 int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-		UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien) {
+        UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien) {
 int old_pos=(*pos)-1;
 long current=ftell(f);
 /* We may read a comment */
 if (read(f,"!--")) {
-	(*pos)+=3;
-	if (!skip_comment(f,pos)) {
-		error("Invalid comment\n");
-		fseek(f,current,SEEK_SET);
-		return 0;
-	}
-	if (options->comments==UNXMLIZE_IGNORE) {
-		write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
-	} else {
-		/* We may have to replace comments by a space */
-		write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-		(*new_pos)++;
-		u_fputc_raw(' ',f_out);
-	}
-	return 1;
+    (*pos)+=3;
+    if (!skip_comment(f,pos)) {
+        error("Invalid comment\n");
+        fseek(f,current,SEEK_SET);
+        return 0;
+    }
+    if (options->comments==UNXMLIZE_IGNORE) {
+        write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
+    } else {
+        /* We may have to replace comments by a space */
+        write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+        (*new_pos)++;
+        u_fputc_raw(' ',f_out);
+    }
+    return 1;
 }
 fseek(f,current,SEEK_SET);
 /* Or a CDATA */
 if (read(f,"![CDATA[")) {
-	(*pos)+=8;
-	write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
-	if (!skip_cdata(f,f_out,pos,new_pos,offsets)) {
-		error("Invalid CDATA\n");
-		fseek(f,current,SEEK_SET);
-		return 0;
-	}
-	return 1;
+    (*pos)+=8;
+    write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
+    if (!skip_cdata(f,f_out,pos,new_pos,offsets)) {
+        error("Invalid CDATA\n");
+        fseek(f,current,SEEK_SET);
+        return 0;
+    }
+    return 1;
 }
 fseek(f,current,SEEK_SET);
 /* Or a html script code */
 if (options->scripts!=UNXMLIZE_DO_NOTHING) {
-	int ok=read2(f,"script ");
-	if (!ok) {
-		fseek(f,current,SEEK_SET);
-		ok=read2(f,"script>");
-	}
-	if (ok) {
-		(*pos)+=7;
-		if (!skip_script(f,pos)) {
-			error("Invalid script code\n");
-			fseek(f,current,SEEK_SET);
-			return 0;
-		}
-		if (options->scripts==UNXMLIZE_IGNORE) {
-			write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
-		} else {
-			/* We replace script sections by a space */
-			write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-			(*new_pos)++;
-			u_fputc_raw(' ',f_out);
-		}
-		return 1;
-	}
+    int ok=read2(f,"script ");
+    if (!ok) {
+        fseek(f,current,SEEK_SET);
+        ok=read2(f,"script>");
+    }
+    if (ok) {
+        (*pos)+=7;
+        if (!skip_script(f,pos)) {
+            error("Invalid script code\n");
+            fseek(f,current,SEEK_SET);
+            return 0;
+        }
+        if (options->scripts==UNXMLIZE_IGNORE) {
+            write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
+        } else {
+            /* We replace script sections by a space */
+            write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+            (*new_pos)++;
+            u_fputc_raw(' ',f_out);
+        }
+        return 1;
+    }
 }
 fseek(f,current,SEEK_SET);
 /* Or a normal tag */
 if (!skip_normal_tag(f,pos,bastien,f_bastien)) {
-	error("Invalid xml tag\n");
-	fseek(f,current,SEEK_SET);
-	return 0;
+    error("Invalid xml tag\n");
+    fseek(f,current,SEEK_SET);
+    return 0;
 }
 if (options->normal_tags==UNXMLIZE_IGNORE) {
-	write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
+    write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
 } else {
-	/* We replace tags by a space */
-	write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-	(*new_pos)++;
-	u_fputc_raw(' ',f_out);
+    /* We replace tags by a space */
+    write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+    (*new_pos)++;
+    u_fputc_raw(' ',f_out);
 }
 return 1;
 }
@@ -539,36 +539,36 @@ return 1;
  * like &gt; or &#206;
  */
 int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-		void* html_ctx) {
+        void* html_ctx) {
 char tmp[32];
 int c,i=0;
 long current=ftell(f);
 while (i<32 && (c=u_fgetc_raw(f))!=';') {
-	if (c>255) {
-		/* Should not happen with valid html chars */
-		tmp[i]='\0';
-		error("Invalid html char: &%s%C;\n",tmp,c);
-		fseek(f,current,SEEK_SET);
-		return 0;
-	}
-	tmp[i++]=(char)c;
-	(*pos)++;
+    if (c>255) {
+        /* Should not happen with valid html chars */
+        tmp[i]='\0';
+        error("Invalid html char: &%s%C;\n",tmp,c);
+        fseek(f,current,SEEK_SET);
+        return 0;
+    }
+    tmp[i++]=(char)c;
+    (*pos)++;
 }
 if (i==32) {
-	/* Should not happen with valid html chars */
-	tmp[31]='\0';
-	error("Too long HTML character: %s\n",tmp);
-	error("This may come from an invalid & found in text instead of &amp;\n");
-	fseek(f,current,SEEK_SET);
-	return 0;
+    /* Should not happen with valid html chars */
+    tmp[31]='\0';
+    error("Too long HTML character: %s\n",tmp);
+    error("This may come from an invalid & found in text instead of &amp;\n");
+    fseek(f,current,SEEK_SET);
+    return 0;
 }
 (*pos)++;
 tmp[i]='\0';
 c=get_HTML_character(html_ctx,tmp,1);
 if (c<0) {
-	error("Invalid html character: &%s;\n",tmp);
-	fseek(f,current,SEEK_SET);
-	return 0;
+    error("Invalid html character: &%s;\n",tmp);
+    fseek(f,current,SEEK_SET);
+    return 0;
 }
 u_fputc_raw((unichar)c,f_out);
 write_offsets(offsets,(*pos)-(2+i),*pos,*new_pos,(*new_pos)+1);

--- a/Xml.h
+++ b/Xml.h
@@ -39,13 +39,13 @@ namespace unitex {
 #define UNXMLIZE_DO_NOTHING 2
 
 typedef struct {
-	char comments;
-	char scripts;
-	char normal_tags;
+    char comments;
+    char scripts;
+    char normal_tags;
 } UnxmlizeOpts;
 
 int unxmlize(U_FILE* input,U_FILE* output,vector_offset* offsets,UnxmlizeOpts* options,
-		unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation);
+        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation);
 
 } // namespace unitex
 

--- a/logger/FilePack.cpp
+++ b/logger/FilePack.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -37,7 +37,7 @@
    modified to create uncompressed zipfile without compression, without zLib
 
 
-   Written 1998-2005 Gilles Vollant 
+   Written 1998-2005 Gilles Vollant
    http://www.winimage.com/zLibDll/minizip.html
 
    Read zip.h - FilePack.h for more info
@@ -96,7 +96,7 @@ namespace logger {
 #endif
 /* compile with -Dlocal if your debugger can't find static symbols */
 
-# define VERSIONMADEBY   (0x0000) 
+# define VERSIONMADEBY   (0x0000)
 
 #ifndef Z_BUFSIZE
 #define Z_BUFSIZE (16384)

--- a/logger/FilePack.h
+++ b/logger/FilePack.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/FilePackCrc32.cpp
+++ b/logger/FilePackCrc32.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -67,7 +67,7 @@ namespace logger {
 
 /* uLong is 32 bits or more */
 /*
- typedef unsigned long  uLong; 
+ typedef unsigned long  uLong;
 */
 
 #ifdef NO_CONST_TABLE
@@ -140,7 +140,7 @@ const uLong dwCRCTable[256] =
  *
  *  OUTPUT      void
  * --------------------------------------------------------------------------
- *  COMMENTS    
+ *  COMMENTS
  * --------------------------------------------------------------------------
  */
 
@@ -156,8 +156,8 @@ static void InitializeCRCTable(void)
     for(j = 8; j > 0; j--)
     {
       if(dwCRC & 1)
-        dwCRC = (dwCRC >> 1) ^ CRC_POLYNOMIAL; 
-      else  
+        dwCRC = (dwCRC >> 1) ^ CRC_POLYNOMIAL;
+      else
         dwCRC >>= 1;
     }
     dwCRCTable[i] = dwCRC;
@@ -204,26 +204,26 @@ uLong crc32(uLong dwCRC, const void* pvBuffer, size_t cbBuffer)
 
     for(i = 0; i < dwHeight ; i++)
     {
-                        
+
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+0)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+1)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+2)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+3)))]);
-      
+
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+4)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+5)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+6)))]);
           dwCRC  = (dwCRC >> 8) ^ (dwCRCTable[(unsigned char)(((unsigned char)dwCRC ^ *(pb+7)))]);
 
           pb+=8;
-    }   
+    }
 
     for(i = 0; i < dwRest; i++)
     {
       dwTmp1 = (dwCRC >> 8) & 0x00FFFFFFL;
       dwTmp2 = dwCRCTable[((int)dwCRC ^ *pb++) & 0xFF];
       dwCRC  = dwTmp1 ^ dwTmp2;
-    }   
+    }
   }
 
   dwCRC ^= 0xffffffff;

--- a/logger/FilePackCrc32.h
+++ b/logger/FilePackCrc32.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/FilePackIo.cpp
+++ b/logger/FilePackIo.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -35,7 +35,7 @@
    files using zlib + zip or unzip API
 
 
-   Written 1998-2005 Gilles Vollant 
+   Written 1998-2005 Gilles Vollant
    http://www.winimage.com/zLibDll/minizip.html
 */
 

--- a/logger/FilePackIo.h
+++ b/logger/FilePackIo.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/FilePackType.h
+++ b/logger/FilePackType.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -53,7 +53,7 @@ typedef unsigned char  Bytef;  /* 8 bits */
 typedef void *voidp;
 typedef void *voidpf;
 
-#define z_off_t size_t 
+#define z_off_t size_t
 
 
 

--- a/logger/FileUnPack.h
+++ b/logger/FileUnPack.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/InstallLingResourcePackage.cpp
+++ b/logger/InstallLingResourcePackage.cpp
@@ -256,7 +256,7 @@ namespace unitex {
                 case 'u': uninstall = 1; break;
                 case 'V': only_verify_arguments = true;
                           break;
-                case 'h': usage(); 
+                case 'h': usage();
                           return SUCCESS_RETURN_CODE;
                 case ':': index == -1 ? error("Missing argument for option -%c\n", options.vars()->optopt) :
                                         error("Missing argument for option --%s\n", lopts_InstallLingResourcePackage[index].name);
@@ -272,7 +272,7 @@ namespace unitex {
                 error("Invalid arguments: rerun with --help\n");
                 return USAGE_ERROR_CODE;
             }*/
-            
+
             if (transform_path_separator == -1)
             {
                 /*

--- a/logger/LingResourcePackage.h
+++ b/logger/LingResourcePackage.h
@@ -58,7 +58,7 @@ namespace unitex {
 
             int install_ling_resource_package(const char* package_name, const char* prefix_destination,
                 int folder_separator_transformation,
-				int persist_file, int persist_graph, int persist_dictionary, int persist_alphabet, int keep_persisted_file,
+                int persist_file, int persist_graph, int persist_dictionary, int persist_alphabet, int keep_persisted_file,
                 char*** file_list, char*** persist_graph_list, char*** persist_dictionary_list, char*** persist_alphabet_list);
 
             UNITEX_FUNC int UNITEX_CALL InstallLingResourcePackage(const char* package_name, const char* prefix_destination,
@@ -68,12 +68,12 @@ namespace unitex {
 
 
             int uninstall_ling_resource_package(const char* package_name, const char* prefix_destination,
-				int persist_file, int folder_separator_transformation,
-				int persist_graph, int persist_dictionary, int persist_alphabet, int kept_persisted_file);
+                int persist_file, int folder_separator_transformation,
+                int persist_graph, int persist_dictionary, int persist_alphabet, int kept_persisted_file);
 
             UNITEX_FUNC int UNITEX_CALL UninstallLingResourcePackage(const char* package_name, const char* prefix_destination,
-				int persist_file, int folder_separator_transformation,
-				int persist_graph, int persist_dictionary, int persist_alphabet, int kept_persisted_file);
+                int persist_file, int folder_separator_transformation,
+                int persist_graph, int persist_dictionary, int persist_alphabet, int kept_persisted_file);
 
 
             int uninstall_ling_resource_package_by_list(char** file_list,
@@ -103,7 +103,7 @@ namespace unitex {
 
             UNITEX_FUNC char** UNITEX_CALL ReadListFilesFromFile(const char* filein_name);
 
-			char** read_list_files_from_file(const char* filein_name);
+            char** read_list_files_from_file(const char* filein_name);
 
             void free_list_files_from_file(char**list);
 

--- a/logger/MzRepairUlp.cpp
+++ b/logger/MzRepairUlp.cpp
@@ -66,7 +66,7 @@ extern const char* usage_MzRepairUlp;
 const char* usage_MzRepairUlp =
          "Usage : MzRepairUlp [OPTIONS] <ulpfile>\n"
          "\n"
-		     "  <ulpfile>: a corrupted ulp file (often, a crashing log)\n"
+             "  <ulpfile>: a corrupted ulp file (often, a crashing log)\n"
          "\n"
          "OPTIONS:\n"
          "  -o X/--output=X: uses X as filename for fixed .ulp file (<ulpfile>.repair by default)\n"
@@ -169,13 +169,13 @@ if (only_verify_arguments) {
 const char* ulpFile=argv[options.vars()->optind];
 
 if (outputFile[0]=='\0') {
-	strcpy(outputFile,ulpFile);
-	strcat(outputFile,".repair");
+    strcpy(outputFile,ulpFile);
+    strcat(outputFile,".repair");
 }
 
 if (tempFile[0]=='\0') {
-	strcpy(tempFile,outputFile);
-	strcat(tempFile,".build");
+    strcpy(tempFile,outputFile);
+    strcat(tempFile,".build");
 }
 
 int retRepair=0;
@@ -184,15 +184,15 @@ uLong bytesRecovered=0;
 
 retRepair=ulpRepair(ulpFile,(const char*)outputFile,(const char*)tempFile,&nRecovered,&bytesRecovered);
 if ((retRepair!=0)) {
-	if ((verbose==1) || (quiet == 0)) {
-		u_printf("error in UlpRepair from %s to %s : return value = %d",ulpFile,outputFile,retRepair);
-	}
+    if ((verbose==1) || (quiet == 0)) {
+        u_printf("error in UlpRepair from %s to %s : return value = %d",ulpFile,outputFile,retRepair);
+    }
 }
 
 if (retRepair==0) {
-	if ((verbose==1) && (quiet == 0)) {
-		u_printf("success in UlpRepair from %s to %s : return value = %d",ulpFile,outputFile,retRepair);
-	}
+    if ((verbose==1) && (quiet == 0)) {
+        u_printf("success in UlpRepair from %s to %s : return value = %d",ulpFile,outputFile,retRepair);
+    }
 }
 return retRepair;
 }

--- a/logger/MzRepairUlp.h
+++ b/logger/MzRepairUlp.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/MzToolsUlp.cpp
+++ b/logger/MzToolsUlp.cpp
@@ -57,15 +57,15 @@ namespace logger {
 
 #define WRITE_8(buff, n) { \
   *((unsigned char*)(buff)) = (unsigned char) ((n) & 0xff); \
-} 
+}
 #define WRITE_16(buff, n)  { \
   WRITE_8((unsigned char*)(buff), n); \
   WRITE_8(((unsigned char*)(buff)) + 1, (n) >> 8); \
-} 
+}
 #define WRITE_32(buff, n)  { \
   WRITE_16((unsigned char*)(buff), (n) & 0xffff); \
   WRITE_16((unsigned char*)(buff) + 2, (n) >> 16); \
-} 
+}
 
 /*
 extern int ZEXPORT unzRepair(file, fileOut, fileOutTmp, nRecovered, bytesRecovered)

--- a/logger/PackFile.cpp
+++ b/logger/PackFile.cpp
@@ -74,7 +74,7 @@ extern const char* usage_PackFile;
 
 int buildPackFile(const char* packFile,int append_status,const char* global_comment,
                   const char* file_or_prefix_to_add,int add_one_file_only,const char* junk_prefix,
-				  int quiet);*/
+                  int quiet);*/
 
 
 const char* usage_PackFile =
@@ -206,16 +206,16 @@ if (only_verify_arguments) {
 }
 
 int retValue = buildPackFile(ulpFile,append,
-	                           global_comment,
+                               global_comment,
                              include_filename,
                              add_one_file_only,
                              junk_prefix,
-				                     quiet);
+                                     quiet);
 if (retValue == 0) {
-	error("Error creating %s\n", ulpFile);
-	return DEFAULT_ERROR_CODE;
+    error("Error creating %s\n", ulpFile);
+    return DEFAULT_ERROR_CODE;
 } else {
-	return SUCCESS_RETURN_CODE;
+    return SUCCESS_RETURN_CODE;
 }
 
 }

--- a/logger/PackFile.cpp
+++ b/logger/PackFile.cpp
@@ -90,7 +90,7 @@ const char* usage_PackFile =
          "  -g X/--global=X: uses X as archive global comment (cosmetic)\n"
          "  -j X/--junk_prefix=X: remove X at the beginning in the stored filename\n"
          "  -V/--only-verify-arguments: only verify arguments syntax and exit\n"
-         "  -h/--help: this help\n"         
+         "  -h/--help: this help\n"
          "\n";
 
 static void usage() {
@@ -170,8 +170,8 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_PackFile,lopts_PackFile,
              decode_writing_encoding_parameter(&encoding_output,&bom_output,options.vars()->optarg);
              break;
    case 'V': only_verify_arguments = true;
-             break;             
-   case 'h': usage(); 
+             break;
+   case 'h': usage();
              return SUCCESS_RETURN_CODE;
    case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                          error("Missing argument for option --%s\n",lopts_PackFile[index].name);

--- a/logger/PackFile.h
+++ b/logger/PackFile.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/PackFileTool.cpp
+++ b/logger/PackFileTool.cpp
@@ -59,18 +59,18 @@ namespace logger {
 static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const char* fileNameToRead,int quiet)
 {
     size_t size_buf=PACK_WRITEBUFFERSIZE;
-	uLong crc = 0;
-	uLong size_done = 0;
+    uLong crc = 0;
+    uLong size_done = 0;
     char* buf = (char*)malloc(size_buf);
 
-	if ((*fileNameInArchive) == '*')
-		fileNameInArchive++;
-	else
-	if (((*fileNameInArchive) == '$') ||
-		(((*fileNameInArchive) >= 'A') && ((*fileNameInArchive) <= 'Z')) ||
-		(((*fileNameInArchive) >= 'z') && ((*fileNameInArchive) <= 'z')))
-		if ((*(fileNameInArchive+1)) == ':')
-			fileNameInArchive+=2;
+    if ((*fileNameInArchive) == '*')
+        fileNameInArchive++;
+    else
+    if (((*fileNameInArchive) == '$') ||
+        (((*fileNameInArchive) >= 'A') && ((*fileNameInArchive) <= 'Z')) ||
+        (((*fileNameInArchive) >= 'z') && ((*fileNameInArchive) <= 'z')))
+        if ((*(fileNameInArchive+1)) == ':')
+            fileNameInArchive+=2;
 
     zip_fileinfo zi;
 
@@ -88,8 +88,8 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
     ABSTRACTFILE*fin;
     int err;
 
-	if (quiet != 0)
-		u_printf("packing %s to %s...",fileNameToRead,fileNameInArchive);
+    if (quiet != 0)
+        u_printf("packing %s to %s...",fileNameToRead,fileNameInArchive);
 
     fin = af_fopen(fileNameToRead,"rb");
     if (fin==NULL)
@@ -157,99 +157,99 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
     af_fclose(fin);
     free(buf);
 
-	if (quiet != 0)
-		u_printf(" done\n");
+    if (quiet != 0)
+        u_printf(" done\n");
 
     return (err == ZIP_OK) ? 1 : 0;
 }
 
 static const char* filterFileNameByJunkPrefix(const char* filename, const char* junk_prefix, int nb_char_remove_end_prefix)
 {
-	if (junk_prefix == NULL)
-		return filename;
+    if (junk_prefix == NULL)
+        return filename;
 
-	if ((*junk_prefix) == '\0')
-		return filename;
+    if ((*junk_prefix) == '\0')
+        return filename;
 
-	size_t len_prefix = strlen(junk_prefix);
-	size_t len_filename = strlen(filename);
+    size_t len_prefix = strlen(junk_prefix);
+    size_t len_filename = strlen(filename);
 
-	if (((int)len_prefix) < nb_char_remove_end_prefix)
-		return filename;
+    if (((int)len_prefix) < nb_char_remove_end_prefix)
+        return filename;
 
-	if (len_filename < (len_prefix - nb_char_remove_end_prefix))
-		return filename;
+    if (len_filename < (len_prefix - nb_char_remove_end_prefix))
+        return filename;
 
-	if (memcmp(filename,junk_prefix,len_prefix - nb_char_remove_end_prefix) == 0)
-		return filename + len_prefix - nb_char_remove_end_prefix;
-	else
-		return filename;
+    if (memcmp(filename,junk_prefix,len_prefix - nb_char_remove_end_prefix) == 0)
+        return filename + len_prefix - nb_char_remove_end_prefix;
+    else
+        return filename;
 }
 
 
 int buildPackFile(const char* packFile,int append,const char* global_comment,
                   const char* file_or_prefix_to_add,int add_one_file_only,const char* junk_prefix,
-				  int quiet)
+                  int quiet)
 {
-	// append_status can be APPEND_STATUS_CREATE
-	zipFile zf=zipOpen(packFile,(append != 0) ?  APPEND_STATUS_ADDINZIP : APPEND_STATUS_CREATE);
+    // append_status can be APPEND_STATUS_CREATE
+    zipFile zf=zipOpen(packFile,(append != 0) ?  APPEND_STATUS_ADDINZIP : APPEND_STATUS_CREATE);
     if (zf==NULL)
     {
         return 1;
     }
 
 
-	int retValue = 1;
+    int retValue = 1;
 
-	if (add_one_file_only != 0)
-		retValue = addFileInPackFile(zf,
-		                   filterFileNameByJunkPrefix(file_or_prefix_to_add,junk_prefix,0),
-						   file_or_prefix_to_add,quiet);
-	else
-	{
-		char ** listfile = af_get_list_file(file_or_prefix_to_add);
-		if (listfile != NULL)
-		{
-			int i=0;
-			while (*(listfile + i) != NULL)
-			{
-				retValue = addFileInPackFile(zf,
-								   filterFileNameByJunkPrefix(*(listfile + i),junk_prefix,0),
-								   *(listfile + i),quiet);
+    if (add_one_file_only != 0)
+        retValue = addFileInPackFile(zf,
+                           filterFileNameByJunkPrefix(file_or_prefix_to_add,junk_prefix,0),
+                           file_or_prefix_to_add,quiet);
+    else
+    {
+        char ** listfile = af_get_list_file(file_or_prefix_to_add);
+        if (listfile != NULL)
+        {
+            int i=0;
+            while (*(listfile + i) != NULL)
+            {
+                retValue = addFileInPackFile(zf,
+                                   filterFileNameByJunkPrefix(*(listfile + i),junk_prefix,0),
+                                   *(listfile + i),quiet);
 
-				if (retValue == 0)
-					break;
+                if (retValue == 0)
+                    break;
 
-				i++;
-			}
+                i++;
+            }
 
-			af_release_list_file(file_or_prefix_to_add,listfile);
-		}
-	}
+            af_release_list_file(file_or_prefix_to_add,listfile);
+        }
+    }
 
-	zipClose(zf,global_comment);
-	return retValue;
+    zipClose(zf,global_comment);
+    return retValue;
 }
 
 
 UNITEX_FUNC int UNITEX_CALL CreateUnitexPackOneFile(const char* packFile,int append_status,
-														const char* file_to_include, const char* junk_prefix,
-														const char* global_comment)
+                                                        const char* file_to_include, const char* junk_prefix,
+                                                        const char* global_comment)
 {
-	int quiet = 1;
-	return buildPackFile( packFile,append_status,  global_comment,
+    int quiet = 1;
+    return buildPackFile( packFile,append_status,  global_comment,
                   file_to_include,1, junk_prefix,
-				  quiet);
+                  quiet);
 }
 
 UNITEX_FUNC int UNITEX_CALL CreateUnitexPackMultiFile(const char* packFile,int append_status,
-														const char* file_to_include, const char* junk_prefix,
-														const char* global_comment)
+                                                        const char* file_to_include, const char* junk_prefix,
+                                                        const char* global_comment)
 {
-	int quiet = 1;
-	return buildPackFile( packFile,append_status,  global_comment,
+    int quiet = 1;
+    return buildPackFile( packFile,append_status,  global_comment,
                   file_to_include,0, junk_prefix,
-				  quiet);
+                  quiet);
 }
 
 } // namespace logger

--- a/logger/PackFileTool.cpp
+++ b/logger/PackFileTool.cpp
@@ -24,7 +24,7 @@
 
 
 
-  
+
 #include "Af_stdio.h"
 #include "DirHelper.h"
 
@@ -55,7 +55,7 @@ namespace logger {
 #define PACK_WRITEBUFFERSIZE (65536)
 
 
-// return 1 if ok, 0 if error	
+// return 1 if ok, 0 if error
 static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const char* fileNameToRead,int quiet)
 {
     size_t size_buf=PACK_WRITEBUFFERSIZE;
@@ -95,7 +95,7 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
     if (fin==NULL)
     {
         err=ZIP_ERRNO;
-        
+
         free(buf);
         return 0;
     }
@@ -114,9 +114,9 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
                 if (size_read < size_buf)
                     if (af_feof(fin)==0)
                 {
-                    
+
                     error("error in reading %s\n",fileNameToRead);
-                    
+
                     err = ZIP_ERRNO;
                 }
 
@@ -125,11 +125,11 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
                     err = zipWriteInFileInZip (zf,buf,(unsigned int)size_read);
                     if (err<0)
                     {
-                        
+
                         error("error in writing %s in the zipfile\n",
                                          fileNameInArchive);
                     }
-                    else 
+                    else
                     {
                         size_done += (unsigned int)size_read;
                         crc = crc32(crc,buf,size_read);
@@ -148,7 +148,7 @@ static int addFileInPackFile(zipFile zf,const char* fileNameInArchive, const cha
             else
             {
                 err = zipCloseFileInZip(zf);
-                
+
                 if (err!=ZIP_OK)
                     error("error in closing %s in the zipfile\n",
                                 fileNameInArchive);
@@ -197,7 +197,7 @@ int buildPackFile(const char* packFile,int append,const char* global_comment,
     {
         return 1;
     }
-    
+
 
 	int retValue = 1;
 
@@ -212,7 +212,7 @@ int buildPackFile(const char* packFile,int append,const char* global_comment,
 		{
 			int i=0;
 			while (*(listfile + i) != NULL)
-			{				
+			{
 				retValue = addFileInPackFile(zf,
 								   filterFileNameByJunkPrefix(*(listfile + i),junk_prefix,0),
 								   *(listfile + i),quiet);

--- a/logger/PackFileTool.h
+++ b/logger/PackFileTool.h
@@ -20,22 +20,22 @@ namespace unitex {
 namespace logger {
 extern "C" {
 #endif
- 
+
 
 
 int buildPackFile(const char* packFile,int append_status,const char* global_comment,
                   const char* file_or_prefix_to_add,int add_one_file_only,const char* junk_prefix,
-				  int quiet);
+                  int quiet);
 
 
 
 UNITEX_FUNC int UNITEX_CALL CreateUnitexPackOneFile(const char* packFile,int append_status,
-														const char* file_to_include, const char* junk_prefix,
-														const char* global_comment);
+                                                        const char* file_to_include, const char* junk_prefix,
+                                                        const char* global_comment);
 
 UNITEX_FUNC int UNITEX_CALL CreateUnitexPackMultiFile(const char* packFile,int append_status,
-														const char* file_to_include, const char* junk_prefix,
-														const char* global_comment);
+                                                        const char* file_to_include, const char* junk_prefix,
+                                                        const char* global_comment);
 
 
 #ifdef __cplusplus
@@ -45,9 +45,9 @@ UNITEX_FUNC int UNITEX_CALL CreateUnitexPackMultiFile(const char* packFile,int a
 #endif
 
 
- 
 
- 
+
+
 
 #endif
 

--- a/logger/ReworkArg.cpp
+++ b/logger/ReworkArg.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -134,7 +134,7 @@ const char* get_filename_to_copy(const char*filename,int skip_star)
 }
 
 
-/* 
+/*
  * Search possible position for filename on an argument
  *
  * "-a" : return -1 (no filename possible)
@@ -334,8 +334,8 @@ void reworkCommandLineAddPrefix(char*dest,const char*arg,const char* FileAddRunP
     else
     {
         size_t len_FileAddRunPath = strlen(FileAddRunPath);
-        int iAddSeparator = 
-        (((*(FileAddRunPath + len_FileAddRunPath - 1)) == '\\') || ((*(FileAddRunPath + len_FileAddRunPath - 1)) == '/')) ? 
+        int iAddSeparator =
+        (((*(FileAddRunPath + len_FileAddRunPath - 1)) == '\\') || ((*(FileAddRunPath + len_FileAddRunPath - 1)) == '/')) ?
             0 : 1;
 
         memcpy(dest,arg,(size_t)PossiblePos);

--- a/logger/ReworkArg.cpp
+++ b/logger/ReworkArg.cpp
@@ -66,18 +66,18 @@ unsigned int get_filename_withoutpath_position(const char*filename)
             if (c_after != '\0')
                 ret=curpos+1;
         }
-		else
-			if (c=='$')
-				if (*(filename+1)==':')
-				{
-					char c_after=*(filename+2);
-					if (c_after != '\0')
-					{
-						curpos++;
-						ret=curpos+1;
-						filename++;
-					}
-				}
+        else
+            if (c=='$')
+                if (*(filename+1)==':')
+                {
+                    char c_after=*(filename+2);
+                    if (c_after != '\0')
+                    {
+                        curpos++;
+                        ret=curpos+1;
+                        filename++;
+                    }
+                }
 
         filename++;
         curpos++;
@@ -91,27 +91,27 @@ const char* get_filename_to_copy(const char*filename,int skip_star)
     const char* filenamecpy=filename;
 
     if (skip_star != 0)
-	{
-		for (;;)
-		{
-			int stop = 1;
-			if (((*filenamecpy)== '*') || ((*(filenamecpy))== '#') || ((*(filenamecpy))== '+'))
-			{
-				filenamecpy ++;
-				stop = 0;
-			}
+    {
+        for (;;)
+        {
+            int stop = 1;
+            if (((*filenamecpy)== '*') || ((*(filenamecpy))== '#') || ((*(filenamecpy))== '+'))
+            {
+                filenamecpy ++;
+                stop = 0;
+            }
 
-			if ((*filenamecpy) == '$')
-				if ((*(filenamecpy+1)) == ':')
-				{
-					filenamecpy += 2;
-					stop = 0;
-				}
+            if ((*filenamecpy) == '$')
+                if ((*(filenamecpy+1)) == ':')
+                {
+                    filenamecpy += 2;
+                    stop = 0;
+                }
 
-			if (stop == 1)
-				break;
-		}
-	}
+            if (stop == 1)
+                break;
+        }
+    }
 
     if (((*filenamecpy)== '\\') && ((*(filenamecpy+1))== '\\'))
     {
@@ -153,7 +153,7 @@ int SearchPossiblePosFileNameInArg(const char*arg)
         else /* we are in --xx args, we search --xx=yy */
         {
             unsigned int j=1;
-			int retValue = -1;
+            int retValue = -1;
             for (;;)
             {
                 if ((*(arg+j)) == '\0')
@@ -163,7 +163,7 @@ int SearchPossiblePosFileNameInArg(const char*arg)
 
                 if ((*(arg+j)) == '=')
                 {
-					retValue = (int)(j+1);
+                    retValue = (int)(j+1);
                 }
 
                 j++;
@@ -171,24 +171,24 @@ int SearchPossiblePosFileNameInArg(const char*arg)
         }
     }
     else
-	{
-		unsigned int j = 0;
-		int retValue = 0;
-		for (;;)
-		{
-			if ((*(arg + j)) == '\0')
-			{
-				return retValue;
-			}
+    {
+        unsigned int j = 0;
+        int retValue = 0;
+        for (;;)
+        {
+            if ((*(arg + j)) == '\0')
+            {
+                return retValue;
+            }
 
-			if ((*(arg + j)) == '=')
-			{
-				retValue = (int)(j + 1);
-			}
+            if ((*(arg + j)) == '=')
+            {
+                retValue = (int)(j + 1);
+            }
 
-			j++;
-		}
-	}
+            j++;
+        }
+    }
 }
 
 
@@ -259,25 +259,25 @@ const char* GetFileNameRemovePrefixIfFound(const char* filename,const char*porti
 
 const char* ExtractUsablePortionOfFileNameForPack(const char*filenamecpy)
 {
- 	for (;;)
-		{
-			int stop = 1;
-			if (((*filenamecpy)== '*') || ((*(filenamecpy))== '#') || ((*(filenamecpy))== '+'))
-			{
-				filenamecpy ++;
-				stop = 0;
-			}
+    for (;;)
+        {
+            int stop = 1;
+            if (((*filenamecpy)== '*') || ((*(filenamecpy))== '#') || ((*(filenamecpy))== '+'))
+            {
+                filenamecpy ++;
+                stop = 0;
+            }
 
-			if ((*filenamecpy) == '$')
-				if ((*(filenamecpy+1)) == ':')
-				{
-					filenamecpy += 2;
-					stop = 0;
-				}
+            if ((*filenamecpy) == '$')
+                if ((*(filenamecpy+1)) == ':')
+                {
+                    filenamecpy += 2;
+                    stop = 0;
+                }
 
-			if (stop == 1)
-				break;
-		}
+            if (stop == 1)
+                break;
+        }
 
 
     if (((*filenamecpy)== '\\') && ((*(filenamecpy+1))== '\\'))

--- a/logger/ReworkArg.h
+++ b/logger/ReworkArg.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/RunTools.cpp
+++ b/logger/RunTools.cpp
@@ -53,129 +53,129 @@ namespace logger {
 
 static int is_space_or_equivalent(char c)
 {
-	if ((c == ' ') || (c == '\t') || (c == '\r') || (c == '\n'))
-		return 1;
-	return 0;
+    if ((c == ' ') || (c == '\t') || (c == '\r') || (c == '\n'))
+        return 1;
+    return 0;
 }
 
 
 
 void do_convert_command_line_synth_to_splitted(
-	const char*file_synth,
-	size_t size_synth,
-	char** ptr_converted,
-	size_t *size_file_converted,
-	char cEndArg, int firsts_line_contain_count,
-	int* p_nb_args)
+    const char*file_synth,
+    size_t size_synth,
+    char** ptr_converted,
+    size_t *size_file_converted,
+    char cEndArg, int firsts_line_contain_count,
+    int* p_nb_args)
 {
-	char* dest = (char*)malloc((size_synth * 2) + 0x100);
-	char begin[0x40];
-	if (firsts_line_contain_count)
-	{
-		sprintf(begin, "%010d\n%010d\n", 0, 0);
-	}
-	else
-	{
-		begin[0] = '\0';
-	}
-	strcpy(dest, begin);
-	char *cur_dest = dest + strlen(dest);
+    char* dest = (char*)malloc((size_synth * 2) + 0x100);
+    char begin[0x40];
+    if (firsts_line_contain_count)
+    {
+        sprintf(begin, "%010d\n%010d\n", 0, 0);
+    }
+    else
+    {
+        begin[0] = '\0';
+    }
+    strcpy(dest, begin);
+    char *cur_dest = dest + strlen(dest);
 
-	const char* lpSrc = file_synth;
-	const char* lpSrcLimit = file_synth + size_synth;
-	int isInQuote = 0;
-	int iNbArg = 0;
+    const char* lpSrc = file_synth;
+    const char* lpSrcLimit = file_synth + size_synth;
+    int isInQuote = 0;
+    int iNbArg = 0;
 
 
-	while (is_space_or_equivalent(*lpSrc) != 0)
-		lpSrc++;
+    while (is_space_or_equivalent(*lpSrc) != 0)
+        lpSrc++;
 
-	if (((*lpSrc) != '\0') && (lpSrc<lpSrcLimit))
-		iNbArg++;
+    if (((*lpSrc) != '\0') && (lpSrc<lpSrcLimit))
+        iNbArg++;
 
-	while (((*lpSrc) != '\0') && (lpSrc<lpSrcLimit))
-	{
-		while (((*lpSrc) == '"') && (lpSrc<lpSrcLimit))
-		{
-			isInQuote = !isInQuote;
-			lpSrc++;
-		}
+    while (((*lpSrc) != '\0') && (lpSrc<lpSrcLimit))
+    {
+        while (((*lpSrc) == '"') && (lpSrc<lpSrcLimit))
+        {
+            isInQuote = !isInQuote;
+            lpSrc++;
+        }
 
-		if ((is_space_or_equivalent(*lpSrc) != 0) && (!isInQuote))
-		{
-			while ((is_space_or_equivalent(*lpSrc) != 0) && (lpSrc<lpSrcLimit))
-				lpSrc++;
-			if (((*lpSrc) == '\0') || (lpSrc == lpSrcLimit))
-				break;
-			*(cur_dest++) = cEndArg;
-			iNbArg++;
-		}
+        if ((is_space_or_equivalent(*lpSrc) != 0) && (!isInQuote))
+        {
+            while ((is_space_or_equivalent(*lpSrc) != 0) && (lpSrc<lpSrcLimit))
+                lpSrc++;
+            if (((*lpSrc) == '\0') || (lpSrc == lpSrcLimit))
+                break;
+            *(cur_dest++) = cEndArg;
+            iNbArg++;
+        }
 
-		while (((*lpSrc) == '"') && (lpSrc<lpSrcLimit))
-		{
-			isInQuote = !isInQuote;
-			lpSrc++;
-		}
+        while (((*lpSrc) == '"') && (lpSrc<lpSrcLimit))
+        {
+            isInQuote = !isInQuote;
+            lpSrc++;
+        }
 
-		*(cur_dest++) = *(lpSrc++);
-	}
-	*(cur_dest) = '\0';
-	*size_file_converted = (size_t)(cur_dest - dest);
+        *(cur_dest++) = *(lpSrc++);
+    }
+    *(cur_dest) = '\0';
+    *size_file_converted = (size_t)(cur_dest - dest);
 
-	if (firsts_line_contain_count)
-	{
-		sprintf(begin, "%010d\n%010d\n", 0, iNbArg);
-	}
-	if (p_nb_args != NULL)
-		*p_nb_args = iNbArg;
-	memcpy(dest, begin, strlen(begin));
-	*ptr_converted = dest;
+    if (firsts_line_contain_count)
+    {
+        sprintf(begin, "%010d\n%010d\n", 0, iNbArg);
+    }
+    if (p_nb_args != NULL)
+        *p_nb_args = iNbArg;
+    memcpy(dest, begin, strlen(begin));
+    *ptr_converted = dest;
 }
 
 
 void do_convert_command_line_synth_to_std(
-	const char*file_synth,
-	size_t size_synth,
-	char** ptr_converted,
-	size_t *size_file_converted
-	)
+    const char*file_synth,
+    size_t size_synth,
+    char** ptr_converted,
+    size_t *size_file_converted
+    )
 {
-	do_convert_command_line_synth_to_splitted(file_synth, size_synth, ptr_converted, size_file_converted, '\n', 1,NULL);
+    do_convert_command_line_synth_to_splitted(file_synth, size_synth, ptr_converted, size_file_converted, '\n', 1,NULL);
 }
 
 
 char** do_convert_command_line_synth_to_std_arg(const char*cmd_line_synth,
-	size_t size_cmd_line_synth, int* param_argc)
+    size_t size_cmd_line_synth, int* param_argc)
 {
-	char* ptr_converted = NULL;
-	size_t size_file_converted = 0;
-	int iNbArgs = 0;
-	do_convert_command_line_synth_to_splitted(cmd_line_synth, size_cmd_line_synth, &ptr_converted, &size_file_converted, '\0',0, &iNbArgs);
+    char* ptr_converted = NULL;
+    size_t size_file_converted = 0;
+    int iNbArgs = 0;
+    do_convert_command_line_synth_to_splitted(cmd_line_synth, size_cmd_line_synth, &ptr_converted, &size_file_converted, '\0',0, &iNbArgs);
 
-	size_t size_needed_ptr_list = sizeof(char*) * (iNbArgs + 3);
+    size_t size_needed_ptr_list = sizeof(char*) * (iNbArgs + 3);
 
-	const char* firstArg = "UnitexTool";
-	size_t len_first_arg = strlen(firstArg);
-	char** converted_list = (char**)malloc(size_needed_ptr_list + len_first_arg + 1 + size_file_converted + 1);
-	char* command_text = ((char*)converted_list) + size_needed_ptr_list;
-	strcpy(command_text, firstArg);
-	memcpy(command_text + len_first_arg + 1, ptr_converted, size_file_converted + 1);
-	free(ptr_converted);
+    const char* firstArg = "UnitexTool";
+    size_t len_first_arg = strlen(firstArg);
+    char** converted_list = (char**)malloc(size_needed_ptr_list + len_first_arg + 1 + size_file_converted + 1);
+    char* command_text = ((char*)converted_list) + size_needed_ptr_list;
+    strcpy(command_text, firstArg);
+    memcpy(command_text + len_first_arg + 1, ptr_converted, size_file_converted + 1);
+    free(ptr_converted);
 
-	char * walk = command_text;
-	for (int i = 0; i < (iNbArgs+1); i++)
-	{
-		*(converted_list + i) = walk;
-		walk += strlen(walk) + 1;
-	}
-	*(converted_list + iNbArgs + 2) = NULL;
-	*param_argc = iNbArgs + 1;
-	return converted_list;
+    char * walk = command_text;
+    for (int i = 0; i < (iNbArgs+1); i++)
+    {
+        *(converted_list + i) = walk;
+        walk += strlen(walk) + 1;
+    }
+    *(converted_list + iNbArgs + 2) = NULL;
+    *param_argc = iNbArgs + 1;
+    return converted_list;
 }
 
 void free_std_arg_converted(char** ptr)
 {
-	free(ptr);
+    free(ptr);
 }
 
 
@@ -185,12 +185,12 @@ void free_std_arg_converted(char** ptr)
  */
 void fill_unique_string_for_pointer(const void* uniquePtr, char* string)
 {
-	size_t value_for_pointer = (size_t)uniquePtr;
-	size_t shift16 = (value_for_pointer >> 16);
-	size_t shift32 = (shift16 >> 16);
-	size_t low = (value_for_pointer & ((size_t)0xffffffff));
-	sprintf(string, "%08lx", (unsigned long)shift32);
-	sprintf(string+strlen(string), "%08lx", (unsigned long)low);
+    size_t value_for_pointer = (size_t)uniquePtr;
+    size_t shift16 = (value_for_pointer >> 16);
+    size_t shift32 = (shift16 >> 16);
+    size_t low = (value_for_pointer & ((size_t)0xffffffff));
+    sprintf(string, "%08lx", (unsigned long)shift32);
+    sprintf(string+strlen(string), "%08lx", (unsigned long)low);
 }
 
 } // namespace logger

--- a/logger/RunTools.cpp
+++ b/logger/RunTools.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -161,7 +161,7 @@ char** do_convert_command_line_synth_to_std_arg(const char*cmd_line_synth,
 	strcpy(command_text, firstArg);
 	memcpy(command_text + len_first_arg + 1, ptr_converted, size_file_converted + 1);
 	free(ptr_converted);
-	
+
 	char * walk = command_text;
 	for (int i = 0; i < (iNbArgs+1); i++)
 	{

--- a/logger/RunTools.h
+++ b/logger/RunTools.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -49,28 +49,28 @@ namespace unitex {
 #define HAS_LOGGER_NAMESPACE 1
 #endif
 
-	namespace logger {
-		//extern "C" {
+    namespace logger {
+        //extern "C" {
 #endif
 
-			void do_convert_command_line_synth_to_std(
-				const char*file_synth,
-				size_t size_synth,
-				char** ptr_converted,
-				size_t *size_file_converted);
+            void do_convert_command_line_synth_to_std(
+                const char*file_synth,
+                size_t size_synth,
+                char** ptr_converted,
+                size_t *size_file_converted);
 
-			char** do_convert_command_line_synth_to_std_arg(const char*cmd_line_synth,
-				size_t size_cmd_line_synth, int* param_argc);
+            char** do_convert_command_line_synth_to_std_arg(const char*cmd_line_synth,
+                size_t size_cmd_line_synth, int* param_argc);
 
-			void free_std_arg_converted(char** ptr);
+            void free_std_arg_converted(char** ptr);
 
 // fill_unique_string_for_pointer needed size (zero terminal included) : (0x10+1) with margin so 0x20
 #define UNIQUE_STRING_FOR_POINTER_MAX_SIZE 0x20
-			void fill_unique_string_for_pointer(const void* uniquePtr, char* unique_string);
+            void fill_unique_string_for_pointer(const void* uniquePtr, char* unique_string);
 
 #ifdef __cplusplus
-		//} // extern "C"
-	} // namespace logger
+        //} // extern "C"
+    } // namespace logger
 } // namespace unitex
 #endif
 

--- a/logger/SyncLogger.h
+++ b/logger/SyncLogger.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/ThreadEmulation.cpp
+++ b/logger/ThreadEmulation.cpp
@@ -33,7 +33,7 @@ namespace ThreadEmulation
     static map<HANDLE, PendingThreadInfo> pendingThreads;
     static mutex pendingThreadsLock;
 
-    
+
     // Thread local storage.
     typedef vector<void*> ThreadLocalData;
 
@@ -99,7 +99,7 @@ namespace ThreadEmulation
         // the caller is responsible for closing the handle returned by CreateThread,
         // and they may do that before or after the thread has finished running.
         HANDLE completionEvent;
-        
+
         if (!DuplicateHandle(GetCurrentProcess(), threadHandle, GetCurrentProcess(), &completionEvent, 0, false, DUPLICATE_SAME_ACCESS))
         {
             CloseHandle(threadHandle);
@@ -127,7 +127,7 @@ namespace ThreadEmulation
                 // Start the thread immediately.
                 StartThread(lpStartAddress, lpParameter, completionEvent, 0);
             }
-    
+
             return threadHandle;
         }
         catch (...)
@@ -210,7 +210,7 @@ namespace ThreadEmulation
                 return;
 
             HANDLE previousEvent = InterlockedCompareExchangePointerRelease(&singletonEvent, sleepEvent, nullptr);
-            
+
             if (previousEvent)
             {
                 // Back out if multiple threads try to demand create at the same time.
@@ -227,7 +227,7 @@ namespace ThreadEmulation
     DWORD WINAPI TlsAlloc()
     {
         lock_guard<mutex> lock(tlsAllocationLock);
-        
+
         // Can we reuse a previously freed TLS slot?
         if (!freeTlsIndices.empty())
         {
@@ -298,7 +298,7 @@ namespace ThreadEmulation
             try
             {
                 threadData = new ThreadLocalData(dwTlsIndex + 1, nullptr);
-                
+
                 lock_guard<mutex> lock(tlsAllocationLock);
 
                 allThreadData.insert(threadData);

--- a/logger/ThreadEmulation.h
+++ b/logger/ThreadEmulation.h
@@ -41,13 +41,13 @@ namespace ThreadEmulation
     HANDLE WINAPI CreateThread(_In_opt_ LPSECURITY_ATTRIBUTES unusedThreadAttributes, _In_ SIZE_T unusedStackSize, _In_ LPTHREAD_START_ROUTINE lpStartAddress, _In_opt_ LPVOID lpParameter, _In_ DWORD dwCreationFlags, _Out_opt_ LPDWORD unusedThreadId);
     DWORD WINAPI ResumeThread(_In_ HANDLE hThread);
     BOOL WINAPI SetThreadPriority(_In_ HANDLE hThread, _In_ int nPriority);
-    
+
     VOID WINAPI Sleep(_In_ DWORD dwMilliseconds);
 
     DWORD WINAPI TlsAlloc();
     BOOL WINAPI TlsFree(_In_ DWORD dwTlsIndex);
     LPVOID WINAPI TlsGetValue(_In_ DWORD dwTlsIndex);
     BOOL WINAPI TlsSetValue(_In_ DWORD dwTlsIndex, _In_opt_ LPVOID lpTlsValue);
-    
+
     void WINAPI TlsShutdown();
 }

--- a/logger/UniLogger.cpp
+++ b/logger/UniLogger.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -62,7 +62,7 @@ namespace unitex {
 
 namespace logger {
 
-struct ArrayExpanding {    
+struct ArrayExpanding {
     unsigned int nb_item_filled;
     unsigned int nb_item_allocated;
     size_t size_item;
@@ -79,7 +79,7 @@ struct ArrayExpanding* InitArrayExpanding(size_t size_item, unsigned int init_al
     pAE = (struct ArrayExpanding*)malloc(sizeof(struct ArrayExpanding));
     if (pAE==NULL)
         return NULL;
-    
+
     pAE->ptrBuffer = (void*)malloc(size_item*init_alloc);
     if (pAE->ptrBuffer == NULL)
     {
@@ -360,7 +360,7 @@ struct ExecutionLogging* InitExecutionLogging(const char*pathZip)
         free(pEL);
         return NULL;
     }
-    
+
     pEL->pAE_FileReading = InitArrayExpanding(sizeof(struct FileReadingInfoItem),0);
     pEL->pAE_FileToWrite = InitArrayExpanding(sizeof(struct FileToWriteInfoItem),0);
 
@@ -371,7 +371,7 @@ struct ExecutionLogging* InitExecutionLogging(const char*pathZip)
     pEL->argc = 0;
     pEL->argv = NULL;
 
-    pEL -> store_file_out_content = pEL -> store_list_file_out_content = 
+    pEL -> store_file_out_content = pEL -> store_list_file_out_content =
     pEL -> store_file_in_content = pEL -> store_list_file_in_content = 0;
     pEL -> store_std_out_content = pEL -> store_std_err_content = 1;
 
@@ -404,7 +404,7 @@ struct ExecutionLogging* InitExecutionLogging(const char*pathZip)
 char* buildDupFileNameWithPrefixDir(const char*szPathPrefix,const char*fn)
 {
     char* szRet;
-    
+
     if (szPathPrefix==NULL)
         szPathPrefix="";
 
@@ -453,7 +453,7 @@ struct ExecutionLogging* BuildAllocInitExecutionLogging(void* privateLoggerPtr,c
         return pEL;
 
     pEL=InitExecutionLogging(szLogFileName);
-        
+
     if (pEL == NULL)
         return NULL;
 
@@ -558,7 +558,7 @@ UNITEX_FUNC int UNITEX_CALL SelectNextLogName(struct UniLoggerSpace *p_ule,const
 static struct ExecutionLogging* BuildAllocInitExecutionLoggingForIncrementedNumber(void* privateLoggerPtr)
 {
     struct ExecutionLogging* pEL = NULL;
- 
+
     struct UniLoggerSpace * pULS=(struct UniLoggerSpace *)privateLoggerPtr;
     struct ActivityLoggerPrivateData* pALPD = (struct ActivityLoggerPrivateData*) pULS->privateUnloggerData;
 
@@ -597,7 +597,7 @@ static struct ExecutionLogging* BuildAllocInitExecutionLoggingForIncrementedNumb
                 sscanf(buf_num_file,"%u",&current_number);
             }
             af_fclose(af_fin);
-            free(buf_num_file);        
+            free(buf_num_file);
         }
 
         current_number++;
@@ -618,7 +618,7 @@ static struct ExecutionLogging* BuildAllocInitExecutionLoggingForIncrementedNumb
         sprintf(szNumFileSuffix,"%s",pULS->szNameLog);
     }
     SyncReleaseMutex(pALPD->pMutexLog);
-    
+
     const char* szLogFileName = buildDupFileNameWithPrefixDir(pULS->szPathLog,szNumFileSuffix);
 
     pEL=BuildAllocInitExecutionLogging(privateLoggerPtr,szLogFileName);
@@ -683,7 +683,7 @@ int DumpFileToPack(struct ExecutionLogging* pEL,const char* filename,const char*
     if (fin==NULL)
     {
         err=ZIP_ERRNO;
-        
+
         free(buf);
         return 0;
     }
@@ -717,7 +717,7 @@ int DumpFileToPack(struct ExecutionLogging* pEL,const char* filename,const char*
                         printf("error in writing %s in the zipfile\n",
                                          filenameinzip);*/
                     }
-                    else 
+                    else
                     {
                         *size_done += (unsigned int)size_read;
                         *crc = crc32(*crc,buf,size_read);
@@ -844,7 +844,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_before_calling_tool(mainFunc*,int argc,c
 
     if (pEL == NULL)
         pEL = BuildAllocInitExecutionLoggingForIncrementedNumber(privateLoggerPtr);
-    
+
     if (pEL == NULL)
         return;
 
@@ -872,7 +872,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_before_calling_tool(mainFunc*,int argc,c
         int add_quote=0;
         const char* curarg=*(pEL->argv+i);
         while ( * (curarg+j) != 0)
-        {            
+        {
             char c=(*(curarg+j));
             if (c==' ') add_quote=1;
             j++;
@@ -883,7 +883,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_before_calling_tool(mainFunc*,int argc,c
         CopyReworkedArgRemoving(param_list+strlen(param_list),curarg,pEL->portion_ignore_pathname);
         if (add_quote != 0)
             strcat(param_list,"\"");
-        
+
         if ((i+1)!=(pEL->argc))
             strcat(param_list," ");
     }
@@ -906,7 +906,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_calling_tool(mainFunc*,int /*argc*
     {
         unsigned int size=0;
         unsigned long crc=0;
-        
+
         if (pEL->store_file_out_content != 0)
         {
           DumpFileToPack(pEL,GetFileToWriteItemFN(pEL,iFile),"dest/",&size,&crc);
@@ -932,7 +932,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_calling_tool(mainFunc*,int /*argc*
         for (iFile=0;iFile<iNbFileWrite;iFile++)
             size_buf_list_file_out += strlen(GetFileToWriteItemFN(pEL,iFile)) + 0x40;
 
-        
+
         buf_list_file_out = (char*)malloc(size_buf_list_file_out);
         *buf_list_file_out=0;
         pos_in_list_file_out = 0;
@@ -995,7 +995,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_calling_tool(mainFunc*,int /*argc*
     }
 
     DumpMemToPack(pEL,"test_info/command_line.txt",param_list,(unsigned int)strlen(param_list));
-    
+
     *param_list=0;
     for (i=0;i<(pEL->argc);i++)
     {
@@ -1003,7 +1003,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_calling_tool(mainFunc*,int /*argc*
         int add_quote=0;
         const char* curarg=*(pEL->argv+i);
         while ( * (curarg+j) != 0)
-        {            
+        {
             char c=(*(curarg+j));
             if (c==' ') add_quote=1;
             j++;
@@ -1014,7 +1014,7 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_calling_tool(mainFunc*,int /*argc*
         CopyReworkedArgRemoving(param_list+strlen(param_list),curarg,pEL->portion_ignore_pathname);
         if (add_quote != 0)
             strcat(param_list,"\"");
-        
+
         if ((i+1)!=(pEL->argc))
             strcat(param_list," ");
     }
@@ -1040,11 +1040,11 @@ void DoFileReadWork(struct ExecutionLogging* pEL,const char* name)
         {
             unsigned int size=0;
             unsigned long crc=0;
-            int file_found=0;                
+            int file_found=0;
 
             if (pEL->store_file_in_content != 0)
               file_found = DumpFileToPack(pEL,name,"src/",&size,&crc);
-            
+
             if ((pEL->store_file_in_content == 0) && (pEL->store_list_file_in_content != 0))
               file_found = ComputeFileCrc(name,&size,&crc);
 
@@ -1277,7 +1277,7 @@ UNITEX_FUNC int UNITEX_CALL AddActivityLogger(struct UniLoggerSpace *p_ule)
     if (pALPD == NULL)
         return 0;
     pALPD -> pTlsSlot = SyncBuildTls();
-    
+
     if (pALPD -> pTlsSlot == NULL)
     {
         free(pALPD);

--- a/logger/UniLogger.cpp
+++ b/logger/UniLogger.cpp
@@ -257,7 +257,7 @@ int SearchFileInFileToWriteArray(struct ExecutionLogging* pEL,const char*fn,unsi
 {
     unsigned int nbItem=GetNbItemPtrArrayExpanding(pEL->pAE_FileToWrite);
     unsigned int i;
-	int len_fn = (int)strlen(fn);
+    int len_fn = (int)strlen(fn);
     for (i=0;i<nbItem;i++)
     {
         const struct FileToWriteInfoItem* pFrif = (const struct FileToWriteInfoItem*)GetItemPtrArrayExpanding(pEL->pAE_FileToWrite,i);
@@ -267,14 +267,14 @@ int SearchFileInFileToWriteArray(struct ExecutionLogging* pEL,const char*fn,unsi
                 *pos=i;
             return 1;
         }
-		if (is_folder) {
-			int len_cur = (int)strlen(pFrif->FileName);
-			if ((len_cur > len_fn) && (memcmp(pFrif->FileName, fn, len_fn) == 0)) {
-				if (pos != NULL)
-					*pos = i;
-				return 1;
-			}
-		}
+        if (is_folder) {
+            int len_cur = (int)strlen(pFrif->FileName);
+            if ((len_cur > len_fn) && (memcmp(pFrif->FileName, fn, len_fn) == 0)) {
+                if (pos != NULL)
+                    *pos = i;
+                return 1;
+            }
+        }
     }
     return 0;
 }
@@ -312,18 +312,18 @@ unsigned int GetNbFileToWrite(struct ExecutionLogging* pEL)
 static void RemoveFileFileOnWriteArray(struct ExecutionLogging* pEL,const char*fn, int is_folder)
 {
     unsigned int pos;
-	for (;;)
-	{
-		if (SearchFileInFileToWriteArray(pEL, fn, &pos, is_folder) == 0)
-			return;
+    for (;;)
+    {
+        if (SearchFileInFileToWriteArray(pEL, fn, &pos, is_folder) == 0)
+            return;
 
-		struct FileToWriteInfoItem* pFrif = (struct FileToWriteInfoItem*)GetItemPtrArrayExpanding(pEL->pAE_FileToWrite, pos);
-		free((void*)pFrif->FileName);
+        struct FileToWriteInfoItem* pFrif = (struct FileToWriteInfoItem*)GetItemPtrArrayExpanding(pEL->pAE_FileToWrite, pos);
+        free((void*)pFrif->FileName);
 
-		DeleteItemPtrArrayExpanding(pEL->pAE_FileToWrite, pos);
-		if (is_folder == 0)
-			return;
-	}
+        DeleteItemPtrArrayExpanding(pEL->pAE_FileToWrite, pos);
+        if (is_folder == 0)
+            return;
+    }
 }
 
 void CleanFileWriteArray(struct ExecutionLogging* pEL)
@@ -586,7 +586,7 @@ static struct ExecutionLogging* BuildAllocInitExecutionLoggingForIncrementedNumb
 
             if (af_fseek(af_fin, 0, SEEK_END) == 0)
             {
-	            size_num_file = af_ftell(af_fin);
+                size_num_file = af_ftell(af_fin);
                 af_fseek(af_fin, 0, SEEK_SET);
             }
 
@@ -1205,12 +1205,12 @@ void ABSTRACT_CALLBACK_UNITEX UniLogger_after_af_remove(const char* name,int res
 
 void ABSTRACT_CALLBACK_UNITEX UniLogger_after_af_remove_folder(const char* name, int result, void* privateLoggerPtr)
 {
-	struct ExecutionLogging* pEL = GetExecutionLogging(privateLoggerPtr);
-	if (pEL == NULL)
-		return;
+    struct ExecutionLogging* pEL = GetExecutionLogging(privateLoggerPtr);
+    if (pEL == NULL)
+        return;
 
-	if (result == 0)
-		RemoveFileFileOnWriteArray(pEL, name, 1);
+    if (result == 0)
+        RemoveFileFileOnWriteArray(pEL, name, 1);
 }
 
 
@@ -1262,8 +1262,8 @@ const t_logger_func_array_ex_1 logger_func_array =
     UniLogger_LogErrWrite,//t_fnc_LogErrWrite fnc_LogErrWrite;
 
 
-	NULL, //t_fnc_before_af_remove fnc_before_af_remove;
-	UniLogger_after_af_remove_folder //t_fnc_after_af_remove fnc_after_af_remove;
+    NULL, //t_fnc_before_af_remove fnc_before_af_remove;
+    UniLogger_after_af_remove_folder //t_fnc_after_af_remove fnc_after_af_remove;
 } ;
 
 

--- a/logger/UniLogger.h
+++ b/logger/UniLogger.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/UniLoggerAutoInstall.cpp
+++ b/logger/UniLoggerAutoInstall.cpp
@@ -71,8 +71,8 @@ void InstallLogger::LoadParamFile(const char* parameter_filename) {
         size_t size_param=0;
 
         if (af_fseek(af_fin, 0, SEEK_END) == 0)
-	    {
-		    size_param = af_ftell(af_fin);
+        {
+            size_param = af_ftell(af_fin);
             af_fseek(af_fin, 0, SEEK_SET);
         }
 
@@ -324,28 +324,28 @@ using namespace logger;
 
 UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLogger()
 {
-	InstallLogger* pInstallLogger = new InstallLogger();
-	return (INSTALLLOGGER)pInstallLogger;
+    InstallLogger* pInstallLogger = new InstallLogger();
+    return (INSTALLLOGGER)pInstallLogger;
 }
 
 UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromArgs(int argc, char* const argv[])
 {
-	InstallLogger* pInstallLogger = new InstallLogger(argc,argv);
-	return (INSTALLLOGGER)pInstallLogger;
+    InstallLogger* pInstallLogger = new InstallLogger(argc,argv);
+    return (INSTALLLOGGER)pInstallLogger;
 }
 
 UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromParamFile(const char* paramFileName)
 {
-	InstallLogger* pInstallLogger = new InstallLogger(paramFileName);
-	return (INSTALLLOGGER)pInstallLogger;
+    InstallLogger* pInstallLogger = new InstallLogger(paramFileName);
+    return (INSTALLLOGGER)pInstallLogger;
 }
 
 UNITEX_FUNC void UNITEX_CALL RemoveLoggerFromParamFile(INSTALLLOGGER logger)
 {
-	InstallLogger* pInstallLogger = (InstallLogger*)logger;
-	if (pInstallLogger != NULL) {
-		delete (pInstallLogger);
-	}
+    InstallLogger* pInstallLogger = (InstallLogger*)logger;
+    if (pInstallLogger != NULL) {
+        delete (pInstallLogger);
+    }
 }
 
 

--- a/logger/UniLoggerAutoInstall.cpp
+++ b/logger/UniLoggerAutoInstall.cpp
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -63,7 +63,7 @@ namespace logger {
 
 void InstallLogger::LoadParamFile(const char* parameter_filename) {
     init_done = 0;
-    
+
     ABSTRACTFILE *af_fin = af_fopen_unlogged((parameter_filename != NULL) ?
                                 parameter_filename : "unitex_logging_parameters.txt","rb");
     if (af_fin!=NULL)
@@ -80,7 +80,7 @@ void InstallLogger::LoadParamFile(const char* parameter_filename) {
         *(param+size_param)=0;
         if (af_fread(param,1,size_param,af_fin) == size_param)
         {
-            
+
             int write_file_out=0;
             char*szPath = (char*)malloc(size_param+1);
             *szPath=0;
@@ -105,7 +105,7 @@ void InstallLogger::LoadParamFile(const char* parameter_filename) {
                 free(szPath);
         }
         af_fclose(af_fin);
-        free(param);        
+        free(param);
     }
 }
 
@@ -206,7 +206,7 @@ InstallLogger::InstallLogger(int argc,char* const argv[]) :
                  break;
        case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                              error("Missing argument for option --%s\n",lopts_CreateLog[index].name);
-                 return;            
+                 return;
        case 'k': if (options.vars()->optarg[0]=='\0') {
                     error("Empty input_encoding argument\n");
                     return;
@@ -237,14 +237,14 @@ InstallLogger::InstallLogger(int argc,char* const argv[]) :
                  }
                  ule.szNameLog = strdup(options.vars()->optarg);
                  break;
-     
+
        case 'd': if (options.vars()->optarg[0]=='\0') {
                     error("You must specify a non empty directory\n");
                     return;
                  }
                  if (ule.szPathLog != NULL) {
                      free((void*)ule.szPathLog);
-                 }    
+                 }
                  ule.szPathLog = strdup(options.vars()->optarg);
                  break;
 

--- a/logger/UniLoggerAutoInstall.h
+++ b/logger/UniLoggerAutoInstall.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -72,15 +72,15 @@ private:
 extern "C" {
 #endif
 
-	struct _INSTALL_LOGGER {
-		void* dummy;
-	};
-	typedef struct _INSTALL_LOGGER* INSTALLLOGGER;
+    struct _INSTALL_LOGGER {
+        void* dummy;
+    };
+    typedef struct _INSTALL_LOGGER* INSTALLLOGGER;
 
-	UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLogger();
-	UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromArgs(int argc, char* const argv[]);
-	UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromParamFile(const char* paramFileName);
-	UNITEX_FUNC void UNITEX_CALL RemoveLoggerFromParamFile(INSTALLLOGGER);
+    UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLogger();
+    UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromArgs(int argc, char* const argv[]);
+    UNITEX_FUNC INSTALLLOGGER UNITEX_CALL BuildLoggerFromParamFile(const char* paramFileName);
+    UNITEX_FUNC void UNITEX_CALL RemoveLoggerFromParamFile(INSTALLLOGGER);
 
 #ifdef __cplusplus
 }

--- a/logger/UniRunLogger.h
+++ b/logger/UniRunLogger.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/

--- a/logger/UniRunScript.h
+++ b/logger/UniRunScript.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/
@@ -53,36 +53,36 @@ namespace unitex {
 
 
 #ifdef __cplusplus
-	extern "C" {
+    extern "C" {
 #endif
 
-		// function export api
+        // function export api
 
 
 #ifdef __cplusplus
-	} // extern "C"
+    } // extern "C"
 #endif
 
 
 
 
-	extern const char* optstring_UniRunScript;
-	extern const struct option_TS lopts_UniRunScript[];
-	extern const char* usage_UniRunScript;
+    extern const char* optstring_UniRunScript;
+    extern const struct option_TS lopts_UniRunScript[];
+    extern const char* usage_UniRunScript;
 
-	int main_UniRunScript(int argc, char* const argv[]);
+    int main_UniRunScript(int argc, char* const argv[]);
 
 
-	extern const char* optstring_UniBatchRunScript;
-	extern const struct option_TS lopts_UniBatchRunScript[];
-	extern const char* usage_UniBatchRunScript;
+    extern const char* optstring_UniBatchRunScript;
+    extern const struct option_TS lopts_UniBatchRunScript[];
+    extern const char* usage_UniBatchRunScript;
 
-	int main_UniBatchRunScript(int argc, char* const argv[]);
+    int main_UniBatchRunScript(int argc, char* const argv[]);
 
 
 #ifdef __cplusplus
-	//        } // extern "C"
-	//    } // namespace logger
+    //        } // extern "C"
+    //    } // namespace logger
 } // namespace unitex
 #endif
 

--- a/logger/UnpackFile.cpp
+++ b/logger/UnpackFile.cpp
@@ -170,7 +170,7 @@ while (EOF!=(val=options.parse_long(argc,argv,optstring_UnpackFile,lopts_UnpackF
                break;
      case 'V': only_verify_arguments = true;
              break;
-     case 'h': usage();  
+     case 'h': usage();
                return SUCCESS_RETURN_CODE;
      case ':': index==-1 ? error("Missing argument for option -%c\n",options.vars()->optopt) :
                            error("Missing argument for option --%s\n",lopts_UnpackFile[index].name);

--- a/logger/UnpackFile.cpp
+++ b/logger/UnpackFile.cpp
@@ -206,17 +206,17 @@ if (only_verify_arguments) {
 
 int retValue = 0;
 if (list != 0) {
-	retValue = do_list_file_in_pack_archive_to_file(ulpFile,outputList,list_only_filename);
+    retValue = do_list_file_in_pack_archive_to_file(ulpFile,outputList,list_only_filename);
 } else {
-	if (selectFile[0] != '\0') {
-		retValue = do_extract_from_pack_archive_onefile(ulpFile,junk_path_in_pack_archive,outputDir,selectFile,transform_path_separator,quiet);
+    if (selectFile[0] != '\0') {
+        retValue = do_extract_from_pack_archive_onefile(ulpFile,junk_path_in_pack_archive,outputDir,selectFile,transform_path_separator,quiet);
   } else {
-		retValue = do_extract_from_pack_archive(ulpFile,junk_path_in_pack_archive,outputDir,transform_path_separator,quiet);
+        retValue = do_extract_from_pack_archive(ulpFile,junk_path_in_pack_archive,outputDir,transform_path_separator,quiet);
   }
 }
 
 if (retValue != UNZ_OK) {
-	error("error in processing %s",ulpFile);
+    error("error in processing %s",ulpFile);
 }
 
 return retValue;

--- a/logger/UnpackFile.h
+++ b/logger/UnpackFile.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * File created and contributed by Gilles Vollant (Ergonotics SAS) 
+ * File created and contributed by Gilles Vollant (Ergonotics SAS)
  * as part of an UNITEX optimization and reliability effort
  *
  * additional information: http://www.ergonotics.com/unitex-contribution/


### PR DESCRIPTION
- add an .editorconfig file unifying the coding style for different editors and IDEs. See http://editorconfig.org for information about how to use it
- add a .clang-format (>= v3.8) configuration file for code formatting. Starting Unitex/GramLab v3.2, we will start to follow the Google C++ Style Guide (https://google.github.io/styleguide/cppguide.html).  For now, this only applies for new code files (i.e not for legacy sources previous to the v3.2-alpha)
- convert tabs into spaces. This closes #6