### PR TITLE
[enhance] Improve the strategy to save matches in Locate

### DIFF
--- a/src/LocateMatches.h
+++ b/src/LocateMatches.h
@@ -59,7 +59,9 @@ int compare_for_sorting(const struct match_list* a, const struct match_list* b);
 struct match_list* merge_sorted_lists(struct match_list* a, struct match_list* b);
 void split_list(struct match_list* source, struct match_list** front, struct match_list** back);
 void sort_matches_left_most_longest_order(struct match_list** match_list_head);
-
+void save_matches_concord_format(U_FILE* f, struct match_list* l,
+                                 OutputPolicy output_policy, unichar header,
+                                 Abstract_allocator prv_alloc);
 } // namespace unitex
 
 #endif

--- a/src/Text_parsing.cpp
+++ b/src/Text_parsing.cpp
@@ -56,9 +56,6 @@ static struct match_list* eliminate_shorter_matches(struct match_list*, int, int
 static struct match_list* save_matches(struct match_list*, int, U_FILE*,
         struct locate_parameters*, Abstract_allocator);
 static inline int at_text_start(struct locate_parameters*,int);
-static void save_concord_file_matches(U_FILE* f, struct match_list* l,
-                                      OutputPolicy output_policy, unichar header,
-                                      Abstract_allocator prv_alloc = NULL);
 
 static long CalcPerfHalfHundred(long text_size, long matching_units) {
     unsigned long text_size_calc_per_halfhundred = text_size;
@@ -88,7 +85,7 @@ static long CalcPerfHalfHundred(long text_size, long matching_units) {
  * Performs the Locate operation on the text, saving the occurrences
  * on the fly.
  */
-void launch_locate(U_FILE*& out, long int text_size, U_FILE* info,
+void launch_locate(U_FILE* out, long int text_size, U_FILE* info,
         struct locate_parameters* p) {
     p->token_error_ctx.n_errors = 0;
     p->token_error_ctx.last_start = -1;
@@ -2312,6 +2309,33 @@ struct match_list* ptr;
         return NULL;
     }
 
+    /**
+     * Delay saving matches strategy
+     *
+     * This strategy involves a thorough check of all matches in the list to ascertain
+     * if they are ready to be saved. The core of this update focuses on ensuring
+     * that matches are fully processed and their end positions do not exceed the
+     * current position in the text processing.
+     *
+     * If any match extends beyond or reaches the current text position, it indicates
+     * that the match could still have changes. In such cases, the function avoid
+     * saving any matches. Instead, it sorts all the matches to maintain their
+     * correct order, which is crucial for accurate output. The function then
+     * returns the list without saving, to ensure that matches are saved only when
+     * they are completely finalized.
+     *
+     * This strategy for delay saving matches is designed to preserve the integrity of
+     * match results, especially under match policies like ALL_MATCHES.
+     */
+    for (ptr = l; ptr != NULL; ptr = ptr->next) {
+      if (ptr->m.end_pos_in_token >= current_position) {
+        // if any match's end position is not less than the current position,
+        // sort the matches and return the list as is, without saving any matches
+        sort_matches_left_most_longest_order(&l);
+        return l;
+      }
+    }
+
     if (l->m.end_pos_in_token < current_position) {
         /* we can save the match (necessary for SHORTEST_MATCHES: there
          * may be no shorter match) */
@@ -2461,43 +2485,6 @@ struct match_list* ptr;
     }
     l->next = save_matches(l->next, current_position, f, p, prv_alloc);
     return l;
-}
-
-void save_concord_file_matches(U_FILE* f, struct match_list* l,
-                               OutputPolicy output_policy, unichar header,
-                               Abstract_allocator prv_alloc) {
-  if (l == NULL) {
-    // no matches to save
-    return;
-  }
-
-  // write header
-  u_fprintf(f, "#%C\n", header);
-
-  struct match_list* current = l;
-  while (current != NULL) {
-    // save the next element before freeing the current one
-    struct match_list* next = current->next;
-
-    // Write match positions
-    u_fprintf(f, "%d.%d.%d %d.%d.%d", current->m.start_pos_in_token,
-              current->m.start_pos_in_char, current->m.start_pos_in_letter,
-              current->m.end_pos_in_token, current->m.end_pos_in_char,
-              current->m.end_pos_in_letter);
-
-    // write match output if applicable
-    if (output_policy != IGNORE_OUTPUTS && current->output != NULL) {
-      u_fprintf(f, " %S", current->output);
-    }
-
-    u_fprintf(f, "\n");
-
-    // free the current element
-    free_match_list_element(current, prv_alloc);
-
-    // move to the next element
-    current = next;
-  }
 }
 
 /**

--- a/src/Text_parsing.h
+++ b/src/Text_parsing.h
@@ -66,7 +66,7 @@ namespace unitex {
 #define COUNT_CANCEL_TRYING_INIT_CONST (1024)
 
 void error_at_token_pos(const char* message,int start,int length,struct locate_parameters* p,const struct optimizedFst2State*);
-void launch_locate(U_FILE*&,long int,U_FILE*,struct locate_parameters*);
+void launch_locate(U_FILE*,long int,U_FILE*,struct locate_parameters*);
 void core_tokenized_locate(/*int,*/OptimizedFst2State,int,/*int,*/struct parsing_info**,struct locate_n_matches*,struct list_context*,struct locate_parameters*);
 unichar* get_token_sequence(struct locate_parameters*, int, int);
 


### PR DESCRIPTION
This commit improves the strategy used on cc12fd5 which addresses a critical issue in the Locate function, specifically when using the ALL_MATCHES policy.

Context:

Before cc12fd5, matches were immediately saved to the concord.ind file by the function `save_matches()`. This function operated under the assumption that matches are ordered from left-most to longest. However, this wasn't guaranteed with the ALL_MATCHES policy, leading to incorrectly ordered matches, especially when multiple matches are found at overlapping or adjacent text positions.

Example:

Consider a dictionary containing the words "risk", "serious", "damage", "risk of serious damage", "serious damage to eyes", and "eyes" and the phrase "risk of serious damage to eyes".

Using Locate with ALL_MATCHES policy to match any word in the dictionary (`<DIC>`), The matches are incorrectly saved as:

```
0.0.0 0.3.0 risk
4.0.0 4.6.0 serious
0.0.0 6.5.0 risk of serious damage
6.0.0 6.5.0 damage
4.0.0 10.3.0 serious damage to eyes
10.0.0 10.3.0 eyes
```

This is: `<risk> of <serious> <damage> to <eyes>`

However, the expected left-most longest order should be:

```
0.0.0 6.5.0 risk of serious damage
0.0.0 0.3.0 risk
4.0.0 10.3.0 serious damage to eyes
4.0.0 4.6.0 serious
6.0.0 6.5.0 damage
10.0.0 10.3.0 eyes
```

This is: `<risk of serious damage> to <eyes>`

Previous strategy:

When using the ALL_MATCHES policy, the fix involved a two-step process after the initial writing. First, we reopen the concord.ind file, load the matches, and sort them according to the left-most longest order. Then, we save the sorted matches back to the file. This ensures the correct match order is maintained, which is particularly crucial when using Concord and the -m/--merge flag, as it affects the logical order of matches on the modified text.

Improved strategy:

The updated strategy involves a thorough check of all matches in the list to ascertain if they are ready to be saved. The core of this update focuses on ensuring that matches are fully processed and their end positions do not exceed the current position in the text processing.

If any match extends beyond or reaches the current text position, it indicates that the match could still have changes. In such cases, the `save_macthes` function avoid saving any matches. Instead, it sorts all the matches to maintain their correct order, which is crucial for accurate output. The function then returns the list without saving, to ensure that matches are saved only when they are completely finalized.

This strategy for delay saving matches is designed to preserve the integrity of match results, especially under match policies like ALL_MATCHES, without the two-step process introduced on cc12fd5.