### PR TITLE
[fix #53] Avoid generating invalid XML concordance files

### DIFF
--- a/Concordance.cpp
+++ b/Concordance.cpp
@@ -561,7 +561,7 @@ while ((c=u_fgetc(f))!=EOF) {
          u_to_char(tmp1,indices);
          int start,end;
          sscanf(tmp1,"%d %d",&start,&end);
-         u_fprintf(out,"<concordance start=\"%d\" end=\"%d\">%S</concordance>\n",start,end,middle);
+         u_fprintf(out,"<concordance start=\"%d\" end=\"%d\"><![CDATA[%S]]></concordance>\n",start,end,middle);
       }
       /* If must must produce an axis file...
          VARIABLES :


### PR DESCRIPTION
## Description
Concordance XML files can be invalid XML because matches are inserted as-is, but can contain special characters.

This patch encloses matches in CDATA sections when generating XML.

It should solve #53.

## How Has This Been Tested?
I re-ran our internal problematic test case and now our XPath queries work as expected, and do not complain that XML is invalid.

## Type of files
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [x] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [ ] None of the above (normal change)

(not sure on this one)

## Type of change
- [ ] `deprecat`: Deprecation of a once-stable feature
- [ ] `enhance`: Enhancement in existing functionality
- [x] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
- [x] My code compiles
- [x] My code follows the code style of this project
- [x] My code includes javadoc/doxygen where appropriate
- [ ] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one

About the repetitive code, I must admit I did not investigate if XML is generated in other places (and maybe the code could be mutualized).

I ran the `unitex-core-tests` and they naturally fail because the expected XML files in `concord_offset_uima_xml.ulp` and `demoRunScript.ulp` are not exactly the same anymore (although functionally it is the same). I could maybe just unpack them, put the matches in `CDATA` sections and be done with it, but maybe it would be cheating ; do you have a better suggestion? I read the 13.1 section in the PDF documentation, but can I replay logs (to generate actual new expected output) instead of recording a new one (that I don't really how to create)? And I'd like to try to add relevant tests to explicitly check for XML conformity even with special chars in input.