### PR TITLE
[major fix] Resolve match ordering for ALL_MATCHES policy in Locate

### DIFF
--- a/src/LocateMatches.h
+++ b/src/LocateMatches.h
@@ -55,6 +55,11 @@ struct match_list* load_match_list(U_FILE*,OutputPolicy*,unichar*,Abstract_alloc
 void filter_unambiguous_outputs(struct match_list* *list,vector_int*);
 int are_ambiguous(struct match_list* a,struct match_list* b);
 
+int compare_for_sorting(const struct match_list* a, const struct match_list* b);
+struct match_list* merge_sorted_lists(struct match_list* a, struct match_list* b);
+void split_list(struct match_list* source, struct match_list** front, struct match_list** back);
+void sort_matches_left_most_longest_order(struct match_list** match_list_head);
+
 } // namespace unitex
 
 #endif

--- a/src/LocatePattern.cpp
+++ b/src/LocatePattern.cpp
@@ -148,6 +148,9 @@ p->max_matches_at_token_pos=MAX_MATCHES_AT_TOKEN_POS;
 p->max_matches_per_subgraph=MAX_MATCHES_PER_SUBGRAPH;
 p->max_errors=MAX_ERRORS;
 
+p->concord_filename=NULL;
+p->versatile_encoding_config=NULL;
+
 p->pos_in_tokens = -1;
 p->pos_in_chars = -1;
 
@@ -266,6 +269,8 @@ U_FILE* out;
 U_FILE* info;
 struct locate_parameters* p=new_locate_parameters(real_elg_extensions_path);
 
+p->versatile_encoding_config = vec;
+
 if (stack_max>0) {
     p->stack_max = stack_max;
 }
@@ -319,6 +324,7 @@ char* concord_info = (buffer_filename + (step_filename_buffer * 1));
 
 strcpy(concord,dynamicDir);
 strcat(concord,"concord.ind");
+p->concord_filename = concord;
 
 strcpy(concord_info,dynamicDir);
 strcat(concord_info,"concord.n");

