### PR TITLE
[enhance] Add --selxpath option in Unxmlize to select a part of xml file

### DIFF
--- a/Ustring.h
+++ b/Ustring.h
@@ -202,6 +202,11 @@ empty(dest);
 u_strcat(dest,src);
 }
 
+inline void u_switch(Ustring* str1,Ustring* str2) {
+Ustring tmp=*str1;
+*str1=*str2;
+*str2=tmp;
+}
 
 /**
  * Removes the '\n' at the end of the given Ustring, if any.

--- a/Xml.cpp
+++ b/Xml.cpp
@@ -31,10 +31,239 @@
 
 namespace unitex {
 
-int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-        UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien);
-int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-        void* html_ctx);
+
+
+struct selpath_info
+{
+    const unichar* tagname;
+    const unichar* tagkey;
+    const unichar* tagvalue;
+    bool entered_conform_name;
+    bool entered_conform_key_value;
+};
+
+class XmlSelect
+{
+   public:
+       XmlSelect() :
+         path_initialized(false), nbDepthSelPath(0), depthCurPath(-1), buf(NULL), paths(NULL), path_conform(true)
+         {};
+       ~XmlSelect() {
+         clear();
+       }
+       bool initSelPath(const char* selPath);
+       void enterNewTag(const unichar* tag, bool& in_selection);
+       void addKeyValueOnTag(const unichar* key, const unichar* value, bool& in_selection);
+       void exitTag(bool& in_selection);
+   private:
+       void clear() {
+           path_initialized=false;
+           nbDepthSelPath=0;
+           depthCurPath=-1;
+           free(paths);
+           paths=NULL;
+           free(buf);
+           buf=NULL;
+           path_conform=true;
+       }
+       bool path_initialized;
+       int nbDepthSelPath;
+       int depthCurPath;
+       unichar* buf;
+       struct selpath_info* paths;
+       bool path_conform;
+};
+
+// exemple: /TEI/teiHeader//sourceDesc//analytic/idno[@type='DOI']
+bool XmlSelect::initSelPath(const char* selPath)
+{
+    int maxDepthSelPath = 0;
+    size_t pos;
+    clear();
+
+    if ((selPath == NULL) || (selPath[0] == '\0'))
+      return true;
+
+    size_t l_path=strlen(selPath);
+    if (selPath[0]!='/') return false;
+    for (pos=0;pos<l_path;pos++) {
+      if (selPath[pos]=='/') maxDepthSelPath++;
+    }
+
+    buf=(unichar*)malloc(sizeof(unichar*)*(size_t)((maxDepthSelPath*4)+(l_path*2)));
+    if (buf == NULL) {
+        alloc_error("initSelPath");
+        clear();
+        return false;
+    }
+    unichar* browse_buf = buf;
+
+
+    paths = (struct selpath_info*)malloc(sizeof(struct selpath_info)*(maxDepthSelPath + 1));
+
+    if (paths == NULL) {
+        alloc_error("initSelPath");
+        clear();
+        return false;
+    }
+
+    size_t i=0;
+    size_t next_start = 1;
+    for (pos=1;pos<=l_path;pos++) {
+      const bool is_end = ((selPath[pos] == '\0') || (selPath[pos] == '/'));
+      if (is_end) {
+        size_t end_tag_name=pos;
+
+        paths[i].tagkey = NULL;
+        paths[i].tagvalue = NULL;
+        paths[i].entered_conform_name = paths[i].entered_conform_key_value = false;
+
+        for (size_t j = next_start; j < pos; j++) {
+          if (selPath[j] == '[') {
+              end_tag_name = j;
+              if (selPath[j+1] != '@') {
+                  clear();
+                  return false;
+              }
+
+              size_t pos_egal;
+              for (pos_egal = j + 1; pos_egal < pos; pos_egal++)
+                  if (selPath[pos_egal] == '=') break;
+              if (pos_egal==pos) {
+                  clear();
+                  return false;
+              }
+
+              u_strcpy_sized(browse_buf, pos_egal - (j+1), selPath + j + 2);
+              paths[i].tagkey = browse_buf;
+              browse_buf += u_strlen(browse_buf) + 1;
+
+              size_t pos_end_tag_val;
+              for (pos_end_tag_val = pos_egal + 1; pos_end_tag_val<l_path;pos_end_tag_val++)
+                if (selPath[pos_end_tag_val] == ']')
+                  break;
+
+              if (pos_end_tag_val == pos) {
+                  clear();
+                  return false;
+              }
+
+              const char* begin_val = selPath + pos_egal + 1;
+              size_t size_val       = pos_end_tag_val - (pos_egal + 1);
+
+              if ((size_val >= 2) && (begin_val[0] == begin_val[size_val - 1]) && (begin_val[0] == '\'')) {
+                begin_val++;
+                size_val -= 2;
+              }
+
+              if ((size_val >= 2) && (begin_val[0] == begin_val[size_val - 1]) && (begin_val[0] == '"')) {
+                begin_val++;
+                size_val -= 2;
+              }
+
+              u_strcpy_sized(browse_buf, size_val+1, begin_val);
+              paths[i].tagvalue = browse_buf;
+              browse_buf += u_strlen(browse_buf) + 1;
+
+              break;
+          }
+        }
+
+        u_strcpy_sized(browse_buf,1+end_tag_name-next_start,selPath+next_start);
+        paths[i].tagname = browse_buf;
+        browse_buf += u_strlen(browse_buf) + 1;
+        i++;
+        next_start = pos + 1;
+      }
+    }
+
+    nbDepthSelPath = (int)i;
+
+    return path_initialized = true;
+}
+
+
+void XmlSelect::enterNewTag(const unichar* tag, bool& in_selection)
+{
+    if (!path_initialized) return;
+    if (u_strcmp(tag, "?xml") == 0)
+        return;
+    if (tag[0] == '/') {
+        exitTag(in_selection);
+        return;
+    }
+
+    bool previousConform = true;
+    if ((depthCurPath>0) && (depthCurPath<nbDepthSelPath))
+        previousConform = (paths[depthCurPath].entered_conform_name) && (paths[depthCurPath].entered_conform_key_value);
+    depthCurPath++;
+
+
+#ifdef XMLSELECT_VERBOSE
+    for (int i = 0; i < depthCurPath;i++) u_printf(" ");
+    u_printf("-> enter tag '%S' (depth %i)\n",tag,depthCurPath);
+#endif
+
+    if ((depthCurPath >= nbDepthSelPath) || (depthCurPath < 0))
+        return;
+    struct selpath_info& curPath = paths[depthCurPath];
+    if ((curPath.tagname == NULL) || (curPath.tagname[0] == '\0'))
+        curPath.entered_conform_name = previousConform;
+    else
+        curPath.entered_conform_name = previousConform && ((u_strcmp(curPath.tagname,tag) == 0));
+
+    if (!curPath.entered_conform_name)
+      curPath.entered_conform_name = curPath.entered_conform_name;
+
+    if (curPath.tagkey == NULL)
+        curPath.entered_conform_key_value = curPath.entered_conform_name;
+    else
+        curPath.entered_conform_key_value = false;
+
+    if ((curPath.entered_conform_name && curPath.entered_conform_key_value) && (depthCurPath+1==nbDepthSelPath))
+        in_selection=true;
+}
+
+void XmlSelect::addKeyValueOnTag(const unichar* key, const unichar* value, bool& in_selection)
+{
+    if (!path_initialized) return;
+#ifdef XMLSELECT_VERBOSE
+    for (int i = 0; i < depthCurPath;i++) u_printf(" ");
+    u_printf("-> add key,value '%S'='%S' (depth %i)\n",key,value,depthCurPath);
+#endif
+
+    if ((depthCurPath>=nbDepthSelPath) || (depthCurPath<0))
+        return;
+    struct selpath_info& curPath = paths[depthCurPath];
+    if ((curPath.entered_conform_name) && (curPath.tagkey != NULL)) {
+        if ((u_strcmp(key,curPath.tagkey)==0) && (u_strcmp(value,curPath.tagvalue)==0)) {
+            curPath.entered_conform_key_value=true;
+            if (depthCurPath+1==nbDepthSelPath)
+                in_selection=true;
+        }
+    }
+}
+
+void XmlSelect::exitTag(bool& in_selection)
+{
+    if (!path_initialized) return;
+
+#ifdef XMLSELECT_VERBOSE
+    for (int i = 0; i < depthCurPath;i++) u_printf(" ");
+    u_printf("Exit tag (depth %i)\n",depthCurPath);
+#endif
+
+    if (depthCurPath+1 == nbDepthSelPath)
+        in_selection = false;
+
+    depthCurPath--;
+}
+
+static int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
+        UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien,
+        Ustring* ustr1, Ustring* ustr2, XmlSelect& xmlSelect, bool& write_enabled);
+static int decode_html_char(U_FILE* f,U_FILE* f_out,bool write_enabled,
+        int *pos,int *new_pos,vector_offset* offsets,void* html_ctx);
 
 
 /**
@@ -45,27 +274,40 @@ int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset
  * (i.e. skipping script code, replacing any tag by a space).
  */
 int unxmlize(U_FILE* input,U_FILE* output,vector_offset* offsets,UnxmlizeOpts* options,
-        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation) {
+        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation, const char* selPath) {
 int c;
 int pos=0,new_pos=0;
 void* html_ctx=init_HTML_character_context();
+XmlSelect xmlSelect;
+// ustr1 and ustr2 are recycling Ustring buffer, to avoid a lot of malloc/free
+Ustring* ustr1 = new_Ustring();
+Ustring* ustr2 = new_Ustring();
+if (selPath == NULL)
+  selPath = "";
+if (!xmlSelect.initSelPath(selPath)) {
+    fatal_error("Invalid xml selection path: '%s'\n", selPath);
+    return 0;
+}
+bool write_enabled = (selPath[0] == '\0');
 while ((c=u_fgetc_raw(input))!=EOF) {
     int markup_malformation=0;
     pos++;
     if (c=='<') {
-        if (!skip_tag(input,output,&pos,&new_pos,offsets,options,bastien,f_bastien)) {
+        if (!skip_tag(input,output,&pos,&new_pos,offsets,options,bastien,f_bastien,ustr1,ustr2,xmlSelect,write_enabled)) {
             //free_HTML_character_context(html_ctx);
             markup_malformation=1;
         }
     }
     else if (c=='&') {
-        if (!decode_html_char(input,output,&pos,&new_pos,offsets,html_ctx)) {
+        if (!decode_html_char(input,output,write_enabled,&pos,&new_pos,offsets,html_ctx)) {
             //free_HTML_character_context(html_ctx);
             markup_malformation=1;
         }
     } else {
-        u_fputc_raw((unichar)c,output);
-        new_pos++;
+        if (write_enabled) {
+            u_fputc_raw((unichar)c,output);
+            new_pos++;
+        }
     }
 
     if (markup_malformation!=0) {
@@ -73,12 +315,17 @@ while ((c=u_fgetc_raw(input))!=EOF) {
             free_HTML_character_context(html_ctx);
             return 0;
         } else {
-          u_fputc_raw((unichar)c,output);
-          new_pos++;
+          if (write_enabled) {
+              u_fputc_raw((unichar)c,output);
+              new_pos++;
+          }
         }
     }
 }
+
 free_HTML_character_context(html_ctx);
+free_Ustring(ustr1);
+free_Ustring(ustr2);
 return 1;
 }
 
@@ -154,7 +401,7 @@ return 1;
  * all text until ]]> is read. This text will be taken as is, except for
  * &gt; that will be turned into a >.
  */
