### PR TITLE
[minor fix] Fix arg parsing for option `-r`

### DIFF
--- a/Fst2List.cpp
+++ b/Fst2List.cpp
@@ -2394,7 +2394,7 @@ int main_Fst2List(int argc, char* const argv[]) {
       options.vars()->optind++;
       // parse the "L[,R]" string
       aa.saveEntre = new unichar[strlen(&options.vars()->optarg[1]) + 1];
-      wordPtr = (char*) &options.vars()->optarg[1];
+      wordPtr = (char*) &options.vars()->optarg[2];
       wordPtr2 = aa.saveEntre;
       wordPtr3 = 0;
       while (*wordPtr) {


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. 
Note that the Title must conform to the subject of a commit message

See the **Commit Message Guidelines** for more information:
https://github.com/UnitexGramLab/unitex-doc-contributor-guidelines/blob/master/pages/05.guidelines/01.commits/docs.md 
-->

## Description
Correct the index for the argument access in option `-r x "L[,R]"`.

## Motivation and Context
Fix a bug introduced in [PR 48](https://github.com/UnitexGramLab/unitex-core/pull/48) which made option `-r x` unusable.

## How Has This Been Tested?
This was tested on graphs containing cycles.

<!-- If this project features any kind of testing (unit, integration, regression), uncomment and complete the following checklist -->
<!-- - [ ] I have added tests to cover my changes  -->
<!-- - [ ] All new and existing tests passed  -->

## Type of files
<!-- What type of files does your pull request modify? Put an `x` in the box (only the mainly type) that apply: -->
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
<!-- What level of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [x] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [ ] None of the above (normal change)

## Type of change
<!-- What type of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `deprecat`: Deprecation of a once-stable feature
- [ ] `enhance`: Enhancement in existing functionality
- [x] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code compiles
- [x] My code follows the code style of this project
- [x] My code includes javadoc/doxygen where appropriate
- [x] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one
<!-- Check if all the points above have an `x`, if so you can submit your PR for review -->
