### PR TITLE
[fix] Fst2List -s0 option on Windows version

### DIFF
--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2428,7 +2428,7 @@ int main_Fst2List(int argc, char* const argv[]) {
     case 'g': // option '--io_separator'
       io_separator:
       if(val=='g') { // check the deprecated option '-s0' wasn't used
-        wordPtr = (char*) &options.vars()->optarg[1]-1;
+        wordPtr = (char*) &options.vars()->optarg[0];
       }
       wordPtr3 = 0;
       wordPtr2 = aa.saveSep = new unichar[strlen(wordPtr) + 1];
@@ -2474,7 +2474,8 @@ int main_Fst2List(int argc, char* const argv[]) {
         u_printf("Warning: '-s0' is deprecated, use '--io_separator' instead\n");
         // manually increment optind to consume more args than expected by getopt
         options.vars()->optind++;
-        wordPtr = (char*) &options.vars()->optarg[2];
+        //wordPtr = (char*) &options.vars()->optarg[2];
+        wordPtr = argv[options.vars()->optind-1];
         // goto the correct switch case to avoid code duplication
         goto io_separator;
       case 's':

--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2474,7 +2474,6 @@ int main_Fst2List(int argc, char* const argv[]) {
         u_printf("Warning: '-s0' is deprecated, use '--io_separator' instead\n");
         // manually increment optind to consume more args than expected by getopt
         options.vars()->optind++;
-        //wordPtr = (char*) &options.vars()->optarg[2];
         wordPtr = argv[options.vars()->optind-1];
         // goto the correct switch case to avoid code duplication
         goto io_separator;


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. 
Note that the Title must conform to the subject of a commit message

See the **Commit Message Guidelines** for more information:
https://github.com/UnitexGramLab/unitex-doc-contributor-guidelines/blob/master/pages/05.guidelines/01.commits/docs.md 
-->

## Description
Change the way `-s0` argument is accessed.
Fix weird pointer manipulation.

## Motivation and Context
Further fix a bug concerning `-s0` option (though deprecated) introduced by [PR 48](https://github.com/UnitexGramLab/unitex-core/pull/48) and partially fixed in [PR 57](https://github.com/UnitexGramLab/unitex-core/pull/57).
An issue remained in the Windows version, which ignored the separator given in argument, making the option useless.

## How Has This Been Tested?
Tested on both Debian and Windows using `-t s -s0 "/"` options.

<!-- If this project features any kind of testing (unit, integration, regression), uncomment and complete the following checklist -->
<!-- - [ ] I have added tests to cover my changes  -->
<!-- - [ ] All new and existing tests passed  -->

## Type of files
<!-- What type of files does your pull request modify? Put an `x` in the box (only the mainly type) that apply: -->
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
<!-- What level of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [ ] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [x] None of the above (normal change)

## Type of change
<!-- What type of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `deprecat`: Deprecation of a once-stable feature
- [ ] `enhance`: Enhancement in existing functionality
- [x] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code compiles
- [x] My code follows the code style of this project
- [x] My code includes javadoc/doxygen where appropriate
- [x] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one
<!-- Check if all the points above have an `x`, if so you can submit your PR for review -->