-int skip_cdata(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets) {
+static int skip_cdata(U_FILE* f,U_FILE* f_out,bool write_enabled,int *pos,int *new_pos,vector_offset* offsets) {
 int c,state=0;
 while (state!=3) {
     c=u_fgetc_raw(f);
@@ -165,8 +412,10 @@ while (state!=3) {
         if (c==']') state=1;
         else if (c=='&') state=4;
         else {
-            u_fputc_raw((unichar)c,f_out);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw((unichar)c,f_out);
+                (*new_pos)++;
+            }
             state=0;
         }
         break;
@@ -177,14 +426,18 @@ while (state!=3) {
             /* To come here, we had read a ] that will not be used as a
              * part of ]]> so we have to dump this char in the output file */
             state=4;
-            u_fputc_raw(']',f_out);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw(']',f_out);
+                (*new_pos)++;
+            }
         }
         else {
             /* We have to save ]c */
-            u_fputc_raw(']',f_out);
-            u_fputc_raw((unichar)c,f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw(']',f_out);
+                u_fputc_raw((unichar)c,f_out);
+                (*new_pos)+=2;
+            }
             state=0;
         }
         break;
@@ -192,24 +445,30 @@ while (state!=3) {
     case 2: {
         if (c==']') {
             /* This is the third ], we have to save one */
-            u_fputc_raw(']',f_out);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw(']',f_out);
+                (*new_pos)++;
+            }
             state=2;
         }
         else if (c=='&') {
             /* We have ]] to save */
-            u_fputc_raw(']',f_out);
-            u_fputc_raw(']',f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw(']',f_out);
+                u_fputc_raw(']',f_out);
+                (*new_pos)+=2;
+            }
             state=4;
         }
         else if (c=='>') state=3;
         else {
             /* We have ]]c to save */
-            u_fputc_raw(']',f_out);
-            u_fputc_raw(']',f_out);
-            u_fputc_raw((unichar)c,f_out);
-            (*new_pos)+=3;
+            if (write_enabled) {
+                u_fputc_raw(']',f_out);
+                u_fputc_raw(']',f_out);
+                u_fputc_raw((unichar)c,f_out);
+                (*new_pos)+=3;
+            }
             state=0;
         }
         break;
@@ -217,22 +476,28 @@ while (state!=3) {
     case 4: {
         if (c==']') {
             /* We have & to save */
-            u_fputc_raw('&',f_out);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                (*new_pos)++;
+            }
             state=1;
         }
         else if (c=='&') {
             /* We have & to save */
-            u_fputc_raw('&',f_out);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                (*new_pos)++;
+            }
             state=4;
         }
         else if (c=='g') state=5;
         else {
             /* We have &c to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw((unichar)c,f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw((unichar)c,f_out);
+                (*new_pos)+=2;
+            }
             state=0;
         }
         break;
@@ -240,22 +505,28 @@ while (state!=3) {
     case 5: {
         if (c==']') {
             /* We have &g to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                (*new_pos)+=2;
+            }
             state=1;
         } else if (c=='&') {
             /* We have &g to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                (*new_pos)+=2;
+            }
             state=4;
         } else if (c=='t') state=6;
         else {
             /* We have &g to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            (*new_pos)+=2;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                (*new_pos)+=2;
+            }
             state=0;
         }
         break;
@@ -263,32 +534,40 @@ while (state!=3) {
     case 6: {
         if (c==']') {
             /* We have &gt to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            u_fputc_raw('t',f_out);
-            (*new_pos)+=3;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                u_fputc_raw('t',f_out);
+                (*new_pos)+=3;
+            }
             state=1;
         }
         else if (c=='&') {
             /* We have &gt to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            u_fputc_raw('t',f_out);
-            (*new_pos)+=3;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                u_fputc_raw('t',f_out);
+                (*new_pos)+=3;
+            }
             state=4;
         } else if (c==';') {
             /* We have to replace &gt; by > */
-            u_fputc_raw('>',f_out);
-            write_offsets(offsets,(*pos)-4,*pos,*new_pos,(*new_pos)+1);
-            (*new_pos)++;
+            if (write_enabled) {
+                u_fputc_raw('>',f_out);
+                write_offsets(offsets,(*pos)-4,*pos,*new_pos,(*new_pos)+1);
+                (*new_pos)++;
+            }
             state=0;
         }
         else {
             /* We have &gt to save */
-            u_fputc_raw('&',f_out);
-            u_fputc_raw('g',f_out);
-            u_fputc_raw('t',f_out);
-            (*new_pos)+=3;
+            if (write_enabled) {
+                u_fputc_raw('&',f_out);
+                u_fputc_raw('g',f_out);
+                u_fputc_raw('t',f_out);
+                (*new_pos)+=3;
+            }
             state=0;
         }
         break;
@@ -305,13 +584,19 @@ return 1;
  * This function is called when < was read and it skips everything
  * until > has been read.
  */
-int skip_normal_tag(U_FILE* f,int *pos,unichar* bastien[],U_FILE* f_bastien) {
+static int skip_normal_tag(U_FILE* f,int *pos,unichar* bastien[],U_FILE* f_bastien,
+                           Ustring* ustr1, Ustring* ustr2, XmlSelect& xmlSelect, bool& write_enabled) {
 int c;
-Ustring* ustr=new_Ustring();
+Ustring* ustr=ustr1;
+Ustring* ustr_key=ustr2;
 int tag_name_found=(bastien!=NULL)?0:-1;
 int tag_index=-1;
 int old_pos=*pos;
-while ((c=u_fgetc_raw(f))!='>') {
+bool read_tag_name=true;
+int prev_c=0;
+empty(ustr);
+empty(ustr_key);
+while ((c = u_fgetc_raw(f)) != '>') {
     if (c==EOF) goto err;
     (*pos)++;
     if (c=='"') {
@@ -356,6 +641,13 @@ while ((c=u_fgetc_raw(f))!='>') {
         u_strcat(ustr,(unichar)c);
     }
     if (c==' ') {
+      if (read_tag_name) {
+          xmlSelect.enterNewTag(ustr->str, write_enabled);
+      } else {
+          xmlSelect.addKeyValueOnTag(ustr_key->str, ustr->str, write_enabled);
+      }
+      empty(ustr_key);
+      read_tag_name = false;
         if (tag_name_found==0) {
             tag_name_found=1;
             unichar z,foo;
@@ -371,14 +663,27 @@ while ((c=u_fgetc_raw(f))!='>') {
                 tag_name_found=2;
             }
         }
+        u_switch(ustr_key, ustr);
         empty(ustr);
     }
+    prev_c=c;
+}
+
+if (read_tag_name) {
+    xmlSelect.enterNewTag(ustr->str,write_enabled);
+}
+
+if (!read_tag_name)
+{
+    xmlSelect.addKeyValueOnTag(ustr_key->str, ustr->str, write_enabled);
+}
+
+if (prev_c =='/') {
+  xmlSelect.exitTag(write_enabled);
 }
 (*pos)++;
-free_Ustring(ustr);
 return 1;
 err:
-free_Ustring(ustr);
 return 0;
 }
 
@@ -455,8 +760,9 @@ return 1;
  * save the offsets shifts.
  * Returns 1 in case of success; 0 if the tag is malformed.
  */
-int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-        UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien) {
+static int skip_tag(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
+                    UnxmlizeOpts* options,unichar* bastien[],U_FILE* f_bastien,
+                    Ustring* ustr1, Ustring* ustr2, XmlSelect& xmlSelect, bool& write_enabled) {
 int old_pos=(*pos)-1;
 long current=ftell(f);
 /* We may read a comment */
@@ -471,9 +777,11 @@ if (read(f,"!--")) {
         write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
     } else {
         /* We may have to replace comments by a space */
-        write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-        (*new_pos)++;
-        u_fputc_raw(' ',f_out);
+        if (write_enabled) {
+            write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+            (*new_pos)++;
+            u_fputc_raw(' ',f_out);
+        }
     }
     return 1;
 }
@@ -482,7 +790,7 @@ fseek(f,current,SEEK_SET);
 if (read(f,"![CDATA[")) {
     (*pos)+=8;
     write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
-    if (!skip_cdata(f,f_out,pos,new_pos,offsets)) {
+    if (!skip_cdata(f,f_out,write_enabled,pos,new_pos,offsets)) {
         error("Invalid CDATA\n");
         fseek(f,current,SEEK_SET);
         return 0;
@@ -508,16 +816,18 @@ if (options->scripts!=UNXMLIZE_DO_NOTHING) {
             write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
         } else {
             /* We replace script sections by a space */
-            write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-            (*new_pos)++;
-            u_fputc_raw(' ',f_out);
+            if (write_enabled) {
+                write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+                (*new_pos)++;
+                u_fputc_raw(' ',f_out);
+            }
         }
         return 1;
     }
 }
 fseek(f,current,SEEK_SET);
 /* Or a normal tag */
-if (!skip_normal_tag(f,pos,bastien,f_bastien)) {
+if (!skip_normal_tag(f,pos,bastien,f_bastien,ustr1,ustr2,xmlSelect,write_enabled)) {
     error("Invalid xml tag\n");
     fseek(f,current,SEEK_SET);
     return 0;
@@ -526,9 +836,11 @@ if (options->normal_tags==UNXMLIZE_IGNORE) {
     write_offsets(offsets,old_pos,*pos,*new_pos,*new_pos);
 } else {
     /* We replace tags by a space */
-    write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
-    (*new_pos)++;
-    u_fputc_raw(' ',f_out);
+    if (write_enabled) {
+        write_offsets(offsets,old_pos,*pos,*new_pos,(*new_pos)+1);
+        (*new_pos)++;
+        u_fputc_raw(' ',f_out);
+    }
 }
 return 1;
 }
@@ -538,8 +850,8 @@ return 1;
  * This function is called when & has been read. It reads an html char
  * like &gt; or &#206;
  */
-int decode_html_char(U_FILE* f,U_FILE* f_out,int *pos,int *new_pos,vector_offset* offsets,
-        void* html_ctx) {
+static int decode_html_char(U_FILE* f,U_FILE* f_out,bool write_enabled,
+                            int *pos,int *new_pos,vector_offset* offsets,void* html_ctx) {
 char tmp[32];
 int c,i=0;
 long current=ftell(f);
@@ -570,9 +882,11 @@ if (c<0) {
     fseek(f,current,SEEK_SET);
     return 0;
 }
-u_fputc_raw((unichar)c,f_out);
-write_offsets(offsets,(*pos)-(2+i),*pos,*new_pos,(*new_pos)+1);
-(*new_pos)++;
+if (write_enabled) {
+    u_fputc_raw((unichar)c,f_out);
+    write_offsets(offsets,(*pos)-(2+i),*pos,*new_pos,(*new_pos)+1);
+    (*new_pos)++;
+}
 return 1;
 }
 

--- a/Xml.h
+++ b/Xml.h
@@ -44,8 +44,12 @@ typedef struct {
     char normal_tags;
 } UnxmlizeOpts;
 
+/* selPath can be a simple form of Xml selection path
+   like /tag1/tag2//
+*/
 int unxmlize(U_FILE* input,U_FILE* output,vector_offset* offsets,UnxmlizeOpts* options,
-        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation);
+        unichar* bastien[],U_FILE* f_bastien, int tolerate_markup_malformation,
+        const char* selPath);
 
 } // namespace unitex
 


### PR DESCRIPTION
[enhance] Add --selxpath option in Unxmlize to select a part of xml file to extract

This commit introduces the option --selxpath=XXX on Unxmlize modules

example:
--selxpath=/tei/text/body/div//s[@xml:id='d1p2s1']
