### PR TITLE
#29 - Fix memory issue in Grf2Fst2 for graphs containing more than 50…

### DIFF
--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -1678,12 +1678,14 @@ for (i=0;i<grf->n_states;i++) {
                 grf->states[next_box]->has_loop = vector_int_contains(grf->states[next_box]->transitions,next_box);
                 grf->states[next_box]->is_first = 1;
                 if (grf->states[next_box]->has_loop != 1) {
-                    //int *visited = NULL;
-                    int visited[50];
+                    // Assigning with twice the potential max size of states
+                    int *visited = (int*)malloc(2*grf->n_states*sizeof(int));
+                    if (visited == NULL) {
+                      fatal_alloc_error("compile_grf");
+                    }
                     int length = 0;
                     grf->states[next_box]->has_loop = check_loop(grf,next_box,next_box, visited,&length);
-                    //if (visited != NULL)
-                      //  free(visited);
+                    free(visited);
                 }
             }
         }

--- a/Grf2Fst2_lib.cpp
+++ b/Grf2Fst2_lib.cpp
@@ -1477,7 +1477,7 @@ int check_loop(Grf *g, int i, int top, int *visited,int *len) {
     for (int x=0,y=g->states[i]->transitions->nbelems;x<y;x++) {
         int next_box = g->states[i]->transitions->tab[x];
         if (next_box !=i) {
-            if(1 == vector_int_contains(g->states[next_box]->transitions,top)) 
+            if(1 == vector_int_contains(g->states[next_box]->transitions,top))
                 return 1;
             if(is_visited(visited,*len,next_box) == 0) {
                 //visited = (int*) realloc(visited, (*len + 1)*sizeof(int));
@@ -1636,8 +1636,8 @@ for (i=0;i<grf->n_states;i++) {
                 } else if(input[j] == ':' && input[j-1] != '\\' && in_Token == 0) {
                     found = 1;
                     break;
-                }   
-            }   
+                }
+            }
             if (found == 0) {
                 input[1] = 'X';
                 input[2] = '/';
@@ -1684,7 +1684,7 @@ for (i=0;i<grf->n_states;i++) {
                     grf->states[next_box]->has_loop = check_loop(grf,next_box,next_box, visited,&length);
                     //if (visited != NULL)
                       //  free(visited);
-                } 
+                }
             }
         }
     }


### PR DESCRIPTION
… states

Removing the hardcoded size of 50 for int pointers in loop checker of Grf2Fst2.
Tests replayed OK, with memory tests.


