### PR TITLE
[bin exp enhance] Enable outputs for subgraphs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ git:
 
 # Save common build configurations as shortcuts, so we can reference them later.
 addons_shortcuts:
-  addons_clang35: &clang35
-    apt:
-      sources:    [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
-      packages:   [ 'clang-3.5', 'cmake', 'cppcheck', 'valgrind' ]
-  addons_clang38: &clang38
-    apt:
-      sources:    [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise' ]
-      packages:   [ 'clang-3.8', 'cmake', 'cppcheck', 'valgrind' ]
+  #addons_clang35: &clang35
+    #apt:
+      #sources:    [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+      #packages:   [ 'clang-3.5', 'cmake', 'cppcheck', 'valgrind' ]
+  #addons_clang38: &clang38
+    #apt:
+      #sources:    [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise' ]
+      #packages:   [ 'clang-3.8', 'cmake', 'cppcheck', 'valgrind' ]
   addons_gcc49:   &gcc47
     apt:
       sources:    [ 'ubuntu-toolchain-r-test' ]
@@ -59,16 +59,16 @@ matrix:
   # the build to finish as soon as possible
   fast_finish: true
   include:
-    - os: linux
-      dist: trusty
-      compiler: "clang"
-      env: CXX=clang++-3.5
-      addons: *clang35
-    - os: linux
-      dist: trusty
-      compiler: "clang"
-      env: CXX=clang++-3.8
-      addons: *clang38
+    #- os: linux
+      #dist: trusty
+      #compiler: "clang"
+      #env: CXX=clang++-3.5
+      #addons: *clang35
+    #- os: linux
+      #dist: trusty
+      #compiler: "clang"
+      #env: CXX=clang++-3.8
+      #addons: *clang38
     - os: linux
       dist: trusty
       compiler: "gcc"

--- a/Cassys_lexical_tags.cpp
+++ b/Cassys_lexical_tags.cpp
@@ -741,6 +741,15 @@ int get_form_lemma_separator_position(unichar *text){
         if(text[i]==',' && brace_level == 1 && i+1<size-1 && text[i+1]=='.'){
             break;
         }
+        else if (text[i]==',' && brace_level == 1) {
+            int y = i+1;
+            while(y<size-1 && text[y] !='.') {
+                y++;
+            }
+            if(y >= size-1)
+                i = 1;
+            break;
+        }
     }
     return i;
 

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -191,6 +191,7 @@ vector_int_add(infos->part_of_precompiled_fst2,0);
 infos->current_saved_graph=0;
 infos->check_outputs=0;
 infos->strict_tokenization=0;
+infos->graph_output=new_string_hash();
 return infos;
 }
 
@@ -205,6 +206,7 @@ free_string_hash(infos->graph_names);
 free_string_hash(infos->tags);
 free_vector_int(infos->renumber);
 free_vector_int(infos->part_of_precompiled_fst2);
+free_string_hash(infos->graph_output);
 free(infos);
 }
 