--- a/src/LocatePattern.h
+++ b/src/LocatePattern.h
@@ -377,6 +377,10 @@ struct locate_parameters {
    void*private_param_locate_trace;
 
    const char* token_filename;
+   const char* concord_filename;
+
+   const VersatileEncodingConfig* versatile_encoding_config;
+
    unichar* recyclable_unichar_buffer;
    unsigned int size_recyclable_unichar_buffer;
 

--- a/src/Match.cpp
+++ b/src/Match.cpp
@@ -30,7 +30,7 @@ namespace unitex {
 /**
  * Returns 1 if a is longer than b; 0 otherwise.
  */
-int is_longer_match(Match* a,Match* b) {
+int is_longer_match(const Match* a,const Match* b) {
 if (a->start_pos_in_token>b->start_pos_in_token) return 0;
 if (a->start_pos_in_token==b->start_pos_in_token) {
    if (a->start_pos_in_char>b->start_pos_in_char) return 0;
@@ -52,7 +52,7 @@ return 1;
 /**
  * Returns 1 if a ends strictly after b.
  */
-int match_end_after(Match* a,Match* b) {
+int match_end_after(const Match* a,const Match* b) {
 if (a->end_pos_in_token<b->end_pos_in_token) return 0;
 if (a->end_pos_in_token>b->end_pos_in_token) return 1;
 /* Same end positions in tokens */
@@ -67,7 +67,7 @@ return 1;
 /**
  * Returns 1 if a begins exactly at the same position that b.
  */
-int same_start_positions(Match* a,Match* b) {
+int same_start_positions(const Match* a,const Match* b) {
 return a->start_pos_in_token==b->start_pos_in_token
     && a->start_pos_in_char==b->start_pos_in_char
     && a->start_pos_in_letter==b->start_pos_in_letter;
@@ -77,7 +77,7 @@ return a->start_pos_in_token==b->start_pos_in_token
 /**
  * Returns 1 if a ends exactly at the same position that b.
  */
-int same_end_positions(Match* a,Match* b) {
+int same_end_positions(const Match* a,const Match* b) {
 return a->end_pos_in_token==b->end_pos_in_token
     && a->end_pos_in_char==b->end_pos_in_char
     && a->end_pos_in_letter==b->end_pos_in_letter;
@@ -87,7 +87,7 @@ return a->end_pos_in_token==b->end_pos_in_token
 /**
  * Returns 1 if a and b have the same bounds.
  */
-int same_positions(Match* a,Match* b) {
+int same_positions(const Match* a,const Match* b) {
 return same_start_positions(a,b) && same_end_positions(a,b);
 }
 
@@ -95,7 +95,7 @@ return same_start_positions(a,b) && same_end_positions(a,b);
 /**
  * Returns 1 if a's start position < b's start position; 0 otherwise
  */
-int match_start_before(Match* a,Match* b) {
+int match_start_before(const Match* a,const Match* b) {
 if (a->start_pos_in_token>b->start_pos_in_token) return 0;
 if (a->start_pos_in_token<b->start_pos_in_token) return 1;
 if (a->start_pos_in_char>b->start_pos_in_char) return 0;
@@ -104,7 +104,7 @@ return a->start_pos_in_letter<b->start_pos_in_letter;
 }
 
 
-int b_starts_after_end_of_a(Match* a,Match* b) {
+int b_starts_after_end_of_a(const Match* a,const Match* b) {
 if (b->start_pos_in_token<a->end_pos_in_token) return 0;
 if (b->start_pos_in_token>a->end_pos_in_token) return 1;
 if (b->start_pos_in_char<a->end_pos_in_char) return 0;
@@ -116,7 +116,7 @@ return b->start_pos_in_letter>a->end_pos_in_letter;
 /**
  * Compares a's positions and b's positions.
  */
-Overlap compare_matches(Match* a,Match* b) {
+Overlap compare_matches(const Match* a,const Match* b) {
 if (match_start_before(a,b)) {
    /* a starts before b starts */
    if (b_starts_after_end_of_a(a,b)) return A_BEFORE_B;
@@ -140,7 +140,7 @@ if (match_start_before(a,b)) {
 /**
  * Returns 1 if a starts before b ends; 0 otherwise.
  */
-int valid_text_interval_tfst(Match* a,Match* b) {
+int valid_text_interval_tfst(const Match* a,const Match* b) {
 if (a->start_pos_in_token<b->end_pos_in_token) return 1;
 if (a->start_pos_in_token>b->end_pos_in_token) return 0;
 return (a->start_pos_in_char<=b->end_pos_in_char);

--- a/src/Match.h
+++ b/src/Match.h
@@ -50,14 +50,14 @@ typedef struct {
 
 
 
-int is_longer_match(Match* a,Match* b);
-int match_end_after(Match* a,Match* b);
-int same_start_positions(Match* a,Match* b);
-int same_end_positions(Match* a,Match* b);
-int same_positions(Match* a,Match* b);
-int match_start_before(Match* a,Match* b);
-Overlap compare_matches(Match* a,Match* b);
-int valid_text_interval_tfst(Match* a,Match* b);
+int is_longer_match(const Match* a,const Match* b);
+int match_end_after(const Match* a,const Match* b);
+int same_start_positions(const Match* a,const Match* b);
+int same_end_positions(const Match* a,const Match* b);
+int same_positions(const Match* a,const Match* b);
+int match_start_before(const Match* a,const Match* b);
+Overlap compare_matches(const Match* a,const Match* b);
+int valid_text_interval_tfst(const Match* a,const Match* b);
 
 } // namespace unitex
 

--- a/src/Text_parsing.h
+++ b/src/Text_parsing.h
@@ -66,7 +66,7 @@ namespace unitex {
 #define COUNT_CANCEL_TRYING_INIT_CONST (1024)
 
 void error_at_token_pos(const char* message,int start,int length,struct locate_parameters* p,const struct optimizedFst2State*);
-void launch_locate(U_FILE*,long int,U_FILE*,struct locate_parameters*);
+void launch_locate(U_FILE*&,long int,U_FILE*,struct locate_parameters*);
 void core_tokenized_locate(/*int,*/OptimizedFst2State,int,/*int,*/struct parsing_info**,struct locate_n_matches*,struct list_context*,struct locate_parameters*);
 unichar* get_token_sequence(struct locate_parameters*, int, int);
 


### PR DESCRIPTION
This commit addresses a critical issue in the Locate function, specifically when using the ALL_MATCHES policy.

Issue:

Matches are immediately saved to the concord.ind file by the save_matches() function. This function operates under the assumption that matches are ordered from left-most to longest. However, this isn't guaranteed with the ALL_MATCHES policy, leading to incorrectly ordered matches, especially when multiple matches are found at overlapping or adjacent text positions.

Example:

Consider a dictionary containing the words "risk", "serious", "damage", "risk of serious damage", "serious damage to eyes", and "eyes" and the phrase "risk of serious damage to eyes".

Using Locate with ALL_MATCHES policy to match any word in the dictionary (<DIC>), The matches are incorrectly saved as:

```
0.0.0 0.3.0 risk
4.0.0 4.6.0 serious
0.0.0 6.5.0 risk of serious damage
6.0.0 6.5.0 damage
4.0.0 10.3.0 serious damage to eyes
10.0.0 10.3.0 eyes
```

This is: `<risk> of <serious> <damage> to <eyes>`

However, the expected left-most longest order should be:

```
0.0.0 6.5.0 risk of serious damage
0.0.0 0.3.0 risk
4.0.0 10.3.0 serious damage to eyes
4.0.0 4.6.0 serious
6.0.0 6.5.0 damage
10.0.0 10.3.0 eyes
```

This is: `<risk of serious damage> to <eyes>`

Solution:

When using the ALL_MATCHES policy, the fix involves a two-step process after the initial writing. First, we reopen the concord.ind file, load the matches, and sort them according to the left-most longest order. Then, we save the sorted matches back to the file. This ensures the correct match order is maintained, which is particularly crucial when using Concord and the -m/--merge flag, as it affects the logical order of matches on the modified text.