### PR TITLE
[fix #56] Add different option processing for `-s0`

### DIFF
--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -1994,7 +1994,7 @@ int CFstApp::outWordsOfGraph(int depth) {
 //
 //
 
-const char* optstring_Fst2List=":o:Sp:a:t:l:i:mdf:vVhs:qr:c:";
+const char* optstring_Fst2List=":o:Sp:a:t:l:i:mdf:vVhs:qr:c:g:";
 const struct option_TS lopts_Fst2List[]= {
   {"output",required_argument_TS,NULL,'o'},
   {"ignore_outputs",required_argument_TS,NULL,'a'},
@@ -2168,7 +2168,9 @@ int main_Fst2List(int argc, char* const argv[]) {
       return USAGE_ERROR_CODE;
     case 'g': // option '--io_separator'
       io_separator:
-      wp = (char*) &options.vars()->optarg[1]-1;
+      if(val=='g') { // check the deprcated option '-s0' wasn't used
+        wp = (char*) &options.vars()->optarg[1]-1;
+      }
       wp3 = 0;
       wp2 = aa.saveSep = new unichar[strlen(wp) + 1];
       while (*wp) {
@@ -2213,6 +2215,7 @@ int main_Fst2List(int argc, char* const argv[]) {
         u_printf("Warning: '-s0' is deprecated, use '--io_separator' instead\n");
         // manually increment optind to consume more args than expected by getopt
         options.vars()->optind++;
+        wp = (char*) &options.vars()->optarg[2];
         // goto the correct switch case to avoid code duplication
         goto io_separator;
       case 's':

--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2168,7 +2168,7 @@ int main_Fst2List(int argc, char* const argv[]) {
       return USAGE_ERROR_CODE;
     case 'g': // option '--io_separator'
       io_separator:
-      if(val=='g') { // check the deprcated option '-s0' wasn't used
+      if(val=='g') { // check the deprecated option '-s0' wasn't used
         wp = (char*) &options.vars()->optarg[1]-1;
       }
       wp3 = 0;


### PR DESCRIPTION
Add different option processing for `-s0`
Also add `-g` as an alternative option (I forgot adding it to `optstring` previously)

## Motivation and Context
Fix issue #56, preventing from using the deprecated `-s0` used by the Java code.

## How Has This Been Tested?
Test graphs, see #56.

## Type of files
<!-- What type of files does your pull request modify? Put an `x` in the box (only the mainly type) that apply: -->
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
<!-- What level of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [ ] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [x] None of the above (normal change)

## Type of change
<!-- What type of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `deprecat`: Deprecation of a once-stable feature
- [ ] `enhance`: Enhancement in existing functionality
- [x] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code compiles
- [x] My code follows the code style of this project
- [x] My code includes javadoc/doxygen where appropriate
- [x] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one
<!-- Check if all the points above have an `x`, if so you can submit your PR for review -->