@@ -800,7 +802,7 @@ return 0;
 static int* token_sequence_2_integer_sequence(struct fifo* u_tokens,unichar* output,
                                               struct compilation_info* infos,
                                               int *n_tokens,int current_graph,int must_add_token_to_debug,
-                                              int must_keep_output) {
+                                              int must_keep_output, int is_first,int has_loop) {
 int* i_tokens = NULL;
 size_t size_alloc_i_token=0;
 reallocate_int_buffer(&i_tokens, &size_alloc_i_token, 1);
@@ -813,6 +815,37 @@ if (is_empty(u_tokens)) {
 *n_tokens=0;
 unichar* token=(unichar*)take_ptr(u_tokens);
 unichar tmp_stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
+    if(is_first == 1) {
+        int idx = get_value_index(infos->graph_names->value[current_graph],infos->graph_output,DONT_INSERT,NULL);
+        if (idx < 0) {
+            int j;
+            idx = get_longest_key_index(infos->graph_names->value[current_graph],&j,infos->graph_output);
+        }
+        if (idx>=0) {
+            int output_len = u_strlen(infos->graph_output->value[idx]) + 1;
+            if(has_loop == 1) {
+                error("WARNING in %S: ignoring self-loop in subgraph call %S\n",token,infos->graph_names->value[current_graph]);
+            }
+	    else if(output != NULL && output_len > 1 && output[0]== '$') {
+	         error("WARNING in %S: ignoring the variable %S in its output in the subgraph call %S\n",token,output,infos->graph_names->value[current_graph]);
+	    }
+	    else {
+            	unichar *new_output = (unichar*) malloc(sizeof(unichar) * output_len);
+            	u_strcpy(new_output,infos->graph_output->value[idx]);
+            	if(output == NULL || output[0]=='\0' ) {
+                    output = (unichar*) malloc(sizeof(unichar) * output_len);
+            	}
+            	else {
+                    int new_output_len =  u_strlen(output) + output_len;
+                    new_output = (unichar*) realloc(new_output,sizeof(unichar) * new_output_len);
+                    u_strcat(new_output,output);
+                    output = (unichar*) malloc(sizeof(unichar) * new_output_len);
+            	}
+                u_strcpy(output,new_output);
+                free(new_output);
+	    }
+        }
+    }
 int is_an_output=(output!=NULL && output[0]!='\0');
 if (!must_keep_output && is_an_output && !u_strcmp(token,"<E>") && output[1]==DEBUG_INFO_COORD_MARK) {
     /* We don't want to produce debug outputs for <E> that had no actual
@@ -833,8 +866,10 @@ if (token[0]==':' && token[1]!='\0') {
         free_choosen_allocated_or_stack_unichar_buffer(tmp,tmp_stack);
     }
     else if (is_an_output) {
-      error("WARNING in %S: ignoring output associated to subgraph call %S\n",
-            infos->graph_names->value[current_graph],token);
+         // store ouput of the sub graph for later
+        get_value_index(token+1,infos->graph_output,output);
+      /*error("WARNING in %S: ignoring output associated to subgraph call %S\n",
+            infos->graph_names->value[current_graph],token);*/
    }
    if (!is_empty(u_tokens)) {
       fatal_error("%S: unexpected token after subgraph call in token_sequence_2_integer_sequence\n",
@@ -991,14 +1026,14 @@ if (infos->strict_tokenization) {
 int* sequence_ent;
 int n_tokens;
 if (!infos->debug) {
-    sequence_ent=token_sequence_2_integer_sequence(sequence,output,infos,&n_tokens,n,1,0);
+    sequence_ent=token_sequence_2_integer_sequence(sequence,output,infos,&n_tokens,n,1,0,state->is_first,state->has_loop);
 } else {
     unichar output2stack[DEFAULT_UNICHAR_TMP_BUFFER_SIZE];
     // added debug info take less than 80 unichar
     unichar*output2 = choose_allocated_or_stack_unichar_buffer(output2stack, DEFAULT_UNICHAR_TMP_BUFFER_SIZE, u_strlen(output) + 0x80);
     u_strcpy(output2,output);
     add_debug_infos(output2,n,state->box_number,line);
-    sequence_ent=token_sequence_2_integer_sequence(sequence,output2,infos,&n_tokens,n,1,0);
+    sequence_ent=token_sequence_2_integer_sequence(sequence,output2,infos,&n_tokens,n,1,0,state->is_first,state->has_loop);
     free_choosen_allocated_or_stack_unichar_buffer(output2, output2stack);
 }
 free_fifo(sequence);
@@ -1014,26 +1049,26 @@ free_reallocate_int_buffer(&sequence_ent);
 static void process_variable_or_context(SingleGraph graph,const unichar* input,
                                         vector_int* transitions,
                                         int current_state,struct compilation_info* infos,
-                                        int current_graph,unichar* debug_output) {
+                                        int current_graph,unichar* debug_output,int is_first, int has_loop) {
 struct fifo* tmp=new_fifo();
 int token[2];
 int i;
 int n=0;
 if (debug_output[0]!='\0' && u_strcmp(input,"$]")) {
     put_ptr(tmp,u_strdup("<E>"));
-    int* i_token1=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
+    int* i_token1=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1,is_first,has_loop);
     *(token + n) = *i_token1;
     n++;
     free_reallocate_int_buffer(&i_token1);
 }
 put_ptr(tmp,u_strdup(input));
-int* i_token2=token_sequence_2_integer_sequence(tmp,NULL,infos,&i,current_graph,0,0);
+int* i_token2=token_sequence_2_integer_sequence(tmp,NULL,infos,&i,current_graph,0,0,is_first,has_loop);
 *(token + n) = *i_token2;
 n++;
 free_reallocate_int_buffer(&i_token2);
 if (debug_output[0]!='\0' && !u_strcmp(input,"$]")) {
     put_ptr(tmp,u_strdup("<E>"));
-    int* i_token3=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1);
+    int* i_token3=token_sequence_2_integer_sequence(tmp,debug_output,infos,&i,current_graph,0,1,is_first,has_loop);
     *(token + n) = *i_token3;
     n++;
     free_reallocate_int_buffer(&i_token3);
@@ -1214,7 +1249,7 @@ if ((length>2 && box_content[0]=='$' &&
        debug_output[size]=DEBUG_INFO_END_MARK;
        debug_output[size+1]='\0';
    }
-   process_variable_or_context(graph,input,transitions,current_state,infos,n,debug_output);
+   process_variable_or_context(graph,input,transitions,current_state,infos,n,debug_output,state->is_first,state->has_loop);
    free_choosen_allocated_or_stack_unichar_buffer(input,input_stack);
    free_choosen_allocated_or_stack_unichar_buffer(debug_output, debug_output_stack);
    return;
@@ -1428,6 +1463,18 @@ for (int i=0;i<fst2->number_of_graphs;i++) {
 free_Ustring(ustr);
 }
 
+int check_loop(Grf *g, int i, int top) {
+    u_printf("In test_crap for %d\n",i);
+    for (int x=0,y=g->states[i]->transitions->nbelems;x<y;x++) {
+        int next_box = g->states[i]->transitions->tab[x];
+        int trans = vector_int_contains(g->states[next_box]->transitions,top);
+        u_printf("%S %d\n",g->states[next_box]->box_content,trans);
+        if (trans == 1)
+            return 1;
+        return check_loop(g,next_box,top);
+    }
+    return -1;
+}
 
 /**
  * This function compiles the graph number #n and saves its states into the
@@ -1522,6 +1569,32 @@ for (i=0;i<grf->n_states;i++) {
        grf->states[i]->transitions->tab[x]=grf->states[i]->transitions->tab[y];
        grf->states[i]->transitions->tab[y]=tmp;
    }
+    if(grf->states[i]->box_number == 0) { // this is start box
+        for (int x=0,y=grf->states[i]->transitions->nbelems;x<y;x++) {
+            int next_box = grf->states[i]->transitions->tab[x];
+            int length = u_strlen(grf->states[next_box]->box_content);
+            if (length>3 && (grf->states[next_box]->box_content)[1]=='$') {
+                if ((grf->states[next_box]->box_content)[length-2]=='('
+                    || !u_strcmp(grf->states[next_box]->box_content,"\"$[\"")
+                    || !u_strcmp(grf->states[next_box]->box_content,"\"$<\""))
+                {
+                    for(int m=0,n=grf->states[next_box]->transitions->nbelems;m<n;m++) {
+                        int second_box = grf->states[next_box]->transitions->tab[m];
+                        grf->states[second_box]->is_first = 1;
+                        grf->states[second_box]->has_loop =
+                            vector_int_contains(grf->states[second_box]->transitions,second_box);
+                    }
+                }
+            }
+            else {
+                grf->states[next_box]->has_loop = vector_int_contains(grf->states[next_box]->transitions,next_box);
+                grf->states[next_box]->is_first = 1;
+                if (grf->states[next_box]->has_loop != 1) {
+                    grf->states[next_box]->has_loop = check_loop(grf,next_box,next_box);
+                }
+            }
+        }
+    }
    process_grf_state(grf->states[i]->box_content+1,grf->states[i]->transitions,graph,i,n,infos,grf->states[i]);
 }
 free_Grf(grf);

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -1584,7 +1584,7 @@ for (i=0;i<grf->n_states;i++) {
        grf->states[i]->transitions->tab[x]=grf->states[i]->transitions->tab[y];
        grf->states[i]->transitions->tab[y]=tmp;
    }
-    if(grf->states[i]->box_number == 0) { // this is start box
+    if(grf->states[i]->box_number == 0 && n > 0) { // this is start box
         for (int x=0,y=grf->states[i]->transitions->nbelems;x<y;x++) {
             int next_box = grf->states[i]->transitions->tab[x];
             int length = u_strlen(grf->states[next_box]->box_content);

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -1463,15 +1463,30 @@ for (int i=0;i<fst2->number_of_graphs;i++) {
 free_Ustring(ustr);
 }
 
-int check_loop(Grf *g, int i, int top) {
-    u_printf("In test_crap for %d\n",i);
+int is_visited(int *visit_list, int len, int i) {
+    if (visit_list == NULL)
+        return 0;
+    for (int j = 0; j < len; j++) {
+        if (visit_list[j] == i)
+            return 1;
+    }
+    return 0;
+}
+
+int check_loop(Grf *g, int i, int top, int *visited,int *len) {
     for (int x=0,y=g->states[i]->transitions->nbelems;x<y;x++) {
         int next_box = g->states[i]->transitions->tab[x];
-        int trans = vector_int_contains(g->states[next_box]->transitions,top);
-        u_printf("%S %d\n",g->states[next_box]->box_content,trans);
-        if (trans == 1)
-            return 1;
-        return check_loop(g,next_box,top);
+        if (next_box !=i) {
+            if(1 == vector_int_contains(g->states[next_box]->transitions,top)) 
+                return 1;
+            if(is_visited(visited,*len,next_box) == 0) {
+                //visited = (int*) realloc(visited, (*len + 1)*sizeof(int));
+                visited[*len] = next_box;
+                *len = *len + 1;
+                if(1== check_loop(g,next_box,top,visited, len))
+                    return 1;
+            }
+        }
     }
     return -1;
 }
@@ -1590,8 +1605,13 @@ for (i=0;i<grf->n_states;i++) {
                 grf->states[next_box]->has_loop = vector_int_contains(grf->states[next_box]->transitions,next_box);
                 grf->states[next_box]->is_first = 1;
                 if (grf->states[next_box]->has_loop != 1) {
-                    grf->states[next_box]->has_loop = check_loop(grf,next_box,next_box);
-                }
+                    //int *visited = NULL;
+                    int visited[50];
+                    int length = 0;
+                    grf->states[next_box]->has_loop = check_loop(grf,next_box,next_box, visited,&length);
+                    //if (visited != NULL)
+                      //  free(visited);
+                } 
             }
         }
     }

--- a/Grf2Fst2_lib.h
+++ b/Grf2Fst2_lib.h
@@ -91,6 +91,8 @@ struct compilation_info {
    int current_saved_graph;
    char check_outputs;
    char strict_tokenization;
+   /* output associated with subgraphs*/
+   struct string_hash* graph_output;
 };
 
 

--- a/Grf_lib.cpp
+++ b/Grf_lib.cpp
@@ -98,6 +98,8 @@ s->box_content=NULL;
 s->transitions=new_vector_int();
 s->rank=-1;
 s->box_number=-1;
+s->is_first=-1;
+s->has_loop=0;
 return s;
 }
 
@@ -112,6 +114,8 @@ s->x=x;
 s->y=y;
 s->box_number=box_number;
 s->rank=rank;
+s->is_first=-1;
+s->has_loop=0;
 return s;
 }
 

--- a/Grf_lib.h
+++ b/Grf_lib.h
@@ -52,6 +52,17 @@ typedef struct {
      * state array of the grf object.
      */
     int box_number;
+
+    /* is_first is used to identify if the box is first one after the start
+     * 1 is for yes
+     * -1 is for no
+     * 0 is for context
+     */
+    int is_first;
+    /* if the box has a self loop
+     * 1 is for yes
+     */
+    int has_loop;
 } GrfState;
 
 


### PR DESCRIPTION
Users can now have outputs on the boxes defined as subgraphs. The output will be ignored if the first box inside the subgraph has a loop or a dictionary variable in case of morphological mode. In other cases, the output will be added to the first box of the subgraph. If the box already has an output then the subgraph’s output will be prepended